### PR TITLE
fix: move attributes.log to body field for filelog/monitored_pods

### DIFF
--- a/internal/backendconnection/otelcolresources/daemonset.config.yaml.template
+++ b/internal/backendconnection/otelcolresources/daemonset.config.yaml.template
@@ -311,7 +311,7 @@ to be compatible with the well-known configuration via annotations.
     # Parse CRI-O format
     - type: regex_parser
       id: parser-crio
-      regex: '^(?P<time>[^ Z]+) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*)?(?P<log>.*)$'
+      regex: '^(?P<time>[^ Z]+) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) ?(?P<log>.*)$'
       output: extract_metadata_from_filepath
       timestamp:
         parse_from: attributes.time
@@ -320,7 +320,7 @@ to be compatible with the well-known configuration via annotations.
     # Parse CRI-Containerd format
     - type: regex_parser
       id: parser-containerd
-      regex: '^(?P<time>[^ ^Z]+Z) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*)?(?P<log>.*)$'
+      regex: '^(?P<time>[^ ^Z]+Z) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) ?(?P<log>.*)$'
       output: extract_metadata_from_filepath
       timestamp:
         parse_from: attributes.time

--- a/internal/backendconnection/otelcolresources/daemonset.config.yaml.template
+++ b/internal/backendconnection/otelcolresources/daemonset.config.yaml.template
@@ -337,6 +337,9 @@ to be compatible with the well-known configuration via annotations.
       output: extract_metadata_from_filepath
       parse_from: body
       parse_to: attributes
+    - type: move
+      from: attributes.log
+      to: body
     # Extract metadata from file path
     - type: regex_parser
       id: extract_metadata_from_filepath


### PR DESCRIPTION
Refined log messages from Kubernetes pods/containers were only available in the `log` attribute but were never copied into the log record body.

This PR adds the necessary `move` operator to move the cleaned up log message from `attributes.log` to `body`.

The operator is also used in the recommended OpenTelemetry Collector configuration for Kubernetes:
https://github.com/open-telemetry/opentelemetry.io/blob/2024.09/content/en/docs/kubernetes/collector/components.md?plain=1#L328-L330

Refs https://github.com/open-telemetry/opentelemetry.io/pull/3073