### PR TITLE
chore(chart): allow disabling secret and otlp endpoint checks

### DIFF
--- a/helm-chart/dash0-operator/templates/operator/verify-preconditions.yaml
+++ b/helm-chart/dash0-operator/templates/operator/verify-preconditions.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.operator.disableSecretCheck -}}
 {{- $secret := lookup "v1" "Secret" .Release.Namespace "dash0-authorization-secret" -}}
 {{- if $secret -}}
 {{- if not (index $secret.data "dash0-authorization-token") -}}
@@ -6,7 +7,11 @@
 {{- else -}}
 {{- fail (printf "Error: There is no secret named \"dash0-authorization-secret\" in the target namespace \"%s\". Please refer to the installation instructions at https://github.com/dash0hq/dash0-operator/tree/main/helm-chart/dash0-operator#installation." .Release.Namespace) -}}
 {{- end -}}
+{{- end -}}
 
-{{- if not (index .Values "opentelemetry-collector").config.exporters.otlp.endpoint -}}
+{{- if not .Values.operator.disableOtlpEndpoingCheck -}}
+{{- $oltpExporter := (index .Values "opentelemetry-collector").config.exporters.otlp -}}
+{{- if not $oltpExporter.endpoint -}}
 {{- fail "Error: You did not provide a value for opentelemetry-collector.config.exporters.otlp.endpoint. Please refer to the installation instructions at https://github.com/dash0hq/dash0-operator/tree/main/helm-chart/dash0-operator#installation." -}}
+{{- end -}}
 {{- end -}}

--- a/helm-chart/dash0-operator/values.yaml
+++ b/helm-chart/dash0-operator/values.yaml
@@ -95,6 +95,8 @@ operator:
   imagePullSecrets: [ ]
 
   developmentMode: false
+  disableSecretCheck: false
+  disableOtlpEndpoingCheck: false
 
 # settings for the OpenTelemetry collector instance that Dash0 will use for reporting data to Dash0
 opentelemetry-collector:

--- a/test/e2e/e2e_helpers.go
+++ b/test/e2e/e2e_helpers.go
@@ -352,6 +352,8 @@ func DeployOperatorWithCollectorAndClearExportedTelemetry(
 		"--values",
 		"test-resources/helm/e2e.values.yaml",
 		"--set", "operator.developmentMode=true",
+		"--set", "operator.disableSecretCheck=true",
+		"--set", "operator.disableOtlpEndpoingCheck=true",
 	}
 	arguments = setIfNotEmpty(arguments, "operator.image.repository", images.operator.repository)
 	arguments = setIfNotEmpty(arguments, "operator.image.tag", images.operator.tag)


### PR DESCRIPTION
This is required to enable the e2e tests to use the Helm chart, as the e2e tests deliberately do not install a secret and set the otlp exporter to null.