### PR TITLE
feat(controller): apply and update instrumentation at startup

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -214,7 +214,7 @@ func startOperatorManager(
 	}
 	setupLog.Info("Dash0 reconciler has been set up.")
 
-	if os.Getenv("ENABLE_WEBHOOKS") != "false" {
+	if os.Getenv("ENABLE_WEBHOOK") != "false" {
 		if err = (&dash0webhook.Handler{
 			Client:               mgr.GetClient(),
 			Recorder:             mgr.GetEventRecorderFor("dash0-webhook"),

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -34,6 +34,7 @@ rules:
   - events
   verbs:
   - create
+  - patch
 - apiGroups:
   - ""
   resources:
@@ -41,12 +42,21 @@ rules:
   verbs:
   - get
 - apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - delete
+  - get
+  - list
+- apiGroups:
   - operator.dash0.com
   resources:
   - dash0s
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch

--- a/helm-chart/bin/publish.sh
+++ b/helm-chart/bin/publish.sh
@@ -53,9 +53,6 @@ echo "switching to gh-pages branch"
 git fetch origin gh-pages:gh-pages
 git switch gh-pages
 
-git status
-git log
-
 # clean up potential left-overs from the --dependency-update flag
 rm -rf helm-chart
 

--- a/helm-chart/dash0-operator/README.md
+++ b/helm-chart/dash0-operator/README.md
@@ -14,13 +14,13 @@ The Dash0 Kubernetes operator installs an OpenTelemetry collector into your clus
 ingress endpoint, with authentication already configured out of the box. Additionally, it will enable gathering
 OpenTelemetry data from applications deployed to the cluster for a selection of supported runtimes.
 
-More information on the Dash0 Kubernetes Operator can be found at 
+More information on the Dash0 Kubernetes Operator can be found at
 https://github.com/dash0hq/dash0-operator/blob/main/README.md.
 
 ## Prerequisites
 
 - [Kubernetes](https://kubernetes.io/) >= 1.xx
-- [Helm](https://helm.sh) >= 3.xx, please refer to Helm's [documentation](https://helm.sh/docs/) for more information 
+- [Helm](https://helm.sh) >= 3.xx, please refer to Helm's [documentation](https://helm.sh/docs/) for more information
   on installing Helm.
 
 ## Installation
@@ -47,7 +47,7 @@ kubectl create secret generic \
 ```
 
 Now you can install the operator into your cluster via Helm with the following command.
-Use the same namespace that you have created in the previous step and which contains the `dash0-authorization-secret`. 
+Use the same namespace that you have created in the previous step and which contains the `dash0-authorization-secret`.
 You will need to replace the value given to `--set opentelemetry-collector.config.exporters.otlp.endpoint` with the
 actual OTLP/gRPC endpoint of your Dash0 organization.
 Again, the correct OTLP/gRPC endpoint can be copied fom https://app.dash0.com/settings.
@@ -58,7 +58,7 @@ helm install \
   --namespace dash0-system \
   --set opentelemetry-collector.config.exporters.otlp.endpoint=your-dash0-ingress-endpoint-here.dash0.com:4317 \
   dash0-operator \
-  dash0-operator/dash0-operator  
+  dash0-operator/dash0-operator
 ```
 
 Note: When installing the chart, you might see a warning like the following printed to the console:
@@ -74,7 +74,8 @@ Note that Dash0 has to be enabled per namespace that you want to monitor, which 
 
 ## Enable Dash0 For a Namespace
 
-For each namespace that you want to monitor with Dash0, enable monitoring by installing a custom Dash0 resource:
+For _each namespace_ that you want to monitor with Dash0, enable monitoring by installing a custom Dash0 resource into
+that namespace:
 
 Create a file `dash0.yaml` with the following content:
 ```yaml
@@ -84,23 +85,32 @@ metadata:
   name: dash0-resource
 ```
 
-Then apply the resource to the namespace you want to monitor:
+Then apply the resource to the namespace you want to monitor.
+For example, if you want to monitor workloads in the namespace `my-nodejs-applications`, use the following command:
+
 ```console
-kubectl apply --namespace my-namespace -f dash0.yaml
+kubectl apply --namespace my-nodejs-applications -f dash0.yaml
+```
+
+If you want to monitor the `default` namespace with Dash0, use the following command:
+```console
+kubectl apply -f dash0.yaml
 ```
 
 ## Disable Dash0 For a Namespace
 
 If you want to stop monitoring a namespace with Dash0, remove the Dash0 resource from that namespace.
+For example, if you want to stop monitoring workloads in the namespace `my-nodejs-applications`, use the following
+command:
 
 ```console
-kubectl delete --namespace my-namespace Dash0 dash0-resource
+kubectl delete --namespace my-nodejs-applications Dash0 dash0-resource
 ```
 
 or, alternatively, by using the `dash0.yaml` file created earlier:
 
 ```console
-kubectl delete --namespace test-namespace -f dash0.yaml
+kubectl delete --namespace my-nodejs-applications -f dash0.yaml
 ```
 
 ## Uninstallation
@@ -114,8 +124,8 @@ helm uninstall dash0-operator --namespace dash0-system
 Depending on the command you used to install the operator, you may need to use a different Helm release name or
 namespace.
 
-This will also automatically disable Dash0 monitoring for all namespaces.
-
+This will also automatically disable Dash0 monitoring for all namespaces by deleting the Dash0 resources in all
+namespaces.
 Optionally, remove the namespace that has been created for the operator:
 
 ```
@@ -127,3 +137,6 @@ If you choose to not remove the namespace, you might consider removing the secre
 ```console
 kubectl delete secret --namespace dash0-system dash0-authorization-secret
 ```
+
+If you later decide to install the operator again, you will need to enable Dash0 in each namespace you want to monitor
+again, see [Enable Dash0 For a Namespace](#enable-dash0-for-a-namespace).

--- a/helm-chart/dash0-operator/templates/operator/cluster-roles.yaml
+++ b/helm-chart/dash0-operator/templates/operator/cluster-roles.yaml
@@ -36,7 +36,7 @@ rules:
   - events
   verbs:
   - create
-
+  - patch
 - apiGroups:
   - ""
   resources:
@@ -45,13 +45,13 @@ rules:
   - get
 
 - apiGroups:
-    - ""
+  - ""
   resources:
   - pods
   verbs:
+  - delete
   - get
   - list
-  - delete
 
 - apiGroups:
   - operator.dash0.com

--- a/helm-chart/dash0-operator/templates/operator/custom-resource-definition.yaml
+++ b/helm-chart/dash0-operator/templates/operator/custom-resource-definition.yaml
@@ -48,6 +48,62 @@ spec:
             type: object
           spec:
             description: Dash0Spec defines the desired state of the Dash0 custom resource.
+            properties:
+              InstrumentNewWorkloads:
+                description: |-
+                  Opt-out for workload instrumentation of newly deployed workloads for the target namespace. You can opt-out of
+                  instrumenting workloads at the time they are deployed by setting this option to false. By default, when the Dash0
+                  custom resource is present in a namespace (and the Dash0 Kubernetes operator is active), the operator will
+                  instrument new workloads to send telemetry to Dash0, at the time they are deployed to that namespace.
+                  Setting this option to false will prevent that behavior, but workloads existing when the Dash0 custom resource
+                  is deployed will still be instrumented (see option InstrumentExistingWorkloads). More fine-grained control over
+                  instrumentation on a per-workload level is available by setting the label dash0.com/enable=false on individual
+                  workloads.
+
+
+                  The default value for this option is true.
+
+
+                  This option has no effect if InstrumentWorkloads is set to false.
+                type: boolean
+              instrumentExistingWorkloads:
+                description: |-
+                  Opt-out for workload instrumentation of existing workloads for the target namespace. You can opt-out of
+                  instrumenting existing workloads by setting this option to false. By default, when the Dash0 custom resource
+                  is deployed to a namespace (and the Dash0 Kubernetes operator is active), the operator will instrument the
+                  workloads already running in that namesapce, to send telemetry to Dash0. Setting this option to false will
+                  prevent that behavior, but workloads that are deployed after Dash0 custom resource will still be instrumented
+                  (see option InstrumentNewWorkloads). More fine-grained control over instrumentation on a per-workload level is
+                  available by setting the label dash0.com/enable=false on individual workloads.
+
+
+                  The default value for this option is true.
+
+
+                  This option has no effect if InstrumentWorkloads is set to false.
+                type: boolean
+              instrumentWorkloads:
+                description: |-
+                  Global opt-out for workload instrumentation for the target namespace. You can opt-out of instrumenting workloads
+                  entirely by setting this option to false. By default, this setting is true and Kubernetes workloads will be
+                  intrumented by the operator to send telemetry to Dash0. Setting it to false will prevent workload instrumentation
+                  in the target namespace. More fine-grained control over instrumentation is available via the settings
+                  InstrumentExistingWorkloads, InstrumentNewWorkloads and UninstrumentWorkloadsOnDelete, as well as by setting the
+                  label dash0.com/enable=false on individual workloads.
+
+
+                  The default value for this option is true.
+                type: boolean
+              uninstrumentWorkloadsOnDelete:
+                description: |-
+                  Opt-out for removing the Dash0 instrumentation from workloads when the Dash0 custom resource is removed from a
+                  namespace, or when the Dash0 Kubernetes operator is deleted entirely. By default, this setting is true and the
+                  operator will revert the instrumentation modifications it applied to workloads to send telemetry to Dash0.
+                  Setting this option to false will prevent this behavior.
+
+
+                  The default value for this option is true.
+                type: boolean
             type: object
           status:
             description: Dash0Status defines the observed state of the Dash0 custom
@@ -56,15 +112,15 @@ spec:
               conditions:
                 items:
                   description: "Condition contains details for one aspect of the current
-                  state of this API Resource.\n---\nThis struct is intended for
-                  direct use as an array at the field path .status.conditions.  For
-                  example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                  observations of a foo's current state.\n\t    // Known .status.conditions.type
-                  are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                  +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                  \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                  patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                  \   // other fields\n\t}"
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -100,9 +156,9 @@ spec:
                     status:
                       description: status of the condition, one of True, False, Unknown.
                       enum:
-                        - "True"
-                        - "False"
-                        - Unknown
+                      - "True"
+                      - "False"
+                      - Unknown
                       type: string
                     type:
                       description: |-
@@ -115,11 +171,11 @@ spec:
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
                   required:
-                    - lastTransitionTime
-                    - message
-                    - reason
-                    - status
-                    - type
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
                   type: object
                 type: array
             type: object

--- a/helm-chart/dash0-operator/templates/operator/deployment.yaml
+++ b/helm-chart/dash0-operator/templates/operator/deployment.yaml
@@ -55,6 +55,10 @@ spec:
         - name: DASH0_INIT_CONTAINER_IMAGE_PULL_POLICY
           value: {{ .Values.operator.initContainerImage.pullPolicy }}
         {{- end }}
+        {{- if not .Values.operator.enableWebhook }}
+        - name: ENABLE_WEBHOOK
+          value: "false"
+        {{- end }}
         {{- if .Values.operator.developmentMode }}
         - name: DASH0_DEVELOPMENT_MODE
           value: {{ .Values.operator.developmentMode | toString | quote }}

--- a/helm-chart/dash0-operator/tests/operator/__snapshot__/cluster-roles_test.yaml.snap
+++ b/helm-chart/dash0-operator/tests/operator/__snapshot__/cluster-roles_test.yaml.snap
@@ -35,6 +35,7 @@ cluster roles should match snapshot:
           - events
         verbs:
           - create
+          - patch
       - apiGroups:
           - ""
         resources:
@@ -46,9 +47,9 @@ cluster roles should match snapshot:
         resources:
           - pods
         verbs:
+          - delete
           - get
           - list
-          - delete
       - apiGroups:
           - operator.dash0.com
         resources:

--- a/helm-chart/dash0-operator/tests/operator/__snapshot__/custom-resource-definition_test.yaml.snap
+++ b/helm-chart/dash0-operator/tests/operator/__snapshot__/custom-resource-definition_test.yaml.snap
@@ -50,6 +50,62 @@ custom resource definition should match snapshot:
                   type: object
                 spec:
                   description: Dash0Spec defines the desired state of the Dash0 custom resource.
+                  properties:
+                    InstrumentNewWorkloads:
+                      description: |-
+                        Opt-out for workload instrumentation of newly deployed workloads for the target namespace. You can opt-out of
+                        instrumenting workloads at the time they are deployed by setting this option to false. By default, when the Dash0
+                        custom resource is present in a namespace (and the Dash0 Kubernetes operator is active), the operator will
+                        instrument new workloads to send telemetry to Dash0, at the time they are deployed to that namespace.
+                        Setting this option to false will prevent that behavior, but workloads existing when the Dash0 custom resource
+                        is deployed will still be instrumented (see option InstrumentExistingWorkloads). More fine-grained control over
+                        instrumentation on a per-workload level is available by setting the label dash0.com/enable=false on individual
+                        workloads.
+
+
+                        The default value for this option is true.
+
+
+                        This option has no effect if InstrumentWorkloads is set to false.
+                      type: boolean
+                    instrumentExistingWorkloads:
+                      description: |-
+                        Opt-out for workload instrumentation of existing workloads for the target namespace. You can opt-out of
+                        instrumenting existing workloads by setting this option to false. By default, when the Dash0 custom resource
+                        is deployed to a namespace (and the Dash0 Kubernetes operator is active), the operator will instrument the
+                        workloads already running in that namesapce, to send telemetry to Dash0. Setting this option to false will
+                        prevent that behavior, but workloads that are deployed after Dash0 custom resource will still be instrumented
+                        (see option InstrumentNewWorkloads). More fine-grained control over instrumentation on a per-workload level is
+                        available by setting the label dash0.com/enable=false on individual workloads.
+
+
+                        The default value for this option is true.
+
+
+                        This option has no effect if InstrumentWorkloads is set to false.
+                      type: boolean
+                    instrumentWorkloads:
+                      description: |-
+                        Global opt-out for workload instrumentation for the target namespace. You can opt-out of instrumenting workloads
+                        entirely by setting this option to false. By default, this setting is true and Kubernetes workloads will be
+                        intrumented by the operator to send telemetry to Dash0. Setting it to false will prevent workload instrumentation
+                        in the target namespace. More fine-grained control over instrumentation is available via the settings
+                        InstrumentExistingWorkloads, InstrumentNewWorkloads and UninstrumentWorkloadsOnDelete, as well as by setting the
+                        label dash0.com/enable=false on individual workloads.
+
+
+                        The default value for this option is true.
+                      type: boolean
+                    uninstrumentWorkloadsOnDelete:
+                      description: |-
+                        Opt-out for removing the Dash0 instrumentation from workloads when the Dash0 custom resource is removed from a
+                        namespace, or when the Dash0 Kubernetes operator is deleted entirely. By default, this setting is true and the
+                        operator will revert the instrumentation modifications it applied to workloads to send telemetry to Dash0.
+                        Setting this option to false will prevent this behavior.
+
+
+                        The default value for this option is true.
+                      type: boolean
                   type: object
                 status:
                   description: Dash0Status defines the observed state of the Dash0 custom resource.

--- a/helm-chart/dash0-operator/tests/operator/deployment_test.yaml
+++ b/helm-chart/dash0-operator/tests/operator/deployment_test.yaml
@@ -54,6 +54,7 @@ tests:
         imagePullSecrets:
           - name: regcred
           - name: anotherSecret
+        enableWebhook: false
         managerPodResources:
           limits:
             cpu: 123m
@@ -61,6 +62,7 @@ tests:
           requests:
             cpu: 5m
             memory: 32Mi
+        developmentMode: true
     asserts:
       - equal:
           path: metadata.labels['label1']
@@ -125,6 +127,18 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].env[3].value
           value: Always
+      - equal:
+          path: spec.template.spec.containers[0].env[4].name
+          value: ENABLE_WEBHOOK
+      - equal:
+          path: spec.template.spec.containers[0].env[4].value
+          value: "false"
+      - equal:
+          path: spec.template.spec.containers[0].env[5].name
+          value: DASH0_DEVELOPMENT_MODE
+      - equal:
+          path: spec.template.spec.containers[0].env[5].value
+          value: "true"
       - equal:
           path: spec.template.spec.containers[0].resources.limits.cpu
           value: 123m

--- a/helm-chart/dash0-operator/values.yaml
+++ b/helm-chart/dash0-operator/values.yaml
@@ -44,6 +44,9 @@ operator:
   #   label2: "value 2"
   podLabels: {}
 
+  # Set this to "false" to disable the admission webhook to instrument new workloads at deploy time.
+  enableWebhook: true
+
   # resources for the controller manager pod(s)
   managerPodResources:
     limits:

--- a/internal/controller/dash0_controller.go
+++ b/internal/controller/dash0_controller.go
@@ -147,9 +147,10 @@ func (r *Dash0Reconciler) InstrumentAtStartup() {
 // To know more about markers see: https://book.kubebuilder.io/reference/markers.html
 //+kubebuilder:rbac:groups=apps,resources=daemonsets;deployments;replicasets;statefulsets,verbs=get;list;watch;update;patch
 //+kubebuilder:rbac:groups=batch,resources=cronjobs;jobs,verbs=get;list;watch;update;patch
-//+kubebuilder:rbac:groups=core,resources=events,verbs=create
+//+kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
 //+kubebuilder:rbac:groups=core,resources=namespaces,verbs=get
-//+kubebuilder:rbac:groups=operator.dash0.com,resources=dash0s,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;delete
+//+kubebuilder:rbac:groups=operator.dash0.com,resources=dash0s,verbs=get;list;watch;create;update;patch;delete;deletecollection
 //+kubebuilder:rbac:groups=operator.dash0.com,resources=dash0s/finalizers,verbs=update
 //+kubebuilder:rbac:groups=operator.dash0.com,resources=dash0s/status,verbs=get;update;patch
 


### PR DESCRIPTION
Run the instrumentation logic directly at process startup, for all
namespaces where a Dash0 resource exists, independently of reconcile
requests for the Dash0 resources. This main intention is to update the
instrumentation modifications for instrumented workloads immediately
when the operator controller image is updated (for example via helm
upgrade).