### PR TITLE
feat(prometheus): watch Prometheus ScrapeConfig CRD & CRs

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -66,6 +66,14 @@ rules:
   - get
   - list
 - apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - scrapeconfigs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - operator.dash0.com
   resources:
   - dash0monitorings

--- a/go.mod
+++ b/go.mod
@@ -69,6 +69,7 @@ require (
 	github.com/nexucis/lamenv v0.5.2 // indirect
 	github.com/perses/common v0.23.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.76.2 // indirect
 	github.com/prometheus/client_golang v1.19.1 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.55.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -111,6 +111,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.76.2 h1:BpGDC87A2SaxbKgONsFLEX3kRcRJee2aLQbjXsuz0hA=
+github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.76.2/go.mod h1:Rd8YnCqz+2FYsiGmE2DMlaLjQRB4v2jFNnzCt9YY4IM=
 github.com/prometheus/client_golang v1.19.1 h1:wZWJDwK+NameRJuPGDhlnFgx8e8HN3XHQeLaYJFJBOE=
 github.com/prometheus/client_golang v1.19.1/go.mod h1:mP78NwGzrVks5S2H6ab8+ZZGJLZUq1hoULYBAYBw1Ho=
 github.com/prometheus/client_model v0.6.1 h1:ZKSh/rekM+n3CeS952MLRAdFwIKqeY8b62p8ais2e9E=

--- a/helm-chart/dash0-operator/templates/operator/cluster-roles.yaml
+++ b/helm-chart/dash0-operator/templates/operator/cluster-roles.yaml
@@ -85,6 +85,16 @@ rules:
   - get
   - list
 
+  # Permissions required to watch for the Prometheus ScrapeConfigs.
+- apiGroups:
+    - monitoring.coreos.com
+  resources:
+    - scrapeconfigs
+  verbs:
+    - get
+    - list
+    - watch
+
 # Permissions required to watch for the Perses dashboard resources.
 - apiGroups:
   - perses.dev

--- a/helm-chart/dash0-operator/tests/operator/__snapshot__/cluster-roles_test.yaml.snap
+++ b/helm-chart/dash0-operator/tests/operator/__snapshot__/cluster-roles_test.yaml.snap
@@ -75,6 +75,14 @@ cluster roles should match snapshot:
           - get
           - list
       - apiGroups:
+          - monitoring.coreos.com
+        resources:
+          - scrapeconfigs
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
           - perses.dev
         resources:
           - persesdashboards

--- a/images/collector/src/builder/config.yaml
+++ b/images/collector/src/builder/config.yaml
@@ -23,6 +23,7 @@ receivers:
   - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver v0.111.0"
   - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver v0.111.0"
   - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver v0.111.0"
+  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.111.0"
 
 processors:
   - gomod: "go.opentelemetry.io/collector/processor/batchprocessor v0.111.0"

--- a/internal/backendconnection/backendconnection_manager_test.go
+++ b/internal/backendconnection/backendconnection_manager_test.go
@@ -59,11 +59,12 @@ var _ = Describe("The backend connection manager", Ordered, func() {
 			OTelCollectorNamePrefix: OTelCollectorNamePrefixTest,
 			OTelColResourceSpecs:    &otelcolresources.DefaultOTelColResourceSpecs,
 		}
-		manager = &BackendConnectionManager{
-			Client:                 k8sClient,
-			Clientset:              clientset,
-			OTelColResourceManager: oTelColResourceManager,
-		}
+		manager = NewBackendConnectionManager(
+			k8sClient,
+			clientset,
+			oTelColResourceManager,
+		)
+
 	})
 
 	AfterEach(func() {

--- a/internal/backendconnection/otelcolresources/collector_config_maps.go
+++ b/internal/backendconnection/otelcolresources/collector_config_maps.go
@@ -80,6 +80,7 @@ func assembleCollectorConfigMap(
 					// logs will compound in case of log parsing errors
 					config.Namespace,
 				},
+				ScrapeConfigs:   config.ScrapeConfigs,
 				DevelopmentMode: config.DevelopmentMode,
 			})
 		if err != nil {

--- a/internal/backendconnection/otelcolresources/deployment.config.yaml.template
+++ b/internal/backendconnection/otelcolresources/deployment.config.yaml.template
@@ -46,6 +46,26 @@ processors:
 
 receivers:
   k8s_cluster: {}
+{{- if .ScrapeConfigs }}
+  prometheus:
+    config:
+      scrape_configs:
+      - job_name: otel-collector
+        scrape_interval: 5s
+        static_configs:
+          - targets: ['0.0.0.0:8888']
+      - job_name: k8s
+        kubernetes_sd_configs:
+        - role: pod
+        relabel_configs:
+        - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+          regex: "true"
+          action: keep
+        metric_relabel_configs:
+        - source_labels: [__name__]
+          regex: "(request_duration_seconds.*|response_duration_seconds.*)"
+          action: keep
+{{- end }}
 
 service:
   extensions:
@@ -56,6 +76,9 @@ service:
     metrics/downstream:
       receivers:
       - k8s_cluster
+      {{- if .ScrapeConfigs }}
+      - prometheus
+      {{- end }}
       processors:
       - memory_limiter
       - resourcedetection

--- a/internal/backendconnection/otelcolresources/desired_state.go
+++ b/internal/backendconnection/otelcolresources/desired_state.go
@@ -28,12 +28,14 @@ type oTelColConfig struct {
 	Export                                  dash0v1alpha1.Export
 	SelfMonitoringAndApiAccessConfiguration selfmonitoringapiaccess.SelfMonitoringAndApiAccessConfiguration
 	Images                                  util.Images
+	ScrapeConfigs                           bool
 	DevelopmentMode                         bool
 }
 
 type collectorConfigurationTemplateValues struct {
 	Exporters                []OtlpExporter
 	IgnoreLogsFromNamespaces []string
+	ScrapeConfigs            bool
 	DevelopmentMode          bool
 }
 

--- a/internal/backendconnection/otelcolresources/otelcol_resources_test.go
+++ b/internal/backendconnection/otelcolresources/otelcol_resources_test.go
@@ -128,6 +128,7 @@ var _ = Describe("The OpenTelemetry Collector resource manager", Ordered, func()
 					OperatorNamespace,
 					TestImages,
 					dash0MonitoringResource,
+					nil,
 					&logger,
 				)
 			Expect(err).ToNot(HaveOccurred())
@@ -149,6 +150,7 @@ var _ = Describe("The OpenTelemetry Collector resource manager", Ordered, func()
 				&dash0v1alpha1.Dash0Monitoring{
 					Spec: dash0v1alpha1.Dash0MonitoringSpec{},
 				},
+				nil,
 				&logger,
 			)
 			Expect(err).ToNot(HaveOccurred())
@@ -165,6 +167,7 @@ var _ = Describe("The OpenTelemetry Collector resource manager", Ordered, func()
 				&dash0v1alpha1.Dash0Monitoring{
 					Spec: dash0v1alpha1.Dash0MonitoringSpec{},
 				},
+				nil,
 				&logger,
 			)
 			Expect(err).To(
@@ -188,6 +191,7 @@ var _ = Describe("The OpenTelemetry Collector resource manager", Ordered, func()
 				&dash0v1alpha1.Dash0Monitoring{
 					Spec: dash0v1alpha1.Dash0MonitoringSpec{},
 				},
+				nil,
 				&logger,
 			)
 			Expect(err).To(MatchError("the provided Dash0Monitoring resource does not have an export configuration " +
@@ -234,6 +238,7 @@ var _ = Describe("The OpenTelemetry Collector resource manager", Ordered, func()
 					OperatorNamespace,
 					TestImages,
 					dash0MonitoringResource,
+					nil,
 					&logger,
 				)
 			Expect(err).ToNot(HaveOccurred())
@@ -263,6 +268,7 @@ var _ = Describe("The OpenTelemetry Collector resource manager", Ordered, func()
 					OperatorNamespace,
 					TestImages,
 					dash0MonitoringResource,
+					nil,
 					&logger,
 				)
 			Expect(err).ToNot(HaveOccurred())
@@ -303,6 +309,7 @@ var _ = Describe("The OpenTelemetry Collector resource manager", Ordered, func()
 					OperatorNamespace,
 					TestImages,
 					dash0MonitoringResource,
+					nil,
 					&logger,
 				)
 			Expect(err).ToNot(HaveOccurred())
@@ -321,6 +328,7 @@ var _ = Describe("The OpenTelemetry Collector resource manager", Ordered, func()
 					OperatorNamespace,
 					TestImages,
 					dash0MonitoringResource,
+					nil,
 					&logger,
 				)
 			Expect(err).ToNot(HaveOccurred())
@@ -343,6 +351,7 @@ var _ = Describe("The OpenTelemetry Collector resource manager", Ordered, func()
 					OperatorNamespace,
 					TestImages,
 					dash0MonitoringResource,
+					nil,
 					&logger,
 				)
 			Expect(err).ToNot(HaveOccurred())
@@ -360,6 +369,7 @@ var _ = Describe("The OpenTelemetry Collector resource manager", Ordered, func()
 				OperatorNamespace,
 				TestImages,
 				dash0MonitoringResource,
+				nil,
 				&logger,
 			)
 			Expect(err).ToNot(HaveOccurred())
@@ -372,6 +382,7 @@ var _ = Describe("The OpenTelemetry Collector resource manager", Ordered, func()
 				OperatorNamespace,
 				TestImages,
 				dash0MonitoringResource,
+				nil,
 				&logger,
 			)
 			Expect(err).ToNot(HaveOccurred())
@@ -386,6 +397,7 @@ var _ = Describe("The OpenTelemetry Collector resource manager", Ordered, func()
 					OperatorNamespace,
 					TestImages,
 					dash0MonitoringResource,
+					nil,
 					&logger,
 				)
 			Expect(err).ToNot(HaveOccurred())
@@ -404,6 +416,7 @@ var _ = Describe("The OpenTelemetry Collector resource manager", Ordered, func()
 				OperatorNamespace,
 				TestImages,
 				dash0MonitoringResource,
+				nil,
 				&logger,
 			)
 			Expect(err).ToNot(HaveOccurred())

--- a/internal/dash0/controller/dash0_controller_test.go
+++ b/internal/dash0/controller/dash0_controller_test.go
@@ -67,11 +67,11 @@ var _ = Describe("The monitoring resource controller", Ordered, func() {
 			OTelCollectorNamePrefix: OTelCollectorNamePrefixTest,
 			OTelColResourceSpecs:    &otelcolresources.DefaultOTelColResourceSpecs,
 		}
-		backendConnectionManager := &backendconnection.BackendConnectionManager{
-			Client:                 k8sClient,
-			Clientset:              clientset,
-			OTelColResourceManager: oTelColResourceManager,
-		}
+		backendConnectionManager := backendconnection.NewBackendConnectionManager(
+			k8sClient,
+			clientset,
+			oTelColResourceManager,
+		)
 		reconciler = &Dash0Reconciler{
 			Client:                   k8sClient,
 			Clientset:                clientset,

--- a/internal/dash0/controller/operator_configuration_controller_test.go
+++ b/internal/dash0/controller/operator_configuration_controller_test.go
@@ -39,7 +39,7 @@ type SelfMonitoringTestConfig struct {
 }
 
 var (
-	reconciler *OperatorConfigurationReconciler
+	operatorConfigurationReconciler *OperatorConfigurationReconciler
 )
 
 var _ = Describe("The operation configuration resource controller", Ordered, func() {
@@ -60,7 +60,7 @@ var _ = Describe("The operation configuration resource controller", Ordered, fun
 		DescribeTable("to reflect self-monitoring and API access auth settings:", func(config SelfMonitoringAndApiAccessTestConfig) {
 			controllerDeployment = config.existingControllerDeployment()
 			EnsureControllerDeploymentExists(ctx, k8sClient, controllerDeployment)
-			reconciler = createReconciler(controllerDeployment)
+			operatorConfigurationReconciler = createOperatorConfigurationReconciler(controllerDeployment)
 
 			initialVersion := controllerDeployment.ResourceVersion
 
@@ -70,7 +70,7 @@ var _ = Describe("The operation configuration resource controller", Ordered, fun
 				config.operatorConfigurationResourceSpec,
 			)
 
-			triggerOperatorConfigurationReconcileRequest(ctx, reconciler)
+			triggerOperatorConfigurationReconcileRequest(ctx, operatorConfigurationReconciler)
 			verifyOperatorConfigurationResourceIsAvailable(ctx)
 
 			expectedDeploymentAfterReconcile := config.expectedControllerDeploymentAfterReconcile()
@@ -349,14 +349,14 @@ var _ = Describe("The operation configuration resource controller", Ordered, fun
 		)
 	})
 
-	Describe("when creating the operator configuration resource", func() {
+	Describe("when creating the Dash0OperatorConfiguration resource", func() {
 
 		BeforeEach(func() {
 			// When creating the resource, we assume the operator has no
 			// self-monitoring enabled
 			controllerDeployment = CreateControllerDeploymentWithoutSelfMonitoringWithoutAuth()
 			EnsureControllerDeploymentExists(ctx, k8sClient, controllerDeployment)
-			reconciler = createReconciler(controllerDeployment)
+			operatorConfigurationReconciler = createOperatorConfigurationReconciler(controllerDeployment)
 		})
 
 		AfterEach(func() {
@@ -379,7 +379,7 @@ var _ = Describe("The operation configuration resource controller", Ordered, fun
 						},
 					)
 
-					triggerOperatorConfigurationReconcileRequest(ctx, reconciler)
+					triggerOperatorConfigurationReconcileRequest(ctx, operatorConfigurationReconciler)
 					verifyOperatorConfigurationResourceIsAvailable(ctx)
 					Eventually(func(g Gomega) {
 						updatedDeployment := LoadOperatorDeploymentOrFail(ctx, k8sClient, g)
@@ -425,7 +425,7 @@ var _ = Describe("The operation configuration resource controller", Ordered, fun
 					},
 				)
 
-				triggerOperatorConfigurationReconcileRequest(ctx, reconciler)
+				triggerOperatorConfigurationReconcileRequest(ctx, operatorConfigurationReconciler)
 				verifyOperatorConfigurationResourceIsAvailable(ctx)
 				Eventually(func(g Gomega) {
 					updatedDeployment := LoadOperatorDeploymentOrFail(ctx, k8sClient, g)
@@ -463,7 +463,7 @@ var _ = Describe("The operation configuration resource controller", Ordered, fun
 					},
 				)
 
-				triggerOperatorConfigurationReconcileRequest(ctx, reconciler)
+				triggerOperatorConfigurationReconcileRequest(ctx, operatorConfigurationReconciler)
 				verifyOperatorConfigurationResourceIsAvailable(ctx)
 				Consistently(func(g Gomega) {
 					updatedDeployment := LoadOperatorDeploymentOrFail(ctx, k8sClient, g)
@@ -490,7 +490,7 @@ var _ = Describe("The operation configuration resource controller", Ordered, fun
 					// self-monitoring enabled
 					controllerDeployment = CreateControllerDeploymentWithSelfMonitoringWithToken()
 					EnsureControllerDeploymentExists(ctx, k8sClient, controllerDeployment)
-					reconciler = createReconciler(controllerDeployment)
+					operatorConfigurationReconciler = createOperatorConfigurationReconciler(controllerDeployment)
 				})
 
 				AfterEach(func() {
@@ -510,7 +510,7 @@ var _ = Describe("The operation configuration resource controller", Ordered, fun
 						},
 					)
 
-					triggerOperatorConfigurationReconcileRequest(ctx, reconciler)
+					triggerOperatorConfigurationReconcileRequest(ctx, operatorConfigurationReconciler)
 					verifyOperatorConfigurationResourceIsAvailable(ctx)
 
 					Consistently(func(g Gomega) {
@@ -531,7 +531,7 @@ var _ = Describe("The operation configuration resource controller", Ordered, fun
 				BeforeEach(func() {
 					controllerDeployment = CreateControllerDeploymentWithoutSelfMonitoringWithoutAuth()
 					EnsureControllerDeploymentExists(ctx, k8sClient, controllerDeployment)
-					reconciler = createReconciler(controllerDeployment)
+					operatorConfigurationReconciler = createOperatorConfigurationReconciler(controllerDeployment)
 
 					CreateOperatorConfigurationResourceWithSpec(
 						ctx,
@@ -558,7 +558,7 @@ var _ = Describe("The operation configuration resource controller", Ordered, fun
 
 					Expect(k8sClient.Update(ctx, resource)).To(Succeed())
 
-					triggerOperatorConfigurationReconcileRequest(ctx, reconciler)
+					triggerOperatorConfigurationReconcileRequest(ctx, operatorConfigurationReconciler)
 					verifyOperatorConfigurationResourceIsAvailable(ctx)
 					Eventually(func(g Gomega) {
 						updatedDeployment := LoadOperatorDeploymentOrFail(ctx, k8sClient, g)
@@ -592,7 +592,7 @@ var _ = Describe("The operation configuration resource controller", Ordered, fun
 
 					controllerDeployment = CreateControllerDeploymentWithSelfMonitoringWithToken()
 					EnsureControllerDeploymentExists(ctx, k8sClient, controllerDeployment)
-					reconciler = createReconciler(controllerDeployment)
+					operatorConfigurationReconciler = createOperatorConfigurationReconciler(controllerDeployment)
 				})
 
 				AfterEach(func() {
@@ -608,7 +608,7 @@ var _ = Describe("The operation configuration resource controller", Ordered, fun
 
 					Expect(k8sClient.Update(ctx, resource)).To(Succeed())
 
-					triggerOperatorConfigurationReconcileRequest(ctx, reconciler)
+					triggerOperatorConfigurationReconcileRequest(ctx, operatorConfigurationReconciler)
 					verifyOperatorConfigurationResourceIsAvailable(ctx)
 					Eventually(func(g Gomega) {
 						updatedDeployment := LoadOperatorDeploymentOrFail(ctx, k8sClient, g)
@@ -639,7 +639,7 @@ var _ = Describe("The operation configuration resource controller", Ordered, fun
 
 					controllerDeployment = CreateControllerDeploymentWithoutSelfMonitoringWithoutAuth()
 					EnsureControllerDeploymentExists(ctx, k8sClient, controllerDeployment)
-					reconciler = createReconciler(controllerDeployment)
+					operatorConfigurationReconciler = createOperatorConfigurationReconciler(controllerDeployment)
 				})
 
 				AfterEach(func() {
@@ -655,7 +655,7 @@ var _ = Describe("The operation configuration resource controller", Ordered, fun
 
 					Expect(k8sClient.Update(ctx, resource)).To(Succeed())
 
-					triggerOperatorConfigurationReconcileRequest(ctx, reconciler)
+					triggerOperatorConfigurationReconcileRequest(ctx, operatorConfigurationReconciler)
 					verifyOperatorConfigurationResourceIsAvailable(ctx)
 					Consistently(func(g Gomega) {
 						updatedDeployment := LoadOperatorDeploymentOrFail(ctx, k8sClient, g)
@@ -690,7 +690,7 @@ var _ = Describe("The operation configuration resource controller", Ordered, fun
 
 				controllerDeployment = CreateControllerDeploymentWithSelfMonitoringWithToken()
 				EnsureControllerDeploymentExists(ctx, k8sClient, controllerDeployment)
-				reconciler = createReconciler(controllerDeployment)
+				operatorConfigurationReconciler = createOperatorConfigurationReconciler(controllerDeployment)
 			})
 
 			AfterEach(func() {
@@ -710,7 +710,7 @@ var _ = Describe("The operation configuration resource controller", Ordered, fun
 				resource := LoadOperatorConfigurationResourceOrFail(ctx, k8sClient, Default)
 				Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
 
-				triggerOperatorConfigurationReconcileRequest(ctx, reconciler)
+				triggerOperatorConfigurationReconcileRequest(ctx, operatorConfigurationReconciler)
 				VerifyOperatorConfigurationResourceByNameDoesNotExist(ctx, k8sClient, Default, resource.Name)
 
 				Eventually(func(g Gomega) {
@@ -741,7 +741,7 @@ var _ = Describe("The operation configuration resource controller", Ordered, fun
 
 				controllerDeployment = CreateControllerDeploymentWithoutSelfMonitoringWithoutAuth()
 				EnsureControllerDeploymentExists(ctx, k8sClient, controllerDeployment)
-				reconciler = createReconciler(controllerDeployment)
+				operatorConfigurationReconciler = createOperatorConfigurationReconciler(controllerDeployment)
 			})
 
 			AfterEach(func() {
@@ -763,7 +763,7 @@ var _ = Describe("The operation configuration resource controller", Ordered, fun
 
 				Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
 
-				triggerOperatorConfigurationReconcileRequest(ctx, reconciler)
+				triggerOperatorConfigurationReconcileRequest(ctx, operatorConfigurationReconciler)
 				VerifyOperatorConfigurationResourceByNameDoesNotExist(ctx, k8sClient, Default, resource.Name)
 
 				Consistently(func(g Gomega) {
@@ -796,7 +796,7 @@ func cleanUpDeploymentSpecForDiff(spec *appsv1.DeploymentSpec) {
 	spec.ProgressDeadlineSeconds = nil
 }
 
-func createReconciler(controllerDeployment *appsv1.Deployment) *OperatorConfigurationReconciler {
+func createOperatorConfigurationReconciler(controllerDeployment *appsv1.Deployment) *OperatorConfigurationReconciler {
 	persesDashboardCrdReconciler := &PersesDashboardCrdReconciler{
 		persesDashboardReconciler: &PersesDashboardReconciler{},
 	}

--- a/internal/dash0/controller/prometheus_scrapeconfig_controller.go
+++ b/internal/dash0/controller/prometheus_scrapeconfig_controller.go
@@ -1,0 +1,276 @@
+// SPDX-FileCopyrightText: Copyright 2024 Dash0 Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"context"
+	"sync/atomic"
+
+	"github.com/go-logr/logr"
+	prometheusoperator "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/workqueue"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	"github.com/dash0hq/dash0-operator/internal/backendconnection"
+)
+
+type PrometheusScrapeConfigCrdReconciler struct {
+	client.Client
+	*kubernetes.Clientset
+	*runtime.Scheme
+	*backendconnection.BackendConnectionReconciler
+	mgr                     ctrl.Manager
+	cancelControllerContext atomic.Pointer[context.CancelFunc]
+	scrapeConfigReconciler  *PrometheusScrapeConfigReconciler
+}
+
+//+kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch
+
+func (r *PrometheusScrapeConfigCrdReconciler) SetupWithManager(
+	ctx context.Context,
+	mgr ctrl.Manager,
+	startupK8sClient client.Client,
+	logger *logr.Logger,
+) error {
+	r.mgr = mgr
+	r.scrapeConfigReconciler = &PrometheusScrapeConfigReconciler{
+		BackendConnectionReconciler: r.BackendConnectionReconciler,
+	}
+
+	if err := startupK8sClient.Get(ctx, client.ObjectKey{
+		Name: "scrapeconfigs.monitoring.coreos.com",
+	}, &apiextensionsv1.CustomResourceDefinition{}); err != nil {
+		if apierrors.IsNotFound(err) {
+			logger.Info("The scrapeconfigs.monitoring.coreos.com custom resource definition does not exist in this " +
+				"cluster, the operator will not watch for ScrapeConfig resources.")
+		} else {
+			logger.Error(err, "unable to call get the scrapeconfigs.monitoring.coreos.com custom resource definition")
+			return err
+		}
+	} else {
+		logger.Info("The scrapeconfigs.monitoring.coreos.com custom resource definition is present in this " +
+			"cluster, the operator will watch for ScrapeConfig resources.")
+		r.startWatchingScrapeConfigs(ctx, logger)
+	}
+
+	if err := ctrl.NewControllerManagedBy(mgr).
+		Named("dash0_scrapeconfig_crd_controller").
+		Watches(
+			&apiextensionsv1.CustomResourceDefinition{},
+			// Deliberately not using a convenience mechanism like &handler.EnqueueRequestForObject{} (which would
+			// feed all events into the Reconcile method) here, since using the lower-level TypedEventHandler interface
+			// directly allows us to distinguish between create and delete events more easily.
+			r,
+			builder.WithPredicates(makeFilterPredicate())).
+		Complete(r); err != nil {
+		logger.Error(err, "unable to create a controller for the PrometheusScrapeConfigReconciler")
+		return err
+	}
+
+	return nil
+}
+
+func makeFilterPredicate() predicate.Funcs {
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			return isScrapeConfigCrd(e.Object)
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			// We are not interested in updates, but we still need to define a filter predicate for it, otherwise _all_
+			// update events for CRDs would be passed to our event handler. We always return false to ignore update
+			// events entirely. Same for generic events.
+			return false
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return isScrapeConfigCrd(e.Object)
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return false
+		},
+	}
+}
+
+func isScrapeConfigCrd(crd_ client.Object) bool {
+	if crd, ok := crd_.(*apiextensionsv1.CustomResourceDefinition); ok {
+		return crd.Spec.Group == "monitoring.coreos.com" &&
+			crd.Spec.Names.Kind == "ScrapeConfig"
+	} else {
+		return false
+	}
+}
+
+func (r *PrometheusScrapeConfigCrdReconciler) Create(
+	ctx context.Context,
+	_ event.TypedCreateEvent[client.Object],
+	_ workqueue.TypedRateLimitingInterface[reconcile.Request],
+) {
+	logger := log.FromContext(ctx)
+	r.startWatchingScrapeConfigs(ctx, &logger)
+}
+
+func (r *PrometheusScrapeConfigCrdReconciler) Update(
+	context.Context,
+	event.TypedUpdateEvent[client.Object],
+	workqueue.TypedRateLimitingInterface[reconcile.Request],
+) {
+	// should not be called, we are not interested in updates
+	// note: update is called twice prior to delete, it is also called twice after an actual create
+}
+
+func (r *PrometheusScrapeConfigCrdReconciler) Delete(
+	ctx context.Context,
+	_ event.TypedDeleteEvent[client.Object],
+	_ workqueue.TypedRateLimitingInterface[reconcile.Request],
+) {
+	logger := log.FromContext(ctx)
+	logger.Info("XXXXXX CRD DELETE")
+
+	cancelControllerContext := r.cancelControllerContext.Load()
+	if cancelControllerContext != nil {
+		logger.Info("No longer watching Prometheus ScrapeConfig custom resources, since the " +
+			"scrapeconfigs.monitoring.coreos.com custom resource definition has been deleted.")
+		(*cancelControllerContext)()
+
+		// Known issue: Despite stopping the controller which owns the watch, the controller runtime is still calling
+		// client.Client#List for v1alpha1.ScrapeConfig every ten seconds, which results in the following error being
+		// logged every ten seconds:
+		// manager W0920 11:02:18.546083 1 reflector.go:561
+		// pkg/mod/k8s.io/client-go@v0.31.1/tools/cache/reflector.go:243: failed to list *v1alpha1.ScrapeConfig:
+		// the server could not find the requested resource (get scrapeconfigs.monitoring.coreos.com)
+	}
+	r.cancelControllerContext.Store(nil)
+}
+
+func (r *PrometheusScrapeConfigCrdReconciler) Generic(
+	context.Context,
+	event.TypedGenericEvent[client.Object],
+	workqueue.TypedRateLimitingInterface[reconcile.Request],
+) {
+	// Should not be called, we are not interested in generic events.
+}
+
+func (r *PrometheusScrapeConfigCrdReconciler) Reconcile(
+	_ context.Context,
+	_ reconcile.Request,
+) (reconcile.Result, error) {
+	// Reconcile should not be called for the PrometheusScrapeConfigCrdReconciler CRD, as we are using the
+	// TypedEventHandler interface directly when setting up the watch. We still need to implement the method, as the
+	// controller builder's Complete method requires implementing the Reconciler interface.
+	return reconcile.Result{}, nil
+}
+
+//+kubebuilder:rbac:groups=monitoring.coreos.com,resources=scrapeconfigs,verbs=get;list;watch
+
+func (r *PrometheusScrapeConfigCrdReconciler) startWatchingScrapeConfigs(
+	ctx context.Context,
+	logger *logr.Logger,
+) {
+	if r.cancelControllerContext.Load() != nil {
+		// We are already watching scrape config resources.
+		return
+	}
+
+	logger.Info("Setting up a watch for Prometheus ScrapeConfig custom resources now.")
+	scrapeConfigWatchingController, err :=
+		controller.NewTypedUnmanaged[reconcile.Request]("dash0_scrapeconfig_controller", r.mgr, controller.Options{
+			Reconciler: r,
+		})
+	if err != nil {
+		logger.Error(err, "Cannot create a new controller to watch Prometheus ScrapeConfigs")
+		return
+	}
+
+	if err = scrapeConfigWatchingController.Watch(
+		source.TypedKind[*prometheusoperator.ScrapeConfig, reconcile.Request](
+			r.mgr.GetCache(),
+			&prometheusoperator.ScrapeConfig{},
+			r.scrapeConfigReconciler,
+		),
+	); err != nil {
+		logger.Error(err, "unable to create a new controller for watching Prometheus ScrapeConfigs")
+		return
+	}
+
+	childContextForController, cancelControllerContext := context.WithCancel(ctx)
+	r.cancelControllerContext.Store(&cancelControllerContext)
+
+	go func() {
+		if err = scrapeConfigWatchingController.Start(childContextForController); err != nil {
+			logger.Error(err, "unable to start the controller for watching Prometheus ScrapeConfigs")
+			return
+		}
+	}()
+}
+
+type PrometheusScrapeConfigReconciler struct {
+	*backendconnection.BackendConnectionReconciler
+}
+
+func (r *PrometheusScrapeConfigReconciler) Create(
+	ctx context.Context,
+	e event.TypedCreateEvent[*prometheusoperator.ScrapeConfig],
+	_ workqueue.TypedRateLimitingInterface[reconcile.Request],
+) {
+	logger := log.FromContext(ctx)
+	logger.Info(
+		"Detected a new Prometheus ScrapeConfig resource",
+		"namespace",
+		e.Object.GetNamespace(),
+		"name",
+		e.Object.GetName(),
+	)
+	r.BackendConnectionReconciler.UpdatePrometheusScrapeConfigs(ctx, e.Object)
+}
+
+func (r *PrometheusScrapeConfigReconciler) Update(
+	ctx context.Context,
+	e event.TypedUpdateEvent[*prometheusoperator.ScrapeConfig],
+	_ workqueue.TypedRateLimitingInterface[reconcile.Request],
+) {
+	logger := log.FromContext(ctx)
+	logger.Info(
+		"Detected a change for a Prometheus ScrapeConfig resource",
+		"namespace",
+		e.ObjectNew.GetNamespace(),
+		"name",
+		e.ObjectNew.GetName(),
+	)
+	r.BackendConnectionReconciler.UpdatePrometheusScrapeConfigs(ctx, e.ObjectNew)
+}
+
+func (r *PrometheusScrapeConfigReconciler) Delete(
+	ctx context.Context,
+	e event.TypedDeleteEvent[*prometheusoperator.ScrapeConfig],
+	_ workqueue.TypedRateLimitingInterface[reconcile.Request],
+) {
+	logger := log.FromContext(ctx)
+	logger.Info(
+		"Detected the deletion of a Prometheus ScrapeConfig resource",
+		"namespace",
+		e.Object.GetNamespace(),
+		"name",
+		e.Object.GetName(),
+	)
+	r.BackendConnectionReconciler.DeletePrometheusScrapeConfigs(ctx, e.Object)
+}
+
+func (r *PrometheusScrapeConfigReconciler) Generic(
+	_ context.Context,
+	_ event.TypedGenericEvent[*prometheusoperator.ScrapeConfig],
+	_ workqueue.TypedRateLimitingInterface[reconcile.Request],
+) {
+	// ignoring generic events
+}

--- a/internal/dash0/predelete/pre_delete_suite_test.go
+++ b/internal/dash0/predelete/pre_delete_suite_test.go
@@ -103,11 +103,11 @@ var _ = BeforeSuite(func() {
 		OTelCollectorNamePrefix: OTelCollectorNamePrefixTest,
 		OTelColResourceSpecs:    &otelcolresources.DefaultOTelColResourceSpecs,
 	}
-	backendConnectionManager := &backendconnection.BackendConnectionManager{
-		Client:                 k8sClient,
-		Clientset:              clientset,
-		OTelColResourceManager: oTelColResourceManager,
-	}
+	backendConnectionManager := backendconnection.NewBackendConnectionManager(
+		k8sClient,
+		clientset,
+		oTelColResourceManager,
+	)
 	reconciler = &controller.Dash0Reconciler{
 		Client:                   k8sClient,
 		Clientset:                clientset,

--- a/internal/dash0/webhooks/attach_dangling_events_test.go
+++ b/internal/dash0/webhooks/attach_dangling_events_test.go
@@ -50,11 +50,11 @@ var _ = Describe("The Dash0 webhook and the Dash0 controller", Ordered, func() {
 			OTelCollectorNamePrefix: OTelCollectorNamePrefixTest,
 			OTelColResourceSpecs:    &otelcolresources.DefaultOTelColResourceSpecs,
 		}
-		backendConnectionManager := &backendconnection.BackendConnectionManager{
-			Client:                 k8sClient,
-			Clientset:              clientset,
-			OTelColResourceManager: oTelColResourceManager,
-		}
+		backendConnectionManager := backendconnection.NewBackendConnectionManager(
+			k8sClient,
+			clientset,
+			oTelColResourceManager,
+		)
 
 		reconciler = &controller.Dash0Reconciler{
 			Client:                   k8sClient,

--- a/test-resources/bin/test-cleanup.sh
+++ b/test-resources/bin/test-cleanup.sh
@@ -61,3 +61,5 @@ kubectl delete clusterrolebinding           --ignore-not-found dash0-operator-op
 kubectl delete clusterrolebinding           --ignore-not-found dash0-operator-proxy-rolebinding
 kubectl delete mutatingwebhookconfiguration --ignore-not-found dash0-operator-injector
 
+kubectl delete --ignore-not-found crd scrapeconfigs.monitoring.coreos.com
+

--- a/test-resources/bin/test-scenario-02-operator-cr-aum.sh
+++ b/test-resources/bin/test-scenario-02-operator-cr-aum.sh
@@ -42,6 +42,14 @@ echo "STEP $step_counter: rebuild images"
 build_all_images
 finish_step
 
+# TODO move this to "install foreign CRDs"
+echo "STEP 5 (a): install scrapeconfig CRD"
+kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.76.2/example/prometheus-operator-crd/monitoring.coreos.com_scrapeconfigs.yaml
+sleep 2
+echo "STEP 5 (b): install a scrapeconfig CR "
+kubectl apply -n test-namespace -f test-resources/customresources/scrapeconfig/scrapeconfig.yaml
+sleep 2
+
 echo "STEP $step_counter: deploy the Dash0 operator using helm"
 deploy_via_helm
 finish_step

--- a/test-resources/customresources/scrapeconfig/scrapeconfig.yaml
+++ b/test-resources/customresources/scrapeconfig/scrapeconfig.yaml
@@ -1,0 +1,12 @@
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: ScrapeConfig
+metadata:
+  name: static-config
+  labels:
+    prometheus: system-monitoring-prometheus
+spec:
+  staticConfigs:
+    - labels:
+        job: prometheus
+      targets:
+        - prometheus.demo.do.prometheus.io:9090

--- a/test-resources/node.js/express/package-lock.json
+++ b/test-resources/node.js/express/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "dash0-app-under-test-express",
+  "name": "dash0-operator-app-under-test-express",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "dash0-app-under-test-express",
+      "name": "dash0-operator-app-under-test-express",
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {

--- a/test-resources/node.js/express/package.json
+++ b/test-resources/node.js/express/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "dash0-app-under-test-express",
+  "name": "dash0-operator-app-under-test-express",
   "version": "1.0.0",
   "description": "",
   "main": "app.js",


### PR DESCRIPTION
If scrape config custom resources are present in the cluster, use them to configure scrape configs for the operator's OTel collector deployment to send the resulting metrics to Dash0.