### PR TITLE
chore(deps): update kube-rbac-proxy + otel-collector chart

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -15,7 +15,7 @@ spec:
           capabilities:
             drop:
             - "ALL"
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.16.1
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/helm-chart/dash0-operator/Chart.lock
+++ b/helm-chart/dash0-operator/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: opentelemetry-collector
   repository: https://open-telemetry.github.io/opentelemetry-helm-charts
-  version: 0.93.1
-digest: sha256:0d1653fa32255a0807c9a6757d7fe58abfb466a530fd6161993747955514ee4e
-generated: "2024-06-07T10:59:38.555357+02:00"
+  version: 0.96.0
+digest: sha256:8ebd7cafd773cf1838db638357c8d5ede2bc6d754c28e9df942444d4729ffda8
+generated: "2024-06-27T11:27:59.759761+02:00"

--- a/helm-chart/dash0-operator/Chart.yaml
+++ b/helm-chart/dash0-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: dash0-operator
-version: "1.0.0"
+version: "1.0.0" # note: will be replaced when building a release
 description: The Dash0 Kubernetes Operator makes observability easy for every Kubernetes setup, simply install the operator into your cluster to get OpenTelemetry data flowing from your applications and infrastructure to Dash0.
 type: application
 keywords:
@@ -19,7 +19,7 @@ maintainers:
   - name: Bastian Krol
     email: bastian.krol@dash0.com
 icon: https://www.dash0.com/shared/logo_colors_128x128.png
-appVersion: "1.0.0"
+appVersion: "1.0.0" # note: will be replaced when building a release
 dependencies:
   - name: opentelemetry-collector
     version: 0.93.1

--- a/helm-chart/dash0-operator/Chart.yaml
+++ b/helm-chart/dash0-operator/Chart.yaml
@@ -22,6 +22,6 @@ icon: https://www.dash0.com/shared/logo_colors_128x128.png
 appVersion: "1.0.0" # note: will be replaced when building a release
 dependencies:
   - name: opentelemetry-collector
-    version: 0.93.1
+    version: 0.96.0
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts
     condition: opentelemetry-collector.enabled

--- a/helm-chart/dash0-operator/README.md
+++ b/helm-chart/dash0-operator/README.md
@@ -73,6 +73,15 @@ helm install \
   dash0-operator/dash0-operator  
 ```
 
+Note: When installing a chart, you might see a warning like the following printed to the console:
+```
+coalesce.go:286: warning: cannot overwrite table with non table for dash0-operator.opentelemetry-collector.config.receivers.prometheus (map[config:map[scrape_configs:[map[job_name:opentelemetry-collector scrape_interval:10s static_configs:[map[targets:[${env:MY_POD_IP}:8888]]]]]]])
+coalesce.go:286: warning: cannot overwrite table with non table for dash0-operator.opentelemetry-collector.config.receivers.zipkin (map[endpoint:${env:MY_POD_IP}:9411])
+coalesce.go:286: warning: cannot overwrite table with non table for dash0-operator.opentelemetry-collector.config.receivers.jaeger (map[protocols:map[grpc:map[endpoint:${env:MY_POD_IP}:14250] thrift_compact:map[endpoint:${env:MY_POD_IP}:6831] thrift_http:map[endpoint:${env:MY_POD_IP}:14268]]])
+```
+
+This can be safely ignored.
+
 ## Uninstallation
 
 To remove the Dash0 Kubernetes Operator from your cluster, run the following command:

--- a/helm-chart/dash0-operator/templates/operator/deployment.yaml
+++ b/helm-chart/dash0-operator/templates/operator/deployment.yaml
@@ -95,7 +95,7 @@ spec:
           initialDelaySeconds: 5
           periodSeconds: 10
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.16.1
         args:
         - --secure-listen-address=0.0.0.0:8443
         - --upstream=http://127.0.0.1:8080/

--- a/helm-chart/dash0-operator/tests/operator/__snapshot__/deployment_test.yaml.snap
+++ b/helm-chart/dash0-operator/tests/operator/__snapshot__/deployment_test.yaml.snap
@@ -85,7 +85,7 @@ deployment should match snapshot (default values):
                 - --upstream=http://127.0.0.1:8080/
                 - --logtostderr=true
                 - --v=0
-              image: gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0
+              image: quay.io/brancz/kube-rbac-proxy:v0.16.1
               name: kube-rbac-proxy
               ports:
                 - containerPort: 8443


### PR DESCRIPTION
Apparently this image is no longer regularly published to gcr.io/kubebuilder/kube-rbac-proxy. Instead, the official repository for it is quay.io/brancz/kube-rbac-proxy.