### PR TITLE
feat: make kubeletstatsreceiver work ootb on Minikube and Docker Desktop

### DIFF
--- a/helm-chart/dash0-operator/README.md
+++ b/helm-chart/dash0-operator/README.md
@@ -887,3 +887,33 @@ You can work around this issue by one of the following methods:
 * using an `amd64` Kubernetes node,
 * by building a multi-platform image for your application, or
 * by building the application as an `arm64` image (e.g. by using `--platform=linux/arm64` when building the image).
+
+## Notes on Running The Operator on Docker Desktop
+
+Docker Desktop's Kubelet `/stats` endpoint uses a self-signed TLS certificate, which is not even signed by the cluster's certificate authority, and it looks invalid from the point of view of the OpenTelemetry collectors operated by the Dash0 operator.
+
+To ensure that you can still have a good experience trying out the Dash0 operator in a local environment, the Dash0 operator detects that is is running via the Kubernetes integrated in Docker Desktop (by matching the node name against `docker-desktop`) and disables the TLS verification for the receiver that retrieve metrics from the Kubelet `/stats` endpoint. If this is the case, you will see the following entry in the logs of the daemonset operated by the Dash0 operator:
+
+```
+This collector seems to run on a node managed by Docker Desktop's Kubernetes, which is known to have self-signed CA certs for the Kubelet stats endpoint: disabling TLS verification for the kubeletstat receiver
+```
+
+## Notes on Running The Operator on Minikube
+
+Docker Desktop's Kubelet `/stats` endpoint uses a self-signed TLS certificate, which is not even signed by the cluster's certificate authority, and it looks invalid from the point of view of the OpenTelemetry collectors operated by the Dash0 operator.
+
+To ensure that you can still have a good experience trying out the Dash0 operator in a local environment, the Dash0 operator detects that is is running via the Kubernetes integrated in Docker Desktop (by matching the node name against `minikube`) and disables the TLS verification for the receiver that retrieve metrics from the Kubelet `/stats` endpoint. If this is the case, you will see the following entry in the logs of the daemonset operated by the Dash0 operator:
+
+```
+This collector seems to run on a node managed by Minikube, which is known to have self-signed CA certs for the Kubelet stats endpoint: disabling TLS verification for the kubeletstat receiver
+```
+
+Note: if you use a minikube profile (`minikube -p <profile_name>`), the node name will change, and the automatic disablement of TLS verification will not work, resulting on missing metrics in Dash0 about your workloads.
+If this is the case, you can run the Dash0 operator in development mode (which results, among other things, in disabling the TLS verification for the Kubelet `/stats` endpoint) by passing the `--set operator.developmentMode=true` configuration to Helm.
+
+## Notes on Running The Operator on Kind
+
+Kind's Kubelet `/stats` endpoint uses a self-signed TLS certificate, which is not even signed by the cluster's certificate authority, and it looks invalid from the point of view of the OpenTelemetry collectors operated by the Dash0 operator.
+
+Unfortunately, unlike the cases for Docker Desktop and Minikube, there is no known heuristic for an operator to know whether it's running on a Kind cluster.
+If you want to collect Kubelet metrics from a Kind cluster, you will need to run the Dash0 operator in development mode (which results, among other things, in disabling the TLS verification for the Kubelet `/stats` endpoint) by passing the `--set operator.developmentMode=true` configuration to Helm.

--- a/images/collector/src/image/entrypoint.sh
+++ b/images/collector/src/image/entrypoint.sh
@@ -1,5 +1,17 @@
 #!/bin/sh
 
+if [ -z "${KUBELET_STATS_TLS_INSECURE:-}" ]; then
+    if [ "${K8S_NODE_NAME:-}" = "minikube" ]; then
+        export "KUBELET_STATS_TLS_INSECURE=true"
+        echo "This collector seems to run on a node managed by Minikube, which is known to have self-signed CA certs for the Kubelet stats endpoint: disabling TLS verification for the kubeletstat receiver"
+    elif [ "${K8S_NODE_NAME:-}" = "docker-desktop" ]; then
+        export "KUBELET_STATS_TLS_INSECURE=true"
+        echo "This collector seems to run on a node managed by Docker Desktop's Kubernetes, which is known to have self-signed CA certs for the Kubelet stats endpoint: disabling TLS verification for the kubeletstat receiver"
+    else
+        export "KUBELET_STATS_TLS_INSECURE=false"
+    fi
+fi
+
 ./otelcol "$@" &
 
 DASH0_COLLECTOR_PID=$!

--- a/internal/backendconnection/otelcolresources/collector_config_maps_test.go
+++ b/internal/backendconnection/otelcolresources/collector_config_maps_test.go
@@ -638,8 +638,9 @@ var _ = Describe("The OpenTelemetry Collector ConfigMaps", func() {
 			kubeletstatsReceiverRaw := readFromMap(collectorConfig, []string{"receivers", "kubeletstats"})
 			Expect(kubeletstatsReceiverRaw).ToNot(BeNil())
 			kubeletstatsReceiver := kubeletstatsReceiverRaw.(map[string]interface{})
-			_, hasInsecureSkipVerifyProperty := kubeletstatsReceiver["insecure_skip_verify"]
-			Expect(hasInsecureSkipVerifyProperty).To(BeFalse())
+			insecureSkipVerifyPropertyValue, hasInsecureSkipVerifyProperty := kubeletstatsReceiver["insecure_skip_verify"]
+			Expect(hasInsecureSkipVerifyProperty).To(BeTrue())
+			Expect(insecureSkipVerifyPropertyValue).To(Equal("${env:KUBELET_STATS_TLS_INSECURE}"))
 
 			pipelines := readPipelines(collectorConfig)
 			metricsReceivers := readPipelineReceivers(pipelines, "metrics/downstream")

--- a/internal/backendconnection/otelcolresources/daemonset.config.yaml.template
+++ b/internal/backendconnection/otelcolresources/daemonset.config.yaml.template
@@ -152,7 +152,6 @@ receivers:
       k8s.pod.memory_request_utilization:
         enabled: true
 
-{{- if .DevelopmentMode }}
 {{- /*
 On Docker Desktop, Kind, etc. the API server uses a self-signed cert. Scraping will not work without
 insecure_skip_verify=true in these environments:
@@ -162,10 +161,8 @@ kubeletstatsreceiver@v0.106.1/scraper.go:104 call to /stats/summary endpoint fai
 \"https://docker-desktop:10250/stats/summary\": tls: failed to verify certificate: x509: certificate signed by unknown
 authority"}
 
-Thus we add this parameter when the helm chart is installed with --set operator.developmentMode=true for local tests and
-e2e tests. */}}
-    insecure_skip_verify: true
-{{- end }}
+This env var is set in the collector image's entrypoint script or in the daemonset spec if DevelopmentMode is active */}}
+    insecure_skip_verify: ${env:KUBELET_STATS_TLS_INSECURE}
 {{- end }}
 
 {{- $hasPrometheusScrapingEnabledForAtLeastOneNamespace := gt (len .NamespacesWithPrometheusScraping) 0 }}

--- a/internal/backendconnection/otelcolresources/desired_state.go
+++ b/internal/backendconnection/otelcolresources/desired_state.go
@@ -626,6 +626,13 @@ func assembleCollectorEnvVars(config *oTelColConfig, goMemLimit string) ([]corev
 		},
 	}
 
+	if config.DevelopmentMode {
+		collectorEnv = append(collectorEnv, corev1.EnvVar{
+			Name:  "KUBELET_STATS_TLS_INSECURE",
+			Value: "true",
+		})
+	}
+
 	if config.Export.Dash0 != nil {
 		authTokenEnvVar, err := util.CreateEnvVarForAuthorization(
 			(*(config.Export.Dash0)).Authorization,


### PR DESCRIPTION
The Kubelet stats endpoint on Minikube, Docker Desktop and Kind appears to use self-signed certificates that are not signed by the cluster's certificate authority. This means that they are invalid for the Daemonset's collector, preventing kubelet-based metrics from being collected, and degrading the first user experience of the operator for end users that try it in a local cluster.

This change works around it by disabling TLS veritification for the kubeletstats receiver if the collector is running on a node named "minikube" or "docker-desktop", and documenting ways to solve the issue for Kind or `minikube -p <profile_name>`.