### PR TITLE
fix(collectors): change fallback_scrape_protocol to PrometheusText0.0.4

### DIFF
--- a/internal/backendconnection/otelcolresources/daemonset.config.yaml.template
+++ b/internal/backendconnection/otelcolresources/daemonset.config.yaml.template
@@ -160,7 +160,7 @@ to be compatible with the well-known configuration via annotations.
       # * `prometheus.io/port`: Scrape the pod on the indicated port instead of the default of `9102`.
       - job_name: 'dash0-kubernetes-pods-scrape-config'
         honor_labels: true
-        fallback_scrape_protocol: "PrometheusText1.0.0"
+        fallback_scrape_protocol: "PrometheusText0.0.4"
 
         kubernetes_sd_configs:
           - role: pod
@@ -233,7 +233,7 @@ to be compatible with the well-known configuration via annotations.
       # * `prometheus.io/port`: Scrape the pod on the indicated port instead of the default of `9102`.
       - job_name: 'dash0-kubernetes-pods-scrape-config-slow'
         honor_labels: true
-        fallback_scrape_protocol: "PrometheusText1.0.0"
+        fallback_scrape_protocol: "PrometheusText0.0.4"
 
         scrape_interval: 5m
         scrape_timeout: 30s


### PR DESCRIPTION
According to
https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/38018/files#r1959868040 the proper default for the fallback protocol is PrometheusText0.0.4.

This is a follow up to fb0c55d7f43509ada73e640e01ee5b2a4d064ff4.