### PR TITLE
fix(controller): reconcile collector from operator configuration

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -198,7 +198,8 @@ More information can be found via the [Kubebuilder Documentation](https://book.k
 When a new release of the operator changes the instrumentation values (new or changed environment variables, new labels,
 new volumes etc.), we need to make sure that previously instrumented workloads are updated correctly. This should always
 be accompanied by corresponding tests (for example new test cases in `workload_modifier_test.go`, see the test suite
-`"when updating instrumentation from 0.5.1 to 0.6.0"` for an example).
+`"when updating instrumentation from 0.5.1 to 0.6.0"` in commit 300a765a64a42d98dcc6d9a66dccc534b610ab65 for an
+example).
 
 ## Contributing
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -47,7 +47,6 @@ import (
 	"github.com/dash0hq/dash0-operator/internal/startup"
 	"github.com/dash0hq/dash0-operator/internal/util"
 	"github.com/dash0hq/dash0-operator/internal/webhooks"
-	//+kubebuilder:scaffold:imports
 )
 
 type environmentVariables struct {
@@ -638,11 +637,13 @@ func startDash0Controllers(
 			persesDashboardCrdReconciler,
 			prometheusRuleCrdReconciler,
 		},
-		Scheme:                  mgr.GetScheme(),
-		Recorder:                mgr.GetEventRecorderFor("dash0-operator-configuration-controller"),
-		DeploymentSelfReference: deploymentSelfReference,
-		Images:                  images,
-		DevelopmentMode:         developmentMode,
+		Scheme:                   mgr.GetScheme(),
+		Recorder:                 mgr.GetEventRecorderFor("dash0-operator-configuration-controller"),
+		BackendConnectionManager: backendConnectionManager,
+		DeploymentSelfReference:  deploymentSelfReference,
+		Images:                   images,
+		OperatorNamespace:        envVars.operatorNamespace,
+		DevelopmentMode:          developmentMode,
 	}
 	if err := operatorConfigurationReconciler.SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("unable to set up the operator configuration reconciler: %w", err)

--- a/internal/backendconnection/backendconnection_manager.go
+++ b/internal/backendconnection/backendconnection_manager.go
@@ -5,7 +5,6 @@ package backendconnection
 
 import (
 	"context"
-	"fmt"
 	"sync/atomic"
 
 	"github.com/go-logr/logr"
@@ -31,8 +30,8 @@ type BackendConnectionManager struct {
 type BackendConnectionReconcileTrigger string
 
 const (
-	TriggeredByWatchEvent         BackendConnectionReconcileTrigger = "watch"
-	TriggeredByMonitoringResource BackendConnectionReconcileTrigger = "resource"
+	TriggeredByWatchEvent             BackendConnectionReconcileTrigger = "watch"
+	TriggeredByDash0ResourceReconcile BackendConnectionReconcileTrigger = "resource"
 )
 
 func (m *BackendConnectionManager) ReconcileOpenTelemetryCollector(
@@ -49,7 +48,7 @@ func (m *BackendConnectionManager) ReconcileOpenTelemetryCollector(
 				logger.Info("OpenTelemetry collector resources have already been deleted, ignoring reconciliation request.")
 			}
 			return nil
-		} else if trigger == TriggeredByMonitoringResource {
+		} else if trigger == TriggeredByDash0ResourceReconcile {
 			if m.DevelopmentMode {
 				logger.Info("resetting resourcesHaveBeenDeletedByOperator")
 			}
@@ -162,12 +161,6 @@ func (m *BackendConnectionManager) removeOpenTelemetryCollector(
 	operatorNamespace string,
 	logger *logr.Logger,
 ) error {
-	logger.Info(
-		fmt.Sprintf(
-			"Deleting the OpenTelemetry collector Kuberenetes resources in the Dash0 operator namespace %s.",
-			operatorNamespace,
-		))
-
 	if err := m.OTelColResourceManager.DeleteResources(
 		ctx,
 		operatorNamespace,

--- a/internal/backendconnection/backendconnection_manager_test.go
+++ b/internal/backendconnection/backendconnection_manager_test.go
@@ -88,7 +88,7 @@ var _ = Describe("The backend connection manager", Ordered, func() {
 						},
 					},
 				},
-				TriggeredByMonitoringResource,
+				TriggeredByDash0ResourceReconcile,
 			)
 			Expect(err).To(MatchError(
 				"cannot assemble the exporters for the configuration: no endpoint provided for the Dash0 exporter, unable to create the OpenTelemetry collector"))
@@ -110,7 +110,7 @@ var _ = Describe("The backend connection manager", Ordered, func() {
 						},
 					},
 				},
-				TriggeredByMonitoringResource,
+				TriggeredByDash0ResourceReconcile,
 			)
 			Expect(err).To(MatchError(
 				"neither token nor secretRef provided for the Dash0 exporter"))
@@ -138,7 +138,7 @@ var _ = Describe("The backend connection manager", Ordered, func() {
 			)
 			Expect(err).ToNot(HaveOccurred())
 
-			DeleteOperatorConfigurationResource(ctx, k8sClient)
+			DeleteAllOperatorConfigurationResources(ctx, k8sClient)
 		})
 
 		It("should create all resources", func() {
@@ -147,7 +147,7 @@ var _ = Describe("The backend connection manager", Ordered, func() {
 				TestImages,
 				operatorNamespace,
 				assembleMonitoringResource(),
-				TriggeredByMonitoringResource,
+				TriggeredByDash0ResourceReconcile,
 			)
 			Expect(err).ToNot(HaveOccurred())
 			VerifyCollectorResources(ctx, k8sClient, operatorNamespace)
@@ -165,7 +165,7 @@ var _ = Describe("The backend connection manager", Ordered, func() {
 				&dash0v1alpha1.Dash0Monitoring{
 					Spec: dash0v1alpha1.Dash0MonitoringSpec{},
 				},
-				TriggeredByMonitoringResource,
+				TriggeredByDash0ResourceReconcile,
 			)
 			Expect(err).ToNot(HaveOccurred())
 			VerifyCollectorResources(ctx, k8sClient, operatorNamespace)
@@ -179,7 +179,7 @@ var _ = Describe("The backend connection manager", Ordered, func() {
 				&dash0v1alpha1.Dash0Monitoring{
 					Spec: dash0v1alpha1.Dash0MonitoringSpec{},
 				},
-				TriggeredByMonitoringResource,
+				TriggeredByDash0ResourceReconcile,
 			)
 			Expect(err).To(
 				MatchError(
@@ -202,7 +202,7 @@ var _ = Describe("The backend connection manager", Ordered, func() {
 				&dash0v1alpha1.Dash0Monitoring{
 					Spec: dash0v1alpha1.Dash0MonitoringSpec{},
 				},
-				TriggeredByMonitoringResource,
+				TriggeredByDash0ResourceReconcile,
 			)
 			Expect(err).To(MatchError("the provided Dash0Monitoring resource does not have an export configuration " +
 				"and the Dash0OperatorConfiguration resource does not have one either"))
@@ -245,7 +245,7 @@ var _ = Describe("The backend connection manager", Ordered, func() {
 				TestImages,
 				operatorNamespace,
 				assembleMonitoringResource(),
-				TriggeredByMonitoringResource,
+				TriggeredByDash0ResourceReconcile,
 			)
 			Expect(err).ToNot(HaveOccurred())
 			VerifyCollectorResources(ctx, k8sClient, operatorNamespace)
@@ -283,7 +283,7 @@ var _ = Describe("The backend connection manager", Ordered, func() {
 				TestImages,
 				operatorNamespace,
 				secondDash0MonitoringResource,
-				TriggeredByMonitoringResource,
+				TriggeredByDash0ResourceReconcile,
 			)
 			Expect(err).ToNot(HaveOccurred())
 			VerifyCollectorResources(ctx, k8sClient, operatorNamespace)
@@ -310,7 +310,7 @@ var _ = Describe("The backend connection manager", Ordered, func() {
 				TestImages,
 				operatorNamespace,
 				existingDash0MonitoringResource,
-				TriggeredByMonitoringResource,
+				TriggeredByDash0ResourceReconcile,
 			)
 			Expect(err).ToNot(HaveOccurred())
 			VerifyCollectorResources(ctx, k8sClient, operatorNamespace)
@@ -355,7 +355,7 @@ var _ = Describe("The backend connection manager", Ordered, func() {
 				TestImages,
 				operatorNamespace,
 				monitoringResource,
-				TriggeredByMonitoringResource,
+				TriggeredByDash0ResourceReconcile,
 			)
 			Expect(err).ToNot(HaveOccurred())
 			VerifyCollectorResources(ctx, k8sClient, operatorNamespace)
@@ -382,7 +382,7 @@ var _ = Describe("The backend connection manager", Ordered, func() {
 				TestImages,
 				operatorNamespace,
 				resource,
-				TriggeredByMonitoringResource,
+				TriggeredByDash0ResourceReconcile,
 			)
 			Expect(err).ToNot(HaveOccurred())
 			VerifyCollectorResources(ctx, k8sClient, operatorNamespace)

--- a/internal/backendconnection/otelcolresources/desired_state.go
+++ b/internal/backendconnection/otelcolresources/desired_state.go
@@ -987,6 +987,9 @@ func assembleDeploymentCollectorContainer(
 	return collectorContainer, nil
 }
 
+// Maintenance note: Names for Kubernetes objects _must_ be unique, otherwise the logic in
+// otelcol_resources.go#deleteResourcesThatAreNoLongerDesired does not work correctly.
+
 func daemonsetServiceAccountName(namePrefix string) string {
 	return renderName(namePrefix, openTelemetryCollector, "sa")
 }

--- a/internal/controller/monitoring_controller.go
+++ b/internal/controller/monitoring_controller.go
@@ -412,7 +412,7 @@ func (r *MonitoringReconciler) reconcileOpenTelemetryCollector(
 		r.Images,
 		r.OperatorNamespace,
 		monitoringResource,
-		backendconnection.TriggeredByMonitoringResource,
+		backendconnection.TriggeredByDash0ResourceReconcile,
 	); err != nil {
 		logger.Error(err, "Failed to reconcile the OpenTelemetry collector, requeuing reconcile request.")
 		return err

--- a/internal/controller/monitoring_controller_test.go
+++ b/internal/controller/monitoring_controller_test.go
@@ -3,7 +3,7 @@
 
 package controller
 
-// Maintenance note: the canonical order/grouping for imports is:
+// Maintenance note: the canonical order/grouping for imports in tests is:
 // - standard library imports
 // - external third-party library imports, except for test libraries
 // - internal imports, except for internal test packages
@@ -788,7 +788,7 @@ var _ = Describe("The monitoring resource controller", Ordered, func() {
 		})
 	})
 
-	Describe("when deleting the Dash0 monitoring resource and removing the collector resources", func() {
+	Describe("when managing the collector resources", func() {
 		BeforeEach(func() {
 			EnsureMonitoringResourceExists(ctx, k8sClient)
 		})
@@ -797,7 +797,7 @@ var _ = Describe("The monitoring resource controller", Ordered, func() {
 			DeleteMonitoringResource(ctx, k8sClient)
 		})
 
-		It("should remove the collector resources", func() {
+		It("should add and remove the collector resources", func() {
 			triggerReconcileRequest(ctx, reconciler, "Trigger first reconcile request")
 			VerifyCollectorResources(ctx, k8sClient, operatorNamespace)
 

--- a/test-resources/bin/util
+++ b/test-resources/bin/util
@@ -149,9 +149,15 @@ deploy_via_helm() {
         helm_install_command+=" --set operator.dash0Export.secretRef.key=token"
       fi
       helm_install_command+=" --set operator.dash0Export.apiEndpoint=https://api.eu-west-1.aws.dash0-dev.com"
-      if [[ -n "${OPERATOR_CONFIGURATION_VIA_HELM_DATASET:-}" ]]; then
-        helm_install_command+=" --set operator.dash0Export.dataset=$OPERATOR_CONFIGURATION_VIA_HELM_DATASET"
-      fi
+    fi
+    if [[ -n "${OPERATOR_CONFIGURATION_VIA_HELM_DATASET:-}" ]]; then
+      helm_install_command+=" --set operator.dash0Export.dataset=$OPERATOR_CONFIGURATION_VIA_HELM_DATASET"
+    fi
+    if [[ "${OPERATOR_CONFIGURATION_VIA_HELM_SELF_MONITORING_ENABLED:-}" == false  ]]; then
+      helm_install_command+=" --set operator.selfMonitoringEnabled=false"
+    fi
+    if [[ "${OPERATOR_CONFIGURATION_VIA_HELM_KUBERNETES_INFRASTRUCTURE_METRICS_COLLECTION_ENABLED:-}" == false  ]]; then
+      helm_install_command+=" --set operator.kubernetesInfrastructureMetricsCollectionEnabled=false"
     fi
   fi
 

--- a/test/e2e/dash0_operator_configuration_resource.go
+++ b/test/e2e/dash0_operator_configuration_resource.go
@@ -112,6 +112,30 @@ func waitForAutoOperatorConfigurationResourceToBecomeAvailable() {
 		))).To(Succeed())
 }
 
+func updateEndpointOfDash0OperatorConfigurationResource(
+	newEndpoint string,
+) {
+	updateDash0OperatorConfigurationResource(
+		fmt.Sprintf("{\"spec\":{\"export\":{\"dash0\":{\"endpoint\":\"%s\"}}}}", newEndpoint),
+	)
+}
+
+func updateDash0OperatorConfigurationResource(
+	jsonPatch string,
+) {
+	Expect(
+		runAndIgnoreOutput(exec.Command(
+			"kubectl",
+			"patch",
+			"Dash0OperatorConfiguration",
+			dash0OperatorConfigurationResourceName,
+			"--type",
+			"merge",
+			"-p",
+			jsonPatch,
+		))).To(Succeed())
+}
+
 func undeployDash0OperatorConfigurationResource() {
 	By("removing the Dash0 operator configuration resource")
 	Expect(

--- a/test/util/monitoring_resource.go
+++ b/test/util/monitoring_resource.go
@@ -97,6 +97,29 @@ func EnsureMonitoringResourceExistsWithNamespacedName(
 	return object.(*dash0v1alpha1.Dash0Monitoring)
 }
 
+func EnsureEmptyMonitoringResourceExistsAndIsAvailable(
+	ctx context.Context,
+	k8sClient client.Client,
+) *dash0v1alpha1.Dash0Monitoring {
+	object := EnsureKubernetesObjectExists(
+		ctx,
+		k8sClient,
+		MonitoringResourceQualifiedName,
+		&dash0v1alpha1.Dash0Monitoring{},
+		&dash0v1alpha1.Dash0Monitoring{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      MonitoringResourceName,
+				Namespace: TestNamespaceName,
+			},
+			Spec: dash0v1alpha1.Dash0MonitoringSpec{},
+		},
+	)
+	monitoringResource := object.(*dash0v1alpha1.Dash0Monitoring)
+	monitoringResource.EnsureResourceIsMarkedAsAvailable()
+	Expect(k8sClient.Status().Update(ctx, monitoringResource)).To(Succeed())
+	return monitoringResource
+}
+
 func CreateDefaultMonitoringResource(
 	ctx context.Context,
 	k8sClient client.Client,

--- a/test/util/operator_resource.go
+++ b/test/util/operator_resource.go
@@ -222,13 +222,6 @@ func CreateOperatorConfigurationResource(
 	return operatorConfigurationResource, err
 }
 
-func DeleteOperatorConfigurationResource(
-	ctx context.Context,
-	k8sClient client.Client,
-) {
-	Expect(k8sClient.DeleteAllOf(ctx, &dash0v1alpha1.Dash0OperatorConfiguration{})).To(Succeed())
-}
-
 func DeleteAllOperatorConfigurationResources(
 	ctx context.Context,
 	k8sClient client.Client,


### PR DESCRIPTION
Trigger a reconciliation of the OTel collector resources when the
operator configuration resource is changed.

Also: Delete a subset of collector resources if operator configuration
resource has changed in a way so that some resources are no longer
required - in particular, when switching from
KubernetesInfrastructureMetricsCollectionEnabled=true to false, delete
the collector deployment for the cluster metrics.