### PR TITLE
chore(test-resources): refactor test scripts and cleanup script

### DIFF
--- a/test-resources/bin/test-cleanup.sh
+++ b/test-resources/bin/test-cleanup.sh
@@ -14,29 +14,38 @@ source test-resources/bin/util
 load_env_file
 verify_kubectx
 
+resource_types=( cronjob daemonset deployment job pod replicaset statefulset )
+for resource_type in "${resource_types[@]}"; do
+  test-resources/node.js/express/undeploy.sh ${target_namespace} ${resource_type}
+done
+
 kubectl delete -n ${target_namespace} -f test-resources/customresources/dash0monitoring/dash0monitoring.secret.yaml --wait=false || true
 sleep 1
 kubectl patch -f test-resources/customresources/dash0monitoring/dash0monitoring.secret.yaml -p '{"metadata":{"finalizers":null}}' --type=merge || true
 kubectl delete -f test-resources/customresources/dash0operatorconfiguration/dash0operatorconfiguration.token.yaml || true
 
-make undeploy-via-helm || true
+if [[ "${target_namespace}" != "default" ]] && [[ "${delete_namespace}" == "true" ]]; then
+  kubectl delete ns ${target_namespace} --ignore-not-found
+fi
+
+helm uninstall --namespace dash0-system dash0-operator --timeout 30s || true
 
 kubectl delete secret \
   --namespace dash0-system \
   dash0-authorization-secret \
   --ignore-not-found
 
-# If the custom resource definitions have been installed by kustomize and the next test scenario attempts to install it
-# via helm, the helm installation will fail because the custom resource definitions already exists and do not have the
-# "app.kubernetes.io/managed-by: Helm" label. Thus we always remove all CRDs explictly and assume the next test scenario
-# will install them again.
-make uninstall || true
+kubectl delete ns dash0-system --ignore-not-found
 
-resource_types=( cronjob daemonset deployment job pod replicaset statefulset )
-for resource_type in "${resource_types[@]}"; do
-  test-resources/node.js/express/undeploy.sh ${target_namespace} ${resource_type}
-done
+kubectl delete --ignore-not-found=true customresourcedefinition dash0monitorings.operator.dash0.com
+kubectl delete --ignore-not-found=true customresourcedefinition dash0operatorconfigurations.operator.dash0.com
 
-if [[ "${target_namespace}" != "default" ]] && [[ "${delete_namespace}" == "true" ]]; then
-  kubectl delete ns ${target_namespace} --ignore-not-found
-fi
+# The following resources are deleted automatically with helm uninstall, unless for example when the operator manager
+# crashes and the helm pre-delete helm hook cannot run, then they might be left behind.
+kubectl delete clusterrole                  --ignore-not-found dash0-operator-manager-role
+kubectl delete clusterrole                  --ignore-not-found dash0-operator-metrics-reader
+kubectl delete clusterrole                  --ignore-not-found dash0-operator-proxy-role
+kubectl delete clusterrolebinding           --ignore-not-found dash0-operator-manager-rolebinding
+kubectl delete clusterrolebinding           --ignore-not-found dash0-operator-proxy-rolebinding
+kubectl delete mutatingwebhookconfiguration --ignore-not-found dash0-operator-injector
+

--- a/test-resources/bin/test-roundtrip-01-aum-operator-cr.sh
+++ b/test-resources/bin/test-roundtrip-01-aum-operator-cr.sh
@@ -15,13 +15,14 @@ load_env_file
 verify_kubectx
 setup_test_environment
 
-echo "STEP 1: creating target namespace (if necessary)"
+echo "STEP 1: remove old test resources"
+test-resources/bin/test-cleanup.sh ${target_namespace} false
 test-resources/bin/ensure-namespace-exists.sh ${target_namespace}
 echo
 echo
 
-echo "STEP 2: remove old test resources"
-test-resources/bin/test-cleanup.sh ${target_namespace} false
+echo "STEP 2: creating target namespace (if necessary)"
+test-resources/bin/ensure-namespace-exists.sh ${target_namespace}
 echo
 echo
 
@@ -53,10 +54,10 @@ echo
 sleep 5
 
 echo "STEP 7: deploy the Dash0 operator configuration resource to cluster"
-kubectl apply -f test-resources/customresources/dash0operatorconfiguration/dash0operatorconfiguration.token.yaml
+install_operator_configuration_resource
 echo
 echo
 
 echo "STEP 8: deploy the Dash0 monitoring resource to namespace ${target_namespace}"
-kubectl apply -n ${target_namespace} -f test-resources/customresources/dash0monitoring/dash0monitoring.secret.yaml
+install_monitoring_resource
 

--- a/test-resources/bin/test-roundtrip-02-operator-cr-aum.sh
+++ b/test-resources/bin/test-roundtrip-02-operator-cr-aum.sh
@@ -15,13 +15,13 @@ load_env_file
 verify_kubectx
 setup_test_environment
 
-echo "STEP 1: creating target namespace (if necessary)"
-test-resources/bin/ensure-namespace-exists.sh ${target_namespace}
+echo "STEP 1: remove old test resources"
+test-resources/bin/test-cleanup.sh ${target_namespace} false
 echo
 echo
 
-echo "STEP 2: remove old test resources"
-test-resources/bin/test-cleanup.sh ${target_namespace} false
+echo "STEP 2: creating target namespace (if necessary)"
+test-resources/bin/ensure-namespace-exists.sh ${target_namespace}
 echo
 echo
 
@@ -48,12 +48,12 @@ echo
 sleep 5
 
 echo "STEP 6: deploy the Dash0 operator configuration resource to cluster"
-kubectl apply -f test-resources/customresources/dash0operatorconfiguration/dash0operatorconfiguration.token.yaml
+install_operator_configuration_resource
 echo
 echo
 
 echo "STEP 7: deploy the Dash0 monitoring resource to namespace ${target_namespace}"
-kubectl apply -n ${target_namespace} -f test-resources/customresources/dash0monitoring/dash0monitoring.secret.yaml
+install_monitoring_resource
 echo
 echo
 

--- a/test-resources/bin/util
+++ b/test-resources/bin/util
@@ -117,3 +117,11 @@ has_been_set_to_empty_string() {
     return 1
   fi
 }
+
+install_operator_configuration_resource() {
+  kubectl apply -f test-resources/customresources/dash0operatorconfiguration/dash0operatorconfiguration.token.yaml
+}
+
+install_monitoring_resource() {
+  kubectl apply -n ${target_namespace} -f test-resources/customresources/dash0monitoring/dash0monitoring.secret.yaml
+}


### PR DESCRIPTION
* add util functions to deploy custom resources
* clean up first, then create test namespace
* delete old resources in this order now
  - applications under monitoring
  - custom resources (monitoring and operator configuration)
  - delete test namespace
  - uninstall operator helm chart
  - delete Dash0 auth token secret
  - delete dash0-system namespace
  - delete CRDs (directly, instead of via make uninstall)
  - delete other cluster-scope resources in case they have been left over
* call helm uninstall directly
