### PR TITLE
fix(webhook): disallow instrumenting workloads in system namespaces

### DIFF
--- a/test/util/monitoring_resource.go
+++ b/test/util/monitoring_resource.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	MonitoringResourceName = "das0-monitoring-test-resource"
+	MonitoringResourceName = "dash0-monitoring-test-resource"
 )
 
 var (
@@ -28,8 +28,8 @@ var (
 		Name:      MonitoringResourceName,
 	}
 	MonitoringResourceDefaultObjectMeta = metav1.ObjectMeta{
-		Name:      MonitoringResourceName,
 		Namespace: TestNamespaceName,
+		Name:      MonitoringResourceName,
 	}
 	MonitoringResourceDefaultSpec = dash0v1alpha1.Dash0MonitoringSpec{
 		Export: &dash0v1alpha1.Export{


### PR DESCRIPTION
Deploying a Dash0 monitoring resource to a system namespace (kube-system, kube-node-lease) is now only deployed with InstrumentWorkloads: none.