### PR TITLE
feat: add default node anti-affinity for all operator pods

### DIFF
--- a/helm-chart/dash0-operator/README.md
+++ b/helm-chart/dash0-operator/README.md
@@ -480,6 +480,31 @@ By default, the operator collects metrics as follows:
 
 Disabling or enabling individual metrics via configuration is currently not supported.
 
+### Preventing Operator Scheduling on Specific Nodes
+
+All the pods deployed by the operator have a default node anti-affinity for the `dash0.com/enable=false` node label.
+That is, if you add the `dash0.com/enable=false` label to a node, none of the pods owned by the operator will schedule
+on that node.
+
+**IMPORTANT:** This includes the daemonset that the operator will set up to receive telemetry from the pods, which might
+leads to situations in which instrumented pods cannot send telemetry because the local node does not have a daemonset
+pod.
+In other words, if you want to monitor workloads with the Dash0 operator and use the `dash0.com/enable=false` node
+anti-affinity, make sure that the workloads you want to monitor have the same anti-affinity:
+
+```yaml
+# Add this to your workloads
+spec:
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: "dash0.com/enable"
+            operator: "NotIn"
+            values: ["false"]
+```
+
 ### Disabling Auto-Instrumentation for Specific Workloads
 
 In namespaces that are Dash0-monitoring enabled, all supported workload types are automatically instrumented for

--- a/helm-chart/dash0-operator/templates/operator/deployment-and-webhooks.yaml
+++ b/helm-chart/dash0-operator/templates/operator/deployment-and-webhooks.yaml
@@ -67,6 +67,14 @@ spec:
         {{- include "dash0-operator.podLabels" . | nindent 8 }}
         {{- end }}
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: "dash0.com/enable"
+                operator: "NotIn"
+                values: ["false"]
       containers:
       - name: manager
         image: {{ include "dash0-operator.image" . | quote }}

--- a/helm-chart/dash0-operator/tests/operator/__snapshot__/deployment-and-webhooks_test.yaml.snap
+++ b/helm-chart/dash0-operator/tests/operator/__snapshot__/deployment-and-webhooks_test.yaml.snap
@@ -29,6 +29,15 @@ deployment should match snapshot (default values):
             app.kubernetes.io/name: dash0-operator
             dash0.com/cert-digest: dJTiBDRVJUSUZJQ
         spec:
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: dash0.com/enable
+                        operator: NotIn
+                        values:
+                          - "false"
           automountServiceAccountToken: true
           containers:
             - args:

--- a/internal/backendconnection/otelcolresources/desired_state.go
+++ b/internal/backendconnection/otelcolresources/desired_state.go
@@ -451,6 +451,23 @@ func assembleCollectorDaemonSet(config *oTelColConfig, resourceSpecs *OTelColRes
 					Labels: daemonSetMatchLabels,
 				},
 				Spec: corev1.PodSpec{
+					Affinity: &corev1.Affinity{
+						NodeAffinity: &corev1.NodeAffinity{
+							RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+								NodeSelectorTerms: []corev1.NodeSelectorTerm{
+									{
+										MatchExpressions: []corev1.NodeSelectorRequirement{
+											{
+												Key:      dash0OptOutLabelKey,
+												Operator: corev1.NodeSelectorOpNotIn,
+												Values:   []string{"false"},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
 					ServiceAccountName: daemonsetServiceAccountName(config.NamePrefix),
 					SecurityContext:    &corev1.PodSecurityContext{},
 					// This setting is required to enable the configuration reloader process to send Unix signals to the
@@ -911,6 +928,23 @@ func assembleCollectorDeployment(
 					Labels: deploymentMatchLabels,
 				},
 				Spec: corev1.PodSpec{
+					Affinity: &corev1.Affinity{
+						NodeAffinity: &corev1.NodeAffinity{
+							RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+								NodeSelectorTerms: []corev1.NodeSelectorTerm{
+									{
+										MatchExpressions: []corev1.NodeSelectorRequirement{
+											{
+												Key:      dash0OptOutLabelKey,
+												Operator: corev1.NodeSelectorOpNotIn,
+												Values:   []string{"false"},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
 					ServiceAccountName: deploymentServiceAccountName(config.NamePrefix),
 					SecurityContext:    &corev1.PodSecurityContext{},
 					// This setting is required to enable the configuration reloader process to send Unix signals to the


### PR DESCRIPTION
This PR adds a default node-antiaffinity that will prevents all pods sc heduled by the operator (manager, otelcol deployment, otelcol daemonset) to be scheduled on nodes with the `dash0.com/enable=false` label