### PR TITLE
chore(collectors): make config maps render nicely in k9s edit view

### DIFF
--- a/internal/backendconnection/otelcolresources/daemonset.config.yaml.template
+++ b/internal/backendconnection/otelcolresources/daemonset.config.yaml.template
@@ -1,3 +1,21 @@
+{{- /*
+Note: Subtle formatting issues will cause the edit mode in k9s to be thwarted because the actual configmap content will
+be displayed as a single long quoted string with literal \n characters, instead of being properly formatted as yaml. In
+particular, having one or multiple space characters appear directly before a line break will cause this.
+See https://github.com/kubernetes/kubernetes/issues/36222#issuecomment-2006988070. This does not affect the collector,
+as it can still parse the config map perfectly fine, but it makes troubleshooting in k9s inconvenient.
+
+Therefore, for text/template pipelines that might result in no output (in particular comments and `if` conditions),
+avoid starting the pipeline with "{{" if it is indented (i.e. there are space characters before "{{"). This would leave
+spaces followed by a line break in the rendered output.
+Instead, either
+1. start the pipeline with "{{-" (to consume leading whitespace), or
+2. start the pipeline with "{{" but omit indentation, i.e. start the pipeline directly at the start of the line without
+   leading space characters.
+
+Note that the first option will also consume _all_ preceding line breaks, so if a line break is desired in the output,
+use option 2.
+*/}}
 extensions:
   health_check:
     endpoint: "{{ .SelfIpReference }}:13133"
@@ -294,9 +312,9 @@ to be compatible with the well-known configuration via annotations.
             target_label: node
 {{- end }}
 
-  {{/*
+{{/*
   TODO Turn on conditionally for monitored namespaces
-  */}}
+*/}}
   filelog/monitored_pods:
     include:
     - /var/log/pods/*/*/*.log
@@ -422,7 +440,7 @@ processors:
         action: insert
   {{- end }}
 
-  {{ if .NamespaceOttlFilter }}
+{{ if .NamespaceOttlFilter }}
   # This is a standard filter which is always on; metrics collection receivers generate metrics for all namespaces in
   # the cluster, however, we only want to collect metrics from monitored namespaces, hence this filter.
   # See filter/metrics/$namespaceName filters for user-configurable filters per namespace.
@@ -430,7 +448,7 @@ processors:
     metrics:
       metric:
         - {{ .NamespaceOttlFilter }}
-  {{- end }}
+{{- end }}
 
   filter/logs/only_dash0_monitored_resources:
     error_mode: ignore
@@ -438,7 +456,7 @@ processors:
       log_record:
       - 'resource.attributes["dash0.monitoring.instrumented"] != "true"'
 
-  {{ if .CustomFilters.HasTraceFilters }}
+{{ if .CustomFilters.HasTraceFilters }}
   filter/traces/custom_telemetry_filter:
     error_mode: {{ .CustomFilters.ErrorMode }}
     traces:
@@ -454,8 +472,8 @@ processors:
         - '{{ $condition }}'
         {{- end }}
       {{- end }}
-  {{- end }}
-  {{ if .CustomFilters.HasMetricFilters }}
+{{- end }}
+{{ if .CustomFilters.HasMetricFilters }}
   filter/metrics/custom_telemetry_filter:
     error_mode: {{ .CustomFilters.ErrorMode }}
     metrics:
@@ -471,8 +489,8 @@ processors:
         - '{{ $condition }}'
         {{- end }}
       {{- end }}
-  {{- end }}
-  {{ if .CustomFilters.HasLogFilters }}
+{{ end }}
+{{ if .CustomFilters.HasLogFilters }}
   filter/logs/custom_telemetry_filter:
     error_mode: {{ .CustomFilters.ErrorMode }}
     logs:
@@ -482,7 +500,7 @@ processors:
         - '{{ $condition }}'
         {{- end }}
       {{- end }}
-  {{- end }}
+{{- end }}
 
   memory_limiter:
     check_interval: 5s

--- a/internal/backendconnection/otelcolresources/deployment.config.yaml.template
+++ b/internal/backendconnection/otelcolresources/deployment.config.yaml.template
@@ -64,12 +64,12 @@ processors:
         action: insert
   {{- end }}
 
-  {{ if .NamespaceOttlFilter }}
+{{ if .NamespaceOttlFilter }}
   filter/metrics/only_monitored_namespaces:
     metrics:
       metric:
         - {{ .NamespaceOttlFilter }}
-  {{- end }}
+{{- end }}
 
   # Remove noisy replicaset metrics (by default, Kubernetes keeps a history of 10 replicasets for each deployment,
   # collecting metrics about all of them leads to a lot of metrics with no value). Removing zero-value datapoints
@@ -81,7 +81,7 @@ processors:
       - metric.name == "k8s.replicaset.available" and value_int == 0
       - metric.name == "k8s.replicaset.desired" and value_int == 0
 
-  {{ if .CustomFilters.HasMetricFilters }}
+{{ if .CustomFilters.HasMetricFilters }}
   filter/metrics/custom_telemetry_filter:
     error_mode: ignore
     metrics:
@@ -97,7 +97,7 @@ processors:
         - '{{ $condition }}'
         {{- end }}
       {{- end }}
-  {{- end }}
+{{- end }}
 
   memory_limiter:
     check_interval: 5s

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -280,6 +280,16 @@ var _ = Describe("Dash0 Operator", Ordered, func() {
 					}, 30*time.Second, pollingInterval).Should(Succeed())
 				})
 			})
+
+			//nolint:lll
+			It("config maps should not contain empty lines with space characters (that is, config maps should render nicely in k9s edit view)", func() {
+				// See comment at the top of internal/backendconnection/otelcolresources/daemonset.config.yaml.template
+				// This test looks for the problematic pattern (space character before line break) in the rendered
+				// config maps.
+				verifyDaemonSetCollectorConfigMapDoesNotContainStrings(operatorNamespace, " \n")
+				verifyDeploymentCollectorConfigMapDoesNotContainStrings(operatorNamespace, " \n")
+			})
+
 		}) // end of suite "with an existing operator deployment::with a deployed Dash0 monitoring resource"
 
 		Describe("without a deployed Dash0 monitoring resource", func() {
@@ -775,7 +785,7 @@ traces:
 					},
 					operatorNamespace,
 				)
-				verifyConfigMapContainsString(
+				verifyDaemonSetCollectorConfigMapContainsString(
 					operatorNamespace,
 					// nolint:lll
 					`'resource.attributes[\"k8s.namespace.name\"] == \"e2e-application-under-test-namespace\" and (attributes[\"http.route\"] == \"/ready\")'`,
@@ -918,7 +928,7 @@ traces:
 				updateEndpointOfDash0OperatorConfigurationResource(newEndpoint)
 
 				By("verify that the config map has been updated by the controller")
-				verifyConfigMapContainsString(operatorNamespace, newEndpoint)
+				verifyDaemonSetCollectorConfigMapContainsString(operatorNamespace, newEndpoint)
 
 				// This step sometimes takes quite a while, for some reason the config map change is not seen immediately
 				// from within the collector pod/config-reloader container process, although it polls the file every second.

--- a/test/e2e/run_command.go
+++ b/test/e2e/run_command.go
@@ -90,3 +90,11 @@ func verifyCommandOutputContainsStrings(command *exec.Cmd, timeout time.Duration
 		}
 	}, timeout, time.Second).Should(Succeed())
 }
+
+func verifyCommandOutputDoesNotContainStrings(command *exec.Cmd, needles ...string) {
+	haystack, err := run(exec.Command(command.Args[0], command.Args[1:]...), false)
+	Expect(err).ToNot(HaveOccurred())
+	for _, needle := range needles {
+		Expect(haystack).ToNot(ContainSubstring(needle))
+	}
+}


### PR DESCRIPTION
If a config map contains a space characters followed by a line break, it is rendered in the edit view of k9s as one long unformatted string with literal \n characters instead of line breaks. The text/template templates for the daemonset and deployment collector configs produced this particular pattern, triggering that effect. This change removes this pattern and adds an e2e test making sure it is not accidentally reintroduced.

See
https://github.com/kubernetes/kubernetes/issues/36222#issuecomment-2006988070