### PR TITLE
fix(collectors): bump filelog receiver to 0.124.1

### DIFF
--- a/images/collector/src/builder/config.yaml
+++ b/images/collector/src/builder/config.yaml
@@ -12,7 +12,7 @@ providers:
   - gomod: "go.opentelemetry.io/collector/confmap/provider/fileprovider v1.30.0"
 receivers:
   - gomod: "go.opentelemetry.io/collector/receiver/otlpreceiver v0.124.0"
-  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver v0.124.0"
+  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver v0.124.1"
   - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver v0.124.0"
   - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver v0.124.0"
   - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver v0.124.0"


### PR DESCRIPTION
To include the fix for
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/39414 (excessive printing of file names).