### PR TITLE
fix(dashboards): start watching dashboards when all conditions are met

### DIFF
--- a/internal/dash0/controller/operator_configuration_controller.go
+++ b/internal/dash0/controller/operator_configuration_controller.go
@@ -168,7 +168,7 @@ func (r *OperatorConfigurationReconciler) Reconcile(ctx context.Context, req ctr
 		r.PersesDashboardCrdReconciler.SetApiEndpointAndDataset(&ApiConfig{
 			Endpoint: resource.Spec.Export.Dash0.ApiEndpoint,
 			Dataset:  dataset,
-		})
+		}, &logger)
 	} else {
 		logger.Info("Settings required for managing dashboards via the operator are missing, the operator will not " +
 			"update dashboards in Dash0.")

--- a/internal/dash0/startup/auto_operator_configuration_handler.go
+++ b/internal/dash0/startup/auto_operator_configuration_handler.go
@@ -42,7 +42,7 @@ type AutoOperatorConfigurationResourceHandler struct {
 const (
 	operatorConfigurationAutoResourceName = "dash0-operator-configuration-auto-resource"
 
-	alreadyExistsMessage = "The operator is configured to deploy an operator configuration resource at startup, but there is already" +
+	alreadyExistsMessage = "The operator is configured to deploy an operator configuration resource at startup, but there is already " +
 		"an operator configuration resource in the cluster. Hence no action is necessary. (This is not an error.)"
 )
 

--- a/test-resources/bin/test-scenario-01-aum-operator-cr.sh
+++ b/test-resources/bin/test-scenario-01-aum-operator-cr.sh
@@ -38,6 +38,13 @@ echo "STEP $step_counter: install foreign custom resource definitions"
 install_foreign_crds
 finish_step
 
+
+if [[ "${DEPLOY_PERSES_DASHBOARD:-}" == true ]]; then
+  echo "STEP $step_counter: deploy a Perses dashboard resource to namespace ${target_namespace}"
+  kubectl apply -n ${target_namespace} -f test-resources/customresources/persesdashboard/persesdashboard.yaml
+  finish_step
+fi
+
 echo "STEP $step_counter: rebuild images"
 build_all_images
 finish_step
@@ -71,10 +78,3 @@ else
   echo
 fi
 
-if [[ "${DEPLOY_PERSES_DASHBOARD:-}" == true ]]; then
-  echo "Waiting 30 seconds before deploying a Perses dashboard resource."
-  sleep 30
-  echo "STEP $step_counter: deploy a Perses dashboard resource to namespace ${target_namespace}"
-  kubectl apply -n ${target_namespace} -f test-resources/customresources/persesdashboard/persesdashboard.yaml
-  finish_step
-fi

--- a/test-resources/bin/test-scenario-02-operator-cr-aum.sh
+++ b/test-resources/bin/test-scenario-02-operator-cr-aum.sh
@@ -72,8 +72,6 @@ if [[ "${DEPLOY_APPLICATION_UNDER_MONITORING:-}" != false ]]; then
 fi
 
 if [[ "${DEPLOY_PERSES_DASHBOARD:-}" == true ]]; then
-  echo "Waiting 30 seconds before deploying a Perses dashboard resource."
-  sleep 30
   echo "STEP $step_counter: deploy a Perses dashboard resource to namespace ${target_namespace}"
   kubectl apply -n ${target_namespace} -f test-resources/customresources/persesdashboard/persesdashboard.yaml
   finish_step


### PR DESCRIPTION
That is:
* do not do anything if there is no auth token
* watch for the Perses dashboard CRD, potentially starting the watch for dashboard resources once it is created
* wait until an API endpoint configuration is available