### PR TITLE
chore(checkrules,dashboards): improve logs for non-leader replicas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,7 @@ go.work
 *.swo
 *~
 
+# Idea run configs
+.run
+
 dash0-operator-values.yaml

--- a/internal/controller/perses_dashboards_controller_test.go
+++ b/internal/controller/perses_dashboards_controller_test.go
@@ -460,14 +460,16 @@ var _ = Describe("The Perses dashboard controller", Ordered, func() {
 })
 
 func createPersesDashboardCrdReconciler() *PersesDashboardCrdReconciler {
-	return &PersesDashboardCrdReconciler{
-		Client: k8sClient,
-		Queue:  testQueuePersesDashboards,
+	crdReconciler := NewPersesDashboardCrdReconciler(
+		k8sClient,
+		testQueuePersesDashboards,
+		&DummyLeaderElectionAware{Leader: true},
+	)
 
-		// We create the controller multiple times in tests, this option is required, otherwise the controller
-		// runtime will complain.
-		skipNameValidation: true,
-	}
+	// We create the controller multiple times in tests, this option is required, otherwise the controller
+	// runtime will complain.
+	crdReconciler.skipNameValidation = true
+	return crdReconciler
 }
 
 func expectDashboardPutRequest(expectedPath string) {

--- a/internal/controller/prometheus_rules_controller_test.go
+++ b/internal/controller/prometheus_rules_controller_test.go
@@ -1172,14 +1172,16 @@ var _ = Describe("The Prometheus rule controller", Ordered, func() {
 })
 
 func createPrometheusRuleCrdReconciler() *PrometheusRuleCrdReconciler {
-	return &PrometheusRuleCrdReconciler{
-		Client: k8sClient,
-		Queue:  testQueuePrometheusRules,
+	crdReconciler := NewPrometheusRuleCrdReconciler(
+		k8sClient,
+		testQueuePrometheusRules,
+		&DummyLeaderElectionAware{Leader: true},
+	)
 
-		// We create the controller multiple times in tests, this option is required, otherwise the controller
-		// runtime will complain.
-		skipNameValidation: true,
-	}
+	// We create the controller multiple times in tests, this option is required, otherwise the controller
+	// runtime will complain.
+	crdReconciler.skipNameValidation = true
+	return crdReconciler
 }
 
 func expectFetchIdGetRequest(clusterId string) {

--- a/internal/startup/instrument_at_startup.go
+++ b/internal/startup/instrument_at_startup.go
@@ -31,7 +31,7 @@ func NewInstrumentAtStartupRunnable(
 }
 
 // NeedLeaderElection implements the LeaderElectionRunnable interface, which indicates
-// the webhook server doesn't need leader election.
+// that the InstrumentAtStartupRunnable requires leader election.
 func (r *InstrumentAtStartupRunnable) NeedLeaderElection() bool {
 	return true
 }

--- a/internal/startup/leader_election_aware_manager.go
+++ b/internal/startup/leader_election_aware_manager.go
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: Copyright 2025 Dash0 Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package startup
+
+import (
+	"context"
+	"sync/atomic"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+type LeaderElectionAware interface {
+	IsLeader() bool
+}
+
+// LeaderElectionAwareRunnable serves the purpos of making the operator manager aware whether it is the current leader
+// or not.
+type LeaderElectionAwareRunnable struct {
+	isLeader atomic.Bool
+}
+
+func NewLeaderElectionAwareRunnable() *LeaderElectionAwareRunnable {
+	return &LeaderElectionAwareRunnable{}
+}
+
+// NeedLeaderElection implements the LeaderElectionRunnable interface, which indicates
+// that the LeaderElectionAwareRunnable requires leader election.
+func (r *LeaderElectionAwareRunnable) NeedLeaderElection() bool {
+	return true
+}
+
+// Start runs the instrumentation procedure.
+func (r *LeaderElectionAwareRunnable) Start(ctx context.Context) error {
+	log.FromContext(ctx).Info("This operator manager replica has just become leader.")
+	r.isLeader.Store(true)
+	return nil
+}
+
+func (r *LeaderElectionAwareRunnable) IsLeader() bool {
+	return r.isLeader.Load()
+}

--- a/internal/webhooks/instrumentation_webhook.go
+++ b/internal/webhooks/instrumentation_webhook.go
@@ -124,7 +124,8 @@ func (h *InstrumentationWebhookHandler) Handle(ctx context.Context, request admi
 	}); err != nil {
 		if apierrors.IsNotFound(err) {
 			return admission.Allowed(fmt.Sprintf(
-				"There is no Dash0 monitoring resource in the namespace %s, the workload will not be instrumented by the webhook.",
+				"There is no Dash0 monitoring resource in the namespace %s, the workload will not be instrumented by "+
+					"the webhook.",
 				targetNamespace,
 			))
 		} else {

--- a/internal/webhooks/instrumentation_webhook.go
+++ b/internal/webhooks/instrumentation_webhook.go
@@ -143,17 +143,12 @@ func (h *InstrumentationWebhookHandler) Handle(ctx context.Context, request admi
 	}
 
 	if len(dash0List.Items) == 0 {
-		msg := fmt.Sprintf(
-			"There is no Dash0 monitoring resource in the namespace %s, the workload will not be instrumented.",
-			targetNamespace,
-		)
-		if request.Operation == admissionv1.Update {
-			// some operators update the resources they manage very frequently (e.g. every few seconds), do not spam
-			// the log with those requests
-			return admission.Allowed(msg)
-		} else {
-			return logAndReturnAllowed(msg, &logger)
-		}
+		return admission.Allowed(
+			fmt.Sprintf(
+				"There is no Dash0 monitoring resource in the namespace %s, the workload will not be instrumented by "+
+					"the webhook.",
+				targetNamespace,
+			))
 	}
 
 	dash0MonitoringResource := dash0List.Items[0]

--- a/test-resources/bin/util
+++ b/test-resources/bin/util
@@ -383,6 +383,9 @@ run_helm() {
     fi
     helm_install_command+=" --set operator.clusterName=$(kubectl config current-context)"
   fi
+  if [[ -n "${OPERATOR_REPLICAS:-}" ]]; then
+    helm_install_command+=" --set operator.replicaCount=${OPERATOR_REPLICAS:-1}"
+  fi
 
   helm_install_command+=" dash0-operator"
   helm_install_command+=" ${OPERATOR_HELM_CHART:-helm-chart/dash0-operator}"

--- a/test/e2e/applications_under_test.go
+++ b/test/e2e/applications_under_test.go
@@ -335,7 +335,7 @@ func runKubectlDelete(namespace string, workloadType string, runtime runtimeType
 			"--ignore-not-found",
 			"-f",
 			manifest(runtime, workloadType),
-		))
+		), false)
 }
 
 func killBatchJobsAndPods(namespace string) {

--- a/test/e2e/operator.go
+++ b/test/e2e/operator.go
@@ -253,7 +253,7 @@ func waitForManagerPodAndWebhookToStart(operatorNamespace string) {
 		g.Expect(err).NotTo(HaveOccurred())
 		podNames := getNonEmptyLines(podOutput)
 		if len(podNames) != 1 {
-			return fmt.Errorf("expect 1 controller pods running, but got %d -- %s", len(podNames), podOutput)
+			return fmt.Errorf("expect 1 controller pod running, but got %d -- %s", len(podNames), podOutput)
 		}
 		managerPodName = podNames[0]
 		g.Expect(managerPodName).To(ContainSubstring("controller"))

--- a/test/e2e/run_command.go
+++ b/test/e2e/run_command.go
@@ -13,8 +13,8 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func runAndIgnoreOutput(cmd *exec.Cmd) error {
-	_, err := run(cmd)
+func runAndIgnoreOutput(cmd *exec.Cmd, logCommandArgs ...bool) error {
+	_, err := run(cmd, logCommandArgs...)
 	return err
 }
 

--- a/test/util/third_party_resource.go
+++ b/test/util/third_party_resource.go
@@ -71,3 +71,11 @@ func ensureThirdPartyResourceExists(
 
 	return crdObject.(*apiextensionsv1.CustomResourceDefinition)
 }
+
+type DummyLeaderElectionAware struct {
+	Leader bool
+}
+
+func (l *DummyLeaderElectionAware) IsLeader() bool {
+	return l.Leader
+}


### PR DESCRIPTION
If the reason the third-party resource reconcilers cannot start watching
their target custom resource type yet is that this replica is not the
leader, then include that reasoning in the log message.
