### PR TITLE
feat(workloads): set OTEL_EXPORTER_OTLP_PROTOCOL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -208,7 +208,7 @@ shellcheck-check-installed:
 .PHONY: shellcheck-lint
 shellcheck-lint: shellcheck-check-installed
 	@echo "-------------------------------- (linting shell scripts)"
-	find . -name \*.sh | xargs shellcheck -x
+	find . -name \*.sh -not -path "./images/instrumentation/injector-experiments/third-party/*" | xargs shellcheck -x
 
 .PHONY: prometheus-crd-version-check
 prometheus-crd-version-check:

--- a/helm-chart/dash0-operator/README.md
+++ b/helm-chart/dash0-operator/README.md
@@ -892,13 +892,15 @@ To do so, you need to [add an OpenTelemetry SDK](#https://opentelemetry.io/docs/
 
 If the workload is in a namespace that is monitored by Dash0, the OpenTelemetry SDK will automatically be configured to
 send telemetry to the OpenTelemetry collectors managed by the Dash0 operator.
-This is because the operator automatically sets `OTEL_EXPORTER_OTLP_ENDPOINT` to the correct value when applying the
-[automatic workload instrumentation](#automatic-workload-instrumentation).
+This is because the operator automatically sets `OTEL_EXPORTER_OTLP_ENDPOINT` and `OTEL_EXPORTER_OTLP_PROTOCOL` to the
+correct values when applying the [automatic workload instrumentation](#automatic-workload-instrumentation).
 
 If the workload is in a namespace that is not monitored by Dash0 (or if
 [`instrumentWorkloads`](#monitoringresource.spec.instrumentWorkloads) is set to `none` in the respective Dash0
-monitoring resource), you need to set the environment variable
-[`OTEL_EXPORTER_OTLP_ENDPOINT`](#https://opentelemetry.io/docs/languages/sdk-configuration/otlp-exporter/) yourself.
+monitoring resource, or if the workload has the label `dash0.com/enable=false`), you need to set the environment
+variable [`OTEL_EXPORTER_OTLP_ENDPOINT`](#https://opentelemetry.io/docs/languages/sdk-configuration/otlp-exporter/)
+(and optionally also
+[`OTEL_EXPORTER_OTLP_PROTOCOL`](https://opentelemetry.io/docs/specs/otel/protocol/exporter/#specify-protocol)) yourself.
 
 The DaemonSet OpenTelemetry collector managed by the Dash0 operator listens on host port 40318 for HTTP traffic and
 40317 for gRPC traffic.
@@ -1167,8 +1169,8 @@ The modifications that are performed for workloads are the following:
 * add an [init container](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/) named
   `dash0-instrumentation` that will copy the OpenTelemetry SDKs and distributions for supported runtimes to the
   `dash0-instrumentation` volume mount, so they are available in the target container's file system
-* add or modifying environment variables (`OTEL_EXPORTER_OTLP_ENDPOINT`, `LD_PRELOAD`, and several Dash0-specific
-  variables prefixed with `DASH0_`) to all containers of the pod
+* add or modifying environment variables (`OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_PROTOCOL`, `LD_PRELOAD`,
+  and several Dash0-specific variables prefixed with `DASH0_`) to all containers of the pod
 * add the Dash0 injector (see below for details) as a startup hook (via the `LD_PRELOAD` environment variable) to all
   containers of the pod
 * add the following labels to the workload metadata:

--- a/internal/webhooks/instrumentation_webhook_test.go
+++ b/internal/webhooks/instrumentation_webhook_test.go
@@ -13,6 +13,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	dash0v1alpha1 "github.com/dash0hq/dash0-operator/api/dash0monitoring/v1alpha1"
+	"github.com/dash0hq/dash0-operator/images/pkg/common"
 	"github.com/dash0hq/dash0-operator/internal/util"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -263,6 +264,9 @@ var _ = Describe("The Dash0 instrumentation webhook", func() {
 								"OTEL_EXPORTER_OTLP_ENDPOINT": {
 									Value: OTelCollectorBaseUrlTest,
 								},
+								"OTEL_EXPORTER_OTLP_PROTOCOL": {
+									Value: common.ProtocolHttpProtobuf,
+								},
 								"DASH0_NAMESPACE_NAME": {
 									ValueFrom: "metadata.namespace",
 								},
@@ -317,6 +321,9 @@ var _ = Describe("The Dash0 instrumentation webhook", func() {
 								},
 								"OTEL_EXPORTER_OTLP_ENDPOINT": {
 									Value: OTelCollectorBaseUrlTest,
+								},
+								"OTEL_EXPORTER_OTLP_PROTOCOL": {
+									Value: common.ProtocolHttpProtobuf,
 								},
 								"DASH0_NAMESPACE_NAME": {
 									ValueFrom: "metadata.namespace",
@@ -394,6 +401,9 @@ var _ = Describe("The Dash0 instrumentation webhook", func() {
 								"OTEL_EXPORTER_OTLP_ENDPOINT": {
 									Value: OTelCollectorBaseUrlTest,
 								},
+								"OTEL_EXPORTER_OTLP_PROTOCOL": {
+									Value: common.ProtocolHttpProtobuf,
+								},
 								"DASH0_NAMESPACE_NAME": {
 									ValueFrom: "metadata.namespace",
 								},
@@ -424,6 +434,9 @@ var _ = Describe("The Dash0 instrumentation webhook", func() {
 								},
 								"OTEL_EXPORTER_OTLP_ENDPOINT": {
 									Value: OTelCollectorBaseUrlTest,
+								},
+								"OTEL_EXPORTER_OTLP_PROTOCOL": {
+									Value: common.ProtocolHttpProtobuf,
 								},
 								"DASH0_NAMESPACE_NAME": {
 									ValueFrom: "metadata.namespace",

--- a/internal/workloads/workload_modifier.go
+++ b/internal/workloads/workload_modifier.go
@@ -17,6 +17,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/dash0hq/dash0-operator/images/pkg/common"
 	"github.com/dash0hq/dash0-operator/internal/collectors/otelcolresources"
 	"github.com/dash0hq/dash0-operator/internal/util"
 )
@@ -31,6 +32,7 @@ const (
 	envVarLdPreloadName                = "LD_PRELOAD"
 	envVarLdPreloadValue               = "/__dash0__/dash0_injector.so"
 	envVarOtelExporterOtlpEndpointName = "OTEL_EXPORTER_OTLP_ENDPOINT"
+	envVarOtelExporterOtlpProtocolName = "OTEL_EXPORTER_OTLP_PROTOCOL"
 	envVarDash0CollectorBaseUrlName    = "DASH0_OTEL_COLLECTOR_BASE_URL"
 	envVarDash0NodeIp                  = "DASH0_NODE_IP"
 	envVarDash0NamespaceName           = "DASH0_NAMESPACE_NAME"
@@ -485,6 +487,14 @@ func (m *ResourceModifier) addEnvironmentVariables(
 	m.addOrReplaceEnvironmentVariable(
 		container,
 		corev1.EnvVar{
+			Name:  envVarOtelExporterOtlpProtocolName,
+			Value: common.ProtocolHttpProtobuf,
+		},
+	)
+
+	m.addOrReplaceEnvironmentVariable(
+		container,
+		corev1.EnvVar{
 			Name: envVarDash0NamespaceName,
 			ValueFrom: &corev1.EnvVarSource{
 				FieldRef: &corev1.ObjectFieldSelector{
@@ -851,6 +861,7 @@ func (m *ResourceModifier) removeEnvironmentVariables(container *corev1.Containe
 	m.removeEnvironmentVariable(container, envVarDash0NodeIp)
 	m.removeEnvironmentVariable(container, envVarDash0CollectorBaseUrlName)
 	m.removeEnvironmentVariable(container, envVarOtelExporterOtlpEndpointName)
+	m.removeEnvironmentVariable(container, envVarOtelExporterOtlpProtocolName)
 	m.removeEnvironmentVariable(container, envVarDash0NamespaceName)
 	m.removeEnvironmentVariable(container, envVarDash0PodName)
 	m.removeEnvironmentVariable(container, envVarDash0PodUid)

--- a/internal/workloads/workload_modifier_test.go
+++ b/internal/workloads/workload_modifier_test.go
@@ -13,6 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
+	"github.com/dash0hq/dash0-operator/images/pkg/common"
 	"github.com/dash0hq/dash0-operator/internal/util"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -99,6 +100,9 @@ var _ = Describe("Dash0 Workload Modification", func() {
 							"OTEL_EXPORTER_OTLP_ENDPOINT": {
 								Value: OTelCollectorBaseUrlTest,
 							},
+							"OTEL_EXPORTER_OTLP_PROTOCOL": {
+								Value: common.ProtocolHttpProtobuf,
+							},
 							"DASH0_NAMESPACE_NAME": {
 								ValueFrom: "metadata.namespace",
 							},
@@ -153,6 +157,9 @@ var _ = Describe("Dash0 Workload Modification", func() {
 							},
 							"OTEL_EXPORTER_OTLP_ENDPOINT": {
 								Value: OTelCollectorBaseUrlTest,
+							},
+							"OTEL_EXPORTER_OTLP_PROTOCOL": {
+								Value: common.ProtocolHttpProtobuf,
 							},
 							"DASH0_NAMESPACE_NAME": {
 								ValueFrom: "metadata.namespace",
@@ -225,6 +232,9 @@ var _ = Describe("Dash0 Workload Modification", func() {
 							"OTEL_EXPORTER_OTLP_ENDPOINT": {
 								Value: OTelCollectorBaseUrlTest,
 							},
+							"OTEL_EXPORTER_OTLP_PROTOCOL": {
+								Value: common.ProtocolHttpProtobuf,
+							},
 							"DASH0_NAMESPACE_NAME": {
 								ValueFrom: "metadata.namespace",
 							},
@@ -255,6 +265,9 @@ var _ = Describe("Dash0 Workload Modification", func() {
 							},
 							"OTEL_EXPORTER_OTLP_ENDPOINT": {
 								Value: OTelCollectorBaseUrlTest,
+							},
+							"OTEL_EXPORTER_OTLP_PROTOCOL": {
+								Value: common.ProtocolHttpProtobuf,
 							},
 							"DASH0_NAMESPACE_NAME": {
 								ValueFrom: "metadata.namespace",

--- a/test/util/resources.go
+++ b/test/util/resources.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/dash0hq/dash0-operator/images/pkg/common"
 	"github.com/dash0hq/dash0-operator/internal/util"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -960,6 +961,10 @@ func simulateInstrumentedPodSpec(podSpec *corev1.PodSpec, meta *metav1.ObjectMet
 		{
 			Name:  "OTEL_EXPORTER_OTLP_ENDPOINT",
 			Value: OTelCollectorBaseUrlTest,
+		},
+		{
+			Name:  "OTEL_EXPORTER_OTLP_PROTOCOL",
+			Value: common.ProtocolHttpProtobuf,
 		},
 		{
 			Name: "DASH0_NAMESPACE_NAME",

--- a/test/util/verification.go
+++ b/test/util/verification.go
@@ -15,10 +15,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
+	"github.com/dash0hq/dash0-operator/images/pkg/common"
+	"github.com/dash0hq/dash0-operator/internal/util"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
-	"github.com/dash0hq/dash0-operator/internal/util"
 )
 
 type EnvVarExpectation struct {
@@ -89,6 +90,9 @@ func BasicInstrumentedPodSpecExpectations() PodSpecExpectations {
 				},
 				"OTEL_EXPORTER_OTLP_ENDPOINT": {
 					Value: OTelCollectorBaseUrlTest,
+				},
+				"OTEL_EXPORTER_OTLP_PROTOCOL": {
+					Value: common.ProtocolHttpProtobuf,
 				},
 				"DASH0_NAMESPACE_NAME": {
 					ValueFrom: "metadata.namespace",


### PR DESCRIPTION
The operator already adds/replaces OTEL_EXPORTER_OTLP_ENDPOINT when instrumenting workloads, to the collector URL that accepts http/protobuf traffic. If OTEL_EXPORTER_OTLP_ENDPOINT is set but the OpenTelemetry SDK in the instrumented workload defaults to gRPC, exporting telemetry will not work. Hence, the operator now also sets OTEL_EXPORTER_OTLP_PROTOCOL to http/protobuf explicitly.