### PR TITLE
test(e2e): fix config reloader e2e test

### DIFF
--- a/test/e2e/collector.go
+++ b/test/e2e/collector.go
@@ -127,6 +127,7 @@ func verifyConfigMapContainsString(operatorNamespace string, s string) {
 			"-o",
 			"json",
 		),
+		20*time.Second,
 		s,
 	)
 }
@@ -134,6 +135,7 @@ func verifyConfigMapContainsString(operatorNamespace string, s string) {
 func verifyCollectorContainerLogContainsStrings(
 	operatorNamespace string,
 	containerName string,
+	timeout time.Duration,
 	needles ...string,
 ) {
 	verifyCommandOutputContainsStrings(
@@ -146,6 +148,7 @@ func verifyCollectorContainerLogContainsStrings(
 			"-c",
 			containerName,
 		),
+		timeout,
 		needles...,
 	)
 }

--- a/test/e2e/run_command.go
+++ b/test/e2e/run_command.go
@@ -80,7 +80,7 @@ func getProjectDir() (string, error) {
 	return wd, nil
 }
 
-func verifyCommandOutputContainsStrings(command *exec.Cmd, needles ...string) {
+func verifyCommandOutputContainsStrings(command *exec.Cmd, timeout time.Duration, needles ...string) {
 	Eventually(func(g Gomega) {
 		// We cannot run the same exec.Command multiple times, thus we create a new instance each time instead.
 		haystack, err := run(exec.Command(command.Args[0], command.Args[1:]...), false)
@@ -88,5 +88,5 @@ func verifyCommandOutputContainsStrings(command *exec.Cmd, needles ...string) {
 		for _, needle := range needles {
 			g.Expect(haystack).To(ContainSubstring(needle))
 		}
-	}, 20*time.Second, time.Second).Should(Succeed())
+	}, timeout, time.Second).Should(Succeed())
 }


### PR DESCRIPTION
It sometimes takes a while for a config map change to actually be seen from within the pod/container (in particular the config-reloader). Might be a Docker Desktop thing. Either way, increasing the timeout makes the test more stable.