### PR TITLE
chore(dashboards): do not duplicate origin in payload

### DIFF
--- a/internal/dash0/controller/perses_dashboards_controller.go
+++ b/internal/dash0/controller/perses_dashboards_controller.go
@@ -312,15 +312,11 @@ func (r *PersesDashboardReconciler) UpsertDashboard(
 		persesDashboard.Spec.Display.Name = fmt.Sprintf("%s/%s", persesDashboard.Namespace, persesDashboard.Name)
 	}
 
+	// Remove all unnecessary metadata (labels & annotations), we basically only need the dashboard spec.
 	serializedDashboard, _ := json.Marshal(
 		map[string]interface{}{
-			"kind": "Dashboard",
+			"kind": persesDashboard.Kind,
 			"spec": persesDashboard.Spec,
-			"metadata": map[string]interface{}{
-				"dash0Extensions": map[string]interface{}{
-					"origin": dashboardOrigin,
-				},
-			},
 		})
 	requestPayload := bytes.NewBuffer(serializedDashboard)
 


### PR DESCRIPTION
The dashboard origin is already specified via the URL, there is no more need to add it to the dashboard payload.