### PR TITLE
feat(chart): support sending data to an existing collector instance

### DIFF
--- a/helm-chart/dash0-operator/README.md
+++ b/helm-chart/dash0-operator/README.md
@@ -25,10 +25,11 @@ https://github.com/dash0hq/dash0-operator/blob/main/README.md.
 
 ## Installation
 
-Before installing the operator, add the Helm repository as follows:
+Before installing the operator, add the required Helm repositories as follows:
 
 ```console
 helm repo add dash0-operator https://dash0hq.github.io/dash0-operator
+helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
 helm repo update
 ```
 

--- a/helm-chart/dash0-operator/templates/_helpers.tpl
+++ b/helm-chart/dash0-operator/templates/_helpers.tpl
@@ -77,3 +77,25 @@ securityContext:
     drop:
     - ALL
 {{- end }}
+
+{{- define "dash0-operator.openTelemetryCollectorBaseUrl" -}}
+{{- if .Values.operator.openTelemetryCollectorBaseUrl -}}
+{{- .Values.operator.openTelemetryCollectorBaseUrl -}}
+{{- else if (index .Values "opentelemetry-collector").enabled -}}
+{{- /*
+Note: This reuses an internal template of the opentelmetry-collector Helm chart, to make sure we render the
+exact same service name for the collector URL as the collector Helm chart does. This might need to be updated
+if the collector Helm chart changes its service name template. Since we control the version of the collector
+Helm chart we use and run rigorous tests when updating to a newer version, this approach should be safe.
+*/ -}}
+{{- $collectorSubChartValues :=
+   dict
+	 "Values" (index .Values "opentelemetry-collector")
+	 "Chart" (dict "Name" "opentelemetry-collector")
+	 "Release" .Release
+-}}
+http://{{ include "opentelemetry-collector.fullname" $collectorSubChartValues }}.{{ .Release.Namespace }}.svc.cluster.local:4318
+{{- else -}}
+{{- fail "Error: The value \"opentelemetry-collector.enabled\" is false and the value \"operator.openTelemetryCollectorBaseUrl\" has not been provided. Please refer to the installation instructions at https://github.com/dash0hq/dash0-operator/tree/main/helm-chart/dash0-operator#installation." -}}
+{{- end -}}
+{{- end -}}

--- a/helm-chart/dash0-operator/templates/operator/deployment.yaml
+++ b/helm-chart/dash0-operator/templates/operator/deployment.yaml
@@ -46,19 +46,7 @@ spec:
         - --leader-elect
         env:
         - name: DASH0_OTEL_COLLECTOR_BASE_URL
-          {{/*
-          Note: This reuses an internal template of the opentelmetry-collector Helm chart, to make sure we render the
-          exact same service name for the collector URL as the collector Helm chart does. This might need to be updated
-          if the collector Helm chart changes its service name template. Since we control the version of the collector
-          Helm chart we use and run rigorous tests when updating to a newer version, this approach should be safe.
-          */}}
-          {{ $collectorSubChartValues :=
-               dict
-                 "Values" (index .Values "opentelemetry-collector")
-                 "Chart" (dict "Name" "opentelemetry-collector")
-                 "Release" .Release
-          }}
-          value: http://{{ include "opentelemetry-collector.fullname" $collectorSubChartValues }}.{{ .Release.Namespace }}.svc.cluster.local:4318
+          value: {{ include "dash0-operator.openTelemetryCollectorBaseUrl" . | quote }}
         - name: DASH0_OPERATOR_IMAGE
           value: {{ include "dash0-operator.image" . | quote }}
         - name: DASH0_INIT_CONTAINER_IMAGE

--- a/helm-chart/dash0-operator/templates/operator/verify-preconditions.yaml
+++ b/helm-chart/dash0-operator/templates/operator/verify-preconditions.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.operator.disableSecretCheck -}}
+{{- if and (index .Values "opentelemetry-collector").enabled (not .Values.operator.disableSecretCheck) -}}
 {{- $secret := lookup "v1" "Secret" .Release.Namespace "dash0-authorization-secret" -}}
 {{- if $secret -}}
 {{- if not (index $secret.data "dash0-authorization-token") -}}
@@ -9,7 +9,7 @@
 {{- end -}}
 {{- end -}}
 
-{{- if not .Values.operator.disableOtlpEndpointCheck -}}
+{{- if and (index .Values "opentelemetry-collector").enabled (not .Values.operator.disableOtlpEndpointCheck) -}}
 {{- $oltpExporter := (index .Values "opentelemetry-collector").config.exporters.otlp -}}
 {{- if not $oltpExporter.endpoint -}}
 {{- fail "Error: You did not provide a value for opentelemetry-collector.config.exporters.otlp.endpoint. Please refer to the installation instructions at https://github.com/dash0hq/dash0-operator/tree/main/helm-chart/dash0-operator#installation." -}}

--- a/helm-chart/dash0-operator/tests/operator/deployment_test.yaml
+++ b/helm-chart/dash0-operator/tests/operator/deployment_test.yaml
@@ -165,3 +165,17 @@ tests:
           value: ghcr.io/dash0hq/instrumentation@sha256:1e8c25853217c7393dbd95e17fe2117bb31b39478bbea4479cc5e7c1257dda01
       - notExists:
           path: spec.template.spec.containers[0].env[3].name
+
+  - it: should support independent collector
+    set:
+      operator:
+        openTelemetryCollectorBaseUrl: "http://opentelemetry-collector-daemonset.opentelemetry.svc.cluster.local:4318"
+      opentelemetry-collector:
+        enabled: false
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[0].name
+          value: DASH0_OTEL_COLLECTOR_BASE_URL
+      - equal:
+          path: spec.template.spec.containers[0].env[0].value
+          value: http://opentelemetry-collector-daemonset.opentelemetry.svc.cluster.local:4318

--- a/helm-chart/dash0-operator/values.yaml
+++ b/helm-chart/dash0-operator/values.yaml
@@ -1,5 +1,5 @@
 # This file contains the default values for the Dash0 Kubernetes Operator Helm chart.
-# Values can be overriden via --set or by providing additional yaml files when doing helm install etc.
+# Values can be overriden via --set or by providing additional yaml files when running helm install.
 
 # settings for the operator/controller
 operator:
@@ -79,7 +79,6 @@ operator:
     tag:
     # pull image by digest instead of tag; if this is set, the tag value will be ignored
     digest:
-
     # override the default image pull policy
     pullPolicy:
 
@@ -103,6 +102,12 @@ operator:
   # otherwise a Zap production config will be used (stacktraces on errors, sampling).
   developmentMode: false
 
+  # If set, the instrumented workloads will send telemetry data to this URL instead of the default URL for the
+  # OpenTelemetry collector instance that this Helm chart deploys. This setting is meant to be used together with
+  # the setting opentelemetry-collector.enabled: false. If opentelemetry-collector.enabled is not set to false, the
+  # setting operator.openTelemetryCollectorBaseUrl should be left unset.
+  openTelemetryCollectorBaseUrl:
+
   # If set to true, the operator Helm chart will skip the check for the Dash0 authorization secret. This should only
   # be done for testing purposes.
   disableSecretCheck: false
@@ -113,6 +118,9 @@ operator:
 
 # settings for the OpenTelemetry collector instance that Dash0 will use for reporting data to Dash0
 opentelemetry-collector:
+  # Set this to false if you do not want the Dash0 Kubernetes operator helm chart to deploy an OpenTelemetry collector
+  # daemonset. Note that if you disable this, you will need to provide your own OpenTelemetry collector instance
+  # and also provide its URL via the setting operator.openTelemetryCollectorBaseUrl.
   enabled: true
 
   image:


### PR DESCRIPTION
Instead of installing a collector together with the operator. This option should only be used in very specific circumstances.