### PR TITLE
fix: do not overwrite manually created operator configuration resource

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -841,7 +841,7 @@ func executeStartupTasks(
 	isIPv6Cluster bool,
 	logger *logr.Logger,
 ) *dash0v1alpha1.Dash0OperatorConfiguration {
-	operatorConfigurationResource := createAutoOperatorConfigurationResource(
+	operatorConfigurationResource := createOrUpdateAutoOperatorConfigurationResource(
 		ctx,
 		startupTasksK8sClient,
 		operatorConfigurationValues,
@@ -883,7 +883,7 @@ func instrumentAtStartup(
 	startupInstrumenter.InstrumentAtStartup(ctx, startupTasksK8sClient, &setupLog)
 }
 
-func createAutoOperatorConfigurationResource(
+func createOrUpdateAutoOperatorConfigurationResource(
 	ctx context.Context,
 	k8sClient client.Client,
 	operatorConfigurationValues *startup.OperatorConfigurationValues,

--- a/helm-chart/dash0-operator/README.md
+++ b/helm-chart/dash0-operator/README.md
@@ -100,6 +100,11 @@ You can consult the chart's
 [values.yaml](https://github.com/dash0hq/dash0-operator/blob/main/helm-chart/dash0-operator/values.yaml) file for a
 complete list of available configuration settings.
 
+See the section
+[Notes on Creating the Operator Configuration Resource Via Helm](#notes-on-creating-the-operator-configuration-resource-via-helm)
+for more information on providing Dash0 export settings via Helm and how it affects manual changes to the operator
+configuration resource.
+
 Last but not least, you can also install the operator without providing a Dash0 backend configuration:
 
 ```console
@@ -216,6 +221,39 @@ Note: All configuration options available in the operator configuration resource
 Helm chart auto-create this resource, as explained in the section [Installation](#installation). You can consult the
 chart's [values.yaml](https://github.com/dash0hq/dash0-operator/blob/main/helm-chart/dash0-operator/values.yaml) file
 for a complete list of available configuration settings.
+
+### Notes on Creating the Operator Configuration Resource Via Helm
+
+Providing the backend connection settings to the operator via Helm parameters is a _convenience mechanism_ to get
+monitoring started right away when installing the operator.
+Setting `operator.dash0Export.enabled` to `true` and providing other necessary `operator.dash0Export.*` values like
+`operator.dash0Export.endpoint` will instruct the operator manager to create an operator configuration resource with the
+provided values at startup.
+This automatically created operator configuration resource will have the name
+`dash0-operator-configuration-auto-resource`.
+
+If an operator configuration resource with any other name already exists in the cluster (e.g. a manually created
+operator configuration resource), the operator will treat this as an error and refuse to overwrite the existing operator
+configuration resource with the values provided via Helm.
+
+If an operator configuration resource with the name `dash0-operator-configuration-auto-resource` already exists in the
+cluster (e.g. a previous startup of the operator manager has created the resource), the operator manager will
+update/overwrite this resource with the values provided via Helm.
+
+Manual changes to the `dash0-operator-configuration-auto-resource` are permissible for quickly experimenting with
+configuration changes, without an operator restart, but you need to be aware that they will be overwritten with the
+settings provided via Helm the next time the operator manager pod is restarted.
+Possible reasons for a restart of the operator manager pod include upgrading to a new operator version, running
+`helm upgrade ...  dash0-operator dash0-operator/dash0-operator`, or Kubernetes moving the operator manager pod to a
+different node.
+
+For this reason, when using this feature, it is recommended to treat the _Helm values_ as the source of truth for the
+operator configuration.
+Any changes you want to be permanent should be applied via Helm and the `operator.dash0Export.*` settings.
+
+If you would rather retain manual control over the operator configuration resource, you should omit any
+`operator.dash0Export.*` Helm values and create and manage the operator configuration resource manually (that is, via
+kubectl, ArgoCD etc.).
 
 ### Enable Dash0 Monitoring For a Namespace
 

--- a/internal/controller/operator_configuration_controller.go
+++ b/internal/controller/operator_configuration_controller.go
@@ -279,21 +279,16 @@ func (r *OperatorConfigurationReconciler) applyApiAccessSettings(
 		authToken = operatorConfigurationResource.Spec.Export.Dash0.Authorization.Token
 		usesSecretRef = operatorConfigurationResource.Spec.Export.Dash0.Authorization.SecretRef != nil
 	}
-
-	if usesSecretRef {
-		for _, apiClient := range r.ApiClients {
-			apiClient.RemoveAuthToken(ctx, &logger)
-		}
-	} else {
+	if !usesSecretRef {
 		if authToken != nil && *authToken != "" {
 			for _, apiClient := range r.ApiClients {
 				apiClient.SetAuthToken(ctx, *authToken, &logger)
 			}
 		} else {
 			// If the auth token is provided via a secret ref, we cannot remove it here, as we might accidentally
-			// delete a token that has been resolved via the secret ref resolver. But if the operator configuration
-			// resource does not have a secret ref, we can and should remove the auth token to keep the API client's
-			// state consistent with the operator configuration resource's state.
+			// delete a token that has been resolved via the secret ref resolver already. But if the operator
+			// configuration resource does not use a secret ref, we can and should remove the auth token to keep the
+			// API client's state consistent with the operator configuration resource's state.
 			logger.Info("The Dash0 auth token required for managing dashboards or check rules via the operator " +
 				"is missing or has been removed, the operator will not update dashboards nor check rules in Dash0.")
 			for _, apiClient := range r.ApiClients {

--- a/internal/controller/operator_configuration_controller_test.go
+++ b/internal/controller/operator_configuration_controller_test.go
@@ -253,14 +253,6 @@ var _ = Describe("The operation configuration resource controller", Ordered, fun
 			}
 		},
 
-			// | operator config resource                  | expected calls |
-			// |-------------------------------------------|----------------|
-			// | no Dash0 export                           | remove         |
-			// | no API endpoint, token                    | remove         |
-			// | no API endpoint, secret ref               | remove         |
-			// | API endpoint, token                       | set            |
-			// | API endpoint, secret ref                  | set            |
-
 			// | no Dash0 export                           | remove         |
 			Entry("no API endpoint, no Dash0 export", ApiClientSetRemoveTestConfig{
 				operatorConfigurationResourceSpec: OperatorConfigurationResourceWithoutExport,
@@ -283,7 +275,7 @@ var _ = Describe("The operation configuration resource controller", Ordered, fun
 				expectSetApiEndpointAndDataset:    false,
 				expectRemoveApiEndpointAndDataset: true,
 				expectSetAuthToken:                false,
-				expectRemoveAuthToken:             true,
+				expectRemoveAuthToken:             false,
 			}),
 			// | API endpoint, token                       | set            |
 			Entry("API endpoint, Dash0 export with token", ApiClientSetRemoveTestConfig{
@@ -299,7 +291,7 @@ var _ = Describe("The operation configuration resource controller", Ordered, fun
 				expectSetApiEndpointAndDataset:    true,
 				expectRemoveApiEndpointAndDataset: false,
 				expectSetAuthToken:                false,
-				expectRemoveAuthToken:             true,
+				expectRemoveAuthToken:             false,
 			}),
 			// | API endpoint, token, custom dataset       | set            |
 			Entry("API endpoint, Dash0 export with token, custom dataset", ApiClientSetRemoveTestConfig{
@@ -317,7 +309,7 @@ var _ = Describe("The operation configuration resource controller", Ordered, fun
 				expectSetApiEndpointAndDataset:    true,
 				expectRemoveApiEndpointAndDataset: false,
 				expectSetAuthToken:                false,
-				expectRemoveAuthToken:             true,
+				expectRemoveAuthToken:             false,
 			}),
 		)
 	})

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -571,6 +571,25 @@ var _ = Describe("Dash0 Operator", Ordered, func() {
 				})
 			})
 
+			Describe("self-monitoring telemetry", func() {
+
+				It("should produce self-monitoring telemetry", func() {
+					// Deploying the Dash0 monitoring resource  will trigger a metric data point for
+					// dash0.operator.manager.monitoring.reconcile_requests to be produced.
+					timestampLowerBound := time.Now()
+					deployDash0MonitoringResource(
+						applicationUnderTestNamespace,
+						dash0MonitoringValuesDefault,
+						operatorNamespace,
+					)
+
+					By("waiting for self-monitoring metrics")
+					Eventually(func(g Gomega) {
+						verifySelfMonitoringMetrics(g, timestampLowerBound)
+					}, 90*time.Second, time.Second).Should(Succeed())
+				})
+			})
+
 		}) // end of suite "with an existing operator deployment and operation configuration resource::without a
 		// deployed Dash0 monitoring resource"
 
@@ -668,27 +687,6 @@ var _ = Describe("Dash0 Operator", Ordered, func() {
 				By("waiting for prometheus receiver metrics")
 				Eventually(func(g Gomega) {
 					verifyPrometheusMetrics(g, timestampLowerBound)
-				}, 90*time.Second, time.Second).Should(Succeed())
-			})
-
-			// TODO this test is temporarily disabled due to the test suite being moved into a scenario without an
-			// operator configuration resource. Needs to be moved into a different suite and reactivated.
-			XIt("should produce self-monitoring telemetry", func() {
-
-				By("updating the Dash0 monitoring resource")
-				// Updating the Dash0 monitoring resource  will trigger a metric data point for
-				// dash0.operator.manager.monitoring.reconcile_requests to be produced. Since we undeploy the
-				// monitoring resource in the AfterAll hook after this test, the change does
-				// not affect anything else (also this suite is not concerned with workload instrumentation or
-				//tracing).
-				updateInstrumentWorkloadsModeOfDash0MonitoringResource(
-					applicationUnderTestNamespace,
-					dash0v1alpha1.CreatedAndUpdated,
-				)
-
-				By("waiting for self-monitoring metrics")
-				Eventually(func(g Gomega) {
-					verifySelfMonitoringMetrics(g, timestampLowerBound)
 				}, 90*time.Second, time.Second).Should(Succeed())
 			})
 		})


### PR DESCRIPTION
...with values provided via Helm.

Previously, when instructed to create/update the operator configuration
resource via Helm, the operator manager would update any operator
configuration resource it finds with the provided value. This would
likely lead to unexpected results if people transition from a manually
configured operator configuration resource to a Helm-managed values.

Now the operator will refuse to overwrite the existing resource in this
scenario and log an error.

Also: Describe the behavior around creating the operator configuration
resource via Helm in more detail in the docs.