### PR TITLE
feat(metrics): collect host metrics

### DIFF
--- a/images/collector/src/builder/config.yaml
+++ b/images/collector/src/builder/config.yaml
@@ -21,6 +21,7 @@ exporters:
 receivers:
   - gomod: "go.opentelemetry.io/collector/receiver/otlpreceiver v0.111.0"
   - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver v0.111.0"
+  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver v0.111.0"
   - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver v0.111.0"
   - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver v0.111.0"
   - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.111.0"

--- a/internal/backendconnection/otelcolresources/collector_config_maps.go
+++ b/internal/backendconnection/otelcolresources/collector_config_maps.go
@@ -24,6 +24,7 @@ type collectorConfigurationTemplateValues struct {
 	Exporters                                        []OtlpExporter
 	IgnoreLogsFromNamespaces                         []string
 	KubernetesInfrastructureMetricsCollectionEnabled bool
+	UseHostMetricsReceiver                           bool
 	ClusterName                                      string
 	NamespaceOttlFilter                              string
 	NamespacesWithPrometheusScraping                 []string
@@ -117,11 +118,12 @@ func assembleCollectorConfigMap(
 					config.Namespace,
 				},
 				KubernetesInfrastructureMetricsCollectionEnabled: config.KubernetesInfrastructureMetricsCollectionEnabled,
-				ClusterName:                      config.ClusterName,
-				NamespaceOttlFilter:              namespaceOttlFilter,
-				NamespacesWithPrometheusScraping: namespacesWithPrometheusScraping,
-				SelfIpReference:                  selfIpReference,
-				DevelopmentMode:                  config.DevelopmentMode,
+				UseHostMetricsReceiver:                           config.UseHostMetricsReceiver,
+				ClusterName:                                      config.ClusterName,
+				NamespaceOttlFilter:                              namespaceOttlFilter,
+				NamespacesWithPrometheusScraping:                 namespacesWithPrometheusScraping,
+				SelfIpReference:                                  selfIpReference,
+				DevelopmentMode:                                  config.DevelopmentMode,
 			})
 		if err != nil {
 			return nil, fmt.Errorf("cannot render the collector configuration template: %w", err)

--- a/internal/backendconnection/otelcolresources/daemonset.config.yaml.template
+++ b/internal/backendconnection/otelcolresources/daemonset.config.yaml.template
@@ -171,7 +171,77 @@ authority"}
 
 This env var is set in the collector image's entrypoint script or in the daemonset spec if DevelopmentMode is active */}}
     insecure_skip_verify: ${env:KUBELET_STATS_TLS_INSECURE}
-{{- end }}
+{{- end }}{{/* if .KubernetesInfrastructureMetricsCollectionEnabled */}}
+
+{{- if .UseHostMetricsReceiver }}
+  hostmetrics:
+    collection_interval: 60s
+    root_path: /hostfs
+    scrapers:
+      cpu:
+        metrics:
+          # disable all metrics that are enabled by default (there is only one)
+          system.cpu.time:
+            enabled: false
+          # Explicitly enable the cpu utilization metric
+          system.cpu.utilization:
+            enabled: true
+      filesystem:
+        metrics:
+          # disable all metrics that are enabled by default
+          system.filesystem.inodes.usage:
+            enabled: false
+          system.filesystem.usage:
+            enabled: false
+          system.filesystem.utilization:
+            enabled: true
+        {{- /*
+        exclude_fs_types and exclude_mount_points are taken from collector's official helm chart:
+        https://github.com/open-telemetry/opentelemetry-helm-charts/blob/f75b282f2867f1c9689ba9e28083cba15a98b66b/charts/opentelemetry-collector/templates/_config.tpl#L69-L115
+        */}}
+        exclude_fs_types:
+          fs_types:
+          - autofs
+          - binfmt_misc
+          - bpf
+          - cgroup2
+          - configfs
+          - debugfs
+          - devpts
+          - devtmpfs
+          - fusectl
+          - hugetlbfs
+          - iso9660
+          - mqueue
+          - nsfs
+          - overlay
+          - proc
+          - procfs
+          - pstore
+          - rpc_pipefs
+          - securityfs
+          - selinuxfs
+          - squashfs
+          - sysfs
+          - tracefs
+          match_type: strict
+        exclude_mount_points:
+          match_type: regexp
+          mount_points:
+          - /dev/*
+          - /proc/*
+          - /sys/*
+          - /run/k3s/containerd/*
+          - /var/lib/docker/*
+          - /var/lib/kubelet/*
+          - /snap/*
+      memory:
+        metrics:
+          system.memory.usage:
+            enabled: false
+          system.memory.utilization:
+            enabled: true
+{{- end }}{{/* if .UseHostMetricsReceiver */}}
 
 {{- $hasPrometheusScrapingEnabledForAtLeastOneNamespace := gt (len .NamespacesWithPrometheusScraping) 0 }}
 
@@ -375,6 +445,9 @@ service:
       - otlp
 {{- if .KubernetesInfrastructureMetricsCollectionEnabled }}
       - kubeletstats
+{{- end }}
+{{- if .UseHostMetricsReceiver }}
+      - hostmetrics
 {{- end }}
 {{- if $hasPrometheusScrapingEnabledForAtLeastOneNamespace }}
       - prometheus


### PR DESCRIPTION
Use the hostmetrics receiver to collect host metrics from the underlying node:
- system.cpu.utilization
- system.filesystem.utilization
- system.memory.utilization