### PR TITLE
feat(webhook): uninstrument workloads when opt-out label is added

### DIFF
--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -35,13 +35,23 @@ webhooks:
     - UPDATE
     resources:
     - cronjobs
-    - jobs
+  - apiGroups:
+      - batch
+    apiVersions:
+      - v1
+    operations:
+      # do not listen to UPDATE for jobs, we cannot revert instrumentation or do anything on UPDATE requests, since jobs
+      # are immutable
+      - CREATE
+    resources:
+      - jobs
   - apiGroups: [""]
     apiVersions:
     - v1
     operations:
-    - CREATE
-    - UPDATE
+    # do not listen to UPDATE for pods, we cannot revert instrumentation or do anything on UPDATE requests, since pods
+    # are effectively immutable (we cannot restart ownerless pods)
+      - CREATE
     resources:
     - pods
   sideEffects: None

--- a/helm-chart/dash0-operator/templates/operator/webhook.yaml
+++ b/helm-chart/dash0-operator/templates/operator/webhook.yaml
@@ -91,13 +91,23 @@ webhooks:
     - UPDATE
     resources:
     - cronjobs
-    - jobs
+  - apiGroups:
+      - batch
+    apiVersions:
+      - v1
+    operations:
+      # do not listen to UPDATE for jobs, we cannot revert instrumentation or do anything on UPDATE requests, since jobs
+      # are immutable
+      - CREATE
+    resources:
+      - jobs
   - apiGroups: [""]
     apiVersions:
     - v1
     operations:
-    - CREATE
-    - UPDATE
+    # do not listen to UPDATE for pods, we cannot revert instrumentation or do anything on UPDATE requests, since pods
+    # are effectively immutable (we cannot restart ownerless pods)
+      - CREATE
     resources:
     - pods
   sideEffects: None

--- a/helm-chart/dash0-operator/tests/operator/__snapshot__/webhook_test.yaml.snap
+++ b/helm-chart/dash0-operator/tests/operator/__snapshot__/webhook_test.yaml.snap
@@ -105,6 +105,13 @@ webhook should match snapshot:
               - UPDATE
             resources:
               - cronjobs
+          - apiGroups:
+              - batch
+            apiVersions:
+              - v1
+            operations:
+              - CREATE
+            resources:
               - jobs
           - apiGroups:
               - ""
@@ -112,7 +119,6 @@ webhook should match snapshot:
               - v1
             operations:
               - CREATE
-              - UPDATE
             resources:
               - pods
         sideEffects: None

--- a/internal/controller/dash0_controller.go
+++ b/internal/controller/dash0_controller.go
@@ -498,7 +498,7 @@ func (r *Dash0Reconciler) addLabelsToImmutableJobsOnInstrumentation(
 		logger.Info("not instrumenting this workload since it is about to be deleted (a deletion timestamp is set)")
 		return
 	}
-	if util.HasOptedOutOfInstrumenationForWorkload(&job.ObjectMeta) {
+	if util.HasOptedOutOfInstrumenation(&job.ObjectMeta) {
 		logger.Info("not instrumenting this workload due to dash0.com/enable=false")
 		return
 	}
@@ -598,7 +598,7 @@ func (r *Dash0Reconciler) instrumentWorkload(
 		logger.Info("not instrumenting this workload since it is about to be deleted (a deletion timestamp is set)")
 		return
 	}
-	if util.HasOptedOutOfInstrumenationForWorkload(workload.getObjectMeta()) {
+	if util.HasOptedOutOfInstrumenation(workload.getObjectMeta()) {
 		logger.Info("not instrumenting this workload due to dash0.com/enable=false")
 		return
 	}
@@ -647,7 +647,7 @@ func (r *Dash0Reconciler) postProcessInstrumentation(
 		// the event are unspecific, would be better if we could differentiate between the two cases.
 		// (Also for revert maybe.)
 		logger.Info("Dash0 instrumentation was already present on this workload, or the workload is part of a higher " +
-			"order workload that will be instrumented, no modification by controller is necessary.")
+			"order workload that will be instrumented, no modification by the controller is necessary.")
 		util.QueueNoInstrumentationNecessaryEvent(r.Recorder, resource, "controller")
 	} else {
 		logger.Info("The controller has added Dash0 instrumentation to the workload.")
@@ -1049,11 +1049,11 @@ func (r *Dash0Reconciler) postProcessUninstrumentation(
 		}
 		util.QueueFailedUninstrumentationEvent(r.Recorder, resource, "controller", retryErr)
 	} else if !hasBeenModified {
-		logger.Info("Dash0 instrumentations was not present on this workload, no modification by controller has been " +
+		logger.Info("Dash0 instrumentations was not present on this workload, no modification by the controller has been " +
 			"necessary.")
 		util.QueueNoUninstrumentationNecessaryEvent(r.Recorder, resource, "controller")
 	} else {
-		logger.Info("The controller has removed Dash0 instrumentation from the workload.")
+		logger.Info("The controller has removed the Dash0 instrumentation from the workload.")
 		util.QueueSuccessfulUninstrumentationEvent(r.Recorder, resource, "controller")
 	}
 }

--- a/internal/util/labels.go
+++ b/internal/util/labels.go
@@ -101,7 +101,19 @@ func readInstrumentationState(meta *metav1.ObjectMeta) instrumentedState {
 	}
 }
 
-func HasOptedOutOfInstrumenationForWorkload(meta *metav1.ObjectMeta) bool {
+func HasOptedOutOfInstrumenation(meta *metav1.ObjectMeta) bool {
+	return hasOptedOutOfInstrumenationForWorkload(meta)
+}
+
+func HasOptedOutOfInstrumenationAndIsUninstrumented(meta *metav1.ObjectMeta) bool {
+	return hasOptedOutOfInstrumenationForWorkload(meta) && !HasBeenInstrumentedSuccessfully(meta)
+}
+
+func WasInstrumentedButHasOptedOutNow(meta *metav1.ObjectMeta) bool {
+	return HasBeenInstrumentedSuccessfully(meta) && hasOptedOutOfInstrumenationForWorkload(meta)
+}
+
+func hasOptedOutOfInstrumenationForWorkload(meta *metav1.ObjectMeta) bool {
 	if meta.Labels == nil {
 		return false
 	}

--- a/internal/workloads/workload_modifier.go
+++ b/internal/workloads/workload_modifier.go
@@ -308,10 +308,6 @@ func (m *ResourceModifier) RevertDeployment(deployment *appsv1.Deployment) bool 
 	return m.revertResource(&deployment.Spec.Template, &deployment.ObjectMeta)
 }
 
-func (m *ResourceModifier) RevertJob(job *batchv1.Job) bool {
-	return m.revertResource(&job.Spec.Template, &job.ObjectMeta)
-}
-
 func (m *ResourceModifier) RemoveLabelsFromImmutableJob(job *batchv1.Job) {
 	util.RemoveInstrumentationLabels(&job.ObjectMeta)
 }

--- a/internal/workloads/workload_modifier.go
+++ b/internal/workloads/workload_modifier.go
@@ -273,6 +273,9 @@ func (m *ResourceModifier) addOrPrependToEnvironmentVariable(
 					name))
 			return
 		}
+		if strings.Contains(previousValue, envVarNodeOptionsValue) {
+			return
+		}
 		container.Env[idx].Value = fmt.Sprintf("%s %s", value, previousValue)
 	}
 }
@@ -407,6 +410,7 @@ func (m *ResourceModifier) removeNodeOptions(container *corev1.Container) {
 			return
 		} else if previousValue == envVarNodeOptionsValue {
 			container.Env = slices.Delete(container.Env, idx, idx+1)
+			return
 		}
 
 		container.Env[idx].Value = strings.Replace(previousValue, envVarNodeOptionsValue, "", -1)

--- a/internal/workloads/workload_modifier_test.go
+++ b/internal/workloads/workload_modifier_test.go
@@ -231,14 +231,6 @@ var _ = Describe("Dash0 Workload Modification", func() {
 			VerifyUnmodifiedDaemonSet(workload)
 		})
 
-		It("should remove Dash0 from an instrumented job", func() {
-			workload := InstrumentedJob(TestNamespaceName, JobNamePrefix)
-			result := workloadModifier.RevertJob(workload)
-
-			Expect(result).To(BeTrue())
-			VerifyUnmodifiedJob(workload)
-		})
-
 		It("should remove Dash0 from an instrumented ownerless replica set", func() {
 			workload := InstrumentedReplicaSet(TestNamespaceName, ReplicaSetNamePrefix)
 			result := workloadModifier.RevertReplicaSet(workload)

--- a/test-resources/node.js/express/daemonset.opt-out.yaml
+++ b/test-resources/node.js/express/daemonset.opt-out.yaml
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: Copyright 2024 Dash0 Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: dash0-operator-nodejs-20-express-test-daemonset-service
+spec:
+  selector:
+    app: dash0-operator-nodejs-20-express-test-daemonset-app
+  ports:
+    - port: 1206
+      targetPort: 1206
+  type: LoadBalancer
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: dash0-operator-nodejs-20-express-test-daemonset
+  labels:
+    app: dash0-operator-nodejs-20-express-test-daemonset-app
+    dash0.com/enable: "false"
+spec:
+  selector:
+    matchLabels:
+      app: dash0-operator-nodejs-20-express-test-daemonset-app
+  template:
+    metadata:
+      labels:
+        app: dash0-operator-nodejs-20-express-test-daemonset-app
+    spec:
+      containers:
+        - name: dash0-operator-nodejs-20-express-test-daemonset-app
+          image: "dash0-operator-nodejs-20-express-test-app:latest"
+          env:
+            - name: PORT
+              value: "1206"
+            - name: DASH0_DEBUG
+              value: "true"
+          ports:
+            - containerPort: 1206
+          imagePullPolicy: Never

--- a/test/util/resources.go
+++ b/test/util/resources.go
@@ -151,7 +151,7 @@ func CreateInstrumentedCronJob(
 
 func CronJobWithOptOutLabel(namespace string, name string) *batchv1.CronJob {
 	workload := BasicCronJob(namespace, name)
-	addOptOutLabel(&workload.ObjectMeta)
+	AddOptOutLabel(&workload.ObjectMeta)
 	return workload
 }
 
@@ -200,7 +200,7 @@ func CreateInstrumentedDaemonSet(
 
 func DaemonSetWithOptOutLabel(namespace string, name string) *appsv1.DaemonSet {
 	workload := BasicDaemonSet(namespace, name)
-	addOptOutLabel(&workload.ObjectMeta)
+	AddOptOutLabel(&workload.ObjectMeta)
 	return workload
 }
 
@@ -249,7 +249,7 @@ func CreateInstrumentedDeployment(
 
 func DeploymentWithOptOutLabel(namespace string, name string) *appsv1.Deployment {
 	workload := BasicDeployment(namespace, name)
-	addOptOutLabel(&workload.ObjectMeta)
+	AddOptOutLabel(&workload.ObjectMeta)
 	return workload
 }
 
@@ -313,7 +313,7 @@ func CreateJobForWhichAnInstrumentationAttemptHasFailed(
 
 func JobWithOptOutLabel(namespace string, name string) *batchv1.Job {
 	workload := BasicJob(namespace, name)
-	addOptOutLabel(&workload.ObjectMeta)
+	AddOptOutLabel(&workload.ObjectMeta)
 	return workload
 }
 
@@ -385,7 +385,7 @@ func CreatePodOwnedByReplicaSet(
 
 func PodWithOptOutLabel(namespace string, name string) *corev1.Pod {
 	workload := BasicPod(namespace, name)
-	addOptOutLabel(&workload.ObjectMeta)
+	AddOptOutLabel(&workload.ObjectMeta)
 	return workload
 }
 
@@ -455,7 +455,7 @@ func InstrumentedReplicaSetOwnedByDeployment(namespace string, name string) *app
 
 func ReplicaSetWithOptOutLabel(namespace string, name string) *appsv1.ReplicaSet {
 	workload := BasicReplicaSet(namespace, name)
-	addOptOutLabel(&workload.ObjectMeta)
+	AddOptOutLabel(&workload.ObjectMeta)
 	return workload
 }
 
@@ -504,7 +504,7 @@ func CreateInstrumentedStatefulSet(
 
 func StatefulSetWithOptOutLabel(namespace string, name string) *appsv1.StatefulSet {
 	workload := BasicStatefulSet(namespace, name)
-	addOptOutLabel(&workload.ObjectMeta)
+	AddOptOutLabel(&workload.ObjectMeta)
 	return workload
 }
 
@@ -541,6 +541,11 @@ func createSelector() *metav1.LabelSelector {
 
 func CreateWorkload(ctx context.Context, k8sClient client.Client, workload client.Object) client.Object {
 	Expect(k8sClient.Create(ctx, workload)).Should(Succeed())
+	return workload
+}
+
+func UpdateWorkload(ctx context.Context, k8sClient client.Client, workload client.Object) client.Object {
+	Expect(k8sClient.Update(ctx, workload)).Should(Succeed())
 	return workload
 }
 
@@ -1014,8 +1019,12 @@ func addInstrumentationLabels(meta *metav1.ObjectMeta, successful bool) {
 	AddLabel(meta, "dash0.com/instrumented-by", "someone")
 }
 
-func addOptOutLabel(meta *metav1.ObjectMeta) {
+func AddOptOutLabel(meta *metav1.ObjectMeta) {
 	AddLabel(meta, "dash0.com/enable", "false")
+}
+
+func RemoveOptOutLabel(meta *metav1.ObjectMeta) {
+	RemoveLabel(meta, "dash0.com/enable")
 }
 
 func AddLabel(meta *metav1.ObjectMeta, key string, value string) {
@@ -1023,6 +1032,14 @@ func AddLabel(meta *metav1.ObjectMeta, key string, value string) {
 		meta.Labels = make(map[string]string, 1)
 	}
 	meta.Labels[key] = value
+}
+
+func UpdateLabel(meta *metav1.ObjectMeta, key string, value string) {
+	meta.Labels[key] = value
+}
+
+func RemoveLabel(meta *metav1.ObjectMeta, key string) {
+	delete(meta.Labels, key)
 }
 
 func DeleteAllCreatedObjects(

--- a/test/util/verification.go
+++ b/test/util/verification.go
@@ -280,7 +280,7 @@ func verifyLabelsAfterSuccessfulModification(meta metav1.ObjectMeta) {
 	Expect(meta.Labels["dash0.com/operator-image"]).To(Equal("some-registry.com_1234_dash0hq_operator-controller_1.2.3"))
 	Expect(meta.Labels["dash0.com/init-container-image"]).To(Equal("some-registry.com_1234_dash0hq_instrumentation_4.5.6"))
 	Expect(meta.Labels["dash0.com/instrumented-by"]).NotTo(Equal(""))
-	Expect(meta.Labels["dash0.com/enable"]).To(Equal(""))
+	Expect(meta.Labels["dash0.com/enable"]).To(Or(Equal(""), Equal("true")))
 }
 
 func verifyLabelsAfterFailureToModify(meta metav1.ObjectMeta) {


### PR DESCRIPTION
Also, instrument workloads via update request when the workload had opted out previously and is no longer opting out.