### PR TITLE
fix(checkrules): delete obsolete check rules in Dash0

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -314,7 +314,7 @@ func main() {
 		startupTasksK8sClient,
 		&setupLog,
 	)
-	pseudoClusterUID := readPseudoClusterUID(ctx, startupTasksK8sClient, &setupLog)
+	pseudoClusterUID := util.ReadPseudoClusterUID(ctx, startupTasksK8sClient, &setupLog)
 	if operatorDeploymentSelfReference, err = findDeploymentReference(
 		ctx,
 		startupTasksK8sClient,
@@ -935,16 +935,6 @@ func detectDocker(
 			isDocker = true
 		}
 	}
-}
-
-func readPseudoClusterUID(ctx context.Context, k8sClient client.Client, logger *logr.Logger) string {
-	kubeSystemNamespace := &corev1.Namespace{}
-	if err := k8sClient.Get(ctx, client.ObjectKey{Name: "kube-system"}, kubeSystemNamespace); err != nil {
-		msg := "unable to get the kube-system namespace uid"
-		logger.Error(err, msg)
-		return "unknown"
-	}
-	return string(kubeSystemNamespace.UID)
 }
 
 func findDeploymentReference(

--- a/internal/controller/perses_dashboards_controller_test.go
+++ b/internal/controller/perses_dashboards_controller_test.go
@@ -450,7 +450,7 @@ var _ = Describe("The Perses dashboard controller", Ordered, func() {
 				k8sClient,
 				dash0v1alpha1.PersesDashboardSynchronizationResults{
 					SynchronizationStatus: dash0v1alpha1.Failed,
-					SynchronizationError:  "^unexpected status code 503 when updating/creating/deleting the dashboard \"test-dashboard\" at https://api.dash0.com/api/dashboards/dash0-operator_.*_test-dataset_test-namespace_test-dashboard\\?dataset=test-dataset, response body is {}\n$",
+					SynchronizationError:  "^unexpected status code 503 when synchronizing the dashboard \"test-dashboard\": PUT https://api.dash0.com/api/dashboards/dash0-operator_.*_test-dataset_test-namespace_test-dashboard\\?dataset=test-dataset, response body is {}\n$",
 					ValidationIssues:      nil,
 				},
 			)
@@ -473,6 +473,7 @@ func createPersesDashboardCrdReconciler() *PersesDashboardCrdReconciler {
 func expectDashboardPutRequest(expectedPath string) {
 	gock.New(ApiEndpointTest).
 		Put(expectedPath).
+		MatchHeader("Authorization", AuthorizationHeaderTest).
 		MatchParam("dataset", DatasetCustomTest).
 		Times(1).
 		Reply(200).
@@ -482,6 +483,7 @@ func expectDashboardPutRequest(expectedPath string) {
 func expectDashboardDeleteRequest(expectedPath string) {
 	gock.New(ApiEndpointTest).
 		Delete(expectedPath).
+		MatchHeader("Authorization", AuthorizationHeaderTest).
 		MatchParam("dataset", DatasetCustomTest).
 		Times(1).
 		Reply(200).

--- a/internal/selfmonitoringapiaccess/otel_init_wait.go
+++ b/internal/selfmonitoringapiaccess/otel_init_wait.go
@@ -198,7 +198,7 @@ func convertExportConfigurationToOTelSDKConfig(
 
 		headers := []dash0v1alpha1.Header{{
 			Name:  util.AuthorizationHeaderName,
-			Value: fmt.Sprintf("Bearer %s", *token),
+			Value: util.RenderAuthorizationHeader(*token),
 		}}
 		if dash0Export.Dataset != "" && dash0Export.Dataset != util.DatasetDefault {
 			headers = append(headers, dash0v1alpha1.Header{

--- a/internal/util/cluster.go
+++ b/internal/util/cluster.go
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: Copyright 2025 Dash0 Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package util
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func ReadPseudoClusterUID(ctx context.Context, k8sClient client.Client, logger *logr.Logger) string {
+	kubeSystemNamespace := &corev1.Namespace{}
+	if err := k8sClient.Get(ctx, client.ObjectKey{Name: "kube-system"}, kubeSystemNamespace); err != nil {
+		msg := "unable to get the kube-system namespace uid"
+		logger.Error(err, msg)
+		return "unknown"
+	}
+	return string(kubeSystemNamespace.UID)
+}

--- a/internal/util/constants.go
+++ b/internal/util/constants.go
@@ -3,13 +3,18 @@
 
 package util
 
+import "fmt"
+
 type WorkloadModifierActor string
 
 const (
-	AuthorizationHeaderName = "Authorization"
-	Dash0DatasetHeaderName  = "Dash0-Dataset"
-	DatasetDefault          = "default"
-	FieldManager            = "dash0-operator"
+	AuthorizationHeaderName  = "Authorization"
+	ContentTypeHeaderName    = "Content-Type"
+	AcceptHeaderName         = "Accept"
+	ApplicationJsonMediaType = "application/json"
+	Dash0DatasetHeaderName   = "Dash0-Dataset"
+	DatasetDefault           = "default"
+	FieldManager             = "dash0-operator"
 
 	ActorController WorkloadModifierActor = "controller"
 	ActorWebhook    WorkloadModifierActor = "webhook"
@@ -21,3 +26,7 @@ const (
 	AppKubernetesIoManagedByLabel = "app.kubernetes.io/managed-by"
 	AppKubernetesIoVersionLabel   = "app.kubernetes.io/version"
 )
+
+func RenderAuthorizationHeader(authToken string) string {
+	return fmt.Sprintf("Bearer %s", authToken)
+}


### PR DESCRIPTION
Delete individual check rules in Dash0 via the API when the corresponding group or rule has been deleted (or renamed) in the PrometheusRules Kubernetes resource.