### PR TITLE
feat(backendconnection): deploy collectors via operator configuration

### DIFF
--- a/internal/backendconnection/backendconnection_manager_test.go
+++ b/internal/backendconnection/backendconnection_manager_test.go
@@ -62,32 +62,24 @@ var _ = Describe("The backend connection manager", Ordered, func() {
 	})
 
 	Describe("when validation checks fail", func() {
-		BeforeEach(func() {
-			// creating a valid monitoring resource beforehand, just so we get past the
-			// m.findAllMonitoringResources step.
-			resource := EnsureMonitoringResourceExistsAndIsAvailable(
-				ctx,
-				k8sClient,
-			)
-			createdObjects = append(createdObjects, resource)
-		})
-
 		It("should fail if no endpoint is provided", func() {
-			err := manager.ReconcileOpenTelemetryCollector(
-				ctx,
-				TestImages,
-				operatorNamespace,
-				&dash0v1alpha1.Dash0Monitoring{
-					Spec: dash0v1alpha1.Dash0MonitoringSpec{
-						Export: &dash0v1alpha1.Export{
-							Dash0: &dash0v1alpha1.Dash0Configuration{
-								Authorization: dash0v1alpha1.Authorization{
-									Token: &AuthorizationTokenTest,
-								},
+			monitoringResource := &dash0v1alpha1.Dash0Monitoring{
+				Spec: dash0v1alpha1.Dash0MonitoringSpec{
+					Export: &dash0v1alpha1.Export{
+						Dash0: &dash0v1alpha1.Dash0Configuration{
+							Authorization: dash0v1alpha1.Authorization{
+								Token: &AuthorizationTokenTest,
 							},
 						},
 					},
 				},
+			}
+			monitoringResource.EnsureResourceIsMarkedAsAvailable()
+			err := manager.ReconcileOpenTelemetryCollector(
+				ctx,
+				TestImages,
+				operatorNamespace,
+				monitoringResource,
 				TriggeredByDash0ResourceReconcile,
 			)
 			Expect(err).To(MatchError(
@@ -96,20 +88,22 @@ var _ = Describe("The backend connection manager", Ordered, func() {
 		})
 
 		It("should fail if neither authorization token nor secret ref are provided for Dash0 exporter", func() {
+			monitoringResource := &dash0v1alpha1.Dash0Monitoring{
+				Spec: dash0v1alpha1.Dash0MonitoringSpec{
+					Export: &dash0v1alpha1.Export{
+						Dash0: &dash0v1alpha1.Dash0Configuration{
+							Endpoint:      EndpointDash0Test,
+							Authorization: dash0v1alpha1.Authorization{},
+						},
+					},
+				},
+			}
+			monitoringResource.EnsureResourceIsMarkedAsAvailable()
 			err := manager.ReconcileOpenTelemetryCollector(
 				ctx,
 				TestImages,
 				operatorNamespace,
-				&dash0v1alpha1.Dash0Monitoring{
-					Spec: dash0v1alpha1.Dash0MonitoringSpec{
-						Export: &dash0v1alpha1.Export{
-							Dash0: &dash0v1alpha1.Dash0Configuration{
-								Endpoint:      EndpointDash0Test,
-								Authorization: dash0v1alpha1.Authorization{},
-							},
-						},
-					},
-				},
+				monitoringResource,
 				TriggeredByDash0ResourceReconcile,
 			)
 			Expect(err).To(MatchError(
@@ -120,18 +114,8 @@ var _ = Describe("The backend connection manager", Ordered, func() {
 
 	Describe("when creating OpenTelemetry collector resources", func() {
 
-		BeforeEach(func() {
-			// creating a valid monitoring resource beforehand, just so we get past the
-			// m.findAllMonitoringResources step.
-			resource := EnsureMonitoringResourceExistsAndIsAvailable(
-				ctx,
-				k8sClient,
-			)
-			createdObjects = append(createdObjects, resource)
-		})
-
 		AfterEach(func() {
-			err := manager.OTelColResourceManager.DeleteResources(
+			_, err := manager.OTelColResourceManager.DeleteResources(
 				ctx,
 				operatorNamespace,
 				&logger,
@@ -141,19 +125,19 @@ var _ = Describe("The backend connection manager", Ordered, func() {
 			DeleteAllOperatorConfigurationResources(ctx, k8sClient)
 		})
 
-		It("should create all resources", func() {
+		It("should do nothing if there is no operator configuration resource and also no monitoring resource", func() {
 			err := manager.ReconcileOpenTelemetryCollector(
 				ctx,
 				TestImages,
 				operatorNamespace,
-				assembleMonitoringResource(),
+				nil,
 				TriggeredByDash0ResourceReconcile,
 			)
 			Expect(err).ToNot(HaveOccurred())
-			VerifyCollectorResources(ctx, k8sClient, operatorNamespace)
+			VerifyCollectorResourcesDoNotExist(ctx, k8sClient, operatorNamespace)
 		})
 
-		It("should fall back to the operator configuration export settings if the monitoring resource has no export", func() {
+		It("should create the Dash0 collectors based on the operator configuration's export settings ", func() {
 			CreateDefaultOperatorConfigurationResource(
 				ctx,
 				k8sClient,
@@ -162,34 +146,131 @@ var _ = Describe("The backend connection manager", Ordered, func() {
 				ctx,
 				TestImages,
 				operatorNamespace,
-				&dash0v1alpha1.Dash0Monitoring{
-					Spec: dash0v1alpha1.Dash0MonitoringSpec{},
-				},
+				nil,
 				TriggeredByDash0ResourceReconcile,
 			)
 			Expect(err).ToNot(HaveOccurred())
-			VerifyCollectorResources(ctx, k8sClient, operatorNamespace)
+			VerifyCollectorResources(ctx, k8sClient, operatorNamespace, EndpointDash0Test, AuthorizationTokenTest)
 		})
 
-		It("should fail if the monitoring resource has no export and there is no operator configuration resource", func() {
+		It("the operator configuration's export settings should have priority over the triggering monitoring source and the existing monitoring resources", func() {
+			CreateDefaultOperatorConfigurationResource(
+				ctx,
+				k8sClient,
+			)
+			monitoringResource := EnsureMonitoringResourceWithSpecExistsAndIsAvailable(
+				ctx,
+				k8sClient,
+				dash0v1alpha1.Dash0MonitoringSpec{
+					Export: &dash0v1alpha1.Export{
+						Dash0: &dash0v1alpha1.Dash0Configuration{
+							Endpoint: EndpointDash0TestAlternative,
+							Authorization: dash0v1alpha1.Authorization{
+								Token: &AuthorizationTokenTestAlternative,
+							},
+						},
+					},
+				},
+			)
+			createdObjects = append(createdObjects, monitoringResource)
 			err := manager.ReconcileOpenTelemetryCollector(
 				ctx,
 				TestImages,
 				operatorNamespace,
-				&dash0v1alpha1.Dash0Monitoring{
-					Spec: dash0v1alpha1.Dash0MonitoringSpec{},
-				},
+				assembleMonitoringResource(EndpointDash0TestAlternative, AuthorizationTokenTestAlternative),
 				TriggeredByDash0ResourceReconcile,
 			)
-			Expect(err).To(
-				MatchError(
-					"the provided Dash0Monitoring resource does not have an export configuration and no " +
-						"Dash0OperatorConfiguration resource has been found"))
+			Expect(err).ToNot(HaveOccurred())
+			VerifyCollectorResources(ctx, k8sClient, operatorNamespace, EndpointDash0Test, AuthorizationTokenTest)
+		})
+
+		It("should use the triggering monitoring resource's export settings if there is no operator configuration resource", func() {
+			// this monitoring resource is just created to verify that the triggering resource takes priority
+			monitoringResource := EnsureMonitoringResourceWithSpecExistsAndIsAvailable(
+				ctx,
+				k8sClient,
+				dash0v1alpha1.Dash0MonitoringSpec{
+					Export: &dash0v1alpha1.Export{
+						Dash0: &dash0v1alpha1.Dash0Configuration{
+							Endpoint: EndpointDash0TestAlternative,
+							Authorization: dash0v1alpha1.Authorization{
+								Token: &AuthorizationTokenTestAlternative,
+							},
+						},
+					},
+				},
+			)
+			createdObjects = append(createdObjects, monitoringResource)
+
+			err := manager.ReconcileOpenTelemetryCollector(
+				ctx,
+				TestImages,
+				operatorNamespace,
+				assembleMonitoringResource(EndpointDash0Test, AuthorizationTokenTest),
+				TriggeredByDash0ResourceReconcile,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			VerifyCollectorResources(ctx, k8sClient, operatorNamespace, EndpointDash0Test, AuthorizationTokenTest)
+		})
+
+		It("should use the export settings from an existing monitoring resource if there is no operator configuration resource and no triggering monitoring resource", func() {
+			monitoringResource := EnsureMonitoringResourceExistsAndIsAvailable(
+				ctx,
+				k8sClient,
+			)
+			createdObjects = append(createdObjects, monitoringResource)
+			err := manager.ReconcileOpenTelemetryCollector(
+				ctx,
+				TestImages,
+				operatorNamespace,
+				nil,
+				TriggeredByDash0ResourceReconcile,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			VerifyCollectorResources(ctx, k8sClient, operatorNamespace, EndpointDash0Test, AuthorizationTokenTest)
+		})
+
+		It("should do nothing if there is no operator configuration resource and the triggering monitoring resource has no export", func() {
+			monitoringResource := &dash0v1alpha1.Dash0Monitoring{
+				Spec: dash0v1alpha1.Dash0MonitoringSpec{},
+			}
+			monitoringResource.EnsureResourceIsMarkedAsAvailable()
+			err := manager.ReconcileOpenTelemetryCollector(
+				ctx,
+				TestImages,
+				operatorNamespace,
+				monitoringResource,
+				TriggeredByDash0ResourceReconcile,
+			)
+			Expect(err).ToNot(HaveOccurred())
 			VerifyCollectorResourcesDoNotExist(ctx, k8sClient, operatorNamespace)
 		})
 
-		It("should fail if the monitoring resource has no export and the existing operator configuration "+
-			"resource has no export either", func() {
+		It("should do nothing if there is no operator configuration resource and the triggering monitoring resource is not marked as available", func() {
+			monitoringResource := &dash0v1alpha1.Dash0Monitoring{
+				Spec: dash0v1alpha1.Dash0MonitoringSpec{
+					Export: &dash0v1alpha1.Export{
+						Dash0: &dash0v1alpha1.Dash0Configuration{
+							Endpoint: EndpointDash0TestAlternative,
+							Authorization: dash0v1alpha1.Authorization{
+								Token: &AuthorizationTokenTestAlternative,
+							},
+						},
+					},
+				},
+			}
+			err := manager.ReconcileOpenTelemetryCollector(
+				ctx,
+				TestImages,
+				operatorNamespace,
+				monitoringResource,
+				TriggeredByDash0ResourceReconcile,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			VerifyCollectorResourcesDoNotExist(ctx, k8sClient, operatorNamespace)
+		})
+
+		It("should do nothing if the operator configuration resource has no export and there is no monitoring resource", func() {
 			CreateOperatorConfigurationResourceWithSpec(
 				ctx,
 				k8sClient,
@@ -199,13 +280,81 @@ var _ = Describe("The backend connection manager", Ordered, func() {
 				ctx,
 				TestImages,
 				operatorNamespace,
-				&dash0v1alpha1.Dash0Monitoring{
-					Spec: dash0v1alpha1.Dash0MonitoringSpec{},
-				},
+				nil,
 				TriggeredByDash0ResourceReconcile,
 			)
-			Expect(err).To(MatchError("the provided Dash0Monitoring resource does not have an export configuration " +
-				"and the Dash0OperatorConfiguration resource does not have one either"))
+			Expect(err).ToNot(HaveOccurred())
+			VerifyCollectorResourcesDoNotExist(ctx, k8sClient, operatorNamespace)
+		})
+
+		It("should do nothing if the operator configuration resource has no export and the triggering monitoring resource has no export", func() {
+			CreateOperatorConfigurationResourceWithSpec(
+				ctx,
+				k8sClient,
+				dash0v1alpha1.Dash0OperatorConfigurationSpec{},
+			)
+			monitoringResource := &dash0v1alpha1.Dash0Monitoring{
+				Spec: dash0v1alpha1.Dash0MonitoringSpec{},
+			}
+			monitoringResource.EnsureResourceIsMarkedAsAvailable()
+			err := manager.ReconcileOpenTelemetryCollector(
+				ctx,
+				TestImages,
+				operatorNamespace,
+				monitoringResource,
+				TriggeredByDash0ResourceReconcile,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			VerifyCollectorResourcesDoNotExist(ctx, k8sClient, operatorNamespace)
+		})
+
+		It("should do nothing if there is no operator configuration resource and neither the triggering nor the existing monitoring resource have an export", func() {
+			existingMonitoringResource := EnsureMonitoringResourceExists(
+				ctx,
+				k8sClient,
+			)
+			createdObjects = append(createdObjects, existingMonitoringResource)
+			triggeringMonitoringResource := &dash0v1alpha1.Dash0Monitoring{
+				Spec: dash0v1alpha1.Dash0MonitoringSpec{
+					Export: &dash0v1alpha1.Export{
+						Dash0: &dash0v1alpha1.Dash0Configuration{
+							Endpoint: EndpointDash0TestAlternative,
+							Authorization: dash0v1alpha1.Authorization{
+								Token: &AuthorizationTokenTestAlternative,
+							},
+						},
+					},
+				},
+			}
+			err := manager.ReconcileOpenTelemetryCollector(
+				ctx,
+				TestImages,
+				operatorNamespace,
+				triggeringMonitoringResource,
+				TriggeredByDash0ResourceReconcile,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			VerifyCollectorResourcesDoNotExist(ctx, k8sClient, operatorNamespace)
+		})
+
+		It("should do nothing if there is no operator configuration resource and neither the triggering nor the existing monitoring are marked as available", func() {
+			existingMonitoringResource := EnsureEmptyMonitoringResourceExistsAndIsAvailable(
+				ctx,
+				k8sClient,
+			)
+			createdObjects = append(createdObjects, existingMonitoringResource)
+			triggeringMonitoringResource := &dash0v1alpha1.Dash0Monitoring{
+				Spec: dash0v1alpha1.Dash0MonitoringSpec{},
+			}
+			triggeringMonitoringResource.EnsureResourceIsMarkedAsAvailable()
+			err := manager.ReconcileOpenTelemetryCollector(
+				ctx,
+				TestImages,
+				operatorNamespace,
+				triggeringMonitoringResource,
+				TriggeredByDash0ResourceReconcile,
+			)
+			Expect(err).ToNot(HaveOccurred())
 			VerifyCollectorResourcesDoNotExist(ctx, k8sClient, operatorNamespace)
 		})
 	})
@@ -244,11 +393,11 @@ var _ = Describe("The backend connection manager", Ordered, func() {
 				ctx,
 				TestImages,
 				operatorNamespace,
-				assembleMonitoringResource(),
+				nil,
 				TriggeredByDash0ResourceReconcile,
 			)
 			Expect(err).ToNot(HaveOccurred())
-			VerifyCollectorResources(ctx, k8sClient, operatorNamespace)
+			VerifyCollectorResources(ctx, k8sClient, operatorNamespace, EndpointDash0Test, AuthorizationTokenTest)
 
 			// verify that all wrong properties that we have set up initially have been removed
 			cm := GetOTelColDaemonSetConfigMap(ctx, k8sClient, operatorNamespace)
@@ -259,23 +408,102 @@ var _ = Describe("The backend connection manager", Ordered, func() {
 		})
 	})
 
-	Describe("when cleaning up OpenTelemetry collector resources when the resource is deleted", func() {
-		It("should not delete the collector if there are still Dash0 monitoring resources", func() {
-			// create multiple Dash0 monitoring resources
+	Describe("when deciding whether to delete the OpenTelemetry collector resources", func() {
+
+		AfterEach(func() {
+			_, err := manager.OTelColResourceManager.DeleteResources(
+				ctx,
+				operatorNamespace,
+				&logger,
+			)
+			Expect(err).ToNot(HaveOccurred())
+
+			DeleteAllOperatorConfigurationResources(ctx, k8sClient)
+		})
+
+		It("should not delete the collector if there is an operator configuration and the Dash0 monitoring resource that is being deleted is the only one left", func() {
+			CreateDefaultOperatorConfigurationResource(
+				ctx,
+				k8sClient,
+			)
+
+			resourceName := types.NamespacedName{Namespace: TestNamespaceName, Name: "dash0-monitoring-test-resource-1"}
+			monitoringResource := EnsureMonitoringResourceExistsInNamespaceAndIsAvailable(ctx, k8sClient, resourceName)
+			createdObjects = append(createdObjects, monitoringResource)
+
+			// Let the manager create the collector so there is something to delete.
+			err := manager.ReconcileOpenTelemetryCollector(
+				ctx,
+				TestImages,
+				operatorNamespace,
+				monitoringResource,
+				TriggeredByDash0ResourceReconcile,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			VerifyCollectorResources(ctx, k8sClient, operatorNamespace, EndpointDash0Test, AuthorizationTokenTest)
+
+			err = manager.ReconcileOpenTelemetryCollector(
+				ctx,
+				TestImages,
+				operatorNamespace,
+				monitoringResource,
+				TriggeredByDash0ResourceReconcile,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			// verify the collector is not deleted even if the monitoring resource provided as a parameter is the only
+			// one left, when there is still an operator configuration left,
+			VerifyCollectorResources(ctx, k8sClient, operatorNamespace, EndpointDash0Test, AuthorizationTokenTest)
+		})
+
+		It("should not delete the collector if there is an operator configuration resource and no monitoring resource exists", func() {
+			CreateDefaultOperatorConfigurationResource(
+				ctx,
+				k8sClient,
+			)
+
+			// Let the manager create the collector so there is something to delete.
+			monitoringResource := EnsureMonitoringResourceExistsAndIsAvailable(
+				ctx,
+				k8sClient,
+			)
+			err := manager.ReconcileOpenTelemetryCollector(
+				ctx,
+				TestImages,
+				operatorNamespace,
+				monitoringResource,
+				TriggeredByDash0ResourceReconcile,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			VerifyCollectorResources(ctx, k8sClient, operatorNamespace, EndpointDash0Test, AuthorizationTokenTest)
+
+			Expect(k8sClient.Delete(ctx, monitoringResource)).To(Succeed())
+
+			err = manager.ReconcileOpenTelemetryCollector(
+				ctx,
+				TestImages,
+				operatorNamespace,
+				monitoringResource,
+				TriggeredByDash0ResourceReconcile,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			// verify the collector is not deleted even if the last monitoring resource has been deleted, but there is
+			// still an operator configuration left,
+			VerifyCollectorResources(ctx, k8sClient, operatorNamespace, EndpointDash0Test, AuthorizationTokenTest)
+		})
+
+		It("should not delete the collector if there is no operator configuration resource but there are still monitoring resources", func() {
+			// create multiple monitoring resources
 			firstName := types.NamespacedName{Namespace: TestNamespaceName, Name: "dash0-monitoring-test-resource-1"}
-			firstDash0MonitoringResource := CreateDefaultMonitoringResource(ctx, k8sClient, firstName)
+			firstDash0MonitoringResource := EnsureMonitoringResourceExistsInNamespaceAndIsAvailable(ctx, k8sClient, firstName)
 			createdObjects = append(createdObjects, firstDash0MonitoringResource)
-			setAvailable(ctx, k8sClient, firstDash0MonitoringResource)
 
 			secondName := types.NamespacedName{Namespace: TestNamespaceName, Name: "dash0-monitoring-test-resource-2"}
-			secondDash0MonitoringResource := CreateDefaultMonitoringResource(ctx, k8sClient, secondName)
+			secondDash0MonitoringResource := EnsureMonitoringResourceExistsInNamespaceAndIsAvailable(ctx, k8sClient, secondName)
 			createdObjects = append(createdObjects, secondDash0MonitoringResource)
-			setAvailable(ctx, k8sClient, secondDash0MonitoringResource)
 
 			thirdName := types.NamespacedName{Namespace: TestNamespaceName, Name: "dash0-monitoring-test-resource-3"}
-			thirdDash0MonitoringResource := CreateDefaultMonitoringResource(ctx, k8sClient, thirdName)
+			thirdDash0MonitoringResource := EnsureMonitoringResourceExistsInNamespaceAndIsAvailable(ctx, k8sClient, thirdName)
 			createdObjects = append(createdObjects, thirdDash0MonitoringResource)
-			setAvailable(ctx, k8sClient, thirdDash0MonitoringResource)
 
 			// Let the manager create the collector so there is something to delete.
 			err := manager.ReconcileOpenTelemetryCollector(
@@ -286,23 +514,24 @@ var _ = Describe("The backend connection manager", Ordered, func() {
 				TriggeredByDash0ResourceReconcile,
 			)
 			Expect(err).ToNot(HaveOccurred())
-			VerifyCollectorResources(ctx, k8sClient, operatorNamespace)
+			VerifyCollectorResources(ctx, k8sClient, operatorNamespace, EndpointDash0Test, AuthorizationTokenTest)
 
-			err = manager.RemoveOpenTelemetryCollectorIfNoMonitoringResourceIsLeft(
+			err = manager.ReconcileOpenTelemetryCollector(
 				ctx,
+				TestImages,
 				operatorNamespace,
 				secondDash0MonitoringResource,
+				TriggeredByDash0ResourceReconcile,
 			)
 			Expect(err).ToNot(HaveOccurred())
-			// since other Dash0 monitoring resources still exist, the collector resources should not be deleted
-			VerifyCollectorResources(ctx, k8sClient, operatorNamespace)
+			// since other monitoring resources still exist, the collector resources should not be deleted
+			VerifyCollectorResources(ctx, k8sClient, operatorNamespace, EndpointDash0Test, AuthorizationTokenTest)
 		})
 
-		It("should not delete the collector if there is only one Dash0 monitoring resource left but it is not the one being deleted", func() {
+		It("should not delete the collector if there is no operator configuration resource, but if there one available resource with an export left", func() {
 			resourceName := types.NamespacedName{Namespace: TestNamespaceName, Name: "dash0-monitoring-test-resource-1"}
-			existingDash0MonitoringResource := CreateDefaultMonitoringResource(ctx, k8sClient, resourceName)
+			existingDash0MonitoringResource := EnsureMonitoringResourceExistsInNamespaceAndIsAvailable(ctx, k8sClient, resourceName)
 			createdObjects = append(createdObjects, existingDash0MonitoringResource)
-			setAvailable(ctx, k8sClient, existingDash0MonitoringResource)
 
 			// Let the manager create the collector so there is something to delete.
 			err := manager.ReconcileOpenTelemetryCollector(
@@ -313,41 +542,124 @@ var _ = Describe("The backend connection manager", Ordered, func() {
 				TriggeredByDash0ResourceReconcile,
 			)
 			Expect(err).ToNot(HaveOccurred())
-			VerifyCollectorResources(ctx, k8sClient, operatorNamespace)
+			VerifyCollectorResources(ctx, k8sClient, operatorNamespace, EndpointDash0Test, AuthorizationTokenTest)
 
-			err = manager.RemoveOpenTelemetryCollectorIfNoMonitoringResourceIsLeft(
-				ctx,
-				operatorNamespace,
-				// We deliberately pass a different resource here, not the one that actually exists in the cluster.
-				// The existing resource should be found and compared to the one that we pass in, and since they do
-				// not match, the collector should not be deleted
-				&dash0v1alpha1.Dash0Monitoring{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "some-other-namespace",
-						Name:      "name",
-						UID:       "3c0e72bb-26a7-40a4-bbdd-b1c978278fc5",
-					},
-					Spec: dash0v1alpha1.Dash0MonitoringSpec{
-						Export: &dash0v1alpha1.Export{
-							Dash0: &dash0v1alpha1.Dash0Configuration{
-								Endpoint: EndpointDash0Test,
-								Authorization: dash0v1alpha1.Authorization{
-									Token: &AuthorizationTokenTest,
-								},
+			triggeringMonitoringResourceNotAvailable := &dash0v1alpha1.Dash0Monitoring{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "some-other-namespace",
+					Name:      "name",
+					UID:       "3c0e72bb-26a7-40a4-bbdd-b1c978278fc5",
+				},
+				Spec: dash0v1alpha1.Dash0MonitoringSpec{
+					Export: &dash0v1alpha1.Export{
+						Dash0: &dash0v1alpha1.Dash0Configuration{
+							Endpoint: EndpointDash0Test,
+							Authorization: dash0v1alpha1.Authorization{
+								Token: &AuthorizationTokenTest,
 							},
 						},
 					},
 				},
+			}
+			err = manager.ReconcileOpenTelemetryCollector(
+				ctx,
+				TestImages,
+				operatorNamespace,
+				// Here the triggering monitoring resource has an export but is not marked as available, so it will not
+				// contribute towards retaining the collector resources; the existing monitoring resource created above
+				// has an export and is available, so ultimately, the collector resources are not deleted.
+				triggeringMonitoringResourceNotAvailable,
+				TriggeredByDash0ResourceReconcile,
 			)
 			Expect(err).ToNot(HaveOccurred())
-			VerifyCollectorResources(ctx, k8sClient, operatorNamespace)
+			VerifyCollectorResources(ctx, k8sClient, operatorNamespace, EndpointDash0Test, AuthorizationTokenTest)
 		})
 
-		It("should delete the collector if the Dash0 monitoring resource that is being deleted is the only one left", func() {
+		It("should delete the collector if the operator configuration is deleted and there are no monitoring resources", func() {
+			operatorConfigurationResource := CreateDefaultOperatorConfigurationResource(
+				ctx,
+				k8sClient,
+			)
+
+			err := manager.ReconcileOpenTelemetryCollector(
+				ctx,
+				TestImages,
+				operatorNamespace,
+				nil,
+				TriggeredByDash0ResourceReconcile,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			VerifyCollectorResources(ctx, k8sClient, operatorNamespace, EndpointDash0Test, AuthorizationTokenTest)
+
+			Expect(k8sClient.Delete(ctx, operatorConfigurationResource)).To(Succeed())
+
+			err = manager.ReconcileOpenTelemetryCollector(
+				ctx,
+				TestImages,
+				operatorNamespace,
+				nil,
+				TriggeredByDash0ResourceReconcile,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			// verify the collector is not deleted even if the last monitoring resource has been deleted, but there is
+			// still an operator configuration left,
+			VerifyCollectorResourcesDoNotExist(ctx, k8sClient, operatorNamespace)
+		})
+
+		It("should delete the collector if the operator configuration is deleted and there are only monitoring resources without an export", func() {
+			operatorConfigurationResource := CreateDefaultOperatorConfigurationResource(
+				ctx,
+				k8sClient,
+			)
+
+			// create multiple monitoring resources, all without export
+			firstName := types.NamespacedName{Namespace: TestNamespaceName, Name: "dash0-monitoring-test-resource-1"}
+			firstDash0MonitoringResource :=
+				EnsureMonitoringResourceWithSpecExistsInNamespaceAndIsAvailable(ctx, k8sClient,
+					dash0v1alpha1.Dash0MonitoringSpec{}, firstName)
+			createdObjects = append(createdObjects, firstDash0MonitoringResource)
+
+			secondName := types.NamespacedName{Namespace: TestNamespaceName, Name: "dash0-monitoring-test-resource-2"}
+			secondDash0MonitoringResource :=
+				EnsureMonitoringResourceWithSpecExistsInNamespaceAndIsAvailable(ctx, k8sClient,
+					dash0v1alpha1.Dash0MonitoringSpec{}, secondName)
+			createdObjects = append(createdObjects, secondDash0MonitoringResource)
+
+			thirdName := types.NamespacedName{Namespace: TestNamespaceName, Name: "dash0-monitoring-test-resource-3"}
+			thirdDash0MonitoringResource :=
+				EnsureMonitoringResourceWithSpecExistsInNamespaceAndIsAvailable(ctx, k8sClient,
+					dash0v1alpha1.Dash0MonitoringSpec{}, thirdName)
+			createdObjects = append(createdObjects, thirdDash0MonitoringResource)
+
+			err := manager.ReconcileOpenTelemetryCollector(
+				ctx,
+				TestImages,
+				operatorNamespace,
+				nil,
+				TriggeredByDash0ResourceReconcile,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			VerifyCollectorResources(ctx, k8sClient, operatorNamespace, EndpointDash0Test, AuthorizationTokenTest)
+
+			Expect(k8sClient.Delete(ctx, operatorConfigurationResource)).To(Succeed())
+
+			err = manager.ReconcileOpenTelemetryCollector(
+				ctx,
+				TestImages,
+				operatorNamespace,
+				nil,
+				TriggeredByDash0ResourceReconcile,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			// verify the collector is not deleted even if the last monitoring resource has been deleted, but there is
+			// still an operator configuration left,
+			VerifyCollectorResourcesDoNotExist(ctx, k8sClient, operatorNamespace)
+		})
+
+		It("should delete the collector if there is no operator configuration, and if the monitoring resource that is being deleted is the only one left", func() {
 			resourceName := types.NamespacedName{Namespace: TestNamespaceName, Name: "dash0-monitoring-test-resource-1"}
-			monitoringResource := CreateDefaultMonitoringResource(ctx, k8sClient, resourceName)
+			monitoringResource := EnsureMonitoringResourceExistsInNamespaceAndIsAvailable(ctx, k8sClient, resourceName)
 			createdObjects = append(createdObjects, monitoringResource)
-			setAvailable(ctx, k8sClient, monitoringResource)
 
 			// Let the manager create the collector so there is something to delete.
 			err := manager.ReconcileOpenTelemetryCollector(
@@ -358,41 +670,54 @@ var _ = Describe("The backend connection manager", Ordered, func() {
 				TriggeredByDash0ResourceReconcile,
 			)
 			Expect(err).ToNot(HaveOccurred())
-			VerifyCollectorResources(ctx, k8sClient, operatorNamespace)
+			VerifyCollectorResources(ctx, k8sClient, operatorNamespace, EndpointDash0Test, AuthorizationTokenTest)
 
-			err = manager.RemoveOpenTelemetryCollectorIfNoMonitoringResourceIsLeft(
+			// When deleting the resource, it will be marked as about to be deleted=degraded in the finalizer handling
+			// before calling manager.ReconcileOpenTelemetryCollector (this happens in
+			// monitoring_controller.go#runCleanup). This is important for ReconcileOpenTelemetryCollector, so it does
+			// not accidentally find an available monitoring resource.
+			monitoringResource.EnsureResourceIsMarkedAsAboutToBeDeleted()
+			Expect(k8sClient.Status().Update(ctx, monitoringResource)).To(Succeed())
+
+			err = manager.ReconcileOpenTelemetryCollector(
 				ctx,
+				TestImages,
 				operatorNamespace,
 				monitoringResource,
+				TriggeredByDash0ResourceReconcile,
 			)
 			Expect(err).ToNot(HaveOccurred())
-			// verify the collector is deleted when the Dash0 monitoring resource provided as a parameter is the only
+			// verify the collector is deleted when the monitoring resource provided as a parameter is the only
 			// one left
 			VerifyCollectorResourcesDoNotExist(ctx, k8sClient, operatorNamespace)
 		})
 
-		It("should delete the collector if no Dash0 monitoring resource exists", func() {
+		It("should delete the collector if no operator configuration and no monitoring resource exists", func() {
 			// Let the manager create the collector so there is something to delete.
-			resource := EnsureMonitoringResourceExistsAndIsAvailable(
+			monitoringResource := EnsureMonitoringResourceExistsAndIsAvailable(
 				ctx,
 				k8sClient,
 			)
+			createdObjects = append(createdObjects, monitoringResource)
 			err := manager.ReconcileOpenTelemetryCollector(
 				ctx,
 				TestImages,
 				operatorNamespace,
-				resource,
+				monitoringResource,
 				TriggeredByDash0ResourceReconcile,
 			)
 			Expect(err).ToNot(HaveOccurred())
-			VerifyCollectorResources(ctx, k8sClient, operatorNamespace)
+			VerifyCollectorResources(ctx, k8sClient, operatorNamespace, EndpointDash0Test, AuthorizationTokenTest)
 
-			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, monitoringResource)).To(Succeed())
+			createdObjects = createdObjects[0 : len(createdObjects)-1]
 
-			err = manager.RemoveOpenTelemetryCollectorIfNoMonitoringResourceIsLeft(
+			err = manager.ReconcileOpenTelemetryCollector(
 				ctx,
+				TestImages,
 				operatorNamespace,
-				resource,
+				nil,
+				TriggeredByDash0ResourceReconcile,
 			)
 			Expect(err).ToNot(HaveOccurred())
 			VerifyCollectorResourcesDoNotExist(ctx, k8sClient, operatorNamespace)
@@ -400,8 +725,8 @@ var _ = Describe("The backend connection manager", Ordered, func() {
 	})
 })
 
-func assembleMonitoringResource() *dash0v1alpha1.Dash0Monitoring {
-	return &dash0v1alpha1.Dash0Monitoring{
+func assembleMonitoringResource(endpoint string, authorizationToken string) *dash0v1alpha1.Dash0Monitoring {
+	monitoringResource := &dash0v1alpha1.Dash0Monitoring{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "dash0-monitoring-test-resource",
 			Namespace: TestNamespaceName,
@@ -409,17 +734,14 @@ func assembleMonitoringResource() *dash0v1alpha1.Dash0Monitoring {
 		Spec: dash0v1alpha1.Dash0MonitoringSpec{
 			Export: &dash0v1alpha1.Export{
 				Dash0: &dash0v1alpha1.Dash0Configuration{
-					Endpoint: EndpointDash0Test,
+					Endpoint: endpoint,
 					Authorization: dash0v1alpha1.Authorization{
-						Token: &AuthorizationTokenTest,
+						Token: &authorizationToken,
 					},
 				},
 			},
 		},
 	}
-}
-
-func setAvailable(ctx context.Context, k8sClient client.Client, monitoringResource *dash0v1alpha1.Dash0Monitoring) {
 	monitoringResource.EnsureResourceIsMarkedAsAvailable()
-	Expect(k8sClient.Status().Update(ctx, monitoringResource)).To(Succeed())
+	return monitoringResource
 }

--- a/internal/backendconnection/otelcolresources/collector_config_maps.go
+++ b/internal/backendconnection/otelcolresources/collector_config_maps.go
@@ -16,6 +16,10 @@ import (
 	"github.com/dash0hq/dash0-operator/internal/util"
 )
 
+const (
+	commonExportErrorPrefix = "cannot assemble the exporters for the configuration:"
+)
+
 type collectorConfigurationTemplateValues struct {
 	Exporters                                        []OtlpExporter
 	IgnoreLogsFromNamespaces                         []string
@@ -94,7 +98,7 @@ func assembleCollectorConfigMap(
 	} else {
 		exporters, err := ConvertExportSettingsToExporterList(config.Export)
 		if err != nil {
-			return nil, fmt.Errorf("cannot assemble the exporters for the configuration: %w", err)
+			return nil, fmt.Errorf("%s %w", commonExportErrorPrefix, err)
 		}
 
 		selfIpReference := "${env:MY_POD_IP}"
@@ -158,7 +162,7 @@ func ConvertExportSettingsToExporterList(export dash0v1alpha1.Export) ([]OtlpExp
 	var exporters []OtlpExporter
 
 	if export.Dash0 == nil && export.Grpc == nil && export.Http == nil {
-		return nil, fmt.Errorf("no exporter configuration found")
+		return nil, fmt.Errorf("%s no exporter configuration found", commonExportErrorPrefix)
 	}
 
 	if export.Dash0 != nil {

--- a/internal/controller/monitoring_controller_test.go
+++ b/internal/controller/monitoring_controller_test.go
@@ -106,7 +106,7 @@ var _ = Describe("The monitoring resource controller", Ordered, func() {
 				By("Trigger reconcile request")
 				triggerReconcileRequest(ctx, reconciler, "")
 				verifyMonitoringResourceIsAvailable(ctx)
-				VerifyCollectorResources(ctx, k8sClient, operatorNamespace)
+				VerifyCollectorResources(ctx, k8sClient, operatorNamespace, EndpointDash0Test, AuthorizationTokenTest)
 			})
 
 			It("should successfully run multiple reconciles (no modifiable workloads exist)", func() {
@@ -123,7 +123,7 @@ var _ = Describe("The monitoring resource controller", Ordered, func() {
 				secondAvailableCondition := verifyMonitoringResourceIsAvailable(ctx)
 				Expect(secondAvailableCondition.LastTransitionTime.Time).To(Equal(originalTransitionTimestamp))
 
-				VerifyCollectorResources(ctx, k8sClient, operatorNamespace)
+				VerifyCollectorResources(ctx, k8sClient, operatorNamespace, EndpointDash0Test, AuthorizationTokenTest)
 			})
 
 			It("should mark only the most recent resource as available and the other ones as degraded when multiple resources exist", func() {
@@ -799,7 +799,7 @@ var _ = Describe("The monitoring resource controller", Ordered, func() {
 
 		It("should add and remove the collector resources", func() {
 			triggerReconcileRequest(ctx, reconciler, "Trigger first reconcile request")
-			VerifyCollectorResources(ctx, k8sClient, operatorNamespace)
+			VerifyCollectorResources(ctx, k8sClient, operatorNamespace, EndpointDash0Test, AuthorizationTokenTest)
 
 			monitoringResource := LoadMonitoringResourceOrFail(ctx, k8sClient, Default)
 			Expect(k8sClient.Delete(ctx, monitoringResource)).To(Succeed())

--- a/internal/controller/operator_configuration_controller_test.go
+++ b/internal/controller/operator_configuration_controller_test.go
@@ -491,7 +491,7 @@ var _ = Describe("The operation configuration resource controller", Ordered, fun
 
 				triggerOperatorConfigurationReconcileRequest(ctx, reconciler)
 
-				VerifyCollectorResources(ctx, k8sClient, operatorNamespace)
+				VerifyCollectorResources(ctx, k8sClient, operatorNamespace, EndpointDash0Test, AuthorizationTokenTest)
 			})
 		})
 
@@ -868,7 +868,7 @@ var _ = Describe("The operation configuration resource controller", Ordered, fun
 				EnsureEmptyMonitoringResourceExistsAndIsAvailable(ctx, k8sClient)
 
 				triggerOperatorConfigurationReconcileRequest(ctx, reconciler)
-				VerifyCollectorResources(ctx, k8sClient, operatorNamespace)
+				VerifyCollectorResources(ctx, k8sClient, operatorNamespace, EndpointDash0Test, AuthorizationTokenTest)
 
 				resource := LoadOperatorConfigurationResourceOrFail(ctx, k8sClient, Default)
 				Expect(k8sClient.Delete(ctx, resource)).To(Succeed())

--- a/internal/predelete/operator_pre_delete_handler_test.go
+++ b/internal/predelete/operator_pre_delete_handler_test.go
@@ -140,7 +140,7 @@ func setupNamespaceWithDash0MonitoringResourceAndWorkload(
 	createdObjects []client.Object,
 ) ([]client.Object, *appv1.Deployment) {
 	EnsureNamespaceExists(ctx, k8sClient, dash0MonitoringResourceName.Namespace)
-	EnsureMonitoringResourceExistsAndIsAvailableInNamespace(ctx, k8sClient, dash0MonitoringResourceName)
+	EnsureMonitoringResourceExistsInNamespaceAndIsAvailable(ctx, k8sClient, dash0MonitoringResourceName)
 	deploymentName := UniqueName(DeploymentNamePrefix)
 	deployment := CreateInstrumentedDeployment(ctx, k8sClient, dash0MonitoringResourceName.Namespace, deploymentName)
 	// make sure the monitoring resource has the finalizer

--- a/test/e2e/match_results.go
+++ b/test/e2e/match_results.go
@@ -28,6 +28,15 @@ func (mrl *MatchResultList[R, O]) addResultForObject(matchResult ObjectMatchResu
 	mrl.objectResults = append(mrl.objectResults, matchResult)
 }
 
+func (mrl *MatchResultList[R, O]) hasMatch(g Gomega) bool {
+	for _, omr := range mrl.objectResults {
+		if omr.isMatch(g) {
+			return true
+		}
+	}
+	return false
+}
+
 func (mrl *MatchResultList[R, O]) expectAtLeastOneMatch(g Gomega, message string) {
 	var bestMatchScoreSoFar float32 = 0
 	bestMatches := make([]ObjectMatchResult[R, O], 0)
@@ -111,17 +120,20 @@ func (rmr *ResourceMatchResult[R]) addSkippedAssertion(id string, message string
 
 // ObjectMatchResult represents results for one potentially matching object.
 type ObjectMatchResult[R any, O any] struct {
+	name              string
 	resource          R
 	object            O
 	assertionOutcomes []AssertionOutcome
 }
 
 func newObjectMatchResult[R any, O any](
+	name string,
 	resource R,
 	resourceMatchResult ResourceMatchResult[R],
 	object O,
 ) ObjectMatchResult[R, O] {
 	omr := ObjectMatchResult[R, O]{
+		name:              name,
 		resource:          resource,
 		object:            object,
 		assertionOutcomes: make([]AssertionOutcome, 0),
@@ -163,7 +175,7 @@ func (omr *ObjectMatchResult[R, O]) matchScore() float32 {
 }
 
 func (omr ObjectMatchResult[R, O]) String() string {
-	s := ""
+	s := omr.name + ":"
 	for _, ao := range omr.assertionOutcomes {
 		s += fmt.Sprintf("\n%s", ao.String())
 	}

--- a/test/util/constants.go
+++ b/test/util/constants.go
@@ -36,6 +36,7 @@ const (
 
 	OTelCollectorBaseUrlTest      = "http://$(DASH0_NODE_IP):40318"
 	EndpointDash0Test             = "endpoint.dash0.com:4317"
+	EndpointDash0TestAlternative  = "endpoint-alternative.dash0.com:4317"
 	EndpointDash0TestQuoted       = "\"endpoint.dash0.com:4317\""
 	EndpointDash0WithProtocolTest = "https://endpoint.dash0.com:4317"
 	EndpointGrpcTest              = "endpoint.backend.com:4317"
@@ -46,8 +47,9 @@ const (
 )
 
 var (
-	AuthorizationTokenTest = "authorization-token"
-	SecretRefTest          = dash0v1alpha1.SecretRef{
+	AuthorizationTokenTest            = "authorization-token"
+	AuthorizationTokenTestAlternative = "authorization-token-test"
+	SecretRefTest                     = dash0v1alpha1.SecretRef{
 		Name: "secret-ref",
 		Key:  "key",
 	}

--- a/test/util/monitoring_resource.go
+++ b/test/util/monitoring_resource.go
@@ -44,15 +44,52 @@ var (
 	}
 )
 
+func CreateDefaultMonitoringResource(
+	ctx context.Context,
+	k8sClient client.Client,
+	monitoringResourceName types.NamespacedName,
+) *dash0v1alpha1.Dash0Monitoring {
+	return CreateMonitoringResource(
+		ctx,
+		k8sClient,
+		&dash0v1alpha1.Dash0Monitoring{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      monitoringResourceName.Name,
+				Namespace: monitoringResourceName.Namespace,
+			},
+			Spec: MonitoringResourceDefaultSpec,
+		},
+	)
+}
+
+func CreateMonitoringResource(
+	ctx context.Context,
+	k8sClient client.Client,
+	monitoringResource *dash0v1alpha1.Dash0Monitoring,
+) *dash0v1alpha1.Dash0Monitoring {
+	resource, err := CreateMonitoringResourceWithPotentialError(ctx, k8sClient, monitoringResource)
+	Expect(err).ToNot(HaveOccurred())
+	return resource
+}
+
+func CreateMonitoringResourceWithPotentialError(
+	ctx context.Context,
+	k8sClient client.Client,
+	monitoringResource *dash0v1alpha1.Dash0Monitoring,
+) (*dash0v1alpha1.Dash0Monitoring, error) {
+	err := k8sClient.Create(ctx, monitoringResource)
+	return monitoringResource, err
+}
+
 func EnsureMonitoringResourceExists(
 	ctx context.Context,
 	k8sClient client.Client,
 ) *dash0v1alpha1.Dash0Monitoring {
-	return EnsureMonitoringResourceExistsWithNamespacedName(
+	return EnsureMonitoringResourceWithSpecExistsInNamespace(
 		ctx,
 		k8sClient,
+		MonitoringResourceDefaultSpec,
 		MonitoringResourceQualifiedName,
-		"",
 	)
 }
 
@@ -61,25 +98,52 @@ func EnsureMonitoringResourceExistsWithInstrumentWorkloadsMode(
 	k8sClient client.Client,
 	instrumentWorkloads dash0v1alpha1.InstrumentWorkloadsMode,
 ) *dash0v1alpha1.Dash0Monitoring {
-	return EnsureMonitoringResourceExistsWithNamespacedName(
-		ctx,
-		k8sClient,
-		MonitoringResourceQualifiedName,
-		instrumentWorkloads,
-	)
-}
-
-func EnsureMonitoringResourceExistsWithNamespacedName(
-	ctx context.Context,
-	k8sClient client.Client,
-	namespacesName types.NamespacedName,
-	instrumentWorkloads dash0v1alpha1.InstrumentWorkloadsMode,
-) *dash0v1alpha1.Dash0Monitoring {
-	By("creating the Dash0 monitoring resource")
 	spec := MonitoringResourceDefaultSpec
 	if instrumentWorkloads != "" {
 		spec.InstrumentWorkloads = instrumentWorkloads
 	}
+	return EnsureMonitoringResourceWithSpecExistsInNamespace(
+		ctx,
+		k8sClient,
+		spec,
+		MonitoringResourceQualifiedName,
+	)
+}
+
+func EnsureMonitoringResourceWithSpecExists(
+	ctx context.Context,
+	k8sClient client.Client,
+	spec dash0v1alpha1.Dash0MonitoringSpec,
+) *dash0v1alpha1.Dash0Monitoring {
+	return EnsureMonitoringResourceWithSpecExistsInNamespace(
+		ctx,
+		k8sClient,
+		spec,
+		MonitoringResourceQualifiedName,
+	)
+}
+
+func EnsureMonitoringResourceExistsInNamespace(
+	ctx context.Context,
+	k8sClient client.Client,
+	namespacesName types.NamespacedName,
+) *dash0v1alpha1.Dash0Monitoring {
+	return EnsureMonitoringResourceWithSpecExistsInNamespace(
+		ctx,
+		k8sClient,
+		MonitoringResourceDefaultSpec,
+		namespacesName,
+	)
+}
+
+func EnsureMonitoringResourceWithSpecExistsInNamespace(
+	ctx context.Context,
+	k8sClient client.Client,
+	spec dash0v1alpha1.Dash0MonitoringSpec,
+	namespacesName types.NamespacedName,
+) *dash0v1alpha1.Dash0Monitoring {
+	By("creating the Dash0 monitoring resource")
+
 	objectMeta := metav1.ObjectMeta{
 		Name:      namespacesName.Name,
 		Namespace: namespacesName.Namespace,
@@ -120,64 +184,55 @@ func EnsureEmptyMonitoringResourceExistsAndIsAvailable(
 	return monitoringResource
 }
 
-func CreateDefaultMonitoringResource(
-	ctx context.Context,
-	k8sClient client.Client,
-	monitoringResourceName types.NamespacedName,
-) *dash0v1alpha1.Dash0Monitoring {
-	return CreateMonitoringResource(
-		ctx,
-		k8sClient,
-		&dash0v1alpha1.Dash0Monitoring{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      monitoringResourceName.Name,
-				Namespace: monitoringResourceName.Namespace,
-			},
-			Spec: MonitoringResourceDefaultSpec,
-		},
-	)
-}
-
-func CreateMonitoringResource(
-	ctx context.Context,
-	k8sClient client.Client,
-	monitoringResource *dash0v1alpha1.Dash0Monitoring,
-) *dash0v1alpha1.Dash0Monitoring {
-	resource, err := CreateMonitoringResourceWithPotentialError(ctx, k8sClient, monitoringResource)
-	Expect(err).ToNot(HaveOccurred())
-	return resource
-}
-
-func CreateMonitoringResourceWithPotentialError(
-	ctx context.Context,
-	k8sClient client.Client,
-	monitoringResource *dash0v1alpha1.Dash0Monitoring,
-) (*dash0v1alpha1.Dash0Monitoring, error) {
-	err := k8sClient.Create(ctx, monitoringResource)
-	return monitoringResource, err
-}
-
 func EnsureMonitoringResourceExistsAndIsAvailable(
 	ctx context.Context,
 	k8sClient client.Client,
 ) *dash0v1alpha1.Dash0Monitoring {
-	return EnsureMonitoringResourceExistsAndIsAvailableInNamespace(
+	return EnsureMonitoringResourceWithSpecExistsInNamespaceAndIsAvailable(
 		ctx,
 		k8sClient,
+		MonitoringResourceDefaultSpec,
 		MonitoringResourceQualifiedName,
 	)
 }
 
-func EnsureMonitoringResourceExistsAndIsAvailableInNamespace(
+func EnsureMonitoringResourceWithSpecExistsAndIsAvailable(
 	ctx context.Context,
 	k8sClient client.Client,
-	namespacedName types.NamespacedName,
+	spec dash0v1alpha1.Dash0MonitoringSpec,
 ) *dash0v1alpha1.Dash0Monitoring {
-	monitoringResource := EnsureMonitoringResourceExistsWithNamespacedName(
+	return EnsureMonitoringResourceWithSpecExistsInNamespaceAndIsAvailable(
 		ctx,
 		k8sClient,
-		namespacedName,
-		"",
+		spec,
+		MonitoringResourceQualifiedName,
+	)
+}
+
+func EnsureMonitoringResourceExistsInNamespaceAndIsAvailable(
+	ctx context.Context,
+	k8sClient client.Client,
+	namespacesName types.NamespacedName,
+) *dash0v1alpha1.Dash0Monitoring {
+	return EnsureMonitoringResourceWithSpecExistsInNamespaceAndIsAvailable(
+		ctx,
+		k8sClient,
+		MonitoringResourceDefaultSpec,
+		namespacesName,
+	)
+}
+
+func EnsureMonitoringResourceWithSpecExistsInNamespaceAndIsAvailable(
+	ctx context.Context,
+	k8sClient client.Client,
+	spec dash0v1alpha1.Dash0MonitoringSpec,
+	namespacesName types.NamespacedName,
+) *dash0v1alpha1.Dash0Monitoring {
+	monitoringResource := EnsureMonitoringResourceWithSpecExistsInNamespace(
+		ctx,
+		k8sClient,
+		spec,
+		namespacesName,
 	)
 	monitoringResource.EnsureResourceIsMarkedAsAvailable()
 	Expect(k8sClient.Status().Update(ctx, monitoringResource)).To(Succeed())

--- a/test/util/operator_resource.go
+++ b/test/util/operator_resource.go
@@ -49,6 +49,7 @@ var (
 		},
 		Export: &dash0v1alpha1.Export{
 			Dash0: &dash0v1alpha1.Dash0Configuration{
+				Endpoint: EndpointDash0Test,
 				Authorization: dash0v1alpha1.Authorization{
 					Token: &AuthorizationTokenTest,
 				},
@@ -63,6 +64,7 @@ var (
 		},
 		Export: &dash0v1alpha1.Export{
 			Dash0: &dash0v1alpha1.Dash0Configuration{
+				Endpoint: EndpointDash0Test,
 				Authorization: dash0v1alpha1.Authorization{
 					SecretRef: &SecretRefTest,
 				},
@@ -77,6 +79,7 @@ var (
 		},
 		Export: &dash0v1alpha1.Export{
 			Dash0: &dash0v1alpha1.Dash0Configuration{
+				Endpoint:    EndpointDash0Test,
 				ApiEndpoint: ApiEndpointTest,
 				Authorization: dash0v1alpha1.Authorization{
 					Token: &AuthorizationTokenTest,
@@ -92,6 +95,7 @@ var (
 		},
 		Export: &dash0v1alpha1.Export{
 			Dash0: &dash0v1alpha1.Dash0Configuration{
+				Endpoint:    EndpointDash0Test,
 				ApiEndpoint: ApiEndpointTest,
 				Authorization: dash0v1alpha1.Authorization{
 					SecretRef: &SecretRefTest,
@@ -107,6 +111,7 @@ var (
 		},
 		Export: &dash0v1alpha1.Export{
 			Dash0: &dash0v1alpha1.Dash0Configuration{
+				Endpoint:    EndpointDash0Test,
 				ApiEndpoint: ApiEndpointTest,
 				Authorization: dash0v1alpha1.Authorization{
 					Token: &AuthorizationTokenTest,
@@ -122,6 +127,7 @@ var (
 		},
 		Export: &dash0v1alpha1.Export{
 			Dash0: &dash0v1alpha1.Dash0Configuration{
+				Endpoint:    EndpointDash0Test,
 				ApiEndpoint: ApiEndpointTest,
 				Authorization: dash0v1alpha1.Authorization{
 					SecretRef: &SecretRefTest,
@@ -163,6 +169,14 @@ var (
 
 	OperatorConfigurationResourceDefaultSpec = OperatorConfigurationResourceWithSelfMonitoringWithToken
 )
+
+func DefaultOperatorConfigurationResource() *dash0v1alpha1.Dash0OperatorConfiguration {
+	operatorConfiguration := dash0v1alpha1.Dash0OperatorConfiguration{
+		ObjectMeta: OperatorConfigurationResourceDefaultObjectMeta,
+		Spec:       OperatorConfigurationResourceDefaultSpec,
+	}
+	return &operatorConfiguration
+}
 
 func EnsureControllerDeploymentExists(
 	ctx context.Context,


### PR DESCRIPTION
Deploy the Dash0 OpenTelemetry collectors as soon as an operator configuration resource with an export is available. In particular, the slightly arbitrary requirement of having at least one Dash0 monitoring resource monitoring a namespace for getting _any_ telemetry from a cluster is removed with this. This enables collecting non-namespace scoped metrics as soon as export settings are available.