### PR TITLE
fix: propagate custom webhook service ports in WebhookConfigurations

### DIFF
--- a/helm-chart/dash0-operator/templates/operator/deployment-and-webhooks.yaml
+++ b/helm-chart/dash0-operator/templates/operator/deployment-and-webhooks.yaml
@@ -277,6 +277,7 @@ webhooks:
     service:
       name: {{ template "dash0-operator.chartName" . }}-webhook-service
       namespace: {{ .Release.Namespace }}
+      port: {{ .Values.operator.webhookPort }}
       path: /v1alpha1/inject/dash0
   failurePolicy: Ignore
   rules:
@@ -339,6 +340,7 @@ webhooks:
       service:
         name: {{ template "dash0-operator.chartName" . }}-webhook-service
         namespace: {{ .Release.Namespace }}
+        port: {{ .Values.operator.webhookPort }}
         path: /v1alpha1/validate/operator-configuration
     admissionReviewVersions:
       - v1
@@ -371,6 +373,7 @@ webhooks:
     service:
       name: {{ template "dash0-operator.chartName" . }}-webhook-service
       namespace: {{ .Release.Namespace }}
+      port: {{ .Values.operator.webhookPort }}
       path: /v1alpha1/validate/monitoring
   admissionReviewVersions:
   - v1


### PR DESCRIPTION
Setting the `operator.webhookPort` value when installing the operator chart could result in calls failing calls to the Mutating and Validation webhooks of the operator.

This, in turn, could prevent, for example, the creation of `Dash0OperatorConfiguration` or `Dash0Monitoring` resources.