### PR TITLE
chore(instrumentation image): use Node distro version from package.json

### DIFF
--- a/images/instrumentation/node.js/build.sh
+++ b/images/instrumentation/node.js/build.sh
@@ -19,20 +19,7 @@ if [[ "${USE_LOCAL_SOURCES_FOR_NODEJS_DISTRIBUTION:-}" = true ]]; then
     --no-audit \
     --no-fund=true \
     dash0hq-opentelemetry-*.tgz
-
 else
-  nodejs_distribution_version="1.0.1"
-  fully_qualified_package_name="@dash0hq/opentelemetry@${nodejs_distribution_version}"
   rm -f dash0hq-opentelemetry-*.tgz
-  echo "Node.js: using @dash0hq/opentelemetry@${nodejs_distribution_version}"
-
-  NPM_CONFIG_UPDATE_NOTIFIER=false \
-  npm install \
-  --save-exact \
-  --package-lock-only \
-  --ignore-scripts \
-  --omit=dev \
-  --no-audit \
-  --no-fund=true \
-  "$fully_qualified_package_name"
+  rm -rf node_modules
 fi


### PR DESCRIPTION
Actually, there is no need at all to do a local npm install before building the image.