### PR TITLE
test(e2e): fix test case for updating the collector configuration

### DIFF
--- a/test/e2e/dash0_monitoring_resource.go
+++ b/test/e2e/dash0_monitoring_resource.go
@@ -92,7 +92,7 @@ func updateEndpointOfDash0MonitoringResource(
 ) {
 	updateDash0MonitoringResource(
 		namespace,
-		fmt.Sprintf("{\"spec\":{\"export\":{\"http\":{\"endpoint\":\"%s\"}}}}", newEndpoint),
+		fmt.Sprintf("{\"spec\":{\"export\":{\"dash0\":{\"endpoint\":\"%s\"}}}}", newEndpoint),
 	)
 }
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -747,9 +747,10 @@ var _ = Describe("Dash0 Kubernetes Operator", Ordered, func() {
 			By("updating the Dash0 monitoring resource endpoint setting")
 			newEndpoint := "ingress.us-east-2.aws.dash0-dev.com:4317"
 			updateEndpointOfDash0MonitoringResource(applicationUnderTestNamespace, newEndpoint)
-			// Note: updating the endpoint in this way will lead to telemetry from the applications under test no longer
-			// being sent to otlp-sink. This is not relevant for this test case, but might be an issue if we ever add
-			// more tests to this suite after this one.
+			defer func() {
+				// reset the endpoint to the default after this test
+				updateEndpointOfDash0MonitoringResource(applicationUnderTestNamespace, defaultEndpoint)
+			}()
 
 			By("waiting for self-monitoring metrics")
 			Eventually(func(g Gomega) {


### PR DESCRIPTION
This test broke in commit 6b4da302a849e8c81e00d61e17b9826c977d5f86, when the export in the monitoring resource for e2e test was changed from an http exporter to a dash0 exporter.