### PR TITLE
docs: various changes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -213,7 +213,7 @@ jobs:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           imageName: operator-controller
           imageTitle: Dash0 Kubernetes Operator Controller
-          imageDescription: the controller for the Dash0 Kubernetes operator
+          imageDescription: the controller for the Dash0 operator for Kubernetes
           imageUrl: https://github.com/dash0hq/dash0-operator/tree/main
           context: .
 
@@ -233,7 +233,7 @@ jobs:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           imageName: collector
           imageTitle: Dash0 Kubernetes Collector
-          imageDescription: the OpenTelemetry collector for the Dash0 Kubernetes operator
+          imageDescription: the OpenTelemetry collector for the Dash0 operator for Kubernetes
           imageUrl: https://github.com/dash0hq/dash0-operator/tree/main/images/collector
           context: images/collector
 
@@ -243,7 +243,7 @@ jobs:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           imageName: configuration-reloader
           imageTitle: Dash0 Kubernetes Configuration Reloader
-          imageDescription: the configuration reloader for the Dash0 Kubernetes operator
+          imageDescription: the configuration reloader for the Dash0 operator for Kubernetes
           imageUrl: https://github.com/dash0hq/dash0-operator/tree/main/images/configreloader
           context: images
           file: images/configreloader/Dockerfile
@@ -254,7 +254,7 @@ jobs:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           imageName: filelog-offset-synch
           imageTitle: Dash0 Kubernetes Filelog Offset Synch
-          imageDescription: the filelog offset synch for the Dash0 Kubernetes operator
+          imageDescription: the filelog offset synch for the Dash0 operator for Kubernetes
           imageUrl: https://github.com/dash0hq/dash0-operator/tree/main
           context: images
           file: images/filelogoffsetsynch/Dockerfile

--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ It also supports scraping Prometheus endpoints exposed by pods according to the 
 
 For more information on how the Dash0 operator scrapes Prometheus endpoints exposed by your applications, see the [Scraping Prometheus endpoints](https://artifacthub.io/packages/helm/dash0-operator/dash0-operator#scraping-prometheus-endpoints) section of the Dash0 operator Helm chart documentation.
 
+### Logs
+
+The Dash0 operator automatically collects pod logs from the pods that it monitors.
+
+For more information on how to have pods monitored by the Dash0 operator, see the [Enable Dash0 Monitoring For a Namespace](https://artifacthub.io/packages/helm/dash0-operator/dash0-operator#enable-dash0-monitoring-for-a-namespace) section of the Dash0 operator Helm chart documentation.
+
 ### Alerting
 
 The Dash0 operator supports the [`PrometheusRule` custom resource definition](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.PrometheusRule) defined by the Prometheus operator.

--- a/README.md
+++ b/README.md
@@ -1,22 +1,45 @@
-# Dash0 Kubernetes Operator
+# Dash0 Operator
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/dash0-operator)](https://artifacthub.io/packages/search?repo=dash0-operator)
 
-The Dash0 Kubernetes Operator makes observability for Kubernetes _easy_.
+The Dash0 Operator makes observability for Kubernetes _easy_.
 Install the operator into your cluster and create a Dash0 monitoring resource to get OpenTelemetry data flowing from your applications and
 infrastructure to Dash0.
 
+The Dash0 operator is currently available as a technical preview.
+
 ## Description
 
-The Dash0 Kubernetes operator enables gathering OpenTelemetry data from your workloads for a selection of supported
+The Dash0 operator enables gathering OpenTelemetry data from your workloads for a selection of supported
 runtimes, automatic log collection and metrics.
 
-The Dash0 Kubernetes operator is currently available as a technical preview.
+### Distributed tracing
 
-Supported runtimes:
+Auto-instrumentation if supported for the following runtimes:
 
-* Node.js 18 and beyond
+* Node.js 18 and beyond, using [Dash0 Node.js OpenTelemetry Distribution](https://github.com/dash0hq/opentelemetry-js-distribution)
+
+For more information on how the Dash0 operator automatically traces your applications, see the [Automatic Workload Instrumentation](https://artifacthub.io/packages/helm/dash0-operator/dash0-operator#automatic-workload-instrumentation) section of the Dash0 operator Helm chart documentation.
+
+### Metrics
+
+The Dash0 operator automatically collects cluster- and workload-related metrics, like node and pod cpu and memory usage.
+It also supports scraping Prometheus endpoints exposed by pods according to the `prometheus.io/*` annotations defined by the Prometheus Helm chart:
+
+For more information on how the Dash0 operator scrapes Prometheus endpoints exposed by your applications, see the [Scraping Prometheus endpoints](https://artifacthub.io/packages/helm/dash0-operator/dash0-operator#scraping-prometheus-endpoints) section of the Dash0 operator Helm chart documentation.
+
+### Alerting
+
+The Dash0 operator supports the [`PrometheusRule` custom resource definition](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.PrometheusRule) defined by the Prometheus operator.
+The alert rules specified in `PrometheusRule` custom resources are used to create [check rules](https://www.dash0.com/documentation/dash0/alerting/check-rules) in Dash0.
+
+For more information on how the Dash0 operator creates check rules based on `PrometheusRule` resources, consult the [Managing Dash0 Check Rules](https://artifacthub.io/packages/helm/dash0-operator/dash0-operator#managing-dash0-check-rules) section of the Dash0 operator Helm chart documentation.
+
+### Dashboards
+
+The Dash0 operator supports the `PersesDashboard` custom resource definition defined by the [Perses operator](https://github.com/perses/perses-operator).
+The Perses dashboards specified in `PersesDashboard` custom resources are used to create [dashboards](https://www.dash0.com/documentation/dash0/dashboards) in Dash0.
 
 ## Getting Started
 

--- a/api/dash0monitoring/v1alpha1/dash0monitoring_types.go
+++ b/api/dash0monitoring/v1alpha1/dash0monitoring_types.go
@@ -43,7 +43,7 @@ type Dash0MonitoringSpec struct {
 	// * instrument existing workloads in the target namespace (i.e. workloads already running in the namespace) when
 	//   the Dash0 monitoring resource is deployed,
 	// * instrument existing workloads or update the instrumentation of already instrumented workloads in the target
-	//   namespace when the Dash0 Kubernetes operator is first started or restarted (for example when updating the
+	//   namespace when the Dash0 operator is first started or restarted (for example when updating the
 	//   operator),
 	// * instrument new workloads in the target namespace when they are deployed, and
 	// * instrument changed workloads in the target namespace when changes are applied to them.
@@ -55,7 +55,7 @@ type Dash0MonitoringSpec struct {
 	// * instrument new workloads in the target namespace when they are deployed, and
 	// * instrument changed workloads in the target namespace when changes are applied to them.
 	// This setting is useful if you want to avoid pod restarts as a side effect of deploying the Dash0 monitoring
-	// resource or restarting the Dash0 Kubernetes operator.
+	// resource or restarting the Dash0 operator.
 	//
 	// You can opt out of instrumenting workloads entirely by setting this option to `none`. With
 	// `instrumentWorkloads: none`, workloads in the target namespace will never be instrumented to send telemetry to

--- a/api/dash0monitoring/v1alpha1/operator_configuration_types.go
+++ b/api/dash0monitoring/v1alpha1/operator_configuration_types.go
@@ -13,7 +13,7 @@ import (
 	dash0common "github.com/dash0hq/dash0-operator/api/dash0monitoring"
 )
 
-// Dash0OperatorConfigurationSpec describes cluster-wide configuration settings for the Dash0 Kubernetes operator.
+// Dash0OperatorConfigurationSpec describes cluster-wide configuration settings for the Dash0 operator.
 type Dash0OperatorConfigurationSpec struct {
 	// The configuration of the default observability backend to which telemetry data will be sent by the operator, as
 	// well as the backend that will receive the operator's self-monitoring data. This property is mandatory.

--- a/config/crd/bases/operator.dash0.com_dash0monitorings.yaml
+++ b/config/crd/bases/operator.dash0.com_dash0monitorings.yaml
@@ -193,7 +193,7 @@ spec:
                   * instrument existing workloads in the target namespace (i.e. workloads already running in the namespace) when
                     the Dash0 monitoring resource is deployed,
                   * instrument existing workloads or update the instrumentation of already instrumented workloads in the target
-                    namespace when the Dash0 Kubernetes operator is first started or restarted (for example when updating the
+                    namespace when the Dash0 operator is first started or restarted (for example when updating the
                     operator),
                   * instrument new workloads in the target namespace when they are deployed, and
                   * instrument changed workloads in the target namespace when changes are applied to them.
@@ -206,7 +206,7 @@ spec:
                   * instrument new workloads in the target namespace when they are deployed, and
                   * instrument changed workloads in the target namespace when changes are applied to them.
                   This setting is useful if you want to avoid pod restarts as a side effect of deploying the Dash0 monitoring
-                  resource or restarting the Dash0 Kubernetes operator.
+                  resource or restarting the Dash0 operator.
 
 
                   You can opt out of instrumenting workloads entirely by setting this option to `none`. With

--- a/config/crd/bases/operator.dash0.com_dash0operatorconfigurations.yaml
+++ b/config/crd/bases/operator.dash0.com_dash0operatorconfigurations.yaml
@@ -39,7 +39,7 @@ spec:
             type: object
           spec:
             description: Dash0OperatorConfigurationSpec describes cluster-wide configuration
-              settings for the Dash0 Kubernetes operator.
+              settings for the Dash0 operator.
             properties:
               export:
                 description: |-

--- a/helm-chart/dash0-operator/Chart.yaml
+++ b/helm-chart/dash0-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: dash0-operator
 version: "0.0.0" # note: will be replaced when building a release
-description: The Dash0 Kubernetes Operator makes observability easy for every Kubernetes setup, simply install the operator into your cluster to get OpenTelemetry data flowing from your applications and infrastructure to Dash0.
+description: The Dash0 Operator makes observability easy for every Kubernetes setup, simply install the operator into your cluster to get OpenTelemetry data flowing from your applications and infrastructure to Dash0.
 type: application
 keywords:
   - OpenTelemetry

--- a/helm-chart/dash0-operator/README.md
+++ b/helm-chart/dash0-operator/README.md
@@ -1,21 +1,21 @@
-# Dash0 Kubernetes Operator Helm Chart
+# Dash0 Operator Helm Chart
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/dash0-operator)](https://artifacthub.io/packages/search?repo=dash0-operator)
 
-This repository contains the [Helm](https://helm.sh/) chart for the Dash0 Kubernetes operator.
+This repository contains the [Helm](https://helm.sh/) chart for the Dash0 operator.
 
-The Dash0 Kubernetes Operator makes observability for Kubernetes _easy_.
+The Dash0 Operator makes observability for Kubernetes _easy_.
 Simply install the operator into your cluster to get OpenTelemetry data flowing from your Kubernetes workloads to Dash0.
 
 ## Description
 
-The Dash0 Kubernetes operator installs an OpenTelemetry collector into your cluster that sends data to your Dash0
+The Dash0 operator installs an OpenTelemetry collector into your cluster that sends data to your Dash0
 ingress endpoint, with authentication already configured out of the box. Additionally, it will enable gathering
 OpenTelemetry data from applications deployed to the cluster for a selection of supported runtimes, plus automatic log
 collection and metrics.
 
-The Dash0 Kubernetes operator is currently available as a technical preview.
+The Dash0 operator is currently available as a technical preview.
 
 ## Supported Runtimes
 
@@ -237,7 +237,7 @@ The Dash0 monitoring resource supports additional configuration settings:
       * instrument existing workloads in the target namespace (i.e. workloads already running in the namespace) when
         the Dash0 monitoring resource is deployed,
       * instrument existing workloads or update the instrumentation of already instrumented workloads in the target
-        namespace when the Dash0 Kubernetes operator is first started or restarted (for example when updating the
+        namespace when the Dash0 operator is first started or restarted (for example when updating the
         operator),
       * instrument new workloads in the target namespace when they are deployed, and
       * instrument changed workloads in the target namespace when changes are applied to them.
@@ -250,7 +250,7 @@ The Dash0 monitoring resource supports additional configuration settings:
       * instrument new workloads in the target namespace when they are deployed, and
       * instrument changed workloads in the target namespace when changes are applied to them.
         This setting is useful if you want to avoid pod restarts as a side effect of deploying the Dash0 monitoring
-        resource or restarting the Dash0 Kubernetes operator.
+        resource or restarting the Dash0 operator.
 
   * `none`: You can opt out of instrumenting workloads entirely by setting this option to `none`.
      With `spec.instrumentWorkloads: none`, workloads in the target namespace will never be instrumented to send
@@ -278,13 +278,13 @@ The Dash0 monitoring resource supports additional configuration settings:
 * `spec.synchronizePersesDashboards`: A namespace-wide opt-out for synchronizing Perses dashboard resources found in the
   target namespace. If enabled, the operator will watch Perses dashboard resources in this namespace and create
   corresponding dashboards in Dash0 via the Dash0 API.
-  See https://github.com/dash0hq/dash0-operator/blob/main/helm-chart/dash0-operator/README.md#managing-dash0-dashboards-with-the-operator
+  See https://github.com/dash0hq/dash0-operator/blob/main/helm-chart/dash0-operator/README.md#managing-dash0-dashboards
   for details. This setting is optional, it defaults to true.
 
 * `spec.synchronizePrometheusRules`: A namespace-wide opt-out for synchronizing Prometheus rule resources found in the
   target namespace. If enabled, the operator will watch Prometheus rule resources in this namespace and create
   corresponding check rules in Dash0 via the Dash0 API.
-  See https://github.com/dash0hq/dash0-operator/blob/main/helm-chart/dash0-operator/README.md#managing-dash0-check-rules-with-the-operator
+  See https://github.com/dash0hq/dash0-operator/blob/main/helm-chart/dash0-operator/README.md#managing-dash0-check-rules
   for details. This setting is optional, it defaults to true.
 
 * `spec.prometheusScrapingEnabled`: A namespace-wide opt-out for Prometheus scraping for the target namespace.
@@ -510,7 +510,7 @@ This restriction will be lifted once exporting telemetry to different backends p
 
 ## Disable Self-Monitoring
 
-By default, self-monitoring is enabled for the Dash0 Kubernetes operator as soon as you deploy a Das0 operator
+By default, self-monitoring is enabled for the Dash0 operator as soon as you deploy a Das0 operator
 configuration resource with an export.
 That means, the operator will send self-monitoring telemetry to the Dash0 Insights dataset of the configured backend.
 Disabling self-monitoring is available as a setting on the Dash0 operator configuration resource.
@@ -548,7 +548,7 @@ kubectl delete --namespace my-nodejs-applications -f dash0-monitoring.yaml
 
 ## Upgrading
 
-To upgrade the Dash0 Kubernetes Operator to a newer version, run the following commands:
+To upgrade the Dash0 Operator to a newer version, run the following commands:
 
 ```console
 helm repo update dash0-operator
@@ -557,7 +557,7 @@ helm upgrade --namespace dash0-system dash0-operator dash0-operator/dash0-operat
 
 ## Uninstallation
 
-To remove the Dash0 Kubernetes Operator from your cluster, run the following command:
+To remove the Dash0 Operator from your cluster, run the following command:
 
 ```
 helm uninstall dash0-operator --namespace dash0-system
@@ -623,9 +623,24 @@ tracing data from all Node.js workloads.
 If you are curious, the source code for the injector is open source and can be found
 [here](https://github.com/dash0hq/dash0-operator/blob/main/images/instrumentation/injector/src/dash0_injector.c).
 
-## Managing Dash0 Dashboards with the Operator
+## Scraping Prometheus endpoints
 
-You can manage your Dash0 dashboards via the Dash0 Kubernetes operator.
+The Dash0 operator automatically scrapes Prometheus endpoints on pods labelled with the `prometheus.io/*` annotations as defined by the [Prometheus Helm chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus#scraping-pod-metrics-via-annotations).
+
+The supported annotations are:
+* `prometheus.io/scrape`: Only scrape pods that have a value of `true`, except if `prometheus.io/scrape-slow` is set to `true` as well. Endpoints on pods annotated with this annotation are scraped every minute, i.e., scrape interval is 1 minute, unless `prometheus.io/scrape-slow` is also set to `true`.
+* `prometheus.io/scrape-slow`: If set to `true`, enables scraping for the pod with scrape interval of 5 minutes. If both `prometheus.io/scrape` and `prometheus.io/scrape-slow` are annotated on a pod with both values set to `true`, the pod will be scraped every 5 minutes.
+* `prometheus.io/scheme`: If the metrics endpoint is secured then you will need to set this to `https`.
+* `prometheus.io/path`: Override the metrics endpoint path if it is not the default `/metrics`.
+* `prometheus.io/port`: Override the metrics endpoint port if it is not the default `9102`.
+
+To be scraped, a pod annotated with the `prometheus.io/scrape` or `prometheus.io/scrape-slow` annotations must belong to namespaces that are configured to be monitored by the Dash0 operator (see [Enable Dash0 Monitoring For a Namespace](#enable-dash0-monitoring-for-a-namespace) section).
+
+The scraping of a pod from is executed from the same Kubernetes node as the pod's.
+
+## Managing Dash0 Dashboards
+
+You can manage your Dash0 dashboards via the Dash0 operator.
 
 Pre-requisites for this feature:
 * A Dash0 operator configuration resource has to be installed in the cluster.
@@ -669,9 +684,9 @@ Perses Dashboard Synchronization Results:
     Synchronized At:            2024-10-25T12:02:12Z
 ```
 
-## Managing Dash0 Check Rules with the Operator
+## Managing Dash0 Check Rules
 
-You can manage your Dash0 check rules via the Dash0 Kubernetes operator.
+You can manage your Dash0 check rules via the Dash0 operator.
 
 Pre-requisites for this feature:
 * A Dash0 operator configuration resource has to be installed in the cluster.

--- a/helm-chart/dash0-operator/templates/NOTES.txt
+++ b/helm-chart/dash0-operator/templates/NOTES.txt
@@ -1,7 +1,7 @@
 {{- if .Release.IsInstall }}
-The Dash0 Kubernetes operator has been installed successfully from the chart {{ .Chart.Name }}.
+The Dash0 operator has been installed successfully from the chart {{ .Chart.Name }}.
 {{- else }}
-The Dash0 Kubernetes operator has been upgraded successfully from the chart {{ .Chart.Name }}.
+The Dash0 operator has been upgraded successfully from the chart {{ .Chart.Name }}.
 {{- end }}
 * Helm release name: {{ .Release.Name | quote }}
-* Dash0 Kubernetes operator namespace: {{ .Release.Namespace | quote }}
+* Dash0 operator namespace: {{ .Release.Namespace | quote }}

--- a/helm-chart/dash0-operator/templates/operator/custom-resource-definition-monitoring.yaml
+++ b/helm-chart/dash0-operator/templates/operator/custom-resource-definition-monitoring.yaml
@@ -193,7 +193,7 @@ spec:
                   * instrument existing workloads in the target namespace (i.e. workloads already running in the namespace) when
                     the Dash0 monitoring resource is deployed,
                   * instrument existing workloads or update the instrumentation of already instrumented workloads in the target
-                    namespace when the Dash0 Kubernetes operator is first started or restarted (for example when updating the
+                    namespace when the Dash0 operator is first started or restarted (for example when updating the
                     operator),
                   * instrument new workloads in the target namespace when they are deployed, and
                   * instrument changed workloads in the target namespace when changes are applied to them.
@@ -206,7 +206,7 @@ spec:
                   * instrument new workloads in the target namespace when they are deployed, and
                   * instrument changed workloads in the target namespace when changes are applied to them.
                   This setting is useful if you want to avoid pod restarts as a side effect of deploying the Dash0 monitoring
-                  resource or restarting the Dash0 Kubernetes operator.
+                  resource or restarting the Dash0 operator.
 
 
                   You can opt out of instrumenting workloads entirely by setting this option to `none`. With

--- a/helm-chart/dash0-operator/templates/operator/custom-resource-definition-operator-configuration.yaml
+++ b/helm-chart/dash0-operator/templates/operator/custom-resource-definition-operator-configuration.yaml
@@ -39,7 +39,7 @@ spec:
             type: object
           spec:
             description: Dash0OperatorConfigurationSpec describes cluster-wide configuration
-              settings for the Dash0 Kubernetes operator.
+              settings for the Dash0 operator.
             properties:
               export:
                 description: |-

--- a/helm-chart/dash0-operator/tests/operator/__snapshot__/custom-resource-definition-monitoring_test.yaml.snap
+++ b/helm-chart/dash0-operator/tests/operator/__snapshot__/custom-resource-definition-monitoring_test.yaml.snap
@@ -181,7 +181,7 @@ custom resource definition should match snapshot:
                         * instrument existing workloads in the target namespace (i.e. workloads already running in the namespace) when
                           the Dash0 monitoring resource is deployed,
                         * instrument existing workloads or update the instrumentation of already instrumented workloads in the target
-                          namespace when the Dash0 Kubernetes operator is first started or restarted (for example when updating the
+                          namespace when the Dash0 operator is first started or restarted (for example when updating the
                           operator),
                         * instrument new workloads in the target namespace when they are deployed, and
                         * instrument changed workloads in the target namespace when changes are applied to them.
@@ -194,7 +194,7 @@ custom resource definition should match snapshot:
                         * instrument new workloads in the target namespace when they are deployed, and
                         * instrument changed workloads in the target namespace when changes are applied to them.
                         This setting is useful if you want to avoid pod restarts as a side effect of deploying the Dash0 monitoring
-                        resource or restarting the Dash0 Kubernetes operator.
+                        resource or restarting the Dash0 operator.
 
 
                         You can opt out of instrumenting workloads entirely by setting this option to `none`. With

--- a/helm-chart/dash0-operator/tests/operator/__snapshot__/custom-resource-definition-operator-configuration_test.yaml.snap
+++ b/helm-chart/dash0-operator/tests/operator/__snapshot__/custom-resource-definition-operator-configuration_test.yaml.snap
@@ -38,7 +38,7 @@ custom resource definition should match snapshot:
                 metadata:
                   type: object
                 spec:
-                  description: Dash0OperatorConfigurationSpec describes cluster-wide configuration settings for the Dash0 Kubernetes operator.
+                  description: Dash0OperatorConfigurationSpec describes cluster-wide configuration settings for the Dash0 operator.
                   properties:
                     export:
                       description: |-

--- a/helm-chart/dash0-operator/values.yaml
+++ b/helm-chart/dash0-operator/values.yaml
@@ -1,4 +1,4 @@
-# This file contains the default values for the Dash0 Kubernetes Operator Helm chart.
+# This file contains the default values for the Dash0 Operator Helm chart.
 # Values can be overriden via --set or by providing additional yaml files when running helm install.
 
 # settings for the operator/controller

--- a/images/collector/src/builder/config.yaml
+++ b/images/collector/src/builder/config.yaml
@@ -1,7 +1,7 @@
 dist:
   module: github.com/dash0hq/dash0-operator
   name: dash0-operator-collector
-  description: OpenTelemetry collector managed by the Dash0 Kubernetes operator
+  description: OpenTelemetry collector managed by the Dash0 operator
   otelcol_version: "0.111.0"
   version: "dash0"
   output_path: dist

--- a/internal/predelete/operator_pre_delete_handler_test.go
+++ b/internal/predelete/operator_pre_delete_handler_test.go
@@ -39,7 +39,7 @@ var (
 	}
 )
 
-var _ = Describe("Uninstalling the Dash0 Kubernetes operator", Ordered, func() {
+var _ = Describe("Uninstalling the Dash0 operator", Ordered, func() {
 
 	ctx := context.Background()
 	var (

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -15,5 +15,5 @@ import (
 func TestE2E(t *testing.T) {
 	RegisterFailHandler(Fail)
 	_, _ = fmt.Fprint(GinkgoWriter, "Starting dash0-operator suite\n")
-	RunSpecs(t, "Dash0 Kubernetes operator end-to-end test suite")
+	RunSpecs(t, "Dash0 operator end-to-end test suite")
 }

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -31,7 +31,7 @@ var (
 	workingDir string
 )
 
-var _ = Describe("Dash0 Kubernetes Operator", Ordered, func() {
+var _ = Describe("Dash0 Operator", Ordered, func() {
 
 	BeforeAll(func() {
 		// Do not truncate string diff output.


### PR DESCRIPTION
1. Add overview of the capailities in main README
2. Document prometheus.io/* annotation support in Helm chart docs
3. Harmonize naming to "Dash0 operator", as "Dash0 Kubernetes operator" is redundant in the context people are looking the operator up