### PR TITLE
docs(chart): suggest a fixed CRD version for Perses dashboards

### DIFF
--- a/helm-chart/dash0-operator/README.md
+++ b/helm-chart/dash0-operator/README.md
@@ -1288,7 +1288,7 @@ Furthermore, the custom resource definition for Perses dashboards needs to be in
 ways to achieve this:
 * Install the Perses dashboard custom resource definition with the following command:
 ```console
-kubectl apply --server-side -f https://raw.githubusercontent.com/perses/perses-operator/main/config/crd/bases/perses.dev_persesdashboards.yaml
+kubectl apply --server-side -f https://raw.githubusercontent.com/perses/perses-operator/refs/tags/v0.1.10/config/crd/bases/perses.dev_persesdashboards.yaml
 ```
 * Alternatively, install the full Perses operator: Go to <https://github.com/perses/perses-operator> and follow the
   installation instructions there.

--- a/test-resources/bin/util
+++ b/test-resources/bin/util
@@ -520,7 +520,7 @@ deploy_application_under_monitoring() {
 }
 
 install_third_party_crds() {
-  kubectl apply --server-side -f https://raw.githubusercontent.com/perses/perses-operator/main/config/crd/bases/perses.dev_persesdashboards.yaml
+  kubectl apply --server-side -f https://raw.githubusercontent.com/perses/perses-operator/refs/tags/v0.1.10/config/crd/bases/perses.dev_persesdashboards.yaml
   kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.77.1/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml
 }
 


### PR DESCRIPTION
https://github.com/perses/perses-operator/pull/128 changed the CRD format, so the previous recommendation to install the CRD from their main branch would breaks things.