### PR TITLE
fix(backendconnection): add another annotation for ArgoCD

### DIFF
--- a/internal/backendconnection/otelcolresources/desired_state.go
+++ b/internal/backendconnection/otelcolresources/desired_state.go
@@ -1091,10 +1091,12 @@ func addCommonMetadata(object client.Object) clientObject {
 	//   level resources are pruned (that is basically the same as resources without an owner reference).
 	// * The docs for preventing this on a resource level are here:
 	//   https://argo-cd.readthedocs.io/en/stable/user-guide/sync-options/#no-prune-resources
+	//   https://argo-cd.readthedocs.io/en/stable/user-guide/compare-options/#ignoring-resources-that-are-extraneous
 	if object.GetAnnotations() == nil {
 		object.SetAnnotations(map[string]string{})
 	}
 	object.GetAnnotations()["argocd.argoproj.io/sync-options"] = "Prune=false"
+	object.GetAnnotations()["argocd.argoproj.io/compare-options"] = "IgnoreExtraneous"
 	return clientObject{
 		object: object,
 	}

--- a/internal/backendconnection/otelcolresources/desired_state_test.go
+++ b/internal/backendconnection/otelcolresources/desired_state_test.go
@@ -61,8 +61,9 @@ var _ = Describe("The desired state of the OpenTelemetry Collector resources", f
 		for _, wrapper := range desiredState {
 			object := wrapper.object
 			annotations := object.GetAnnotations()
-			Expect(annotations).To(HaveLen(1))
+			Expect(annotations).To(HaveLen(2))
 			Expect(annotations["argocd.argoproj.io/sync-options"]).To(Equal("Prune=false"))
+			Expect(annotations["argocd.argoproj.io/compare-options"]).To(Equal("IgnoreExtraneous"))
 		}
 		collectorConfigConfigMapContent := getDaemonSetCollectorConfigConfigMapContent(desiredState)
 		Expect(collectorConfigConfigMapContent).To(ContainSubstring(fmt.Sprintf("endpoint: %s", EndpointDash0TestQuoted)))


### PR DESCRIPTION
This is a follow-up to 9b3360f41933bc60ef793e230ee27c2b8b6703eb. In addition to adding the annotation
argocd.argoproj.io/sync-options: Prune=false, we now also set argocd.argoproj.io/compare-options: IgnoreExtraneous.

This should exclude the resources managed by the operator ArgoCD sync completely.

See
https://argo-cd.readthedocs.io/en/stable/user-guide/compare-options/#ignoring-resources-that-are-extraneous