### PR TITLE
feat(chart): update operator configuration resource via helm chart

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -820,7 +820,7 @@ func createOperatorConfiguration(
 			OperatorNamespace: envVars.operatorNamespace,
 			NamePrefix:        envVars.oTelCollectorNamePrefix,
 		}
-		if err := handler.CreateOperatorConfigurationResource(ctx, operatorConfiguration, logger); err != nil {
+		if err := handler.CreateOrUpdateOperatorConfigurationResource(ctx, operatorConfiguration, logger); err != nil {
 			logger.Error(err, "Failed to create the requested Dash0 operator configuration resource.")
 		}
 	}

--- a/internal/startup/auto_operator_configuration_handler_test.go
+++ b/internal/startup/auto_operator_configuration_handler_test.go
@@ -46,24 +46,8 @@ var _ = Describe("Create an operator configuration resource at startup", Ordered
 		DeleteAllOperatorConfigurationResources(ctx, k8sClient)
 	})
 
-	It("should not do anything if there already is an operator configuration resource in the cluster", func() {
-		CreateDefaultOperatorConfigurationResource(ctx, k8sClient)
-		// verify that there is only one resource
-		list := v1alpha1.Dash0OperatorConfigurationList{}
-		Expect(k8sClient.List(ctx, &list)).To(Succeed())
-		Expect(list.Items).To(HaveLen(1))
-		Expect(list.Items[0].Name).To(Equal(OperatorConfigurationResourceName))
-
-		Expect(handler.CreateOperatorConfigurationResource(ctx, &OperatorConfigurationValues{}, &logger)).To(Succeed())
-		// verify that there is _still_ only one resource, and that its name is not the one that would be automatically
-		// created by AutoOperatorConfigurationResourceHandler.
-		Expect(k8sClient.List(ctx, &list)).To(Succeed())
-		Expect(list.Items).To(HaveLen(1))
-		Expect(list.Items[0].Name).To(Equal(OperatorConfigurationResourceName))
-	})
-
 	It("should fail validation if no endpoint has been provided", func() {
-		Expect(handler.CreateOperatorConfigurationResource(ctx, &OperatorConfigurationValues{
+		Expect(handler.CreateOrUpdateOperatorConfigurationResource(ctx, &OperatorConfigurationValues{
 			Token: AuthorizationTokenTest,
 		}, &logger)).To(
 			MatchError(
@@ -72,7 +56,7 @@ var _ = Describe("Create an operator configuration resource at startup", Ordered
 	})
 
 	It("should fail validation if no token and no secret reference have been provided", func() {
-		Expect(handler.CreateOperatorConfigurationResource(ctx, &OperatorConfigurationValues{
+		Expect(handler.CreateOrUpdateOperatorConfigurationResource(ctx, &OperatorConfigurationValues{
 			Endpoint: AuthorizationTokenTest,
 		}, &logger)).To(
 			MatchError(
@@ -82,7 +66,7 @@ var _ = Describe("Create an operator configuration resource at startup", Ordered
 	})
 
 	It("should fail validation if no token and no secret reference key have been provided", func() {
-		Expect(handler.CreateOperatorConfigurationResource(ctx, &OperatorConfigurationValues{
+		Expect(handler.CreateOrUpdateOperatorConfigurationResource(ctx, &OperatorConfigurationValues{
 			Endpoint: AuthorizationTokenTest,
 			SecretRef: SecretRef{
 				Name: "test-secret",
@@ -94,9 +78,9 @@ var _ = Describe("Create an operator configuration resource at startup", Ordered
 						"been provided")))
 	})
 
-	It("should create an operator configuration resource with a token", func() {
+	It("should create a new operator configuration resource with a token", func() {
 		Expect(
-			handler.CreateOperatorConfigurationResource(ctx, &operatorConfigurationValuesWithToken, &logger),
+			handler.CreateOrUpdateOperatorConfigurationResource(ctx, &operatorConfigurationValuesWithToken, &logger),
 		).To(Succeed())
 
 		Eventually(func(g Gomega) {
@@ -122,9 +106,9 @@ var _ = Describe("Create an operator configuration resource at startup", Ordered
 		}, 5*time.Second, 100*time.Millisecond).Should(Succeed())
 	})
 
-	It("should create an operator configuration resource with a secret reference", func() {
+	It("should create a new operator configuration resource with a secret reference", func() {
 		Expect(
-			handler.CreateOperatorConfigurationResource(ctx, &operatorConfigurationValuesWithSecretRef, &logger),
+			handler.CreateOrUpdateOperatorConfigurationResource(ctx, &operatorConfigurationValuesWithSecretRef, &logger),
 		).To(Succeed())
 
 		Eventually(func(g Gomega) {
@@ -153,7 +137,7 @@ var _ = Describe("Create an operator configuration resource at startup", Ordered
 
 	It("should set the API endpoint", func() {
 		Expect(
-			handler.CreateOperatorConfigurationResource(ctx, &OperatorConfigurationValues{
+			handler.CreateOrUpdateOperatorConfigurationResource(ctx, &OperatorConfigurationValues{
 				Endpoint:    EndpointDash0Test,
 				Token:       AuthorizationTokenTest,
 				ApiEndpoint: ApiEndpointTest,
@@ -177,7 +161,7 @@ var _ = Describe("Create an operator configuration resource at startup", Ordered
 
 	It("should set a custom dataset", func() {
 		Expect(
-			handler.CreateOperatorConfigurationResource(ctx, &OperatorConfigurationValues{
+			handler.CreateOrUpdateOperatorConfigurationResource(ctx, &OperatorConfigurationValues{
 				Endpoint: EndpointDash0Test,
 				Token:    AuthorizationTokenTest,
 				Dataset:  "custom",
@@ -196,6 +180,81 @@ var _ = Describe("Create an operator configuration resource at startup", Ordered
 			dash0Export := export.Dash0
 			g.Expect(dash0Export).ToNot(BeNil())
 			g.Expect(dash0Export.Dataset).To(Equal("custom"))
+		}, 5*time.Second, 100*time.Millisecond).Should(Succeed())
+	})
+
+	It("should update the existing resource if there already is an auto-operator-configuration-resource", func() {
+		Expect(
+			handler.CreateOrUpdateOperatorConfigurationResource(ctx, &OperatorConfigurationValues{
+				Endpoint:              "endpoint-1.dash0.com:4317",
+				Token:                 AuthorizationTokenTest,
+				ApiEndpoint:           "https://api-1.dash0.com",
+				Dataset:               "dataset-1",
+				SelfMonitoringEnabled: false,
+				KubernetesInfrastructureMetricsCollectionEnabled: true,
+			}, &logger),
+		).To(Succeed())
+
+		Eventually(func(g Gomega) {
+			list := v1alpha1.Dash0OperatorConfigurationList{}
+			g.Expect(k8sClient.List(ctx, &list)).To(Succeed())
+			g.Expect(list.Items).To(HaveLen(1))
+			operatorConfiguration := list.Items[0]
+			g.Expect(operatorConfiguration.Name).To(Equal(operatorConfigurationAutoResourceName))
+			g.Expect(operatorConfiguration.Annotations).To(HaveLen(1))
+			g.Expect(operatorConfiguration.Annotations["argocd.argoproj.io/sync-options"]).To(Equal("Prune=false"))
+			export := operatorConfiguration.Spec.Export
+			g.Expect(export).ToNot(BeNil())
+			dash0Export := export.Dash0
+			g.Expect(dash0Export).ToNot(BeNil())
+			g.Expect(export.Grpc).To(BeNil())
+			g.Expect(export.Http).To(BeNil())
+			g.Expect(dash0Export.Endpoint).To(Equal("endpoint-1.dash0.com:4317"))
+			g.Expect(dash0Export.Authorization.Token).ToNot(BeNil())
+			g.Expect(*dash0Export.Authorization.Token).To(Equal(AuthorizationTokenTest))
+			g.Expect(dash0Export.Authorization.SecretRef).To(BeNil())
+			g.Expect(dash0Export.ApiEndpoint).To(Equal("https://api-1.dash0.com"))
+			g.Expect(dash0Export.Dataset).To(Equal("dataset-1"))
+			g.Expect(*operatorConfiguration.Spec.SelfMonitoring.Enabled).To(BeFalse())
+			g.Expect(*operatorConfiguration.Spec.KubernetesInfrastructureMetricsCollectionEnabled).To(BeTrue())
+		}, 5*time.Second, 100*time.Millisecond).Should(Succeed())
+
+		// Now call the handler a second time, simulating a new startup of the operator manager process, with different
+		// operator-configuration-xxx flags
+		Expect(handler.CreateOrUpdateOperatorConfigurationResource(ctx,
+			&OperatorConfigurationValues{
+				Endpoint:              "endpoint-2.dash0.com:4317",
+				SecretRef:             secretRef,
+				ApiEndpoint:           "https://api-2.dash0.com",
+				Dataset:               "dataset-2",
+				SelfMonitoringEnabled: true,
+				KubernetesInfrastructureMetricsCollectionEnabled: false,
+			}, &logger)).To(Succeed())
+
+		// verify that there is _still_ only one resource, and that its settings have been updated.
+		Eventually(func(g Gomega) {
+			list := v1alpha1.Dash0OperatorConfigurationList{}
+			g.Expect(k8sClient.List(ctx, &list)).To(Succeed())
+			g.Expect(list.Items).To(HaveLen(1))
+			operatorConfiguration := list.Items[0]
+			g.Expect(operatorConfiguration.Name).To(Equal(operatorConfigurationAutoResourceName))
+			g.Expect(operatorConfiguration.Annotations).To(HaveLen(1))
+			g.Expect(operatorConfiguration.Annotations["argocd.argoproj.io/sync-options"]).To(Equal("Prune=false"))
+			export := operatorConfiguration.Spec.Export
+			g.Expect(export).ToNot(BeNil())
+			dash0Export := export.Dash0
+			g.Expect(dash0Export).ToNot(BeNil())
+			g.Expect(export.Grpc).To(BeNil())
+			g.Expect(export.Http).To(BeNil())
+			g.Expect(dash0Export.Endpoint).To(Equal("endpoint-2.dash0.com:4317"))
+			g.Expect(dash0Export.Authorization.Token).To(BeNil())
+			g.Expect(dash0Export.Authorization.SecretRef).ToNot(BeNil())
+			g.Expect(dash0Export.Authorization.SecretRef.Name).To(Equal("test-secret"))
+			g.Expect(dash0Export.Authorization.SecretRef.Key).To(Equal("test-key"))
+			g.Expect(dash0Export.ApiEndpoint).To(Equal("https://api-2.dash0.com"))
+			g.Expect(dash0Export.Dataset).To(Equal("dataset-2"))
+			g.Expect(*operatorConfiguration.Spec.SelfMonitoring.Enabled).To(BeTrue())
+			g.Expect(*operatorConfiguration.Spec.KubernetesInfrastructureMetricsCollectionEnabled).To(BeFalse())
 		}, 5*time.Second, 100*time.Millisecond).Should(Succeed())
 	})
 })

--- a/internal/webhooks/monitoring_validation_webhook_test.go
+++ b/internal/webhooks/monitoring_validation_webhook_test.go
@@ -4,7 +4,6 @@
 package webhooks
 
 import (
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -62,48 +61,6 @@ var _ = Describe("The validation webhook for the monitoring resource", func() {
 			Expect(err).To(MatchError(ContainSubstring("admission webhook \"validate-monitoring.dash0.com\" denied " +
 				"the request: The provided Dash0 monitoring resource does not have an export configuration, and no " +
 				"Dash0 operator configuration resources are available.")))
-		})
-
-		It("should reject monitoring resources without export if more than one operator configuration resource is available", func() {
-			opConfRes1, err := CreateOperatorConfigurationResource(
-				ctx,
-				k8sClient,
-				&dash0v1alpha1.Dash0OperatorConfiguration{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "dash0-operator-test-resource-1",
-					},
-					Spec: OperatorConfigurationResourceDefaultSpec,
-				},
-			)
-			Expect(err).ToNot(HaveOccurred())
-			opConfRes2, err := CreateOperatorConfigurationResource(
-				ctx,
-				k8sClient,
-				&dash0v1alpha1.Dash0OperatorConfiguration{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "dash0-operator-test-resource-2",
-					},
-					Spec: OperatorConfigurationResourceDefaultSpec,
-				},
-			)
-			Expect(err).ToNot(HaveOccurred())
-
-			opConfRes1.EnsureResourceIsMarkedAsAvailable()
-			Expect(k8sClient.Status().Update(ctx, opConfRes1)).To(Succeed())
-			opConfRes2.EnsureResourceIsMarkedAsAvailable()
-			Expect(k8sClient.Status().Update(ctx, opConfRes2)).To(Succeed())
-
-			_, err = CreateMonitoringResourceWithPotentialError(ctx, k8sClient, &dash0v1alpha1.Dash0Monitoring{
-				ObjectMeta: MonitoringResourceDefaultObjectMeta,
-				Spec: dash0v1alpha1.Dash0MonitoringSpec{
-					InstrumentWorkloads: dash0v1alpha1.All,
-				},
-			})
-
-			Expect(err).To(MatchError(ContainSubstring("admission webhook \"validate-monitoring.dash0.com\" denied " +
-				"the request: The provided Dash0 monitoring resource does not have an export configuration, and " +
-				"there is more than one available Dash0 operator configuration, remove all but one Dash0 operator " +
-				"configuration resource.")))
 		})
 
 		It("should reject monitoring resources without export if there is an operator configuration resource, but it has no export either", func() {

--- a/internal/webhooks/operator_configuration_validation_webhook_test.go
+++ b/internal/webhooks/operator_configuration_validation_webhook_test.go
@@ -4,6 +4,7 @@
 package webhooks
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
 	dash0v1alpha1 "github.com/dash0hq/dash0-operator/api/dash0monitoring/v1alpha1"
@@ -20,82 +21,134 @@ var _ = Describe("The validation webhook for the operator configuration resource
 		DeleteAllOperatorConfigurationResources(ctx, k8sClient)
 	})
 
-	Describe("when validating", Ordered, func() {
+	It("should reject a new operator configuration resources if there already is one in the cluster", func() {
+		_, err := CreateOperatorConfigurationResource(
+			ctx,
+			k8sClient,
+			&dash0v1alpha1.Dash0OperatorConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "dash0-operator-configuration-test-1",
+				},
+				Spec: OperatorConfigurationResourceDefaultSpec,
+			})
+		Expect(err).ToNot(HaveOccurred())
 
-		It("should reject operator configuration resources without spec (and thus without export) since self-monitoring defaults to true", func() {
-			_, err := CreateOperatorConfigurationResource(
-				ctx,
-				k8sClient,
-				&dash0v1alpha1.Dash0OperatorConfiguration{
-					ObjectMeta: OperatorConfigurationResourceDefaultObjectMeta,
-				})
-			Expect(err).To(MatchError(ContainSubstring(
-				"admission webhook \"validate-operator-configuration.dash0.com\" denied the request: The provided " +
-					"Dash0 operator configuration resource has self-monitoring enabled, but it does not have an " +
-					"export configuration. Either disable self-monitoring or provide an export configuration for " +
-					"self-monitoring telemetry.")))
-		})
+		_, err = CreateOperatorConfigurationResource(
+			ctx,
+			k8sClient,
+			&dash0v1alpha1.Dash0OperatorConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "dash0-operator-configuration-test-2",
+				},
+				Spec: OperatorConfigurationResourceDefaultSpec,
+			})
+		Expect(err).To(MatchError(ContainSubstring(
+			"admission webhook \"validate-operator-configuration.dash0.com\" denied the request: At least one Dash0 " +
+				"operator configuration resource (dash0-operator-configuration-test-1) already exists in this " +
+				"cluster. Only one operator configuration resource is allowed per cluster.")))
+	})
 
-		It("should reject operator configuration resources without export if self-monitoring is unset and defaults to true", func() {
-			_, err := CreateOperatorConfigurationResource(
-				ctx,
-				k8sClient,
-				&dash0v1alpha1.Dash0OperatorConfiguration{
-					ObjectMeta: OperatorConfigurationResourceDefaultObjectMeta,
-					Spec: dash0v1alpha1.Dash0OperatorConfigurationSpec{
-						SelfMonitoring: dash0v1alpha1.SelfMonitoring{},
+	It("should reject operator configuration resources without spec (and thus without export) since self-monitoring defaults to true", func() {
+		_, err := CreateOperatorConfigurationResource(
+			ctx,
+			k8sClient,
+			&dash0v1alpha1.Dash0OperatorConfiguration{
+				ObjectMeta: OperatorConfigurationResourceDefaultObjectMeta,
+			})
+		Expect(err).To(MatchError(ContainSubstring(
+			"admission webhook \"validate-operator-configuration.dash0.com\" denied the request: The provided " +
+				"Dash0 operator configuration resource has self-monitoring enabled, but it does not have an " +
+				"export configuration. Either disable self-monitoring or provide an export configuration for " +
+				"self-monitoring telemetry.")))
+	})
+
+	It("should reject operator configuration resources without export if self-monitoring is unset and defaults to true", func() {
+		_, err := CreateOperatorConfigurationResource(
+			ctx,
+			k8sClient,
+			&dash0v1alpha1.Dash0OperatorConfiguration{
+				ObjectMeta: OperatorConfigurationResourceDefaultObjectMeta,
+				Spec: dash0v1alpha1.Dash0OperatorConfigurationSpec{
+					SelfMonitoring: dash0v1alpha1.SelfMonitoring{},
+				},
+			})
+		Expect(err).To(MatchError(ContainSubstring(
+			"admission webhook \"validate-operator-configuration.dash0.com\" denied the request: The provided " +
+				"Dash0 operator configuration resource has self-monitoring enabled, but it does not have an " +
+				"export configuration. Either disable self-monitoring or provide an export configuration for " +
+				"self-monitoring telemetry.")))
+	})
+
+	It("should reject operator configuration resources without export if self-monitoring is enabled", func() {
+		_, err := CreateOperatorConfigurationResource(
+			ctx,
+			k8sClient,
+			&dash0v1alpha1.Dash0OperatorConfiguration{
+				ObjectMeta: OperatorConfigurationResourceDefaultObjectMeta,
+				Spec: dash0v1alpha1.Dash0OperatorConfigurationSpec{
+					SelfMonitoring: dash0v1alpha1.SelfMonitoring{
+						Enabled: ptr.To(true),
 					},
-				})
-			Expect(err).To(MatchError(ContainSubstring(
-				"admission webhook \"validate-operator-configuration.dash0.com\" denied the request: The provided " +
-					"Dash0 operator configuration resource has self-monitoring enabled, but it does not have an " +
-					"export configuration. Either disable self-monitoring or provide an export configuration for " +
-					"self-monitoring telemetry.")))
-		})
+				},
+			})
+		Expect(err).To(MatchError(ContainSubstring(
+			"admission webhook \"validate-operator-configuration.dash0.com\" denied the request: The provided " +
+				"Dash0 operator configuration resource has self-monitoring enabled, but it does not have an " +
+				"export configuration. Either disable self-monitoring or provide an export configuration for " +
+				"self-monitoring telemetry.")))
+	})
 
-		It("should reject operator configuration resources without export if self-monitoring is enabled", func() {
-			_, err := CreateOperatorConfigurationResource(
-				ctx,
-				k8sClient,
-				&dash0v1alpha1.Dash0OperatorConfiguration{
-					ObjectMeta: OperatorConfigurationResourceDefaultObjectMeta,
-					Spec: dash0v1alpha1.Dash0OperatorConfigurationSpec{
-						SelfMonitoring: dash0v1alpha1.SelfMonitoring{
-							Enabled: ptr.To(true),
-						},
+	It("should allow an operator configuration resource without export if self-monitoring is disabled", func() {
+		_, err := CreateOperatorConfigurationResource(
+			ctx,
+			k8sClient,
+			&dash0v1alpha1.Dash0OperatorConfiguration{
+				ObjectMeta: OperatorConfigurationResourceDefaultObjectMeta,
+				Spec: dash0v1alpha1.Dash0OperatorConfigurationSpec{
+					SelfMonitoring: dash0v1alpha1.SelfMonitoring{
+						Enabled: ptr.To(false),
 					},
-				})
-			Expect(err).To(MatchError(ContainSubstring(
-				"admission webhook \"validate-operator-configuration.dash0.com\" denied the request: The provided " +
-					"Dash0 operator configuration resource has self-monitoring enabled, but it does not have an " +
-					"export configuration. Either disable self-monitoring or provide an export configuration for " +
-					"self-monitoring telemetry.")))
-		})
+				},
+			})
+		Expect(err).ToNot(HaveOccurred())
+	})
 
-		It("should allow an operator configuration resource without export if self-monitoring is disabled", func() {
-			_, err := CreateOperatorConfigurationResource(
-				ctx,
-				k8sClient,
-				&dash0v1alpha1.Dash0OperatorConfiguration{
-					ObjectMeta: OperatorConfigurationResourceDefaultObjectMeta,
-					Spec: dash0v1alpha1.Dash0OperatorConfigurationSpec{
-						SelfMonitoring: dash0v1alpha1.SelfMonitoring{
-							Enabled: ptr.To(false),
-						},
+	It("should allow an operator configuration resource with self-monitoring enabled if it has an export", func() {
+		_, err := CreateOperatorConfigurationResource(
+			ctx,
+			k8sClient,
+			&dash0v1alpha1.Dash0OperatorConfiguration{
+				ObjectMeta: OperatorConfigurationResourceDefaultObjectMeta,
+				Spec:       OperatorConfigurationResourceDefaultSpec,
+			})
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("should allow updating an existing operator configuration resource", func() {
+		operatorConfiguration, err := CreateOperatorConfigurationResource(
+			ctx,
+			k8sClient,
+			&dash0v1alpha1.Dash0OperatorConfiguration{
+				ObjectMeta: OperatorConfigurationResourceDefaultObjectMeta,
+				Spec: dash0v1alpha1.Dash0OperatorConfigurationSpec{
+					SelfMonitoring: dash0v1alpha1.SelfMonitoring{
+						Enabled: ptr.To(false),
 					},
-				})
-			Expect(err).ToNot(HaveOccurred())
-		})
+				},
+			})
+		Expect(err).ToNot(HaveOccurred())
 
-		It("should allow an operator configuration resource with self-monitoring enabled if it has an export", func() {
-			_, err := CreateOperatorConfigurationResource(
-				ctx,
-				k8sClient,
-				&dash0v1alpha1.Dash0OperatorConfiguration{
-					ObjectMeta: OperatorConfigurationResourceDefaultObjectMeta,
-					Spec:       OperatorConfigurationResourceDefaultSpec,
-				})
-			Expect(err).ToNot(HaveOccurred())
-		})
+		operatorConfiguration.Spec.SelfMonitoring.Enabled = ptr.To(true)
+		operatorConfiguration.Spec.Export = &dash0v1alpha1.Export{
+			Dash0: &dash0v1alpha1.Dash0Configuration{
+				Endpoint: EndpointDash0Test,
+				Authorization: dash0v1alpha1.Authorization{
+					Token: &AuthorizationTokenTest,
+				},
+			},
+		}
+
+		err = k8sClient.Update(ctx, operatorConfiguration)
+		Expect(err).ToNot(HaveOccurred())
 	})
 })


### PR DESCRIPTION
If an operator configuration resource has been requested via Helm values, and there is already an existing operator configuration resource in the cluster, update it according to the values provided via Helm instead of ignoring the Helm values.