### PR TITLE
chore(self-monitoring): remove insights dataset

### DIFF
--- a/api/dash0monitoring/v1alpha1/operator_configuration_types.go
+++ b/api/dash0monitoring/v1alpha1/operator_configuration_types.go
@@ -47,8 +47,8 @@ type Dash0OperatorConfigurationSpec struct {
 
 // SelfMonitoring describes how the operator will report telemetry about its working to the backend.
 type SelfMonitoring struct {
-	// If enabled, the operator will collect self-monitoring telemetry and send it to the Dash0 Insights dataset of
-	// the configured Dash0 backend. This setting is optional, it defaults to true.
+	// If enabled, the operator will collect self-monitoring telemetry and send it to the configured Dash0 backend.
+	// This setting is optional, it defaults to true.
 	//
 	// +kubebuilder:default=true
 	Enabled *bool `json:"enabled"`

--- a/config/crd/bases/operator.dash0.com_dash0operatorconfigurations.yaml
+++ b/config/crd/bases/operator.dash0.com_dash0operatorconfigurations.yaml
@@ -198,8 +198,8 @@ spec:
                   enabled:
                     default: true
                     description: |-
-                      If enabled, the operator will collect self-monitoring telemetry and send it to the Dash0 Insights dataset of
-                      the configured Dash0 backend. This setting is optional, it defaults to true.
+                      If enabled, the operator will collect self-monitoring telemetry and send it to the configured Dash0 backend.
+                      This setting is optional, it defaults to true.
                     type: boolean
                 required:
                 - enabled

--- a/helm-chart/dash0-operator/README.md
+++ b/helm-chart/dash0-operator/README.md
@@ -189,8 +189,7 @@ Here is a list of configuration options for this resource:
   -> organization settings -> "Endpoints" -> "API". The correct endpoint value will always start with "https://api." and
   end in ".dash0.com". If this property is omitted, managing dashboards and check rules via the operator will not work.
 * `spec.selfMonitoring.enabled`: An opt-out for self-monitoring for the operator.
-  If enabled, the operator will collect self-monitoring telemetry and send it to the Dash0 Insights dataset of the
-  configured Dash0 backend.
+  If enabled, the operator will collect self-monitoring telemetry and send it to the configured Dash0 backend.
   This setting is optional, it defaults to true.
 * `spec.kubernetesInfrastructureMetricsCollectionEnabled`: If enabled, the operator will collect Kubernetes
   infrastructure metrics.
@@ -725,7 +724,7 @@ This restriction will be lifted once exporting telemetry to different backends p
 
 By default, self-monitoring is enabled for the Dash0 operator as soon as you deploy a Das0 operator
 configuration resource with an export.
-That means, the operator will send self-monitoring telemetry to the Dash0 Insights dataset of the configured backend.
+That means, the operator will send self-monitoring telemetry to the configured Dash0 backend.
 Disabling self-monitoring is available as a setting on the Dash0 operator configuration resource.
 Dash0 does not recommend to disable the operator's self-monitoring.
 

--- a/helm-chart/dash0-operator/templates/operator/custom-resource-definition-operator-configuration.yaml
+++ b/helm-chart/dash0-operator/templates/operator/custom-resource-definition-operator-configuration.yaml
@@ -198,8 +198,8 @@ spec:
                   enabled:
                     default: true
                     description: |-
-                      If enabled, the operator will collect self-monitoring telemetry and send it to the Dash0 Insights dataset of
-                      the configured Dash0 backend. This setting is optional, it defaults to true.
+                      If enabled, the operator will collect self-monitoring telemetry and send it to the configured Dash0 backend.
+                      This setting is optional, it defaults to true.
                     type: boolean
                 required:
                 - enabled

--- a/helm-chart/dash0-operator/tests/operator/__snapshot__/custom-resource-definition-operator-configuration_test.yaml.snap
+++ b/helm-chart/dash0-operator/tests/operator/__snapshot__/custom-resource-definition-operator-configuration_test.yaml.snap
@@ -184,8 +184,8 @@ custom resource definition should match snapshot:
                         enabled:
                           default: true
                           description: |-
-                            If enabled, the operator will collect self-monitoring telemetry and send it to the Dash0 Insights dataset of
-                            the configured Dash0 backend. This setting is optional, it defaults to true.
+                            If enabled, the operator will collect self-monitoring telemetry and send it to the configured Dash0 backend.
+                            This setting is optional, it defaults to true.
                           type: boolean
                       required:
                         - enabled

--- a/helm-chart/dash0-operator/values.yaml
+++ b/helm-chart/dash0-operator/values.yaml
@@ -66,8 +66,8 @@ operator:
     disableSecretValidation: false
 
   # An opt-out for operator self-monitoring. If set to false, self monitoring for the operator will be disabled, that
-  # is, the operator will not send self-monitoring telemetry to the Dash0 Insights dataset of the configured Dash0
-  # backend. This setting is optional, it defaults to true.
+  # is, the operator will not send self-monitoring telemetry to the configured Dash0 backend. This setting is optional,
+  # it defaults to true.
   #
   # This setting has no effect if operator.dash0Export.enabled is false, as no Dash0OperatorConfiguration
   # resource will be created by the Helm chart then.

--- a/internal/selfmonitoringapiaccess/self_monitoring_and_api_access.go
+++ b/internal/selfmonitoringapiaccess/self_monitoring_and_api_access.go
@@ -118,7 +118,7 @@ func convertResourceToDash0ExportConfiguration(
 		Export: dash0v1alpha1.Export{
 			Dash0: &dash0v1alpha1.Dash0Configuration{
 				Endpoint:      dash0Export.Endpoint,
-				Dataset:       util.DatasetInsights,
+				Dataset:       dash0Export.Dataset,
 				Authorization: dash0Export.Authorization,
 				ApiEndpoint:   dash0Export.ApiEndpoint,
 			},
@@ -144,13 +144,7 @@ func convertResourceToGrpcExportConfiguration(
 		Export: dash0v1alpha1.Export{
 			Grpc: &dash0v1alpha1.GrpcConfiguration{
 				Endpoint: grpcExport.Endpoint,
-				Headers: append(
-					grpcExport.Headers,
-					dash0v1alpha1.Header{
-						Name:  util.Dash0DatasetHeaderName,
-						Value: util.DatasetInsights,
-					},
-				),
+				Headers:  grpcExport.Headers,
 			},
 		},
 	}, nil
@@ -171,13 +165,7 @@ func convertResourceToHttpExportConfiguration(
 		Export: dash0v1alpha1.Export{
 			Http: &dash0v1alpha1.HttpConfiguration{
 				Endpoint: httpExport.Endpoint,
-				Headers: append(
-					httpExport.Headers,
-					dash0v1alpha1.Header{
-						Name:  util.Dash0DatasetHeaderName,
-						Value: util.DatasetInsights,
-					},
-				),
+				Headers:  httpExport.Headers,
 				Encoding: httpExport.Encoding,
 			},
 		},

--- a/internal/util/constants.go
+++ b/internal/util/constants.go
@@ -9,7 +9,6 @@ const (
 	AuthorizationHeaderName                 = "Authorization"
 	Dash0DatasetHeaderName                  = "Dash0-Dataset"
 	DatasetDefault                          = "default"
-	DatasetInsights                         = "dash0-internal"
 	SelfMonitoringAndApiAuthTokenEnvVarName = "SELF_MONITORING_AND_API_AUTH_TOKEN"
 	FieldManager                            = "dash0-operator"
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -929,12 +929,7 @@ var _ = Describe("Dash0 Operator", Ordered, func() {
 			// Note: changing the endpoint will trigger a metric data point for
 			// dash0.operator.manager.monitoring.reconcile_requests to be produced.
 			// Since we do not mess with the endpoint for the operator configuration resource, the self-monitoring
-			// telemetry still ends up in otlp-sink. We do not test explicitly for the dataset header which is set
-			// on the operator manager deployment via the env var OTEL_EXPORTER_OTLP_HEADERS
-			// (with value Authorization=Bearer $(SELF_MONITORING_AND_API_AUTH_TOKEN),Dash0-Dataset=dash0-internal)
-			// as the headers are not available in the telemetry on disk, but there are other tests (for example
-			// operator_configuration_controller_test.go->"enabling self-monitoring"->
-			// "it enables self-monitoring in the controller deployment" that verify this.
+			// telemetry still ends up in otlp-sink.
 			By("updating the Dash0 monitoring resource endpoint setting")
 			newEndpoint := "ingress.us-east-2.aws.dash0-dev.com:4317"
 			updateEndpointOfDash0MonitoringResource(applicationUnderTestNamespace, newEndpoint)

--- a/test/util/constants.go
+++ b/test/util/constants.go
@@ -98,6 +98,18 @@ func Dash0ExportWithEndpointAndToken() dash0v1alpha1.Export {
 	}
 }
 
+func Dash0ExportWithEndpointTokenAndCustomDataset() dash0v1alpha1.Export {
+	return dash0v1alpha1.Export{
+		Dash0: &dash0v1alpha1.Dash0Configuration{
+			Endpoint: EndpointDash0Test,
+			Dataset:  DatasetTest,
+			Authorization: dash0v1alpha1.Authorization{
+				Token: &AuthorizationTokenTest,
+			},
+		},
+	}
+}
+
 func Dash0ExportWithEndpointAndTokenAndApiEndpoint() dash0v1alpha1.Export {
 	return dash0v1alpha1.Export{
 		Dash0: &dash0v1alpha1.Dash0Configuration{
@@ -106,18 +118,6 @@ func Dash0ExportWithEndpointAndTokenAndApiEndpoint() dash0v1alpha1.Export {
 				Token: &AuthorizationTokenTest,
 			},
 			ApiEndpoint: ApiEndpointTest,
-		},
-	}
-}
-
-func Dash0ExportWithEndpointTokenAndInsightsDataset() dash0v1alpha1.Export {
-	return dash0v1alpha1.Export{
-		Dash0: &dash0v1alpha1.Dash0Configuration{
-			Endpoint: EndpointDash0Test,
-			Dataset:  util.DatasetInsights,
-			Authorization: dash0v1alpha1.Authorization{
-				Token: &AuthorizationTokenTest,
-			},
 		},
 	}
 }

--- a/test/util/controller_deployment.go
+++ b/test/util/controller_deployment.go
@@ -65,7 +65,7 @@ func appendSelfMonitoringEnvVars(env []corev1.EnvVar) []corev1.EnvVar {
 		},
 		corev1.EnvVar{
 			Name:  "OTEL_EXPORTER_OTLP_HEADERS",
-			Value: "Authorization=Bearer $(SELF_MONITORING_AND_API_AUTH_TOKEN),Dash0-Dataset=dash0-internal",
+			Value: "Authorization=Bearer $(SELF_MONITORING_AND_API_AUTH_TOKEN)",
 		},
 		corev1.EnvVar{
 			Name:  "OTEL_EXPORTER_OTLP_PROTOCOL",


### PR DESCRIPTION
Instead of using the Dash0 insights data set for self-monitoring telementry, send self-monitoring telemetry to the configured dataset (or to the default dataset if no custom dataset is configured) as well.

This change is in preparation for Dash0 dropping the concept of the Dash0 insights dataset entirely.