### PR TITLE
chore(metrics): disable noisy cluster metrics that do not add value

### DIFF
--- a/internal/backendconnection/otelcolresources/deployment.config.yaml.template
+++ b/internal/backendconnection/otelcolresources/deployment.config.yaml.template
@@ -86,7 +86,13 @@ processors:
 receivers:
   k8s_cluster:
     metrics:
+      k8s.container.restarts:
+        enabled: false
       k8s.namespace.phase:
+        enabled: false
+      k8s.replicaset.desired:
+        enabled: false
+      k8s.replicaset.available:
         enabled: false
 
 service:

--- a/test/e2e/k8s_cluster_receiver_metrics.txt
+++ b/test/e2e/k8s_cluster_receiver_metrics.txt
@@ -6,7 +6,6 @@ k8s.container.ephemeralstorage_request
 k8s.container.memory_limit
 k8s.container.memory_request
 k8s.container.ready
-k8s.container.restarts
 k8s.container.storage_limit
 k8s.container.storage_request
 k8s.cronjob.active_jobs
@@ -29,8 +28,6 @@ k8s.namespace.phase
 k8s.node.condition
 k8s.pod.phase
 k8s.pod.status_reason
-k8s.replicaset.available
-k8s.replicaset.desired
 k8s.replication_controller.available
 k8s.replication_controller.desired
 k8s.resource_quota.hard_limit


### PR DESCRIPTION
In particular, the following metrics were dropped:
* k8s.container.restarts
* k8s.replicaset.desired
* k8s.replicaset.available