### PR TITLE
fix(backendconnection): add annotation to prevent ArgoCD pruning

### DIFF
--- a/internal/backendconnection/otelcolresources/otelcol_resources.go
+++ b/internal/backendconnection/otelcolresources/otelcol_resources.go
@@ -102,7 +102,8 @@ func (m *OTelColResourceManager) CreateOrUpdateOpenTelemetryCollectorResources(
 	}
 	resourcesHaveBeenCreated := false
 	resourcesHaveBeenUpdated := false
-	for _, desiredResource := range desiredState {
+	for _, wrapper := range desiredState {
+		desiredResource := wrapper.object
 		isNew, isChanged, err := m.createOrUpdateResource(
 			ctx,
 			desiredResource,
@@ -346,7 +347,8 @@ func (m *OTelColResourceManager) DeleteResources(
 		return err
 	}
 	var allErrors []error
-	for _, desiredResource := range desiredResources {
+	for _, wrapper := range desiredResources {
+		desiredResource := wrapper.object
 		err = m.Client.Delete(ctx, desiredResource)
 		if err != nil {
 			if apierrors.IsNotFound(err) {


### PR DESCRIPTION
For clusters managed by ArgoCD, we need to prevent ArgoCD to prune
Kubernetes resources necessary for the OTel collector managed by the
operator. If pruning is enabled in ArgoCD, it will automatically delete
resources which have no owner reference. This applies to all
cluster-scoped resources which the operator creates (since
cluster-scoped resource cannot be owned by namespace-scoped resources).

In particular, this affects the cluster role & cluster role binding.

References:
* https://github.com/argoproj/argo-cd/issues/4764#issuecomment-722661940
  this indicates that only top level resources are pruned (which is
  basically the same as resources without an owner reference).
* The docs for preventing this on a resource level are here:
  https://argo-cd.readthedocs.io/en/stable/user-guide/sync-options/#no-prune-resources