### PR TITLE
fix(collectors): make sure config map rendering is stable

### DIFF
--- a/internal/backendconnection/otelcolresources/desired_state.go
+++ b/internal/backendconnection/otelcolresources/desired_state.go
@@ -6,6 +6,7 @@ package otelcolresources
 import (
 	"fmt"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -197,6 +198,11 @@ func assembleDesiredState(
 	resourceSpecs *OTelColResourceSpecs,
 	forDeletion bool,
 ) ([]clientObject, error) {
+	// Make sure the resulting objects (in particular the config maps) are do not depend on the (potentially non-stable)
+	// sort order of the input slices.
+	slices.Sort(monitoredNamespaces)
+	slices.Sort(namespacesWithPrometheusScraping)
+
 	var desiredState []clientObject
 	desiredState = append(desiredState, addCommonMetadata(assembleServiceAccountForDaemonSet(config)))
 	daemonSetCollectorConfigMap, err := assembleDaemonSetCollectorConfigMap(

--- a/test/util/monitoring_resource.go
+++ b/test/util/monitoring_resource.go
@@ -27,7 +27,6 @@ var (
 		Namespace: TestNamespaceName,
 		Name:      MonitoringResourceName,
 	}
-
 	MonitoringResourceDefaultObjectMeta = metav1.ObjectMeta{
 		Name:      MonitoringResourceName,
 		Namespace: TestNamespaceName,


### PR DESCRIPTION
In particular with respect to the inherently non-deterministic ordering of the list of monitoring resources.

fixes ENG-3946