### PR TITLE
feat(chart): add option operator.collectors.disableHostPorts

### DIFF
--- a/helm-chart/dash0-operator/README.md
+++ b/helm-chart/dash0-operator/README.md
@@ -912,7 +912,9 @@ variable [`OTEL_EXPORTER_OTLP_ENDPOINT`](#https://opentelemetry.io/docs/language
 [`OTEL_EXPORTER_OTLP_PROTOCOL`](https://opentelemetry.io/docs/specs/otel/protocol/exporter/#specify-protocol)) yourself.
 
 The DaemonSet OpenTelemetry collector managed by the Dash0 operator listens on host port 40318 for HTTP traffic and
-40317 for gRPC traffic.
+40317 for gRPC traffic
+(unless the Helm chart has been deployed with `operator.collectors.disableHostPorts=true`, which disables the host
+ports for the collector pods).
 Additionally, there is also a service for the DaemonSet collector, which listens on the standard ports, that is 4318 for
 HTTP and 4317 for gRPC.
 
@@ -1223,6 +1225,11 @@ The modifications that are performed for workloads are the following:
    to have the workload send telemetry to the collectors managed by the Dash0 operator, using gRPC.
    Note that this is not relevant for workloads that do not have an OpenTelemetry SDK at all, since they will ignore
    `OTEL_EXPORTER_OTLP_ENDPOINT`.
+   In case the Dash0 operator Helm chart has been deployed with `operator.collectors.forceUseServiceUrl=true` or
+   `operator.collectors.disableHostPorts=true`, `OTEL_EXPORTER_OTLP_ENDPOINT` is not set to `http://$(NODE_IP):40318`,
+   but to the HTTP port of the DaemonSet collector's service URL
+   `http://${helm-release-name}-opentelemetry-collector-service.${namespace-of-the-dash0-operator}.svc.cluster.local:4318`
+   instead.
 
 The remainder of this section provides a more detailed step-by-step description of how the Dash0 operator's workload
 instrumentation for tracing works internally, intended for the technically curious reader.

--- a/helm-chart/dash0-operator/templates/operator/deployment-and-webhooks.yaml
+++ b/helm-chart/dash0-operator/templates/operator/deployment-and-webhooks.yaml
@@ -124,6 +124,7 @@ spec:
         - --operator-configuration-dataset={{ .Values.operator.dash0Export.dataset }}
 {{- end }}
         - --force-use-otel-collector-service-url={{ .Values.operator.collectors.forceUseServiceUrl }}
+        - --disable-otel-collector-host-ports={{ .Values.operator.collectors.disableHostPorts }}
 {{- if .Values.operator.instrumentationDelayAfterEachWorkloadMillis }}
         - --instrumentation-delay-after-each-workload-millis={{ .Values.operator.instrumentationDelayAfterEachWorkloadMillis }}
 {{- end }}

--- a/helm-chart/dash0-operator/tests/operator/__snapshot__/deployment-and-webhooks_test.yaml.snap
+++ b/helm-chart/dash0-operator/tests/operator/__snapshot__/deployment-and-webhooks_test.yaml.snap
@@ -45,6 +45,7 @@ deployment should match snapshot (default values):
                 - --metrics-bind-address=127.0.0.1:8080
                 - --leader-elect
                 - --force-use-otel-collector-service-url=false
+                - --disable-otel-collector-host-ports=false
               command:
                 - /manager
               env:

--- a/helm-chart/dash0-operator/tests/operator/deployment-and-webhooks_test.yaml
+++ b/helm-chart/dash0-operator/tests/operator/deployment-and-webhooks_test.yaml
@@ -149,6 +149,7 @@ tests:
           debugVerbosityDetailed: true
           sendBatchMaxSize: 32768
           forceUseServiceUrl: true
+          disableHostPorts: true
 
     asserts:
       - equal:
@@ -202,8 +203,11 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].args[3]
           value: --force-use-otel-collector-service-url=true
-      - notExists:
+      - equal:
           path: spec.template.spec.containers[0].args[4]
+          value: --disable-otel-collector-host-ports=true
+      - notExists:
+          path: spec.template.spec.containers[0].args[5]
       - equal:
           path: spec.template.spec.containers[0].env[0].name
           value: DASH0_OPERATOR_NAMESPACE

--- a/helm-chart/dash0-operator/values.yaml
+++ b/helm-chart/dash0-operator/values.yaml
@@ -282,6 +282,10 @@ operator:
     # port. This can be useful if you employ mechanisms that block host ports, like certain Istio configurations.
     forceUseServiceUrl: false
 
+    # If set to true, the host ports of the OpenTelemetry collector pods managed by the operator will be disaabled.
+    # Implies forceUseServiceUrl: true.
+    disableHostPorts: false
+
     # A reference to a persistent volume to use for the filelog offset sync. Specify this is you have a cluster
     # with more than pods 100 pods active at the same time. By default, the filelog offset sync will use a config map
     # for its peristent storage, but ConfigMaps are limited to 1 MB in size. If you have around 100 pods running in

--- a/internal/collectors/otelcolresources/otelcol_resources.go
+++ b/internal/collectors/otelcolresources/otelcol_resources.go
@@ -48,6 +48,7 @@ type OTelColResourceManager struct {
 	PseudoClusterUID                 string
 	IsIPv6Cluster                    bool
 	IsDocker                         bool
+	DisableHostPorts                 bool
 	DevelopmentMode                  bool
 	DebugVerbosityDetailed           bool
 	obsoleteResourcesHaveBeenDeleted atomic.Bool
@@ -95,6 +96,7 @@ func NewOTelColResourceManager(
 	pseudoClusterUID string,
 	isIPv6Cluster bool,
 	isDocker bool,
+	disableHostPorts bool,
 	developmentMode bool,
 	debugVerbosityDetailed bool,
 ) *OTelColResourceManager {
@@ -109,6 +111,7 @@ func NewOTelColResourceManager(
 		NodeName:                  nodeName,
 		PseudoClusterUID:          pseudoClusterUID,
 		IsIPv6Cluster:             isIPv6Cluster,
+		DisableHostPorts:          disableHostPorts,
 		IsDocker:                  isDocker,
 		DevelopmentMode:           developmentMode,
 		DebugVerbosityDetailed:    debugVerbosityDetailed,
@@ -177,6 +180,7 @@ func (m *OTelColResourceManager) CreateOrUpdateOpenTelemetryCollectorResources(
 		// https://github.com/prometheus/node_exporter/issues/2002#issuecomment-801763211 and similar.
 		// For this reason, we do not allow enabling the hostmetrics receiver when the node runtime is Docker.
 		UseHostMetricsReceiver: kubernetesInfrastructureMetricsCollectionEnabled && !m.IsDocker,
+		DisableHostPorts:       m.DisableHostPorts,
 		ClusterName:            clusterName,
 		PseudoClusterUID:       m.PseudoClusterUID,
 		Images:                 images,
@@ -413,7 +417,8 @@ func (m *OTelColResourceManager) DeleteResources(
 		// related resources, we always try to delete all collector resources (daemonset & deployment), no matter
 		// whether both sets have been created earlier or not.
 		KubernetesInfrastructureMetricsCollectionEnabled: true,
-		UseHostMetricsReceiver:                           !m.IsDocker, // irrelevant for deletion
+		UseHostMetricsReceiver:                           !m.IsDocker,        // irrelevant for deletion
+		DisableHostPorts:                                 m.DisableHostPorts, // irrelevant for deletion
 		Images:                                           dummyImagesForDeletion,
 		IsIPv6Cluster:                                    m.IsIPv6Cluster,
 		DevelopmentMode:                                  m.DevelopmentMode,

--- a/test-resources/bin/test-cleanup.sh
+++ b/test-resources/bin/test-cleanup.sh
@@ -19,7 +19,14 @@ resource_types=( cronjob daemonset deployment job pod replicaset statefulset )
 for resource_type in "${resource_types[@]}"; do
   test-resources/node.js/express/undeploy.sh "$target_namespace" "$resource_type"
   pushd test-resources/jvm/spring-boot > /dev/null
-    kubectl delete --namespace "$target_namespace" --ignore-not-found -f "$resource_type.yaml"
+    if [[ -f "$resource_type.yaml" ]]; then
+      kubectl delete --namespace "$target_namespace" --ignore-not-found -f "$resource_type.yaml"
+    fi
+  popd > /dev/null
+  pushd test-resources/dotnet > /dev/null
+    if [[ -f "$resource_type.yaml" ]]; then
+      kubectl delete --namespace "$target_namespace" --ignore-not-found -f "$resource_type.yaml"
+    fi
   popd > /dev/null
 done
 


### PR DESCRIPTION
This disables the host ports of the OpenTelemetry DaemonSet collector pods. Workloads are instructed to send telemetry to the collector's service URL instead. The option is off by default, that is, host ports are enabled and telemetry is sent to the host ports.