### PR TITLE
fix(chart): remove default resource requests for init container

### DIFF
--- a/helm-chart/dash0-operator/tests/operator/__snapshot__/extra-config-map_test.yaml.snap
+++ b/helm-chart/dash0-operator/tests/operator/__snapshot__/extra-config-map_test.yaml.snap
@@ -4,9 +4,7 @@ extra config map should match snapshot:
     data:
       extra.yaml: |-
         initContainerResources:
-          requests:
-            cpu: 100m
-            memory: 150Mi
+          {}
         collectorDaemonSetCollectorContainerResources:
           gomemlimit: 400MiB
           limits:

--- a/helm-chart/dash0-operator/tests/operator/extra-config-map_test.yaml
+++ b/helm-chart/dash0-operator/tests/operator/extra-config-map_test.yaml
@@ -207,9 +207,7 @@ tests:
           path: data['extra.yaml']
           value:  |-
             initContainerResources:
-              requests:
-                cpu: 100m
-                memory: 150Mi
+              {}
             collectorDaemonSetCollectorContainerResources:
               gomemlimit: 301MiB
               limits:

--- a/helm-chart/dash0-operator/values.yaml
+++ b/helm-chart/dash0-operator/values.yaml
@@ -170,7 +170,7 @@ operator:
 
   # Resource settings for the dash0-instrumentation init container that will be added to each pod when automatic
   # workload instrumentation is enabled.
-  initContainerResources:
+  initContainerResources: {}
     # By default, this container defines no resource limits, but if required, they can be set here.
     # Note that putting a low CPU limit on the init container might slow down pod startup for instrumented pods
     # considerably.
@@ -178,11 +178,18 @@ operator:
     #   cpu:
     #   memory:
     #   ephemeral-storage:
-    requests:
-      cpu: 100m
-      memory: 150Mi
-      # By default, this container defines no ephemeral-storage request limits, but if required, it can be set here.
-      # ephemeral-storage:
+    #
+    # By default, this container defines no resource requests; if required, they can be set here. However, be aware that
+    # setting requests for init containers might have unintended consequences. In particular, contrary to what one might
+    # think intuitively, requested resources are _not_ freed up after the init container has completed. See the
+    # discussion in https://github.com/kubernetes/kubernetes/issues/124282. This can make setting resource requests
+    # rather expensive and lead to CPU/memory being needlessly reserved by the scheduler for the already finished init
+    # container, although it will actually never be used again.
+    #
+    # requests:
+    #   cpu: 100m
+    #   memory: 150Mi
+    #   ephemeral-storage:
 
   # the port for the metrics service
   metricsPort: 8443

--- a/internal/util/extraconfig.go
+++ b/internal/util/extraconfig.go
@@ -34,12 +34,7 @@ type ExtraConfig struct {
 
 var (
 	ExtraConfigDefaults = ExtraConfig{
-		InstrumentationInitContainerResources: ResourceRequirementsWithGoMemLimit{
-			Requests: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("100m"),
-				corev1.ResourceMemory: resource.MustParse("150Mi"),
-			},
-		},
+		InstrumentationInitContainerResources: ResourceRequirementsWithGoMemLimit{},
 		CollectorDaemonSetCollectorContainerResources: ResourceRequirementsWithGoMemLimit{
 			Limits: corev1.ResourceList{
 				corev1.ResourceMemory: resource.MustParse("500Mi"),

--- a/internal/util/extraconfig_test.go
+++ b/internal/util/extraconfig_test.go
@@ -351,9 +351,7 @@ var _ = Describe("limits and requests for containers", func() {
 
 				Expect(extraConfig.InstrumentationInitContainerResources.Limits).To(BeNil())
 				Expect(extraConfig.InstrumentationInitContainerResources.GoMemLimit).To(BeEmpty())
-				Expect(extraConfig.InstrumentationInitContainerResources.Requests.Cpu().String()).To(Equal("100m"))
-				Expect(extraConfig.InstrumentationInitContainerResources.Requests.Memory().String()).To(Equal("150Mi"))
-				Expect(extraConfig.InstrumentationInitContainerResources.Requests.StorageEphemeral().IsZero()).To(BeTrue())
+				Expect(extraConfig.InstrumentationInitContainerResources.Requests).To(BeNil())
 
 				Expect(extraConfig.CollectorDaemonSetCollectorContainerResources.Limits.Cpu().IsZero()).To(BeTrue())
 				Expect(extraConfig.CollectorDaemonSetCollectorContainerResources.Limits.Memory().String()).To(Equal("500Mi"))
@@ -561,9 +559,7 @@ var _ = Describe("limits and requests for containers", func() {
 				Expect(extraConfig.InstrumentationInitContainerResources.Limits.Memory().IsZero()).To(BeTrue())
 				Expect(extraConfig.InstrumentationInitContainerResources.Limits.StorageEphemeral().IsZero()).To(BeTrue())
 				Expect(extraConfig.InstrumentationInitContainerResources.GoMemLimit).To(BeEmpty())
-				Expect(extraConfig.InstrumentationInitContainerResources.Requests.Cpu().String()).To(Equal("100m"))
-				Expect(extraConfig.InstrumentationInitContainerResources.Requests.Memory().String()).To(Equal("150Mi"))
-				Expect(extraConfig.InstrumentationInitContainerResources.Requests.StorageEphemeral().IsZero()).To(BeTrue())
+				Expect(extraConfig.InstrumentationInitContainerResources.Requests).To(BeNil())
 
 				Expect(extraConfig.CollectorDaemonSetCollectorContainerResources.Limits.Cpu().String()).To(Equal("900m"))
 				Expect(extraConfig.CollectorDaemonSetCollectorContainerResources.Limits.Memory().String()).To(Equal("500Mi"))
@@ -616,9 +612,7 @@ var _ = Describe("limits and requests for containers", func() {
 
 				containerResources := extraConfig.InstrumentationInitContainerResources.ToResourceRequirements()
 				Expect(containerResources.Limits).To(BeNil())
-				Expect(containerResources.Requests.Cpu().String()).To(Equal("100m"))
-				Expect(containerResources.Requests.Memory().String()).To(Equal("150Mi"))
-				Expect(containerResources.Requests.StorageEphemeral().IsZero()).To(BeTrue())
+				Expect(containerResources.Requests).To(BeNil())
 
 				containerResources = extraConfig.CollectorDaemonSetCollectorContainerResources.ToResourceRequirements()
 				Expect(containerResources.Limits.Cpu().IsZero()).To(BeTrue())
@@ -812,9 +806,7 @@ var _ = Describe("limits and requests for containers", func() {
 				Expect(containerResources.Limits.Cpu().String()).To(Equal("200m"))
 				Expect(containerResources.Limits.Memory().IsZero()).To(BeTrue())
 				Expect(containerResources.Limits.StorageEphemeral().IsZero()).To(BeTrue())
-				Expect(containerResources.Requests.Cpu().String()).To(Equal("100m"))
-				Expect(containerResources.Requests.Memory().String()).To(Equal("150Mi"))
-				Expect(containerResources.Requests.StorageEphemeral().IsZero()).To(BeTrue())
+				Expect(containerResources.Requests).To(BeNil())
 
 				containerResources = extraConfig.CollectorDaemonSetCollectorContainerResources.ToResourceRequirements()
 				Expect(containerResources.Limits.Cpu().String()).To(Equal("900m"))


### PR DESCRIPTION
This removes the default resource requests (cpu: 100m, memory: 150Mi)
for the Dash0 instrumentation init container.

Turns out, default resource requests for an init container that is
added to all pods has quite negative side effects: Contrary to what
one might intuitively assume, requested resources are _not_ freed up
after the init container has completed. See the discussion in
https://github.com/kubernetes/kubernetes/issues/124282.

This can make setting resource requests expensive, and can lead to
CPU/memory being needlessly reserved by the scheduler for the already
finished init container, although it will actually never be used again.

BREAKING CHANGE: This is a breaking change if you actually want
resource requests for the Dash0 instrumentation init container _and_
you are currently relying on the default resource requests instead of
defining explicit values for the Helm chart via
operator.initContainerResources.requests. To remedy this, set explicit
resource requests for the init container before installing this release.