### PR TITLE
test(e2e): remove BUILD_... image switches

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,12 +73,7 @@ make test-e2e
 
 The tests can also be run with remote images, like this:
 ```
-BUILD_OPERATOR_CONTROLLER_IMAGE=false \
-  BUILD_INSTRUMENTATION_IMAGE=false \
-  BUILD_COLLECTOR_IMAGE=false \
-  BUILD_CONFIGURATION_RELOADER_IMAGE=false \
-  BUILD_FILELOG_OFFSET_SYNCH_IMAGE=false \
-  CONTROLLER_IMG_REPOSITORY=ghcr.io/dash0hq/operator-controller \
+CONTROLLER_IMG_REPOSITORY=ghcr.io/dash0hq/operator-controller \
   CONTROLLER_IMG_TAG=main-dev \
   CONTROLLER_IMG_PULL_POLICY="" \
   INSTRUMENTATION_IMG_REPOSITORY=ghcr.io/dash0hq/instrumentation \
@@ -96,18 +91,10 @@ BUILD_OPERATOR_CONTROLLER_IMAGE=false \
   make test-e2e
 ```
 
-The settings `BUILD_OPERATOR_CONTROLLER_IMAGE=false` plus `BUILD_INSTRUMENTATION_IMAGE=false` will skip building these
-images locally, which is not required when using remote images from a registry.
-
 The test suite can also be run with a Helm chart from a remote repository:
 
 ```
-BUILD_OPERATOR_CONTROLLER_IMAGE=false \
-  BUILD_INSTRUMENTATION_IMAGE=false \
-  BUILD_COLLECTOR_IMAGE=false \
-  BUILD_CONFIGURATION_RELOADER_IMAGE=false \
-  BUILD_FILELOG_OFFSET_SYNCH_IMAGE=false \
-  OPERATOR_HELM_CHART=dash0-operator/dash0-operator \
+OPERATOR_HELM_CHART=dash0-operator/dash0-operator \
   OPERATOR_HELM_CHART_URL=https://dash0hq.github.io/dash0-operator \
   CONTROLLER_IMG_REPOSITORY="" \
   CONTROLLER_IMG_TAG="" \
@@ -155,11 +142,6 @@ they deploy in their `AfterAll`/`AfterEach` hooks. The scripts in `test-resource
       * To run the scenario with the images that have been built from the main branch and pushed to ghcr.io most 
         recently:
         ```
-        BUILD_OPERATOR_CONTROLLER_IMAGE=false \
-          BUILD_INSTRUMENTATION_IMAGE=false \
-          BUILD_COLLECTOR_IMAGE=false \
-          BUILD_CONFIGURATION_RELOADER_IMAGE=false \
-          BUILD_FILELOG_OFFSET_SYNCH_IMAGE=false \
           CONTROLLER_IMG_REPOSITORY=ghcr.io/dash0hq/operator-controller \
           CONTROLLER_IMG_TAG=main-dev \
           CONTROLLER_IMG_PULL_POLICY="" \
@@ -180,11 +162,6 @@ they deploy in their `AfterAll`/`AfterEach` hooks. The scripts in `test-resource
       * To run the scenario with the helm chart from the official remote repository and the default images referenced in
         that chart (the Helm repository must have been installed beforehand): 
         ```
-        BUILD_OPERATOR_CONTROLLER_IMAGE=false \
-          BUILD_INSTRUMENTATION_IMAGE=false \
-          BUILD_COLLECTOR_IMAGE=false \
-          BUILD_CONFIGURATION_RELOADER_IMAGE=false \
-          BUILD_FILELOG_OFFSET_SYNCH_IMAGE=false \
           OPERATOR_HELM_CHART=dash0-operator/dash0-operator \
           CONTROLLER_IMG_REPOSITORY="" \
           CONTROLLER_IMG_TAG="" \

--- a/Makefile
+++ b/Makefile
@@ -102,8 +102,6 @@ CONTAINER_TOOL ?= docker
 SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 
--include test-resources/.env
-
 .PHONY: all
 all: build
 
@@ -233,16 +231,6 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 
 .PHONY: deploy-via-helm
 deploy-via-helm: ## Deploy the controller via helm to the K8s cluster specified in ~/.kube/config.
-# Note: We need the values from test-resources/.env here for the helm install command but they are not actually read at
-# this point. Instead, they have been already read via the -include directive at the top of this Makefile. The
-# "-include" will fail silently if the file does not exist, so we need to check for the existence of the file here.
-# Using "include" (which does not fail silently but aborts make immediately is not a good alternative, since it fails
-# with a somewhat cryptic error message, plus most make targets do not require the file.
-	@if test ! -f test-resources/.env; then \
-		echo "error: The file test-resources/.env does not exist. Copy test-resources/.env.template to test-resources/.env and edit it to provide a Dash0 authorization token."; \
-		exit 1; \
-	fi
-
 	test-resources/bin/render-templates.sh
 	helm upgrade --install \
 		--namespace dash0-system \

--- a/helm-chart/dash0-operator/README.md
+++ b/helm-chart/dash0-operator/README.md
@@ -77,16 +77,18 @@ At this point, you need to provide two configuration settings:
   The correct OTLP/gRPC endpoint can be copied fom https://app.dash0.com/settings.
   Note that the correct endpoint value will always start with `ingress.` and end in `dash0.com:4317`.
   A protocol prefix (eg. `https://`) should not be included in the value.
-* `spec.export.dash0.token` or `spec.export.dash0.secretRef`: Exactly one of these two properties needs to be provided.
+* `spec.export.dash0.authorization.token` or `spec.export.dash0.authorization.secretRef`: Exactly one of these two
+  properties needs to be provided.
   Providing both will cause a validation error when installing the Dash0Monitoring resource.
-    * `spec.export.dash0.token`: Replace the value in the example above with the Dash0 authorization token of your
-      organization.
+    * `spec.export.dash0.authorization.token`: Replace the value in the example above with the Dash0 authorization token
+      of your organization.
       The authorization token for your Dash0 organization can be copied from https://app.dash0.com/settings.
       The prefix `Bearer ` must *not* be included in the value.
       Note that the value will be rendered verbatim into a Kubernetes ConfigMap object.
       Anyone with API access to the Kubernetes cluster will be able to read the value.
       Use the `secretRef` property and a Kubernetes secret if you want to avoid that.
-    * `spec.export.dash0.secretRef`: A reference to an existing Kubernetes secret in the Dash0 operator's namespace.
+    * `spec.export.dash0.authorization.secretRef`: A reference to an existing Kubernetes secret in the Dash0 operator's
+       namespace.
        See the next section for an example file that uses a `secretRef`.
        The secret needs to contain the Dash0 authorization token.
        See below for details on how exactly the secret should be created and configured.
@@ -194,7 +196,7 @@ spec:
           key: token
 ```
 
-Since the name `dash0-authorization-secret` and the key `token` are the defaults, this secretRef could have also been
+Since the name `dash0-authorization-secret` and the key `token` are the defaults, this `secretRef` could have also been
 written as follows:
 ```yaml
 apiVersion: operator.dash0.com/v1alpha1

--- a/test/e2e/container_images.go
+++ b/test/e2e/container_images.go
@@ -59,24 +59,10 @@ var (
 			pullPolicy: "Never",
 		},
 	}
-
-	buildOperatorControllerImageFromLocalSources    = true
-	buildInstrumentationImageFromLocalSources       = true
-	buildCollectorImageFromLocalSources             = true
-	buildConfigurationReloaderImageFromLocalSources = true
-	buildFileLogOffsetSynchImageFromLocalSources    = true
 )
 
-func rebuildOperatorControllerImage(operatorImage ImageSpec, buildImageLocally bool) {
-	if !buildImageLocally {
-		return
-	}
-	if strings.Contains(operatorImage.repository, "/") {
-		By(
-			fmt.Sprintf(
-				"not rebuilding the operator controller image %s, this looks like a remote image",
-				renderFullyQualifiedImageName(operatorImage),
-			))
+func rebuildOperatorControllerImage(operatorImage ImageSpec) {
+	if !shouldBuildImageLocally(operatorImage) {
 		return
 	}
 
@@ -104,16 +90,8 @@ func rebuildOperatorControllerImage(operatorImage ImageSpec, buildImageLocally b
 			))).To(Succeed())
 }
 
-func rebuildInstrumentationImage(instrumentationImage ImageSpec, buildImageLocally bool) {
-	if !buildImageLocally {
-		return
-	}
-	if strings.Contains(instrumentationImage.repository, "/") {
-		By(
-			fmt.Sprintf(
-				"not rebuilding the instrumenation image %s, this looks like a remote image",
-				renderFullyQualifiedImageName(instrumentationImage),
-			))
+func rebuildInstrumentationImage(instrumentationImage ImageSpec) {
+	if !shouldBuildImageLocally(instrumentationImage) {
 		return
 	}
 
@@ -140,16 +118,8 @@ func rebuildInstrumentationImage(instrumentationImage ImageSpec, buildImageLocal
 			))).To(Succeed())
 }
 
-func rebuildCollectorImage(collectorImage ImageSpec, buildImageLocally bool) {
-	if !buildImageLocally {
-		return
-	}
-	if strings.Contains(collectorImage.repository, "/") {
-		By(
-			fmt.Sprintf(
-				"not rebuilding the collector image %s, this looks like a remote image",
-				renderFullyQualifiedImageName(collectorImage),
-			))
+func rebuildCollectorImage(collectorImage ImageSpec) {
+	if !shouldBuildImageLocally(collectorImage) {
 		return
 	}
 
@@ -178,16 +148,8 @@ func rebuildCollectorImage(collectorImage ImageSpec, buildImageLocally bool) {
 			))).To(Succeed())
 }
 
-func rebuildConfigurationReloaderImage(configurationReloaderImage ImageSpec, buildImageLocally bool) {
-	if !buildImageLocally {
-		return
-	}
-	if strings.Contains(configurationReloaderImage.repository, "/") {
-		By(
-			fmt.Sprintf(
-				"not rebuilding the configuration reloader image %s, this looks like a remote image",
-				renderFullyQualifiedImageName(configurationReloaderImage),
-			))
+func rebuildConfigurationReloaderImage(configurationReloaderImage ImageSpec) {
+	if !shouldBuildImageLocally(configurationReloaderImage) {
 		return
 	}
 
@@ -217,16 +179,8 @@ func rebuildConfigurationReloaderImage(configurationReloaderImage ImageSpec, bui
 			))).To(Succeed())
 }
 
-func rebuildFileLogOffsetSynchImage(fileLogOffsetSynchImage ImageSpec, buildImageLocally bool) {
-	if !buildImageLocally {
-		return
-	}
-	if strings.Contains(fileLogOffsetSynchImage.repository, "/") {
-		By(
-			fmt.Sprintf(
-				"not rebuilding the filelog offset synch image %s, this looks like a remote image",
-				renderFullyQualifiedImageName(fileLogOffsetSynchImage),
-			))
+func rebuildFileLogOffsetSynchImage(fileLogOffsetSynchImage ImageSpec) {
+	if !shouldBuildImageLocally(fileLogOffsetSynchImage) {
 		return
 	}
 
@@ -254,4 +208,20 @@ func rebuildFileLogOffsetSynchImage(fileLogOffsetSynchImage ImageSpec, buildImag
 				renderFullyQualifiedImageName(fileLogOffsetSynchImage),
 				renderFullyQualifiedImageName(additionalTag),
 			))).To(Succeed())
+}
+
+func shouldBuildImageLocally(image ImageSpec) bool {
+	if strings.Contains(image.repository, "/") {
+		By(fmt.Sprintf(
+			"not rebuilding the image %s, this looks like a remote image", renderFullyQualifiedImageName(image),
+		))
+		return false
+	}
+
+	if image.repository == "" && operatorHelmChartUrl != "" {
+		By("not rebuilding image, a remote Helm chart is used with the default image from the chart")
+		return false
+	}
+
+	return true
 }

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -60,11 +59,11 @@ var _ = Describe("Dash0 Kubernetes Operator", Ordered, func() {
 		recreateNamespace(applicationUnderTestNamespace)
 
 		readAndApplyEnvironmentVariables()
-		rebuildOperatorControllerImage(images.operator, buildOperatorControllerImageFromLocalSources)
-		rebuildInstrumentationImage(images.instrumentation, buildInstrumentationImageFromLocalSources)
-		rebuildCollectorImage(images.collector, buildCollectorImageFromLocalSources)
-		rebuildConfigurationReloaderImage(images.configurationReloader, buildConfigurationReloaderImageFromLocalSources)
-		rebuildFileLogOffsetSynchImage(images.fileLogOffsetSynch, buildFileLogOffsetSynchImageFromLocalSources)
+		rebuildOperatorControllerImage(images.operator)
+		rebuildInstrumentationImage(images.instrumentation)
+		rebuildCollectorImage(images.collector)
+		rebuildConfigurationReloaderImage(images.configurationReloader)
+		rebuildFileLogOffsetSynchImage(images.fileLogOffsetSynch)
 		rebuildNodeJsApplicationContainerImage()
 
 		setupFinishedSuccessfully = true
@@ -784,26 +783,14 @@ func cleanupAll() {
 }
 
 func readAndApplyEnvironmentVariables() {
-	var err error
-
 	operatorHelmChart = getEnvOrDefault("OPERATOR_HELM_CHART", operatorHelmChart)
 	operatorHelmChartUrl = getEnvOrDefault("OPERATOR_HELM_CHART_URL", operatorHelmChartUrl)
 
-	buildOperatorControllerImageFromLocalSourcesRaw := getEnvOrDefault("BUILD_OPERATOR_CONTROLLER_IMAGE", "")
-	if buildOperatorControllerImageFromLocalSourcesRaw != "" {
-		buildOperatorControllerImageFromLocalSources, err = strconv.ParseBool(buildOperatorControllerImageFromLocalSourcesRaw)
-		Expect(err).NotTo(HaveOccurred())
-	}
 	images.operator.repository = getEnvOrDefault("CONTROLLER_IMG_REPOSITORY", images.operator.repository)
 	images.operator.tag = getEnvOrDefault("CONTROLLER_IMG_TAG", images.operator.tag)
 	images.operator.digest = getEnvOrDefault("CONTROLLER_IMG_DIGEST", images.operator.digest)
 	images.operator.pullPolicy = getEnvOrDefault("CONTROLLER_IMG_PULL_POLICY", images.operator.pullPolicy)
 
-	buildInstrumentationImageFromLocalSourcesRaw := getEnvOrDefault("BUILD_INSTRUMENTATION_IMAGE", "")
-	if buildInstrumentationImageFromLocalSourcesRaw != "" {
-		buildInstrumentationImageFromLocalSources, err = strconv.ParseBool(buildInstrumentationImageFromLocalSourcesRaw)
-		Expect(err).NotTo(HaveOccurred())
-	}
 	images.instrumentation.repository = getEnvOrDefault(
 		"INSTRUMENTATION_IMG_REPOSITORY",
 		images.instrumentation.repository,
@@ -815,11 +802,6 @@ func readAndApplyEnvironmentVariables() {
 		images.instrumentation.pullPolicy,
 	)
 
-	buildCollectorImageFromLocalSourcesRaw := getEnvOrDefault("BUILD_COLLECTOR_IMAGE", "")
-	if buildCollectorImageFromLocalSourcesRaw != "" {
-		buildCollectorImageFromLocalSources, err = strconv.ParseBool(buildCollectorImageFromLocalSourcesRaw)
-		Expect(err).NotTo(HaveOccurred())
-	}
 	images.collector.repository = getEnvOrDefault(
 		"COLLECTOR_IMG_REPOSITORY",
 		images.collector.repository,
@@ -831,12 +813,6 @@ func readAndApplyEnvironmentVariables() {
 		images.collector.pullPolicy,
 	)
 
-	buildConfigurationReloaderImageFromLocalSourcesRaw := getEnvOrDefault("BUILD_CONFIGURATION_RELOADER_IMAGE", "")
-	if buildConfigurationReloaderImageFromLocalSourcesRaw != "" {
-		buildConfigurationReloaderImageFromLocalSources, err =
-			strconv.ParseBool(buildConfigurationReloaderImageFromLocalSourcesRaw)
-		Expect(err).NotTo(HaveOccurred())
-	}
 	images.configurationReloader.repository = getEnvOrDefault(
 		"CONFIGURATION_RELOADER_IMG_REPOSITORY",
 		images.configurationReloader.repository,
@@ -849,12 +825,6 @@ func readAndApplyEnvironmentVariables() {
 		images.configurationReloader.pullPolicy,
 	)
 
-	buildFileLogOffsetSynchImageFromLocalSourcesRaw := getEnvOrDefault("BUILD_FILELOG_OFFSET_SYNCH_IMAGE", "")
-	if buildFileLogOffsetSynchImageFromLocalSourcesRaw != "" {
-		buildFileLogOffsetSynchImageFromLocalSources, err =
-			strconv.ParseBool(buildFileLogOffsetSynchImageFromLocalSourcesRaw)
-		Expect(err).NotTo(HaveOccurred())
-	}
 	images.fileLogOffsetSynch.repository = getEnvOrDefault(
 		"FILELOG_OFFSET_SYNCH_IMG_REPOSITORY",
 		images.fileLogOffsetSynch.repository,

--- a/test/e2e/operator.go
+++ b/test/e2e/operator.go
@@ -146,10 +146,16 @@ func ensureDash0OperatorHelmRepoIsInstalled(
 	} else {
 		fmt.Fprintf(
 			GinkgoWriter,
-			"The helm repo %s (%s) is already installed.\n",
+			"The helm repo %s (%s) is already installed, updating it now.\n",
 			repositoryName,
 			operatorHelmChartUrl,
 		)
+		Expect(runAndIgnoreOutput(
+			exec.Command(
+				"helm",
+				"repo",
+				"update",
+			))).To(Succeed())
 	}
 }
 


### PR DESCRIPTION
This is no longer necessary, as no value from .env is used in the Makefile since #cbd57b53a3.