### PR TITLE
fix(dashboards): avoid validation error for Dash0FilterVariable

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -77,7 +77,6 @@ jobs:
           # Get the last successful commit on main branch (actually, on the target branch for the PR, but that is
           # usually main).
           main-branch-name: ${{ steps.branch-name.outputs.base_ref_branch }}
-          workflow_id: 'ci.yml'
 
       # We use the changed-files action to potentially skip the injector & instrumentation tests on PRs that contain no
       # changes for the instrumentation image. This is because running the tests requires to build the instrumentation

--- a/internal/controller/prometheus_rules_controller_test.go
+++ b/internal/controller/prometheus_rules_controller_test.go
@@ -5,6 +5,7 @@ package controller
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -12,6 +13,7 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -255,8 +257,8 @@ var _ = Describe("The Prometheus rule controller", Ordered, func() {
 			ruleResource := createDefaultRuleResource()
 			prometheusRuleReconciler.Create(
 				ctx,
-				event.TypedCreateEvent[client.Object]{
-					Object: ruleResource,
+				event.TypedCreateEvent[*unstructured.Unstructured]{
+					Object: &ruleResource,
 				},
 				&controllertest.TypedQueue[reconcile.Request]{},
 			)
@@ -275,8 +277,8 @@ var _ = Describe("The Prometheus rule controller", Ordered, func() {
 			ruleResource := createDefaultRuleResource()
 			prometheusRuleReconciler.Create(
 				ctx,
-				event.TypedCreateEvent[client.Object]{
-					Object: ruleResource,
+				event.TypedCreateEvent[*unstructured.Unstructured]{
+					Object: &ruleResource,
 				},
 				&controllertest.TypedQueue[reconcile.Request]{},
 			)
@@ -296,8 +298,8 @@ var _ = Describe("The Prometheus rule controller", Ordered, func() {
 			ruleResource := createDefaultRuleResource()
 			prometheusRuleReconciler.Create(
 				ctx,
-				event.TypedCreateEvent[client.Object]{
-					Object: ruleResource,
+				event.TypedCreateEvent[*unstructured.Unstructured]{
+					Object: &ruleResource,
 				},
 				&controllertest.TypedQueue[reconcile.Request]{},
 			)
@@ -315,8 +317,8 @@ var _ = Describe("The Prometheus rule controller", Ordered, func() {
 			ruleResource := createDefaultRuleResource()
 			prometheusRuleReconciler.Create(
 				ctx,
-				event.TypedCreateEvent[client.Object]{
-					Object: ruleResource,
+				event.TypedCreateEvent[*unstructured.Unstructured]{
+					Object: &ruleResource,
 				},
 				&controllertest.TypedQueue[reconcile.Request]{},
 			)
@@ -338,8 +340,8 @@ var _ = Describe("The Prometheus rule controller", Ordered, func() {
 			ruleResource := createDefaultRuleResource()
 			prometheusRuleReconciler.Update(
 				ctx,
-				event.TypedUpdateEvent[client.Object]{
-					ObjectNew: ruleResource,
+				event.TypedUpdateEvent[*unstructured.Unstructured]{
+					ObjectNew: &ruleResource,
 				},
 				&controllertest.TypedQueue[reconcile.Request]{},
 			)
@@ -361,8 +363,8 @@ var _ = Describe("The Prometheus rule controller", Ordered, func() {
 			ruleResource := createDefaultRuleResource()
 			prometheusRuleReconciler.Delete(
 				ctx,
-				event.TypedDeleteEvent[client.Object]{
-					Object: ruleResource,
+				event.TypedDeleteEvent[*unstructured.Unstructured]{
+					Object: &ruleResource,
 				},
 				&controllertest.TypedQueue[reconcile.Request]{},
 			)
@@ -453,8 +455,8 @@ var _ = Describe("The Prometheus rule controller", Ordered, func() {
 				})
 			prometheusRuleReconciler.Create(
 				ctx,
-				event.TypedCreateEvent[client.Object]{
-					Object: ruleResource,
+				event.TypedCreateEvent[*unstructured.Unstructured]{
+					Object: &ruleResource,
 				},
 				&controllertest.TypedQueue[reconcile.Request]{},
 			)
@@ -546,8 +548,8 @@ var _ = Describe("The Prometheus rule controller", Ordered, func() {
 				})
 			prometheusRuleReconciler.Create(
 				ctx,
-				event.TypedCreateEvent[client.Object]{
-					Object: ruleResource,
+				event.TypedCreateEvent[*unstructured.Unstructured]{
+					Object: &ruleResource,
 				},
 				&controllertest.TypedQueue[reconcile.Request]{},
 			)
@@ -981,12 +983,12 @@ func expectRuleDeleteRequests(expectedPaths []string) {
 	}
 }
 
-func createDefaultRuleResource() *prometheusv1.PrometheusRule {
+func createDefaultRuleResource() unstructured.Unstructured {
 	return createRuleResource(createDefaultSpec())
 }
 
-func createRuleResource(spec prometheusv1.PrometheusRuleSpec) *prometheusv1.PrometheusRule {
-	return &prometheusv1.PrometheusRule{
+func createRuleResource(spec prometheusv1.PrometheusRuleSpec) unstructured.Unstructured {
+	rule := prometheusv1.PrometheusRule{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "monitoring.coreos.com/v1",
 			Kind:       "PrometheusRule",
@@ -997,6 +999,12 @@ func createRuleResource(spec prometheusv1.PrometheusRuleSpec) *prometheusv1.Prom
 		},
 		Spec: spec,
 	}
+	marshalled, err := json.Marshal(rule)
+	Expect(err).NotTo(HaveOccurred())
+	unstructuredObject := unstructured.Unstructured{}
+	err = json.Unmarshal(marshalled, &unstructuredObject)
+	Expect(err).NotTo(HaveOccurred())
+	return unstructuredObject
 }
 
 func createDefaultSpec() prometheusv1.PrometheusRuleSpec {

--- a/test-resources/customresources/persesdashboard/persesdashboard.yaml
+++ b/test-resources/customresources/persesdashboard/persesdashboard.yaml
@@ -55,6 +55,17 @@ spec:
         name: text
         value: test
         constant: true
+    - kind: Dash0FilterVariable
+      spec:
+        attributeKey: cloud_region
+        capturingRegexp: ""
+        display:
+          description: ""
+          hidden: false
+          name: cloud region
+        name: cloud_region
+        operator: is_not_set
+        values: []
   panels:
     defaultTimeSeriesChart:
       kind: Panel


### PR DESCRIPTION
Fixed by moving back from using the actual type
(&persesv1alpha1.PersesDashboard{}, &prometheusv1.PrometheusRule{}) when creating the watch, to watching for *unstructured.Unstructured with group/version/kind attributes. We cannot watch for the specific third-party resource type directly since when we do that, the validation for the resource in question would be triggered before the resource is handed over to the event handler.

This validation potentially fails for dashboards, because Dash0 dashboards allow variable types (like Dash0FilterVariable) that plain vanilla Perses dashboards do not support, and the following validation error is triggered:
reflector.go:158] "Unhandled Error"
err="pkg/mod/k8s.io/client-go@v0.31.2/tools/cache/reflector.go:243: Failed to watch *v1alpha1.PersesDashboard: failed to list *v1alpha1.PersesDashboard: unknown variable.kind