### PR TITLE
fix(controller): use clearly identifiable field manager

### DIFF
--- a/internal/controller/monitoring_controller_test.go
+++ b/internal/controller/monitoring_controller_test.go
@@ -455,7 +455,7 @@ var _ = Describe("The monitoring resource controller", Ordered, func() {
 			CreateFn:           WrapCronJobFnAsTestableWorkload(CreateInstrumentedCronJob),
 			GetFn:              WrapCronJobFnAsTestableWorkload(GetCronJob),
 			VerifyPreFn: func(workload TestableWorkload) {
-				VerifyModifiedCronJob(workload.Get().(*batchv1.CronJob), BasicInstrumentedPodSpecExpectations())
+				VerifyModifiedCronJob(workload.Get().(*batchv1.CronJob), BasicInstrumentedPodSpecExpectations(), IgnoreManagedFields)
 			},
 			VerifyFn: func(workload TestableWorkload) {
 				VerifyUnmodifiedCronJob(workload.Get().(*batchv1.CronJob))
@@ -465,7 +465,7 @@ var _ = Describe("The monitoring resource controller", Ordered, func() {
 			CreateFn:           WrapDaemonSetFnAsTestableWorkload(CreateInstrumentedDaemonSet),
 			GetFn:              WrapDaemonSetFnAsTestableWorkload(GetDaemonSet),
 			VerifyPreFn: func(workload TestableWorkload) {
-				VerifyModifiedDaemonSet(workload.Get().(*appsv1.DaemonSet), BasicInstrumentedPodSpecExpectations())
+				VerifyModifiedDaemonSet(workload.Get().(*appsv1.DaemonSet), BasicInstrumentedPodSpecExpectations(), IgnoreManagedFields)
 			},
 			VerifyFn: func(workload TestableWorkload) {
 				VerifyUnmodifiedDaemonSet(workload.Get().(*appsv1.DaemonSet))
@@ -475,7 +475,7 @@ var _ = Describe("The monitoring resource controller", Ordered, func() {
 			CreateFn:           WrapDeploymentFnAsTestableWorkload(CreateInstrumentedDeployment),
 			GetFn:              WrapDeploymentFnAsTestableWorkload(GetDeployment),
 			VerifyPreFn: func(workload TestableWorkload) {
-				VerifyModifiedDeployment(workload.Get().(*appsv1.Deployment), BasicInstrumentedPodSpecExpectations())
+				VerifyModifiedDeployment(workload.Get().(*appsv1.Deployment), BasicInstrumentedPodSpecExpectations(), IgnoreManagedFields)
 			},
 			VerifyFn: func(workload TestableWorkload) {
 				VerifyUnmodifiedDeployment(workload.Get().(*appsv1.Deployment))
@@ -485,7 +485,7 @@ var _ = Describe("The monitoring resource controller", Ordered, func() {
 			CreateFn:           WrapReplicaSetFnAsTestableWorkload(CreateInstrumentedReplicaSet),
 			GetFn:              WrapReplicaSetFnAsTestableWorkload(GetReplicaSet),
 			VerifyPreFn: func(workload TestableWorkload) {
-				VerifyModifiedReplicaSet(workload.Get().(*appsv1.ReplicaSet), BasicInstrumentedPodSpecExpectations())
+				VerifyModifiedReplicaSet(workload.Get().(*appsv1.ReplicaSet), BasicInstrumentedPodSpecExpectations(), IgnoreManagedFields)
 			},
 			VerifyFn: func(workload TestableWorkload) {
 				VerifyUnmodifiedReplicaSet(workload.Get().(*appsv1.ReplicaSet))
@@ -495,7 +495,7 @@ var _ = Describe("The monitoring resource controller", Ordered, func() {
 			CreateFn:           WrapStatefulSetFnAsTestableWorkload(CreateInstrumentedStatefulSet),
 			GetFn:              WrapStatefulSetFnAsTestableWorkload(GetStatefulSet),
 			VerifyPreFn: func(workload TestableWorkload) {
-				VerifyModifiedStatefulSet(workload.Get().(*appsv1.StatefulSet), BasicInstrumentedPodSpecExpectations())
+				VerifyModifiedStatefulSet(workload.Get().(*appsv1.StatefulSet), BasicInstrumentedPodSpecExpectations(), IgnoreManagedFields)
 			},
 			VerifyFn: func(workload TestableWorkload) {
 				VerifyUnmodifiedStatefulSet(workload.Get().(*appsv1.StatefulSet))
@@ -597,7 +597,7 @@ var _ = Describe("The monitoring resource controller", Ordered, func() {
 			CreateFn:           WrapCronJobFnAsTestableWorkload(CreateBasicCronJob),
 			GetFn:              WrapCronJobFnAsTestableWorkload(GetCronJob),
 			VerifyPreFn: func(workload TestableWorkload) {
-				VerifyModifiedCronJob(workload.Get().(*batchv1.CronJob), BasicInstrumentedPodSpecExpectations())
+				VerifyModifiedCronJob(workload.Get().(*batchv1.CronJob), BasicInstrumentedPodSpecExpectations(), IgnoreManagedFields)
 			},
 			VerifyFn: func(workload TestableWorkload) {
 				VerifyUnmodifiedCronJob(workload.Get().(*batchv1.CronJob))
@@ -607,7 +607,7 @@ var _ = Describe("The monitoring resource controller", Ordered, func() {
 			CreateFn:           WrapDaemonSetFnAsTestableWorkload(CreateBasicDaemonSet),
 			GetFn:              WrapDaemonSetFnAsTestableWorkload(GetDaemonSet),
 			VerifyPreFn: func(workload TestableWorkload) {
-				VerifyModifiedDaemonSet(workload.Get().(*appsv1.DaemonSet), BasicInstrumentedPodSpecExpectations())
+				VerifyModifiedDaemonSet(workload.Get().(*appsv1.DaemonSet), BasicInstrumentedPodSpecExpectations(), IgnoreManagedFields)
 			},
 			VerifyFn: func(workload TestableWorkload) {
 				VerifyUnmodifiedDaemonSet(workload.Get().(*appsv1.DaemonSet))
@@ -617,7 +617,7 @@ var _ = Describe("The monitoring resource controller", Ordered, func() {
 			CreateFn:           WrapDeploymentFnAsTestableWorkload(CreateBasicDeployment),
 			GetFn:              WrapDeploymentFnAsTestableWorkload(GetDeployment),
 			VerifyPreFn: func(workload TestableWorkload) {
-				VerifyModifiedDeployment(workload.Get().(*appsv1.Deployment), BasicInstrumentedPodSpecExpectations())
+				VerifyModifiedDeployment(workload.Get().(*appsv1.Deployment), BasicInstrumentedPodSpecExpectations(), IgnoreManagedFields)
 			},
 			VerifyFn: func(workload TestableWorkload) {
 				VerifyUnmodifiedDeployment(workload.Get().(*appsv1.Deployment))
@@ -627,7 +627,7 @@ var _ = Describe("The monitoring resource controller", Ordered, func() {
 			CreateFn:           WrapReplicaSetFnAsTestableWorkload(CreateBasicReplicaSet),
 			GetFn:              WrapReplicaSetFnAsTestableWorkload(GetReplicaSet),
 			VerifyPreFn: func(workload TestableWorkload) {
-				VerifyModifiedReplicaSet(workload.Get().(*appsv1.ReplicaSet), BasicInstrumentedPodSpecExpectations())
+				VerifyModifiedReplicaSet(workload.Get().(*appsv1.ReplicaSet), BasicInstrumentedPodSpecExpectations(), IgnoreManagedFields)
 			},
 			VerifyFn: func(workload TestableWorkload) {
 				VerifyUnmodifiedReplicaSet(workload.Get().(*appsv1.ReplicaSet))
@@ -637,7 +637,7 @@ var _ = Describe("The monitoring resource controller", Ordered, func() {
 			CreateFn:           WrapStatefulSetFnAsTestableWorkload(CreateBasicStatefulSet),
 			GetFn:              WrapStatefulSetFnAsTestableWorkload(GetStatefulSet),
 			VerifyPreFn: func(workload TestableWorkload) {
-				VerifyModifiedStatefulSet(workload.Get().(*appsv1.StatefulSet), BasicInstrumentedPodSpecExpectations())
+				VerifyModifiedStatefulSet(workload.Get().(*appsv1.StatefulSet), BasicInstrumentedPodSpecExpectations(), IgnoreManagedFields)
 			},
 			VerifyFn: func(workload TestableWorkload) {
 				VerifyUnmodifiedStatefulSet(workload.Get().(*appsv1.StatefulSet))

--- a/internal/controller/operator_configuration_controller.go
+++ b/internal/controller/operator_configuration_controller.go
@@ -232,7 +232,11 @@ func (r *OperatorConfigurationReconciler) Reconcile(ctx context.Context, req ctr
 			return ctrl.Result{}, err
 		}
 
-		if err = r.Client.Update(ctx, controllerDeployment); err != nil {
+		if err = r.Client.Update(
+			ctx,
+			controllerDeployment,
+			&client.UpdateOptions{FieldManager: util.FieldManager},
+		); err != nil {
 			logger.Error(err, "cannot update the controller deployment")
 			if statusUpdateErr := r.markAsDegraded(
 				ctx,
@@ -319,7 +323,7 @@ func (r *OperatorConfigurationReconciler) removeSelfMonitoringAndApiAccessAndUpd
 		return fmt.Errorf("cannot apply settings to disable self-monitoring to the controller deployment: %w", err)
 	}
 
-	return r.Client.Update(ctx, updatedDeployment)
+	return r.Client.Update(ctx, updatedDeployment, &client.UpdateOptions{FieldManager: util.FieldManager})
 }
 
 func (r *OperatorConfigurationReconciler) markAsDegraded(

--- a/internal/instrumentation/instrumenter.go
+++ b/internal/instrumentation/instrumenter.go
@@ -363,7 +363,7 @@ func (i *Instrumenter) handleJobJobOnInstrumentation(
 		}
 
 		if hasBeenModified {
-			return i.Client.Update(ctx, &job)
+			return i.Client.Update(ctx, &job, &client.UpdateOptions{FieldManager: util.FieldManager})
 		} else {
 			return nil
 		}
@@ -504,7 +504,7 @@ func (i *Instrumenter) instrumentWorkload(
 		}
 
 		if hasBeenModified {
-			return i.Client.Update(ctx, workload.asClientObject())
+			return i.Client.Update(ctx, workload.asClientObject(), &client.UpdateOptions{FieldManager: util.FieldManager})
 		} else {
 			return nil
 		}
@@ -731,7 +731,7 @@ func (i *Instrumenter) handleJobOnUninstrumentation(ctx context.Context, job bat
 
 			// Apparently for jobs we do not need to set the "dash0.com/webhook-ignore-once" label, since changing their
 			// labels does not trigger a new admission request.
-			return i.Client.Update(ctx, &job)
+			return i.Client.Update(ctx, &job, &client.UpdateOptions{FieldManager: util.FieldManager})
 		} else {
 			// No dash0.com/instrumented label is present, do nothing.
 			return nil
@@ -853,7 +853,7 @@ func (i *Instrumenter) revertWorkloadInstrumentation(
 			// workload via the webhook immediately. To prevent this, we add a label that the webhook can check to
 			// prevent instrumentation.
 			util.AddWebhookIgnoreOnceLabel(objectMeta)
-			return i.Client.Update(ctx, workload.asClientObject())
+			return i.Client.Update(ctx, workload.asClientObject(), &client.UpdateOptions{FieldManager: util.FieldManager})
 		} else {
 			return nil
 		}

--- a/internal/instrumentation/instrumenter_test.go
+++ b/internal/instrumentation/instrumenter_test.go
@@ -331,42 +331,42 @@ var _ = Describe("The instrumenter", Ordered, func() {
 			CreateFn:           WrapCronJobFnAsTestableWorkload(CreateInstrumentedCronJob),
 			GetFn:              WrapCronJobFnAsTestableWorkload(GetCronJob),
 			VerifyFn: func(workload TestableWorkload) {
-				VerifyModifiedCronJob(workload.Get().(*batchv1.CronJob), BasicInstrumentedPodSpecExpectations())
+				VerifyModifiedCronJob(workload.Get().(*batchv1.CronJob), BasicInstrumentedPodSpecExpectations(), IgnoreManagedFields)
 			},
 		}), Entry("should not touch a successfully instrumented daemon set", WorkloadTestConfig{
 			WorkloadNamePrefix: DaemonSetNamePrefix,
 			CreateFn:           WrapDaemonSetFnAsTestableWorkload(CreateInstrumentedDaemonSet),
 			GetFn:              WrapDaemonSetFnAsTestableWorkload(GetDaemonSet),
 			VerifyFn: func(workload TestableWorkload) {
-				VerifyModifiedDaemonSet(workload.Get().(*appsv1.DaemonSet), BasicInstrumentedPodSpecExpectations())
+				VerifyModifiedDaemonSet(workload.Get().(*appsv1.DaemonSet), BasicInstrumentedPodSpecExpectations(), IgnoreManagedFields)
 			},
 		}), Entry("should not touch a successfully instrumented deployment", WorkloadTestConfig{
 			WorkloadNamePrefix: DeploymentNamePrefix,
 			CreateFn:           WrapDeploymentFnAsTestableWorkload(CreateInstrumentedDeployment),
 			GetFn:              WrapDeploymentFnAsTestableWorkload(GetDeployment),
 			VerifyFn: func(workload TestableWorkload) {
-				VerifyModifiedDeployment(workload.Get().(*appsv1.Deployment), BasicInstrumentedPodSpecExpectations())
+				VerifyModifiedDeployment(workload.Get().(*appsv1.Deployment), BasicInstrumentedPodSpecExpectations(), IgnoreManagedFields)
 			},
 		}), Entry("should not touch a successfully instrumented job", WorkloadTestConfig{
 			WorkloadNamePrefix: JobNamePrefix,
 			CreateFn:           WrapJobFnAsTestableWorkload(CreateInstrumentedJob),
 			GetFn:              WrapJobFnAsTestableWorkload(GetJob),
 			VerifyFn: func(workload TestableWorkload) {
-				VerifyModifiedJob(workload.Get().(*batchv1.Job), BasicInstrumentedPodSpecExpectations())
+				VerifyModifiedJob(workload.Get().(*batchv1.Job), BasicInstrumentedPodSpecExpectations(), IgnoreManagedFields)
 			},
 		}), Entry("should not touch a successfully instrumented replica set", WorkloadTestConfig{
 			WorkloadNamePrefix: ReplicaSetNamePrefix,
 			CreateFn:           WrapReplicaSetFnAsTestableWorkload(CreateInstrumentedReplicaSet),
 			GetFn:              WrapReplicaSetFnAsTestableWorkload(GetReplicaSet),
 			VerifyFn: func(workload TestableWorkload) {
-				VerifyModifiedReplicaSet(workload.Get().(*appsv1.ReplicaSet), BasicInstrumentedPodSpecExpectations())
+				VerifyModifiedReplicaSet(workload.Get().(*appsv1.ReplicaSet), BasicInstrumentedPodSpecExpectations(), IgnoreManagedFields)
 			},
 		}), Entry("should not touch a successfully instrumented stateful set", WorkloadTestConfig{
 			WorkloadNamePrefix: StatefulSetNamePrefix,
 			CreateFn:           WrapStatefulSetFnAsTestableWorkload(CreateInstrumentedStatefulSet),
 			GetFn:              WrapStatefulSetFnAsTestableWorkload(GetStatefulSet),
 			VerifyFn: func(workload TestableWorkload) {
-				VerifyModifiedStatefulSet(workload.Get().(*appsv1.StatefulSet), BasicInstrumentedPodSpecExpectations())
+				VerifyModifiedStatefulSet(workload.Get().(*appsv1.StatefulSet), BasicInstrumentedPodSpecExpectations(), IgnoreManagedFields)
 			},
 		}),
 		)
@@ -437,7 +437,7 @@ var _ = Describe("The instrumenter", Ordered, func() {
 						"been successful. Error message: Dash0 cannot remove the instrumentation from the existing job "+
 						"test-namespace/%s, since this type of workload is immutable.", name),
 				)
-				VerifyModifiedJob(GetJob(ctx, k8sClient, namespace, name), BasicInstrumentedPodSpecExpectations())
+				VerifyModifiedJob(GetJob(ctx, k8sClient, namespace, name), BasicInstrumentedPodSpecExpectations(), IgnoreManagedFields)
 			})
 
 			It("should remove instrumentation labels from an existing job for which an instrumentation attempt has failed", func() {
@@ -461,7 +461,7 @@ var _ = Describe("The instrumenter", Ordered, func() {
 				uninstrumentWorkloadsIfAvailable(ctx, instrumenter, dash0MonitoringResource, &logger)
 
 				VerifyNoEvents(ctx, clientset, namespace)
-				VerifyModifiedPod(GetPod(ctx, k8sClient, namespace, name), BasicInstrumentedPodSpecExpectations())
+				VerifyModifiedPod(GetPod(ctx, k8sClient, namespace, name), BasicInstrumentedPodSpecExpectations(), IgnoreManagedFields)
 			})
 
 			It("should leave existing uninstrumented pod owned by a replica set alone", func() {

--- a/internal/util/constants.go
+++ b/internal/util/constants.go
@@ -4,10 +4,10 @@
 package util
 
 const (
-	AuthorizationHeaderName = "Authorization"
-	Dash0DatasetHeaderName  = "Dash0-Dataset"
-	DatasetDefault          = "default"
-	DatasetInsights         = "dash0-internal"
-
+	AuthorizationHeaderName                 = "Authorization"
+	Dash0DatasetHeaderName                  = "Dash0-Dataset"
+	DatasetDefault                          = "default"
+	DatasetInsights                         = "dash0-internal"
 	SelfMonitoringAndApiAuthTokenEnvVarName = "SELF_MONITORING_AND_API_AUTH_TOKEN"
+	FieldManager                            = "dash0-operator"
 )

--- a/internal/webhooks/instrumentation_webhook_test.go
+++ b/internal/webhooks/instrumentation_webhook_test.go
@@ -55,49 +55,49 @@ var _ = Describe("The Dash0 instrumentation webhook", func() {
 			CreateFn:           WrapCronJobFnAsTestableWorkload(CreateBasicCronJob),
 			GetFn:              WrapCronJobFnAsTestableWorkload(GetCronJob),
 			VerifyFn: func(workload TestableWorkload) {
-				VerifyModifiedCronJob(workload.Get().(*batchv1.CronJob), BasicInstrumentedPodSpecExpectations())
+				VerifyModifiedCronJob(workload.Get().(*batchv1.CronJob), BasicInstrumentedPodSpecExpectations(), VerifyNoManagedFields)
 			},
 		}), Entry("should instrument a new basic daemon set", WorkloadTestConfig{
 			WorkloadNamePrefix: DaemonSetNamePrefix,
 			CreateFn:           WrapDaemonSetFnAsTestableWorkload(CreateBasicDaemonSet),
 			GetFn:              WrapDaemonSetFnAsTestableWorkload(GetDaemonSet),
 			VerifyFn: func(workload TestableWorkload) {
-				VerifyModifiedDaemonSet(workload.Get().(*appsv1.DaemonSet), BasicInstrumentedPodSpecExpectations())
+				VerifyModifiedDaemonSet(workload.Get().(*appsv1.DaemonSet), BasicInstrumentedPodSpecExpectations(), VerifyNoManagedFields)
 			},
 		}), Entry("should instrument a new basic deployment", WorkloadTestConfig{
 			WorkloadNamePrefix: DeploymentNamePrefix,
 			CreateFn:           WrapDeploymentFnAsTestableWorkload(CreateBasicDeployment),
 			GetFn:              WrapDeploymentFnAsTestableWorkload(GetDeployment),
 			VerifyFn: func(workload TestableWorkload) {
-				VerifyModifiedDeployment(workload.Get().(*appsv1.Deployment), BasicInstrumentedPodSpecExpectations())
+				VerifyModifiedDeployment(workload.Get().(*appsv1.Deployment), BasicInstrumentedPodSpecExpectations(), VerifyNoManagedFields)
 			},
 		}), Entry("should instrument a new basic job", WorkloadTestConfig{
 			WorkloadNamePrefix: JobNamePrefix,
 			CreateFn:           WrapJobFnAsTestableWorkload(CreateBasicJob),
 			GetFn:              WrapJobFnAsTestableWorkload(GetJob),
 			VerifyFn: func(workload TestableWorkload) {
-				VerifyModifiedJob(workload.Get().(*batchv1.Job), BasicInstrumentedPodSpecExpectations())
+				VerifyModifiedJob(workload.Get().(*batchv1.Job), BasicInstrumentedPodSpecExpectations(), VerifyNoManagedFields)
 			},
 		}), Entry("should instrument a new basic ownerless pod", WorkloadTestConfig{
 			WorkloadNamePrefix: PodNamePrefix,
 			CreateFn:           WrapPodFnAsTestableWorkload(CreateBasicPod),
 			GetFn:              WrapPodFnAsTestableWorkload(GetPod),
 			VerifyFn: func(workload TestableWorkload) {
-				VerifyModifiedPod(workload.Get().(*corev1.Pod), BasicInstrumentedPodSpecExpectations())
+				VerifyModifiedPod(workload.Get().(*corev1.Pod), BasicInstrumentedPodSpecExpectations(), VerifyNoManagedFields)
 			},
 		}), Entry("should instrument a new basic ownerless replica set", WorkloadTestConfig{
 			WorkloadNamePrefix: ReplicaSetNamePrefix,
 			CreateFn:           WrapReplicaSetFnAsTestableWorkload(CreateBasicReplicaSet),
 			GetFn:              WrapReplicaSetFnAsTestableWorkload(GetReplicaSet),
 			VerifyFn: func(workload TestableWorkload) {
-				VerifyModifiedReplicaSet(workload.Get().(*appsv1.ReplicaSet), BasicInstrumentedPodSpecExpectations())
+				VerifyModifiedReplicaSet(workload.Get().(*appsv1.ReplicaSet), BasicInstrumentedPodSpecExpectations(), VerifyNoManagedFields)
 			},
 		}), Entry("should instrument a new basic stateful set", WorkloadTestConfig{
 			WorkloadNamePrefix: StatefulSetNamePrefix,
 			CreateFn:           WrapStatefulSetFnAsTestableWorkload(CreateBasicStatefulSet),
 			GetFn:              WrapStatefulSetFnAsTestableWorkload(GetStatefulSet),
 			VerifyFn: func(workload TestableWorkload) {
-				VerifyModifiedStatefulSet(workload.Get().(*appsv1.StatefulSet), BasicInstrumentedPodSpecExpectations())
+				VerifyModifiedStatefulSet(workload.Get().(*appsv1.StatefulSet), BasicInstrumentedPodSpecExpectations(), VerifyNoManagedFields)
 			},
 		}))
 
@@ -212,7 +212,9 @@ var _ = Describe("The Dash0 instrumentation webhook", func() {
 							Dash0CollectorBaseUrlEnvVarExpectedValue: OTelCollectorBaseUrlTest,
 						},
 					},
-				})
+				},
+					VerifyNoManagedFields,
+				)
 				VerifySuccessfulInstrumentationEvent(ctx, clientset, TestNamespaceName, name, "webhook")
 			})
 		})
@@ -252,7 +254,9 @@ var _ = Describe("The Dash0 instrumentation webhook", func() {
 							Dash0CollectorBaseUrlEnvVarExpectedValue: OTelCollectorBaseUrlTest,
 						},
 					},
-				})
+				},
+					VerifyNoManagedFields,
+				)
 				VerifySuccessfulInstrumentationEvent(ctx, clientset, TestNamespaceName, name, "webhook")
 			})
 		})
@@ -327,21 +331,21 @@ var _ = Describe("The Dash0 instrumentation webhook", func() {
 			CreateFn:           WrapCronJobFnAsTestableWorkload(CreateCronJobWithOptOutLabel),
 			GetFn:              WrapCronJobFnAsTestableWorkload(GetCronJob),
 			VerifyFn: func(workload TestableWorkload) {
-				VerifyModifiedCronJob(workload.Get().(*batchv1.CronJob), BasicInstrumentedPodSpecExpectations())
+				VerifyModifiedCronJob(workload.Get().(*batchv1.CronJob), BasicInstrumentedPodSpecExpectations(), VerifyNoManagedFields)
 			},
 		}), Entry("should add Dash0 to an uninstrumented daemon set when dash0.com/enable=false is removed", WorkloadTestConfig{
 			WorkloadNamePrefix: DaemonSetNamePrefix,
 			CreateFn:           WrapDaemonSetFnAsTestableWorkload(CreateDaemonSetWithOptOutLabel),
 			GetFn:              WrapDaemonSetFnAsTestableWorkload(GetDaemonSet),
 			VerifyFn: func(workload TestableWorkload) {
-				VerifyModifiedDaemonSet(workload.Get().(*appsv1.DaemonSet), BasicInstrumentedPodSpecExpectations())
+				VerifyModifiedDaemonSet(workload.Get().(*appsv1.DaemonSet), BasicInstrumentedPodSpecExpectations(), VerifyNoManagedFields)
 			},
 		}), Entry("should add Dash0 to an uninstrumented deployment when dash0.com/enable=false is removed", WorkloadTestConfig{
 			WorkloadNamePrefix: DeploymentNamePrefix,
 			CreateFn:           WrapDeploymentFnAsTestableWorkload(CreateDeploymentWithOptOutLabel),
 			GetFn:              WrapDeploymentFnAsTestableWorkload(GetDeployment),
 			VerifyFn: func(workload TestableWorkload) {
-				VerifyModifiedDeployment(workload.Get().(*appsv1.Deployment), BasicInstrumentedPodSpecExpectations())
+				VerifyModifiedDeployment(workload.Get().(*appsv1.Deployment), BasicInstrumentedPodSpecExpectations(), VerifyNoManagedFields)
 			},
 
 			// The test cases for jobs and pods are deliberately missing here, since we do not listen to UPDATE requests
@@ -352,14 +356,14 @@ var _ = Describe("The Dash0 instrumentation webhook", func() {
 			CreateFn:           WrapReplicaSetFnAsTestableWorkload(CreateReplicaSetWithOptOutLabel),
 			GetFn:              WrapReplicaSetFnAsTestableWorkload(GetReplicaSet),
 			VerifyFn: func(workload TestableWorkload) {
-				VerifyModifiedReplicaSet(workload.Get().(*appsv1.ReplicaSet), BasicInstrumentedPodSpecExpectations())
+				VerifyModifiedReplicaSet(workload.Get().(*appsv1.ReplicaSet), BasicInstrumentedPodSpecExpectations(), VerifyNoManagedFields)
 			},
 		}), Entry("should add Dash0 to an uninstrumented stateful set when dash0.com/enable=false is removed", WorkloadTestConfig{
 			WorkloadNamePrefix: StatefulSetNamePrefix,
 			CreateFn:           WrapStatefulSetFnAsTestableWorkload(CreateStatefulSetWithOptOutLabel),
 			GetFn:              WrapStatefulSetFnAsTestableWorkload(GetStatefulSet),
 			VerifyFn: func(workload TestableWorkload) {
-				VerifyModifiedStatefulSet(workload.Get().(*appsv1.StatefulSet), BasicInstrumentedPodSpecExpectations())
+				VerifyModifiedStatefulSet(workload.Get().(*appsv1.StatefulSet), BasicInstrumentedPodSpecExpectations(), VerifyNoManagedFields)
 			},
 		}))
 
@@ -380,21 +384,21 @@ var _ = Describe("The Dash0 instrumentation webhook", func() {
 			CreateFn:           WrapCronJobFnAsTestableWorkload(CreateCronJobWithOptOutLabel),
 			GetFn:              WrapCronJobFnAsTestableWorkload(GetCronJob),
 			VerifyFn: func(workload TestableWorkload) {
-				VerifyModifiedCronJob(workload.Get().(*batchv1.CronJob), BasicInstrumentedPodSpecExpectations())
+				VerifyModifiedCronJob(workload.Get().(*batchv1.CronJob), BasicInstrumentedPodSpecExpectations(), VerifyNoManagedFields)
 			},
 		}), Entry("should add Dash0 to an uninstrumented daemon set when dash0.com/enable flips from false to true", WorkloadTestConfig{
 			WorkloadNamePrefix: DaemonSetNamePrefix,
 			CreateFn:           WrapDaemonSetFnAsTestableWorkload(CreateDaemonSetWithOptOutLabel),
 			GetFn:              WrapDaemonSetFnAsTestableWorkload(GetDaemonSet),
 			VerifyFn: func(workload TestableWorkload) {
-				VerifyModifiedDaemonSet(workload.Get().(*appsv1.DaemonSet), BasicInstrumentedPodSpecExpectations())
+				VerifyModifiedDaemonSet(workload.Get().(*appsv1.DaemonSet), BasicInstrumentedPodSpecExpectations(), VerifyNoManagedFields)
 			},
 		}), Entry("should add Dash0 to an uninstrumented deployment when dash0.com/enable flips from false to true", WorkloadTestConfig{
 			WorkloadNamePrefix: DeploymentNamePrefix,
 			CreateFn:           WrapDeploymentFnAsTestableWorkload(CreateDeploymentWithOptOutLabel),
 			GetFn:              WrapDeploymentFnAsTestableWorkload(GetDeployment),
 			VerifyFn: func(workload TestableWorkload) {
-				VerifyModifiedDeployment(workload.Get().(*appsv1.Deployment), BasicInstrumentedPodSpecExpectations())
+				VerifyModifiedDeployment(workload.Get().(*appsv1.Deployment), BasicInstrumentedPodSpecExpectations(), VerifyNoManagedFields)
 			},
 
 			// The test cases for jobs and pods are deliberately missing here, since we do not listen to UPDATE requests
@@ -405,14 +409,14 @@ var _ = Describe("The Dash0 instrumentation webhook", func() {
 			CreateFn:           WrapReplicaSetFnAsTestableWorkload(CreateReplicaSetWithOptOutLabel),
 			GetFn:              WrapReplicaSetFnAsTestableWorkload(GetReplicaSet),
 			VerifyFn: func(workload TestableWorkload) {
-				VerifyModifiedReplicaSet(workload.Get().(*appsv1.ReplicaSet), BasicInstrumentedPodSpecExpectations())
+				VerifyModifiedReplicaSet(workload.Get().(*appsv1.ReplicaSet), BasicInstrumentedPodSpecExpectations(), VerifyNoManagedFields)
 			},
 		}), Entry("should add Dash0 to an uninstrumented stateful set when dash0.com/enable flips from false to true", WorkloadTestConfig{
 			WorkloadNamePrefix: StatefulSetNamePrefix,
 			CreateFn:           WrapStatefulSetFnAsTestableWorkload(CreateStatefulSetWithOptOutLabel),
 			GetFn:              WrapStatefulSetFnAsTestableWorkload(GetStatefulSet),
 			VerifyFn: func(workload TestableWorkload) {
-				VerifyModifiedStatefulSet(workload.Get().(*appsv1.StatefulSet), BasicInstrumentedPodSpecExpectations())
+				VerifyModifiedStatefulSet(workload.Get().(*appsv1.StatefulSet), BasicInstrumentedPodSpecExpectations(), VerifyNoManagedFields)
 			},
 		}))
 
@@ -553,7 +557,7 @@ func verifyThatDeploymentIsInstrumented(createdObjects []client.Object) []client
 	workload := CreateBasicDeployment(ctx, k8sClient, TestNamespaceName, name)
 	createdObjects = append(createdObjects, workload)
 	workload = GetDeployment(ctx, k8sClient, TestNamespaceName, name)
-	VerifyModifiedDeployment(workload, BasicInstrumentedPodSpecExpectations())
+	VerifyModifiedDeployment(workload, BasicInstrumentedPodSpecExpectations(), VerifyNoManagedFields)
 	VerifySuccessfulInstrumentationEvent(ctx, clientset, TestNamespaceName, name, "webhook")
 	return createdObjects
 }

--- a/internal/workloads/workload_modifier_test.go
+++ b/internal/workloads/workload_modifier_test.go
@@ -41,7 +41,7 @@ var _ = Describe("Dash0 Workload Modification", func() {
 			hasBeenModified := workloadModifier.ModifyCronJob(workload)
 
 			Expect(hasBeenModified).To(BeTrue())
-			VerifyModifiedCronJob(workload, BasicInstrumentedPodSpecExpectations())
+			VerifyModifiedCronJob(workload, BasicInstrumentedPodSpecExpectations(), IgnoreManagedFields)
 		})
 
 		It("should instrument a basic daemon set", func() {
@@ -49,7 +49,7 @@ var _ = Describe("Dash0 Workload Modification", func() {
 			hasBeenModified := workloadModifier.ModifyDaemonSet(workload)
 
 			Expect(hasBeenModified).To(BeTrue())
-			VerifyModifiedDaemonSet(workload, BasicInstrumentedPodSpecExpectations())
+			VerifyModifiedDaemonSet(workload, BasicInstrumentedPodSpecExpectations(), IgnoreManagedFields)
 		})
 
 		It("should add Dash0 to a basic deployment", func() {
@@ -57,7 +57,7 @@ var _ = Describe("Dash0 Workload Modification", func() {
 			hasBeenModified := workloadModifier.ModifyDeployment(workload)
 
 			Expect(hasBeenModified).To(BeTrue())
-			VerifyModifiedDeployment(workload, BasicInstrumentedPodSpecExpectations())
+			VerifyModifiedDeployment(workload, BasicInstrumentedPodSpecExpectations(), IgnoreManagedFields)
 		})
 
 		It("should instrument a deployment that has multiple containers, and already has volumes and init containers", func() {
@@ -90,7 +90,9 @@ var _ = Describe("Dash0 Workload Modification", func() {
 						Dash0CollectorBaseUrlEnvVarExpectedValue: OTelCollectorBaseUrlTest,
 					},
 				},
-			})
+			},
+				IgnoreManagedFields,
+			)
 		})
 
 		It("should update existing Dash0 artifacts in a deployment", func() {
@@ -125,7 +127,9 @@ var _ = Describe("Dash0 Workload Modification", func() {
 						Dash0CollectorBaseUrlEnvVarExpectedValue: OTelCollectorBaseUrlTest,
 					},
 				},
-			})
+			},
+				IgnoreManagedFields,
+			)
 		})
 
 		It("should instrument a basic job", func() {
@@ -133,7 +137,7 @@ var _ = Describe("Dash0 Workload Modification", func() {
 			hasBeenModified := workloadModifier.ModifyJob(workload)
 
 			Expect(hasBeenModified).To(BeTrue())
-			VerifyModifiedJob(workload, BasicInstrumentedPodSpecExpectations())
+			VerifyModifiedJob(workload, BasicInstrumentedPodSpecExpectations(), IgnoreManagedFields)
 		})
 
 		It("should instrument a basic ownerless pod", func() {
@@ -141,7 +145,7 @@ var _ = Describe("Dash0 Workload Modification", func() {
 			hasBeenModified := workloadModifier.ModifyPod(workload)
 
 			Expect(hasBeenModified).To(BeTrue())
-			VerifyModifiedPod(workload, BasicInstrumentedPodSpecExpectations())
+			VerifyModifiedPod(workload, BasicInstrumentedPodSpecExpectations(), IgnoreManagedFields)
 		})
 
 		It("should not instrument a basic pod owned by another higher level workload", func() {
@@ -157,7 +161,7 @@ var _ = Describe("Dash0 Workload Modification", func() {
 			hasBeenModified := workloadModifier.ModifyReplicaSet(workload)
 
 			Expect(hasBeenModified).To(BeTrue())
-			VerifyModifiedReplicaSet(workload, BasicInstrumentedPodSpecExpectations())
+			VerifyModifiedReplicaSet(workload, BasicInstrumentedPodSpecExpectations(), IgnoreManagedFields)
 		})
 
 		It("should not instrument a basic replica set that is owned by a deployment", func() {
@@ -173,7 +177,7 @@ var _ = Describe("Dash0 Workload Modification", func() {
 			hasBeenModified := workloadModifier.ModifyStatefulSet(workload)
 
 			Expect(hasBeenModified).To(BeTrue())
-			VerifyModifiedStatefulSet(workload, BasicInstrumentedPodSpecExpectations())
+			VerifyModifiedStatefulSet(workload, BasicInstrumentedPodSpecExpectations(), IgnoreManagedFields)
 		})
 	})
 
@@ -185,7 +189,7 @@ var _ = Describe("Dash0 Workload Modification", func() {
 			instrumentedOnce := workload.DeepCopy()
 			hasBeenModified = workloadModifier.ModifyCronJob(workload)
 			Expect(hasBeenModified).To(BeFalse())
-			VerifyModifiedCronJob(workload, BasicInstrumentedPodSpecExpectations())
+			VerifyModifiedCronJob(workload, BasicInstrumentedPodSpecExpectations(), IgnoreManagedFields)
 			Expect(reflect.DeepEqual(instrumentedOnce, workload)).To(BeTrue())
 		})
 
@@ -196,7 +200,7 @@ var _ = Describe("Dash0 Workload Modification", func() {
 			instrumentedOnce := workload.DeepCopy()
 			hasBeenModified = workloadModifier.ModifyDaemonSet(workload)
 			Expect(hasBeenModified).To(BeFalse())
-			VerifyModifiedDaemonSet(workload, BasicInstrumentedPodSpecExpectations())
+			VerifyModifiedDaemonSet(workload, BasicInstrumentedPodSpecExpectations(), IgnoreManagedFields)
 			Expect(reflect.DeepEqual(instrumentedOnce, workload)).To(BeTrue())
 		})
 
@@ -207,7 +211,7 @@ var _ = Describe("Dash0 Workload Modification", func() {
 			instrumentedOnce := workload.DeepCopy()
 			hasBeenModified = workloadModifier.ModifyDeployment(workload)
 			Expect(hasBeenModified).To(BeFalse())
-			VerifyModifiedDeployment(workload, BasicInstrumentedPodSpecExpectations())
+			VerifyModifiedDeployment(workload, BasicInstrumentedPodSpecExpectations(), IgnoreManagedFields)
 			Expect(reflect.DeepEqual(instrumentedOnce, workload)).To(BeTrue())
 		})
 
@@ -218,7 +222,7 @@ var _ = Describe("Dash0 Workload Modification", func() {
 			instrumentedOnce := workload.DeepCopy()
 			hasBeenModified = workloadModifier.ModifyJob(workload)
 			Expect(hasBeenModified).To(BeFalse())
-			VerifyModifiedJob(workload, BasicInstrumentedPodSpecExpectations())
+			VerifyModifiedJob(workload, BasicInstrumentedPodSpecExpectations(), IgnoreManagedFields)
 			Expect(reflect.DeepEqual(instrumentedOnce, workload)).To(BeTrue())
 		})
 
@@ -229,7 +233,7 @@ var _ = Describe("Dash0 Workload Modification", func() {
 			instrumentedOnce := workload.DeepCopy()
 			hasBeenModified = workloadModifier.ModifyPod(workload)
 			Expect(hasBeenModified).To(BeFalse())
-			VerifyModifiedPod(workload, BasicInstrumentedPodSpecExpectations())
+			VerifyModifiedPod(workload, BasicInstrumentedPodSpecExpectations(), IgnoreManagedFields)
 			Expect(reflect.DeepEqual(instrumentedOnce, workload)).To(BeTrue())
 		})
 
@@ -240,7 +244,7 @@ var _ = Describe("Dash0 Workload Modification", func() {
 			instrumentedOnce := workload.DeepCopy()
 			hasBeenModified = workloadModifier.ModifyReplicaSet(workload)
 			Expect(hasBeenModified).To(BeFalse())
-			VerifyModifiedReplicaSet(workload, BasicInstrumentedPodSpecExpectations())
+			VerifyModifiedReplicaSet(workload, BasicInstrumentedPodSpecExpectations(), IgnoreManagedFields)
 			Expect(reflect.DeepEqual(instrumentedOnce, workload)).To(BeTrue())
 		})
 
@@ -251,7 +255,7 @@ var _ = Describe("Dash0 Workload Modification", func() {
 			instrumentedOnce := workload.DeepCopy()
 			hasBeenModified = workloadModifier.ModifyStatefulSet(workload)
 			Expect(hasBeenModified).To(BeFalse())
-			VerifyModifiedStatefulSet(workload, BasicInstrumentedPodSpecExpectations())
+			VerifyModifiedStatefulSet(workload, BasicInstrumentedPodSpecExpectations(), IgnoreManagedFields)
 			Expect(reflect.DeepEqual(instrumentedOnce, workload)).To(BeTrue())
 		})
 	})
@@ -325,7 +329,7 @@ var _ = Describe("Dash0 Workload Modification", func() {
 			hasBeenModified := workloadModifier.RevertReplicaSet(workload)
 
 			Expect(hasBeenModified).To(BeFalse())
-			VerifyModifiedReplicaSet(workload, BasicInstrumentedPodSpecExpectations())
+			VerifyModifiedReplicaSet(workload, BasicInstrumentedPodSpecExpectations(), IgnoreManagedFields)
 		})
 
 		It("should remove Dash0 from an instrumented stateful set", func() {

--- a/test-resources/bin/test-scenario-03-update-operator.sh
+++ b/test-resources/bin/test-scenario-03-update-operator.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright 2024 Dash0 Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")"/../..
+
+target_namespace=${1:-test-namespace}
+
+source test-resources/bin/util
+load_env_file
+verify_kubectx
+setup_test_environment
+
+step_counter=1
+
+echo "STEP $step_counter: rebuild images"
+build_all_images
+finish_step
+
+echo "STEP $step_counter: deploy the Dash0 operator using helm"
+update_via_helm
+finish_step
+

--- a/test-resources/bin/util
+++ b/test-resources/bin/util
@@ -60,9 +60,18 @@ build_all_images() {
 }
 
 deploy_via_helm() {
+  run_helm install
+}
+
+update_via_helm() {
+  run_helm upgrade
+}
+
+run_helm() {
   deploy_otlp_sink_if_requested
 
-  local helm_install_command="helm install --namespace dash0-system"
+  local action=${1:-install}
+  local helm_install_command="helm $action --namespace dash0-system"
   if [[ -n "${OPERATOR_HELM_CHART_VERSION:-}" ]]; then
     helm_install_command+=" --version $OPERATOR_HELM_CHART_VERSION"
   fi

--- a/test/util/resources.go
+++ b/test/util/resources.go
@@ -20,6 +20,8 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/dash0hq/dash0-operator/internal/util"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -880,6 +882,7 @@ func InstrumentedDeploymentWithMoreBellsAndWhistles(namespace string, name strin
 func simulateInstrumentedResource(podTemplateSpec *corev1.PodTemplateSpec, meta *metav1.ObjectMeta) {
 	simulateInstrumentedPodSpec(&podTemplateSpec.Spec, meta)
 	addInstrumentationLabels(&podTemplateSpec.ObjectMeta, true)
+	AddManagedFields(meta)
 }
 
 func simulateInstrumentedPodSpec(podSpec *corev1.PodSpec, meta *metav1.ObjectMeta) {
@@ -1061,6 +1064,19 @@ func UpdateLabel(meta *metav1.ObjectMeta, key string, value string) {
 
 func RemoveLabel(meta *metav1.ObjectMeta, key string) {
 	delete(meta.Labels, key)
+}
+
+func AddManagedFields(meta *metav1.ObjectMeta) {
+	meta.ManagedFields = append(meta.ManagedFields, metav1.ManagedFieldsEntry{
+		Manager:    util.FieldManager,
+		Operation:  metav1.ManagedFieldsOperationUpdate,
+		Time:       ptr.To(metav1.Now()),
+		FieldsType: "FieldsV1",
+		FieldsV1: &metav1.FieldsV1{
+			//nolint:lll
+			Raw: []byte(`{\"f:metadata\":{\"f:labels\":{\".\":{},\"f:dash0.com/init-container-image\":{},\"f:dash0.com/instrumented\":{},\"f:dash0.com/instrumented-by\":{},\"f:dash0.com/operator-image\":{}}},\"f:spec\":{\"f:template\":{\"f:metadata\":{\"f:labels\":{\"f:dash0.com/init-container-image\":{},\"f:dash0.com/instrumented\":{},\"f:dash0.com/instrumented-by\":{},\"f:dash0.com/operator-image\":{}}},\"f:spec\":{\"f:containers\":{\"k:{\\\"name\\\":\\\"test-container-0\\\"}\":{\"f:env\":{\".\":{},\"k:{\\\"name\\\":\\\"DASH0_NODE_IP\\\"}\":{\".\":{},\"f:name\":{},\"f:valueFrom\":{\".\":{},\"f:fieldRef\":{}}},\"k:{\\\"name\\\":\\\"DASH0_OTEL_COLLECTOR_BASE_URL\\\"}\":{\".\":{},\"f:name\":{},\"f:value\":{}},\"k:{\\\"name\\\":\\\"LD_PRELOAD\\\"}\":{\".\":{},\"f:name\":{},\"f:value\":{}}},\"f:volumeMounts\":{\".\":{},\"k:{\\\"mountPath\\\":\\\"/__dash0__\\\"}\":{\".\":{},\"f:mountPath\":{},\"f:name\":{}}}}},\"f:initContainers\":{\".\":{},\"k:{\\\"name\\\":\\\"dash0-instrumentation\\\"}\":{\".\":{},\"f:env\":{\".\":{},\"k:{\\\"name\\\":\\\"DASH0_INSTRUMENTATION_FOLDER_DESTINATION\\\"}\":{\".\":{},\"f:name\":{},\"f:value\":{}}},\"f:image\":{},\"f:imagePullPolicy\":{},\"f:name\":{},\"f:resources\":{},\"f:securityContext\":{\".\":{},\"f:allowPrivilegeEscalation\":{},\"f:privileged\":{},\"f:readOnlyRootFilesystem\":{},\"f:runAsGroup\":{},\"f:runAsUser\":{}},\"f:terminationMessagePath\":{},\"f:terminationMessagePolicy\":{},\"f:volumeMounts\":{\".\":{},\"k:{\\\"mountPath\\\":\\\"/__dash0__\\\"}\":{\".\":{},\"f:mountPath\":{},\"f:name\":{}}}}},\"f:volumes\":{\".\":{},\"k:{\\\"name\\\":\\\"dash0-instrumentation\\\"}\":{\".\":{},\"f:emptyDir\":{\".\":{},\"f:sizeLimit\":{}},\"f:name\":{}}}}}}}`),
+		},
+	})
 }
 
 func DeleteAllCreatedObjects(


### PR DESCRIPTION
Set the field manager to dash0-operator when instrumenting workloads. This makes it easier to identify which managed fields have been written by the Dash0 operator.