### PR TITLE
fix(controller): self-heal degraded resource states in reconcile

### DIFF
--- a/internal/collectors/collector_manager.go
+++ b/internal/collectors/collector_manager.go
@@ -19,6 +19,7 @@ import (
 
 	dash0v1alpha1 "github.com/dash0hq/dash0-operator/api/dash0monitoring/v1alpha1"
 	"github.com/dash0hq/dash0-operator/internal/collectors/otelcolresources"
+	"github.com/dash0hq/dash0-operator/internal/resources"
 	"github.com/dash0hq/dash0-operator/internal/util"
 )
 
@@ -210,7 +211,7 @@ func (m *CollectorManager) findOperatorConfigurationResource(
 	ctx context.Context,
 	logger *logr.Logger,
 ) (*dash0v1alpha1.Dash0OperatorConfiguration, error) {
-	operatorConfigurationResource, err := util.FindUniqueOrMostRecentResourceInScope(
+	operatorConfigurationResource, err := resources.FindUniqueOrMostRecentResourceInScope(
 		ctx,
 		m.Client,
 		"", /* cluster-scope, thus no namespace */

--- a/internal/collectors/collector_manager_test.go
+++ b/internal/collectors/collector_manager_test.go
@@ -30,7 +30,7 @@ var _ = Describe("The collector manager", Ordered, func() {
 	ctx := context.Background()
 	logger := log.FromContext(ctx)
 
-	var createdObjects []client.Object
+	var createdObjectsCollectorManagerTest []client.Object
 
 	var manager *CollectorManager
 
@@ -40,7 +40,7 @@ var _ = Describe("The collector manager", Ordered, func() {
 	})
 
 	BeforeEach(func() {
-		createdObjects = make([]client.Object, 0)
+		createdObjectsCollectorManagerTest = make([]client.Object, 0)
 		oTelColResourceManager := &otelcolresources.OTelColResourceManager{
 			Client:                    k8sClient,
 			Scheme:                    k8sClient.Scheme(),
@@ -56,7 +56,7 @@ var _ = Describe("The collector manager", Ordered, func() {
 	})
 
 	AfterEach(func() {
-		createdObjects = DeleteAllCreatedObjects(ctx, k8sClient, createdObjects)
+		createdObjectsCollectorManagerTest = DeleteAllCreatedObjects(ctx, k8sClient, createdObjectsCollectorManagerTest)
 		DeleteAllEvents(ctx, clientset, operatorNamespace)
 		err := k8sClient.DeleteAllOf(ctx, &corev1.ConfigMap{}, client.InNamespace(operatorNamespace))
 		Expect(err).ToNot(HaveOccurred())
@@ -177,7 +177,7 @@ var _ = Describe("The collector manager", Ordered, func() {
 					},
 				},
 			)
-			createdObjects = append(createdObjects, monitoringResource)
+			createdObjectsCollectorManagerTest = append(createdObjectsCollectorManagerTest, monitoringResource)
 			err, hasBeenReconciled := manager.ReconcileOpenTelemetryCollector(
 				ctx,
 				TestImages,
@@ -206,7 +206,7 @@ var _ = Describe("The collector manager", Ordered, func() {
 					},
 				},
 			)
-			createdObjects = append(createdObjects, monitoringResource)
+			createdObjectsCollectorManagerTest = append(createdObjectsCollectorManagerTest, monitoringResource)
 
 			err, hasBeenReconciled := manager.ReconcileOpenTelemetryCollector(
 				ctx,
@@ -225,7 +225,7 @@ var _ = Describe("The collector manager", Ordered, func() {
 				ctx,
 				k8sClient,
 			)
-			createdObjects = append(createdObjects, monitoringResource)
+			createdObjectsCollectorManagerTest = append(createdObjectsCollectorManagerTest, monitoringResource)
 			err, hasBeenReconciled := manager.ReconcileOpenTelemetryCollector(
 				ctx,
 				TestImages,
@@ -325,7 +325,7 @@ var _ = Describe("The collector manager", Ordered, func() {
 				ctx,
 				k8sClient,
 			)
-			createdObjects = append(createdObjects, existingMonitoringResource)
+			createdObjectsCollectorManagerTest = append(createdObjectsCollectorManagerTest, existingMonitoringResource)
 			triggeringMonitoringResource := &dash0v1alpha1.Dash0Monitoring{
 				Spec: dash0v1alpha1.Dash0MonitoringSpec{
 					Export: &dash0v1alpha1.Export{
@@ -355,7 +355,7 @@ var _ = Describe("The collector manager", Ordered, func() {
 				ctx,
 				k8sClient,
 			)
-			createdObjects = append(createdObjects, existingMonitoringResource)
+			createdObjectsCollectorManagerTest = append(createdObjectsCollectorManagerTest, existingMonitoringResource)
 			triggeringMonitoringResource := &dash0v1alpha1.Dash0Monitoring{
 				Spec: dash0v1alpha1.Dash0MonitoringSpec{},
 			}
@@ -382,7 +382,7 @@ var _ = Describe("The collector manager", Ordered, func() {
 				ctx,
 				k8sClient,
 			)
-			createdObjects = append(createdObjects, resource)
+			createdObjectsCollectorManagerTest = append(createdObjectsCollectorManagerTest, resource)
 		})
 
 		It("should update the resources", func() {
@@ -444,7 +444,7 @@ var _ = Describe("The collector manager", Ordered, func() {
 
 			resourceName := types.NamespacedName{Namespace: TestNamespaceName, Name: "dash0-monitoring-test-resource-1"}
 			monitoringResource := EnsureMonitoringResourceExistsInNamespaceAndIsAvailable(ctx, k8sClient, resourceName)
-			createdObjects = append(createdObjects, monitoringResource)
+			createdObjectsCollectorManagerTest = append(createdObjectsCollectorManagerTest, monitoringResource)
 
 			// Let the manager create the collector so there is something to delete.
 			err, _ := manager.ReconcileOpenTelemetryCollector(
@@ -512,15 +512,15 @@ var _ = Describe("The collector manager", Ordered, func() {
 			// create multiple monitoring resources
 			firstName := types.NamespacedName{Namespace: TestNamespaceName, Name: "dash0-monitoring-test-resource-1"}
 			firstDash0MonitoringResource := EnsureMonitoringResourceExistsInNamespaceAndIsAvailable(ctx, k8sClient, firstName)
-			createdObjects = append(createdObjects, firstDash0MonitoringResource)
+			createdObjectsCollectorManagerTest = append(createdObjectsCollectorManagerTest, firstDash0MonitoringResource)
 
 			secondName := types.NamespacedName{Namespace: TestNamespaceName, Name: "dash0-monitoring-test-resource-2"}
 			secondDash0MonitoringResource := EnsureMonitoringResourceExistsInNamespaceAndIsAvailable(ctx, k8sClient, secondName)
-			createdObjects = append(createdObjects, secondDash0MonitoringResource)
+			createdObjectsCollectorManagerTest = append(createdObjectsCollectorManagerTest, secondDash0MonitoringResource)
 
 			thirdName := types.NamespacedName{Namespace: TestNamespaceName, Name: "dash0-monitoring-test-resource-3"}
 			thirdDash0MonitoringResource := EnsureMonitoringResourceExistsInNamespaceAndIsAvailable(ctx, k8sClient, thirdName)
-			createdObjects = append(createdObjects, thirdDash0MonitoringResource)
+			createdObjectsCollectorManagerTest = append(createdObjectsCollectorManagerTest, thirdDash0MonitoringResource)
 
 			// Let the manager create the collector so there is something to delete.
 			err, _ := manager.ReconcileOpenTelemetryCollector(
@@ -549,7 +549,7 @@ var _ = Describe("The collector manager", Ordered, func() {
 		It("should not delete the collector if there is no operator configuration resource, but if there one available resource with an export left", func() {
 			resourceName := types.NamespacedName{Namespace: TestNamespaceName, Name: "dash0-monitoring-test-resource-1"}
 			existingDash0MonitoringResource := EnsureMonitoringResourceExistsInNamespaceAndIsAvailable(ctx, k8sClient, resourceName)
-			createdObjects = append(createdObjects, existingDash0MonitoringResource)
+			createdObjectsCollectorManagerTest = append(createdObjectsCollectorManagerTest, existingDash0MonitoringResource)
 
 			// Let the manager create the collector so there is something to delete.
 			err, _ := manager.ReconcileOpenTelemetryCollector(
@@ -637,19 +637,19 @@ var _ = Describe("The collector manager", Ordered, func() {
 			firstDash0MonitoringResource :=
 				EnsureMonitoringResourceWithSpecExistsInNamespaceAndIsAvailable(ctx, k8sClient,
 					dash0v1alpha1.Dash0MonitoringSpec{}, firstName)
-			createdObjects = append(createdObjects, firstDash0MonitoringResource)
+			createdObjectsCollectorManagerTest = append(createdObjectsCollectorManagerTest, firstDash0MonitoringResource)
 
 			secondName := types.NamespacedName{Namespace: TestNamespaceName, Name: "dash0-monitoring-test-resource-2"}
 			secondDash0MonitoringResource :=
 				EnsureMonitoringResourceWithSpecExistsInNamespaceAndIsAvailable(ctx, k8sClient,
 					dash0v1alpha1.Dash0MonitoringSpec{}, secondName)
-			createdObjects = append(createdObjects, secondDash0MonitoringResource)
+			createdObjectsCollectorManagerTest = append(createdObjectsCollectorManagerTest, secondDash0MonitoringResource)
 
 			thirdName := types.NamespacedName{Namespace: TestNamespaceName, Name: "dash0-monitoring-test-resource-3"}
 			thirdDash0MonitoringResource :=
 				EnsureMonitoringResourceWithSpecExistsInNamespaceAndIsAvailable(ctx, k8sClient,
 					dash0v1alpha1.Dash0MonitoringSpec{}, thirdName)
-			createdObjects = append(createdObjects, thirdDash0MonitoringResource)
+			createdObjectsCollectorManagerTest = append(createdObjectsCollectorManagerTest, thirdDash0MonitoringResource)
 
 			err, hasBeenReconciled := manager.ReconcileOpenTelemetryCollector(
 				ctx,
@@ -681,7 +681,7 @@ var _ = Describe("The collector manager", Ordered, func() {
 		It("should delete the collector if there is no operator configuration, and if the monitoring resource that is being deleted is the only one left", func() {
 			resourceName := types.NamespacedName{Namespace: TestNamespaceName, Name: "dash0-monitoring-test-resource-1"}
 			monitoringResource := EnsureMonitoringResourceExistsInNamespaceAndIsAvailable(ctx, k8sClient, resourceName)
-			createdObjects = append(createdObjects, monitoringResource)
+			createdObjectsCollectorManagerTest = append(createdObjectsCollectorManagerTest, monitoringResource)
 
 			// Let the manager create the collector so there is something to delete.
 			err, hasBeenReconciled := manager.ReconcileOpenTelemetryCollector(
@@ -722,7 +722,7 @@ var _ = Describe("The collector manager", Ordered, func() {
 				ctx,
 				k8sClient,
 			)
-			createdObjects = append(createdObjects, monitoringResource)
+			createdObjectsCollectorManagerTest = append(createdObjectsCollectorManagerTest, monitoringResource)
 			err, hasBeenReconciled := manager.ReconcileOpenTelemetryCollector(
 				ctx,
 				TestImages,
@@ -735,7 +735,7 @@ var _ = Describe("The collector manager", Ordered, func() {
 			VerifyCollectorResources(ctx, k8sClient, operatorNamespace, EndpointDash0Test, AuthorizationTokenTest)
 
 			Expect(k8sClient.Delete(ctx, monitoringResource)).To(Succeed())
-			createdObjects = createdObjects[0 : len(createdObjects)-1]
+			createdObjectsCollectorManagerTest = createdObjectsCollectorManagerTest[0 : len(createdObjectsCollectorManagerTest)-1]
 
 			err, hasBeenReconciled = manager.ReconcileOpenTelemetryCollector(
 				ctx,

--- a/internal/controller/operator_configuration_controller.go
+++ b/internal/controller/operator_configuration_controller.go
@@ -19,6 +19,7 @@ import (
 
 	dash0v1alpha1 "github.com/dash0hq/dash0-operator/api/dash0monitoring/v1alpha1"
 	"github.com/dash0hq/dash0-operator/internal/collectors"
+	"github.com/dash0hq/dash0-operator/internal/resources"
 	"github.com/dash0hq/dash0-operator/internal/selfmonitoringapiaccess"
 	"github.com/dash0hq/dash0-operator/internal/util"
 )
@@ -108,7 +109,7 @@ func (r *OperatorConfigurationReconciler) Reconcile(ctx context.Context, req ctr
 	logger.Info("processing reconcile request for an operator configuration resource")
 
 	resourceDeleted := false
-	checkResourceResult, err := util.VerifyThatResourceExists(
+	checkResourceResult, err := resources.VerifyThatResourceExists(
 		ctx,
 		r.Client,
 		req,
@@ -135,13 +136,9 @@ func (r *OperatorConfigurationReconciler) Reconcile(ctx context.Context, req ctr
 	}
 
 	operatorConfigurationResource := checkResourceResult.Resource.(*dash0v1alpha1.Dash0OperatorConfiguration)
-	if operatorConfigurationResource.IsDegraded() {
-		r.removeAllOperatorConfigurationSettings(ctx, logger)
-		logger.Info("The operator configuration resource is degraded, stopping reconciliation.")
-		return ctrl.Result{}, nil
-	}
+
 	stopReconcile, err :=
-		util.VerifyThatResourceIsUniqueInScope(
+		resources.VerifyThatResourceIsUniqueInScope(
 			ctx,
 			r.Client,
 			req,
@@ -157,7 +154,7 @@ func (r *OperatorConfigurationReconciler) Reconcile(ctx context.Context, req ctr
 		return ctrl.Result{}, nil
 	}
 
-	if _, err = util.InitStatusConditions(
+	if _, err = resources.InitStatusConditions(
 		ctx,
 		r.Client,
 		operatorConfigurationResource,

--- a/internal/controller/third_party_crd_common.go
+++ b/internal/controller/third_party_crd_common.go
@@ -39,6 +39,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	dash0v1alpha1 "github.com/dash0hq/dash0-operator/api/dash0monitoring/v1alpha1"
+	"github.com/dash0hq/dash0-operator/internal/resources"
 	"github.com/dash0hq/dash0-operator/internal/util"
 )
 
@@ -682,7 +683,7 @@ func validatePreconditions(
 	namespace := thirdPartyResource.GetNamespace()
 	name := thirdPartyResource.GetName()
 
-	monitoringRes, err := util.FindUniqueOrMostRecentResourceInScope(
+	monitoringRes, err := resources.FindUniqueOrMostRecentResourceInScope(
 		ctx,
 		resourceReconciler.K8sClient(),
 		thirdPartyResource.GetNamespace(),

--- a/internal/instrumentation/instrumenter.go
+++ b/internal/instrumentation/instrumenter.go
@@ -22,6 +22,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	dash0v1alpha1 "github.com/dash0hq/dash0-operator/api/dash0monitoring/v1alpha1"
+	"github.com/dash0hq/dash0-operator/internal/resources"
 	"github.com/dash0hq/dash0-operator/internal/util"
 	"github.com/dash0hq/dash0-operator/internal/workloads"
 )
@@ -146,7 +147,7 @@ func (i *Instrumenter) InstrumentAtStartup(
 				Name:      dash0MonitoringResource.Name,
 			},
 		}
-		checkResourceResult, err := util.VerifyThatUniqueNonDegradedResourceExists(
+		checkResourceResult, err := resources.VerifyThatUniqueNonDegradedResourceExists(
 			ctx,
 			i.Client,
 			pseudoReconcileRequest,

--- a/internal/instrumentation/instrumenter_test.go
+++ b/internal/instrumentation/instrumenter_test.go
@@ -36,7 +36,7 @@ var (
 var _ = Describe("The instrumenter", Ordered, func() {
 	ctx := context.Background()
 	logger := log.FromContext(ctx)
-	var createdObjects []client.Object
+	var createdObjectsInstrumenterTest []client.Object
 
 	var instrumenter *Instrumenter
 	var dash0MonitoringResource *dash0v1alpha1.Dash0Monitoring
@@ -49,7 +49,7 @@ var _ = Describe("The instrumenter", Ordered, func() {
 	BeforeEach(func() {
 		dash0MonitoringResource = EnsureMonitoringResourceExistsAndIsAvailable(ctx, k8sClient)
 
-		createdObjects = make([]client.Object, 0)
+		createdObjectsInstrumenterTest = make([]client.Object, 0)
 
 		instrumenter = NewInstrumenter(
 			k8sClient,
@@ -63,7 +63,7 @@ var _ = Describe("The instrumenter", Ordered, func() {
 	})
 
 	AfterEach(func() {
-		createdObjects = DeleteAllCreatedObjects(ctx, k8sClient, createdObjects)
+		createdObjectsInstrumenterTest = DeleteAllCreatedObjects(ctx, k8sClient, createdObjectsInstrumenterTest)
 		DeleteAllEvents(ctx, clientset, namespace)
 
 		DeleteMonitoringResource(ctx, k8sClient)
@@ -74,7 +74,7 @@ var _ = Describe("The instrumenter", Ordered, func() {
 		DescribeTable("when instrumenting existing workloads", func(config WorkloadTestConfig) {
 			name := UniqueName(config.WorkloadNamePrefix)
 			workload := config.CreateFn(ctx, k8sClient, TestNamespaceName, name)
-			createdObjects = append(createdObjects, workload.Get())
+			createdObjectsInstrumenterTest = append(createdObjectsInstrumenterTest, workload.Get())
 
 			checkSettingsAndInstrumentExistingWorkloads(ctx, instrumenter, dash0MonitoringResource, &logger)
 
@@ -144,7 +144,7 @@ var _ = Describe("The instrumenter", Ordered, func() {
 				name := UniqueName(JobNamePrefix)
 				By("Inititalize a job")
 				job := CreateBasicJob(ctx, k8sClient, namespace, name)
-				createdObjects = append(createdObjects, job)
+				createdObjectsInstrumenterTest = append(createdObjectsInstrumenterTest, job)
 
 				checkSettingsAndInstrumentExistingWorkloads(ctx, instrumenter, dash0MonitoringResource, &logger)
 
@@ -164,7 +164,7 @@ var _ = Describe("The instrumenter", Ordered, func() {
 				name := UniqueName(PodNamePrefix)
 				By("Inititalize a pod")
 				pod := CreateBasicPod(ctx, k8sClient, namespace, name)
-				createdObjects = append(createdObjects, pod)
+				createdObjectsInstrumenterTest = append(createdObjectsInstrumenterTest, pod)
 
 				checkSettingsAndInstrumentExistingWorkloads(ctx, instrumenter, dash0MonitoringResource, &logger)
 
@@ -178,7 +178,7 @@ var _ = Describe("The instrumenter", Ordered, func() {
 				name := UniqueName(PodNamePrefix)
 				By("Inititalize a pod")
 				pod := CreatePodOwnedByReplicaSet(ctx, k8sClient, namespace, name)
-				createdObjects = append(createdObjects, pod)
+				createdObjectsInstrumenterTest = append(createdObjectsInstrumenterTest, pod)
 
 				checkSettingsAndInstrumentExistingWorkloads(ctx, instrumenter, dash0MonitoringResource, &logger)
 
@@ -190,7 +190,7 @@ var _ = Describe("The instrumenter", Ordered, func() {
 				name := UniqueName(ReplicaSetNamePrefix)
 				By("Inititalize a replicaset")
 				replicaSet := CreateReplicaSetOwnedByDeployment(ctx, k8sClient, namespace, name)
-				createdObjects = append(createdObjects, replicaSet)
+				createdObjectsInstrumenterTest = append(createdObjectsInstrumenterTest, replicaSet)
 
 				checkSettingsAndInstrumentExistingWorkloads(ctx, instrumenter, dash0MonitoringResource, &logger)
 
@@ -201,7 +201,7 @@ var _ = Describe("The instrumenter", Ordered, func() {
 		DescribeTable("when existing workloads have the opt-out label", func(config WorkloadTestConfig) {
 			name := UniqueName(config.WorkloadNamePrefix)
 			workload := config.CreateFn(ctx, k8sClient, namespace, name)
-			createdObjects = append(createdObjects, workload.Get())
+			createdObjectsInstrumenterTest = append(createdObjectsInstrumenterTest, workload.Get())
 
 			checkSettingsAndInstrumentExistingWorkloads(ctx, instrumenter, dash0MonitoringResource, &logger)
 
@@ -249,7 +249,7 @@ var _ = Describe("The instrumenter", Ordered, func() {
 				name := UniqueName(JobNamePrefix)
 				By("Inititalize a job")
 				job := CreateJobWithOptOutLabel(ctx, k8sClient, namespace, name)
-				createdObjects = append(createdObjects, job)
+				createdObjectsInstrumenterTest = append(createdObjectsInstrumenterTest, job)
 
 				checkSettingsAndInstrumentExistingWorkloads(ctx, instrumenter, dash0MonitoringResource, &logger)
 
@@ -261,7 +261,7 @@ var _ = Describe("The instrumenter", Ordered, func() {
 		DescribeTable("when the opt-out label is added to an already instrumented workload", func(config WorkloadTestConfig) {
 			name := UniqueName(config.WorkloadNamePrefix)
 			workload := config.CreateFn(ctx, k8sClient, TestNamespaceName, name)
-			createdObjects = append(createdObjects, workload.Get())
+			createdObjectsInstrumenterTest = append(createdObjectsInstrumenterTest, workload.Get())
 			AddOptOutLabel(workload.GetObjectMeta())
 			UpdateWorkload(ctx, k8sClient, workload.Get())
 			checkSettingsAndInstrumentExistingWorkloads(ctx, instrumenter, dash0MonitoringResource, &logger)
@@ -309,7 +309,7 @@ var _ = Describe("The instrumenter", Ordered, func() {
 			It("should report the failure to remove Dash0 from an instrumented job when dash0.com/enable=false is added", func() {
 				name := UniqueName(JobNamePrefix)
 				workload := CreateInstrumentedJob(ctx, k8sClient, TestNamespaceName, name)
-				createdObjects = append(createdObjects, workload)
+				createdObjectsInstrumenterTest = append(createdObjectsInstrumenterTest, workload)
 				AddOptOutLabel(&workload.ObjectMeta)
 				UpdateWorkload(ctx, k8sClient, workload)
 				checkSettingsAndInstrumentExistingWorkloads(ctx, instrumenter, dash0MonitoringResource, &logger)
@@ -329,7 +329,7 @@ var _ = Describe("The instrumenter", Ordered, func() {
 				name := UniqueName(JobNamePrefix)
 				workload := CreateJobForWhichAnInstrumentationAttemptHasFailed(
 					ctx, k8sClient, TestNamespaceName, name)
-				createdObjects = append(createdObjects, workload)
+				createdObjectsInstrumenterTest = append(createdObjectsInstrumenterTest, workload)
 				AddOptOutLabel(&workload.ObjectMeta)
 				UpdateWorkload(ctx, k8sClient, workload)
 				checkSettingsAndInstrumentExistingWorkloads(ctx, instrumenter, dash0MonitoringResource, &logger)
@@ -347,7 +347,7 @@ var _ = Describe("The instrumenter", Ordered, func() {
 		DescribeTable("when a workload is already instrumented by the same version", func(config WorkloadTestConfig) {
 			name := UniqueName(config.WorkloadNamePrefix)
 			workload := config.CreateFn(ctx, k8sClient, TestNamespaceName, name)
-			createdObjects = append(createdObjects, workload.Get())
+			createdObjectsInstrumenterTest = append(createdObjectsInstrumenterTest, workload.Get())
 			checkSettingsAndInstrumentExistingWorkloads(ctx, instrumenter, dash0MonitoringResource, &logger)
 			config.VerifyFn(config.GetFn(ctx, k8sClient, TestNamespaceName, name))
 			VerifyNoEvents(ctx, clientset, TestNamespaceName)
@@ -399,7 +399,7 @@ var _ = Describe("The instrumenter", Ordered, func() {
 		DescribeTable("when uninstrumenting workloads when the Dash0 monitoring resource is deleted", func(config WorkloadTestConfig) {
 			name := UniqueName(config.WorkloadNamePrefix)
 			workload := config.CreateFn(ctx, k8sClient, TestNamespaceName, name)
-			createdObjects = append(createdObjects, workload.Get())
+			createdObjectsInstrumenterTest = append(createdObjectsInstrumenterTest, workload.Get())
 
 			uninstrumentWorkloadsIfAvailable(ctx, instrumenter, dash0MonitoringResource, &logger)
 
@@ -470,7 +470,7 @@ var _ = Describe("The instrumenter", Ordered, func() {
 				name := UniqueName(JobNamePrefix)
 				By("Create an instrumented job")
 				job := CreateInstrumentedJob(ctx, k8sClient, namespace, name)
-				createdObjects = append(createdObjects, job)
+				createdObjectsInstrumenterTest = append(createdObjectsInstrumenterTest, job)
 
 				uninstrumentWorkloadsIfAvailable(ctx, instrumenter, dash0MonitoringResource, &logger)
 
@@ -490,7 +490,7 @@ var _ = Describe("The instrumenter", Ordered, func() {
 				name := UniqueName(JobNamePrefix)
 				By("Create a job with label dash0.com/instrumented=false")
 				job := CreateJobForWhichAnInstrumentationAttemptHasFailed(ctx, k8sClient, namespace, name)
-				createdObjects = append(createdObjects, job)
+				createdObjectsInstrumenterTest = append(createdObjectsInstrumenterTest, job)
 
 				uninstrumentWorkloadsIfAvailable(ctx, instrumenter, dash0MonitoringResource, &logger)
 
@@ -502,7 +502,7 @@ var _ = Describe("The instrumenter", Ordered, func() {
 				name := UniqueName(PodNamePrefix)
 				By("Create an instrumented pod")
 				pod := CreateInstrumentedPod(ctx, k8sClient, namespace, name)
-				createdObjects = append(createdObjects, pod)
+				createdObjectsInstrumenterTest = append(createdObjectsInstrumenterTest, pod)
 
 				uninstrumentWorkloadsIfAvailable(ctx, instrumenter, dash0MonitoringResource, &logger)
 
@@ -521,7 +521,7 @@ var _ = Describe("The instrumenter", Ordered, func() {
 					UID:        "35b829cb-78dc-4544-b7a9-5a8e51b7f322",
 				}}
 				UpdateWorkload(ctx, k8sClient, pod)
-				createdObjects = append(createdObjects, pod)
+				createdObjectsInstrumenterTest = append(createdObjectsInstrumenterTest, pod)
 
 				uninstrumentWorkloadsIfAvailable(ctx, instrumenter, dash0MonitoringResource, &logger)
 
@@ -533,7 +533,7 @@ var _ = Describe("The instrumenter", Ordered, func() {
 				name := UniqueName(PodNamePrefix)
 				By("Create an instrumented pod owned by a deployment")
 				pod := CreatePodOwnedByReplicaSet(ctx, k8sClient, namespace, name)
-				createdObjects = append(createdObjects, pod)
+				createdObjectsInstrumenterTest = append(createdObjectsInstrumenterTest, pod)
 
 				uninstrumentWorkloadsIfAvailable(ctx, instrumenter, dash0MonitoringResource, &logger)
 
@@ -545,7 +545,7 @@ var _ = Describe("The instrumenter", Ordered, func() {
 				name := UniqueName(ReplicaSetNamePrefix)
 				By("Create an instrumented replica set owned by a deployment")
 				replicaSet := CreateReplicaSetOwnedByDeployment(ctx, k8sClient, namespace, name)
-				createdObjects = append(createdObjects, replicaSet)
+				createdObjectsInstrumenterTest = append(createdObjectsInstrumenterTest, replicaSet)
 
 				uninstrumentWorkloadsIfAvailable(ctx, instrumenter, dash0MonitoringResource, &logger)
 
@@ -557,7 +557,7 @@ var _ = Describe("The instrumenter", Ordered, func() {
 		DescribeTable("when attempting to revert the instrumentation on cleanup but the resource has an opt-out label", func(config WorkloadTestConfig) {
 			name := UniqueName(config.WorkloadNamePrefix)
 			workload := config.CreateFn(ctx, k8sClient, TestNamespaceName, name)
-			createdObjects = append(createdObjects, workload.Get())
+			createdObjectsInstrumenterTest = append(createdObjectsInstrumenterTest, workload.Get())
 
 			uninstrumentWorkloadsIfAvailable(ctx, instrumenter, dash0MonitoringResource, &logger)
 
@@ -614,7 +614,7 @@ var _ = Describe("The instrumenter", Ordered, func() {
 	DescribeTable("should instrument existing uninstrumented workloads at startup", func(config WorkloadTestConfig) {
 		name := UniqueName(config.WorkloadNamePrefix)
 		workload := config.CreateFn(ctx, k8sClient, namespace, name)
-		createdObjects = append(createdObjects, workload.Get())
+		createdObjectsInstrumenterTest = append(createdObjectsInstrumenterTest, workload.Get())
 
 		instrumenter.InstrumentAtStartup(ctx, &logger)
 
@@ -662,7 +662,7 @@ var _ = Describe("The instrumenter", Ordered, func() {
 		It("should record a failure event when attempting to instrument an existing job at startup and add labels", func() {
 			name := UniqueName(JobNamePrefix)
 			job := CreateBasicJob(ctx, k8sClient, namespace, name)
-			createdObjects = append(createdObjects, job)
+			createdObjectsInstrumenterTest = append(createdObjectsInstrumenterTest, job)
 
 			instrumenter.InstrumentAtStartup(ctx, &logger)
 
@@ -682,7 +682,7 @@ var _ = Describe("The instrumenter", Ordered, func() {
 	DescribeTable("when updating instrumented workloads at startup", func(config WorkloadTestConfig) {
 		name := UniqueName(config.WorkloadNamePrefix)
 		workload := config.CreateFn(ctx, k8sClient, TestNamespaceName, name)
-		createdObjects = append(createdObjects, workload.Get())
+		createdObjectsInstrumenterTest = append(createdObjectsInstrumenterTest, workload.Get())
 		workload.GetObjectMeta().Labels["dash0.com/operator-image"] = olderOperatorControllerImageLabel
 		workload.GetObjectMeta().Labels["dash0.com/init-container-image"] = olderInitContainerImageLabel
 		UpdateWorkload(ctx, k8sClient, workload.Get())
@@ -733,7 +733,7 @@ var _ = Describe("The instrumenter", Ordered, func() {
 		It("should not override outdated instrumentation settings for a job at startup", func() {
 			name := UniqueName(JobNamePrefix)
 			workload := CreateInstrumentedJob(ctx, k8sClient, TestNamespaceName, name)
-			createdObjects = append(createdObjects, workload)
+			createdObjectsInstrumenterTest = append(createdObjectsInstrumenterTest, workload)
 			workload.ObjectMeta.Labels["dash0.com/operator-image"] = "some-registry.com_1234_dash0hq_operator-controller_0.9.8"
 			workload.ObjectMeta.Labels["dash0.com/init-container-image"] = "some-registry.com_1234_dash0hq_instrumentation_2.3.4"
 			UpdateWorkload(ctx, k8sClient, workload)

--- a/internal/predelete/operator_pre_delete_handler_test.go
+++ b/internal/predelete/operator_pre_delete_handler_test.go
@@ -43,9 +43,9 @@ var _ = Describe("Uninstalling the Dash0 operator", Ordered, func() {
 
 	ctx := context.Background()
 	var (
-		createdObjects []client.Object
-		deployment1    *appv1.Deployment
-		deployment2    *appv1.Deployment
+		createdObjectsPreDeleteHandlerTest []client.Object
+		deployment1                        *appv1.Deployment
+		deployment2                        *appv1.Deployment
 	)
 
 	BeforeAll(func() {
@@ -53,22 +53,22 @@ var _ = Describe("Uninstalling the Dash0 operator", Ordered, func() {
 	})
 
 	BeforeEach(func() {
-		createdObjects, deployment1 = setupNamespaceWithDash0MonitoringResourceAndWorkload(
+		createdObjectsPreDeleteHandlerTest, deployment1 = setupNamespaceWithDash0MonitoringResourceAndWorkload(
 			ctx,
 			k8sClient,
 			dash0MonitoringResourceName1,
-			createdObjects,
+			createdObjectsPreDeleteHandlerTest,
 		)
-		createdObjects, deployment2 = setupNamespaceWithDash0MonitoringResourceAndWorkload(
+		createdObjectsPreDeleteHandlerTest, deployment2 = setupNamespaceWithDash0MonitoringResourceAndWorkload(
 			ctx,
 			k8sClient,
 			dash0MonitoringResourceName2,
-			createdObjects,
+			createdObjectsPreDeleteHandlerTest,
 		)
 	})
 
 	AfterEach(func() {
-		createdObjects = DeleteAllCreatedObjects(ctx, k8sClient, createdObjects)
+		createdObjectsPreDeleteHandlerTest = DeleteAllCreatedObjects(ctx, k8sClient, createdObjectsPreDeleteHandlerTest)
 		DeleteMonitoringResourceByName(ctx, k8sClient, dash0MonitoringResourceName1, false)
 		DeleteMonitoringResourceByName(ctx, k8sClient, dash0MonitoringResourceName2, false)
 	})

--- a/internal/resources/resources_suite_test.go
+++ b/internal/resources/resources_suite_test.go
@@ -1,19 +1,17 @@
-// SPDX-FileCopyrightText: Copyright 2024 Dash0 Inc.
+// SPDX-FileCopyrightText: Copyright 2025 Dash0 Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-package controller
+package resources
 
 import (
 	"fmt"
 	"path/filepath"
 	"runtime"
-	"time"
 
 	persesv1alpha1 "github.com/perses/perses-operator/api/v1alpha1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -29,23 +27,17 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 )
 
-const (
-	timeout         = 5 * time.Second
-	pollingInterval = 50 * time.Millisecond
-)
-
 var (
 	mgr       ctrl.Manager
 	cfg       *rest.Config
 	k8sClient client.Client
 	clientset *kubernetes.Clientset
-	recorder  record.EventRecorder
 	testEnv   *envtest.Environment
 )
 
-func TestController(t *testing.T) {
+func TestResources(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Controller Suite")
+	RunSpecs(t, "Resources Util Suite")
 }
 
 var _ = BeforeSuite(func() {
@@ -82,7 +74,6 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(mgr).NotTo(BeNil())
-	recorder = mgr.GetEventRecorderFor("dash0-controller")
 })
 
 var _ = AfterSuite(func() {

--- a/internal/resources/resources_util_test.go
+++ b/internal/resources/resources_util_test.go
@@ -1,0 +1,292 @@
+// SPDX-FileCopyrightText: Copyright 2025 Dash0 Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package resources
+
+import (
+	"context"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	dash0v1alpha1 "github.com/dash0hq/dash0-operator/api/dash0monitoring/v1alpha1"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	. "github.com/dash0hq/dash0-operator/test/util"
+)
+
+type statusExpectation struct {
+	status  metav1.ConditionStatus
+	reason  string
+	message string
+}
+
+type statusExpectations struct {
+	available *statusExpectation
+	degraded  *statusExpectation
+}
+
+type verifyThatResourceIsUniqueInScopeTest struct {
+	createResources          func() *dash0v1alpha1.Dash0Monitoring
+	expectedStopReconcile    bool
+	expectedStatusConditions map[types.NamespacedName]statusExpectations
+}
+
+const (
+	timeout         = 1 * time.Second
+	pollingInterval = 50 * time.Millisecond
+
+	statusConditionReason     = "TestReason"
+	statusConditionMessage    = "This is a test message."
+	updateStatusFailedMessage = "failed to update status"
+)
+
+var (
+	resourceName1 = types.NamespacedName{Namespace: TestNamespaceName, Name: "resource1"}
+	resourceName2 = types.NamespacedName{Namespace: TestNamespaceName, Name: "resource2"}
+	resourceName3 = types.NamespacedName{Namespace: TestNamespaceName, Name: "resource3"}
+
+	reconcileRequest = ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: TestNamespaceName,
+		},
+	}
+
+	resourceIsAvailable = statusExpectations{
+		available: &statusExpectation{
+			status:  metav1.ConditionTrue,
+			reason:  "ReconcileFinished",
+			message: "Dash0 monitoring is active in this namespace now.",
+		},
+		degraded: nil,
+	}
+
+	resourceIsDegradedTestReason = statusExpectations{
+		available: &statusExpectation{
+			status:  metav1.ConditionFalse,
+			reason:  statusConditionReason,
+			message: statusConditionMessage,
+		},
+		degraded: &statusExpectation{
+			status:  metav1.ConditionTrue,
+			reason:  statusConditionReason,
+			message: statusConditionMessage,
+		},
+	}
+
+	resourceIsDegradedNewerResourcePresent = statusExpectations{
+		available: &statusExpectation{
+			status: metav1.ConditionFalse,
+			reason: "NewerResourceIsPresent",
+			message: "There is a more recently created Dash0 monitoring resource in this namespace, please remove " +
+				"all but one resource instance.",
+		},
+		degraded: &statusExpectation{
+			status: metav1.ConditionTrue,
+			reason: "NewerResourceIsPresent",
+			message: "There is a more recently created Dash0 monitoring resource in this namespace, please remove " +
+				"all but one resource instance.",
+		},
+	}
+)
+
+var _ = Describe("resource util functions", Ordered, func() {
+	ctx := context.Background()
+	logger := log.FromContext(ctx)
+
+	var createdObjectsResourcesUtilTest []client.Object
+
+	BeforeAll(func() {
+		EnsureTestNamespaceExists(ctx, k8sClient)
+	})
+
+	BeforeEach(func() {
+		createdObjectsResourcesUtilTest = make([]client.Object, 0)
+	})
+
+	AfterEach(func() {
+		createdObjectsResourcesUtilTest = DeleteAllCreatedObjects(ctx, k8sClient, createdObjectsResourcesUtilTest)
+	})
+
+	DescribeTable("VerifyThatResourceIsUniqueInScope", func(testConfig verifyThatResourceIsUniqueInScopeTest) {
+		reconciledResource := testConfig.createResources()
+
+		stopRecconile, err := VerifyThatResourceIsUniqueInScope(
+			ctx,
+			k8sClient,
+			reconcileRequest,
+			reconciledResource,
+			updateStatusFailedMessage,
+			&logger,
+		)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(stopRecconile).To(Equal(testConfig.expectedStopReconcile))
+
+		Eventually(func(g Gomega) {
+			for resName, expectations := range testConfig.expectedStatusConditions {
+				availableCondition := LoadMonitoringResourceStatusCondition(ctx, k8sClient, resName, dash0v1alpha1.ConditionTypeAvailable)
+				verifyResourceStatusCondition(
+					g,
+					availableCondition,
+					expectations.available,
+				)
+				degradedCondition := LoadMonitoringResourceStatusCondition(ctx, k8sClient, resName, dash0v1alpha1.ConditionTypeDegraded)
+				verifyResourceStatusCondition(
+					g,
+					degradedCondition,
+					expectations.degraded,
+				)
+			}
+		}, timeout, pollingInterval).Should(Succeed())
+	},
+		Entry("no resources exist", verifyThatResourceIsUniqueInScopeTest{
+			createResources:       DefaultMonitoringResource,
+			expectedStopReconcile: false,
+		}),
+		Entry("one degraded resource", verifyThatResourceIsUniqueInScopeTest{
+			createResources: func() *dash0v1alpha1.Dash0Monitoring {
+				resource := CreateDefaultMonitoringResource(ctx, k8sClient, resourceName1)
+				createdObjectsResourcesUtilTest = append(createdObjectsResourcesUtilTest, resource)
+				resource.EnsureResourceIsMarkedAsDegraded(statusConditionReason, statusConditionMessage)
+				Expect(k8sClient.Status().Update(ctx, resource)).To(Succeed())
+				return resource
+			},
+			expectedStopReconcile: false,
+			expectedStatusConditions: map[types.NamespacedName]statusExpectations{
+				resourceName1: resourceIsDegradedTestReason,
+			},
+		}),
+		Entry("one available resource", verifyThatResourceIsUniqueInScopeTest{
+			createResources: func() *dash0v1alpha1.Dash0Monitoring {
+				resource := CreateDefaultMonitoringResource(ctx, k8sClient, resourceName1)
+				createdObjectsResourcesUtilTest = append(createdObjectsResourcesUtilTest, resource)
+				resource.EnsureResourceIsMarkedAsAvailable()
+				Expect(k8sClient.Status().Update(ctx, resource)).To(Succeed())
+				return resource
+			},
+			expectedStopReconcile: false,
+			expectedStatusConditions: map[types.NamespacedName]statusExpectations{
+				resourceName1: resourceIsAvailable,
+			},
+		}),
+		Entry("multiple resources, the reconciled resource is the most recent one and it is degraded", verifyThatResourceIsUniqueInScopeTest{
+			createResources: func() *dash0v1alpha1.Dash0Monitoring {
+				resource1 := CreateDefaultMonitoringResource(ctx, k8sClient, resourceName1)
+				createdObjectsResourcesUtilTest = append(createdObjectsResourcesUtilTest, resource1)
+				resource1.EnsureResourceIsMarkedAsAvailable()
+				Expect(k8sClient.Status().Update(ctx, resource1)).To(Succeed())
+				time.Sleep(10 * time.Millisecond)
+
+				resource2 := CreateDefaultMonitoringResource(ctx, k8sClient, resourceName2)
+				createdObjectsResourcesUtilTest = append(createdObjectsResourcesUtilTest, resource2)
+				resource2.EnsureResourceIsMarkedAsAvailable()
+				Expect(k8sClient.Status().Update(ctx, resource2)).To(Succeed())
+				time.Sleep(10 * time.Millisecond)
+
+				resource3 := CreateDefaultMonitoringResource(ctx, k8sClient, resourceName3)
+				createdObjectsResourcesUtilTest = append(createdObjectsResourcesUtilTest, resource3)
+				resource3.EnsureResourceIsMarkedAsDegraded(statusConditionReason, statusConditionMessage)
+				Expect(k8sClient.Status().Update(ctx, resource3)).To(Succeed())
+
+				// simulate a reconcile request for resource3, the most recent resource
+				return resource3
+			},
+			expectedStopReconcile: false,
+			expectedStatusConditions: map[types.NamespacedName]statusExpectations{
+				// Not the most recent one, we expect VerifyThatResourceIsUniqueInScope to switch its status to degraded
+				resourceName1: resourceIsDegradedNewerResourcePresent,
+				// Not the most recent one, we expect VerifyThatResourceIsUniqueInScope to switch its status to degraded
+				resourceName2: resourceIsDegradedNewerResourcePresent,
+				// The most recent one, but it was degraded before, we do not expect VerifyThatResourceIsUniqueInScope
+				// to set its status to available, this is done by code calling VerifyThatResourceIsUniqueInScope
+				resourceName3: resourceIsDegradedTestReason,
+			},
+		}),
+		Entry("multiple resources, the reconciled resource is the most recent one and it is available", verifyThatResourceIsUniqueInScopeTest{
+			createResources: func() *dash0v1alpha1.Dash0Monitoring {
+				resource1 := CreateDefaultMonitoringResource(ctx, k8sClient, resourceName1)
+				createdObjectsResourcesUtilTest = append(createdObjectsResourcesUtilTest, resource1)
+				resource1.EnsureResourceIsMarkedAsAvailable()
+				Expect(k8sClient.Status().Update(ctx, resource1)).To(Succeed())
+				time.Sleep(10 * time.Millisecond)
+
+				resource2 := CreateDefaultMonitoringResource(ctx, k8sClient, resourceName2)
+				createdObjectsResourcesUtilTest = append(createdObjectsResourcesUtilTest, resource2)
+				resource2.EnsureResourceIsMarkedAsAvailable()
+				Expect(k8sClient.Status().Update(ctx, resource2)).To(Succeed())
+				time.Sleep(10 * time.Millisecond)
+
+				resource3 := CreateDefaultMonitoringResource(ctx, k8sClient, resourceName3)
+				createdObjectsResourcesUtilTest = append(createdObjectsResourcesUtilTest, resource3)
+				resource3.EnsureResourceIsMarkedAsAvailable()
+				Expect(k8sClient.Status().Update(ctx, resource3)).To(Succeed())
+
+				// simulate a reconcile request for resource3, the most recent resource
+				return resource3
+			},
+			expectedStopReconcile: false,
+			expectedStatusConditions: map[types.NamespacedName]statusExpectations{
+				// Not the most recent one, we expect VerifyThatResourceIsUniqueInScope to switch its status to degraded
+				resourceName1: resourceIsDegradedNewerResourcePresent,
+				// Not the most recent one, we expect VerifyThatResourceIsUniqueInScope to switch its status to degraded
+				resourceName2: resourceIsDegradedNewerResourcePresent,
+				// The most recent one, but it was degraded before, we do not expect VerifyThatResourceIsUniqueInScope
+				// to set its status to available, this is done by code calling VerifyThatResourceIsUniqueInScope.
+				resourceName3: resourceIsAvailable,
+			},
+		}),
+		Entry("multiple resources, the reconciled resource is not the ost recent one", verifyThatResourceIsUniqueInScopeTest{
+			createResources: func() *dash0v1alpha1.Dash0Monitoring {
+				resource1 := CreateDefaultMonitoringResource(ctx, k8sClient, resourceName1)
+				createdObjectsResourcesUtilTest = append(createdObjectsResourcesUtilTest, resource1)
+				resource1.EnsureResourceIsMarkedAsAvailable()
+				Expect(k8sClient.Status().Update(ctx, resource1)).To(Succeed())
+				time.Sleep(10 * time.Millisecond)
+
+				resource2 := CreateDefaultMonitoringResource(ctx, k8sClient, resourceName2)
+				createdObjectsResourcesUtilTest = append(createdObjectsResourcesUtilTest, resource2)
+				resource2.EnsureResourceIsMarkedAsAvailable()
+				Expect(k8sClient.Status().Update(ctx, resource2)).To(Succeed())
+				time.Sleep(10 * time.Millisecond)
+
+				resource3 := CreateDefaultMonitoringResource(ctx, k8sClient, resourceName3)
+				createdObjectsResourcesUtilTest = append(createdObjectsResourcesUtilTest, resource3)
+				resource3.EnsureResourceIsMarkedAsDegraded(statusConditionReason, statusConditionMessage)
+				Expect(k8sClient.Status().Update(ctx, resource3)).To(Succeed())
+
+				// simulate a reconcile request for resource2, which is not the most recent one
+				return resource2
+			},
+			expectedStopReconcile: true,
+			expectedStatusConditions: map[types.NamespacedName]statusExpectations{
+				// Not the most recent one, we expect VerifyThatResourceIsUniqueInScope to switch its status to degraded
+				resourceName1: resourceIsDegradedNewerResourcePresent,
+				// Not the most recent one, we expect VerifyThatResourceIsUniqueInScope to switch its status to degraded
+				resourceName2: resourceIsDegradedNewerResourcePresent,
+				// The most recent one, but it was degraded before, we do not expect VerifyThatResourceIsUniqueInScope
+				// to set its status to available, this is done by code calling VerifyThatResourceIsUniqueInScope.
+				resourceName3: resourceIsDegradedTestReason,
+			},
+		}),
+	)
+})
+
+func verifyResourceStatusCondition(g Gomega, condition *metav1.Condition, expectation *statusExpectation) {
+	if expectation == nil {
+		g.Expect(condition).To(BeNil())
+	} else {
+		VerifyResourceStatusCondition(
+			g,
+			condition,
+			expectation.status,
+			expectation.reason,
+			expectation.message,
+		)
+	}
+}

--- a/internal/selfmonitoringapiaccess/self_monitoring_and_api_access_test.go
+++ b/internal/selfmonitoringapiaccess/self_monitoring_and_api_access_test.go
@@ -707,7 +707,7 @@ var _ = Describe("self monitoring and API access", Ordered, func() {
 				authTokenClient1,
 				authTokenClient2,
 			}
-			createdObjects []client.Object
+			createdObjectsSelfMonitoringTest []client.Object
 		)
 
 		BeforeEach(func() {
@@ -717,14 +717,14 @@ var _ = Describe("self monitoring and API access", Ordered, func() {
 		})
 
 		AfterEach(func() {
-			createdObjects = DeleteAllCreatedObjects(ctx, k8sClient, createdObjects)
+			createdObjectsSelfMonitoringTest = DeleteAllCreatedObjects(ctx, k8sClient, createdObjectsSelfMonitoringTest)
 		})
 
 		DescribeTable("should fetch and decode the auth token", func(testConfig exchangeTestConfig) {
 			if testConfig.secret != nil {
 				EnsureOperatorNamespaceExists(ctx, k8sClient)
 				Expect(k8sClient.Create(ctx, testConfig.secret)).To(Succeed())
-				createdObjects = append(createdObjects, testConfig.secret)
+				createdObjectsSelfMonitoringTest = append(createdObjectsSelfMonitoringTest, testConfig.secret)
 			}
 			err := ExchangeSecretRefForToken(
 				ctx,

--- a/internal/util/env_vars.go
+++ b/internal/util/env_vars.go
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: Copyright 2025 Dash0 Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package util
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+
+	dash0v1alpha1 "github.com/dash0hq/dash0-operator/api/dash0monitoring/v1alpha1"
+)
+
+func CreateEnvVarForAuthorization(
+	dash0Authorization dash0v1alpha1.Authorization,
+	envVarName string,
+) (corev1.EnvVar, error) {
+	token := dash0Authorization.Token
+	secretRef := dash0Authorization.SecretRef
+	if token != nil && *token != "" {
+		return corev1.EnvVar{
+			Name:  envVarName,
+			Value: *token,
+		}, nil
+	} else if secretRef != nil && secretRef.Name != "" && secretRef.Key != "" {
+		return corev1.EnvVar{
+			Name: envVarName,
+			ValueFrom: &corev1.EnvVarSource{
+				SecretKeyRef: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: secretRef.Name,
+					},
+					Key: secretRef.Key,
+				},
+			},
+		}, nil
+	} else {
+		return corev1.EnvVar{}, fmt.Errorf("neither token nor secretRef provided for the Dash0 exporter")
+	}
+}

--- a/internal/util/types.go
+++ b/internal/util/types.go
@@ -5,8 +5,10 @@ package util
 
 import (
 	"strings"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 type Reason string
@@ -69,3 +71,8 @@ const (
 	ModificationModeInstrumentation   ModificationMode = "instrumentation"
 	ModificationModeUninstrumentation ModificationMode = "uninstrumentation"
 )
+
+type DanglingEventsTimeouts struct {
+	InitialTimeout time.Duration
+	Backoff        wait.Backoff
+}

--- a/internal/webhooks/attach_dangling_events_test.go
+++ b/internal/webhooks/attach_dangling_events_test.go
@@ -31,7 +31,7 @@ import (
 var _ = Describe("The Dash0 webhook and the Dash0 controller", Ordered, func() {
 	var reconciler *controller.MonitoringReconciler
 	var dash0MonitoringResource *dash0v1alpha1.Dash0Monitoring
-	var createdObjects []client.Object
+	var createdObjectsAttachEventsTest []client.Object
 
 	BeforeAll(func() {
 		EnsureOperatorNamespaceExists(ctx, k8sClient)
@@ -77,18 +77,18 @@ var _ = Describe("The Dash0 webhook and the Dash0 controller", Ordered, func() {
 	})
 
 	BeforeEach(func() {
-		createdObjects = make([]client.Object, 0)
+		createdObjectsAttachEventsTest = make([]client.Object, 0)
 	})
 
 	AfterEach(func() {
-		createdObjects = DeleteAllCreatedObjects(ctx, k8sClient, createdObjects)
+		createdObjectsAttachEventsTest = DeleteAllCreatedObjects(ctx, k8sClient, createdObjectsAttachEventsTest)
 		DeleteAllEvents(ctx, clientset, TestNamespaceName)
 	})
 
 	DescribeTable("when attaching events to their involved objects", func(config WorkloadTestConfig) {
 		name := UniqueName(config.WorkloadNamePrefix)
 		workload := config.CreateFn(ctx, k8sClient, TestNamespaceName, name)
-		createdObjects = append(createdObjects, workload.Get())
+		createdObjectsAttachEventsTest = append(createdObjectsAttachEventsTest, workload.Get())
 		workload = config.GetFn(ctx, k8sClient, TestNamespaceName, name)
 		event := VerifySuccessfulInstrumentationEvent(ctx, clientset, TestNamespaceName, name, "webhook")
 

--- a/internal/webhooks/instrumentation_webhook_test.go
+++ b/internal/webhooks/instrumentation_webhook_test.go
@@ -32,14 +32,14 @@ const (
 )
 
 var _ = Describe("The Dash0 instrumentation webhook", func() {
-	var createdObjects []client.Object
+	var createdObjectsInstrumentationWebhookTest []client.Object
 
 	BeforeEach(func() {
-		createdObjects = make([]client.Object, 0)
+		createdObjectsInstrumentationWebhookTest = make([]client.Object, 0)
 	})
 
 	AfterEach(func() {
-		createdObjects = DeleteAllCreatedObjects(ctx, k8sClient, createdObjects)
+		createdObjectsInstrumentationWebhookTest = DeleteAllCreatedObjects(ctx, k8sClient, createdObjectsInstrumentationWebhookTest)
 		DeleteAllEvents(ctx, clientset, TestNamespaceName)
 	})
 
@@ -55,7 +55,7 @@ var _ = Describe("The Dash0 instrumentation webhook", func() {
 		DescribeTable("when mutating new workloads", func(config WorkloadTestConfig) {
 			name := UniqueName(config.WorkloadNamePrefix)
 			workload := config.CreateFn(ctx, k8sClient, TestNamespaceName, name)
-			createdObjects = append(createdObjects, workload.Get())
+			createdObjectsInstrumentationWebhookTest = append(createdObjectsInstrumentationWebhookTest, workload.Get())
 			workload = config.GetFn(ctx, k8sClient, TestNamespaceName, name)
 			config.VerifyFn(workload)
 			VerifySuccessfulInstrumentationEvent(ctx, clientset, TestNamespaceName, name, testActor)
@@ -156,7 +156,7 @@ var _ = Describe("The Dash0 instrumentation webhook", func() {
 			It("should not instrument a new pod owned by a replica set", func() {
 				name := UniqueName(PodNamePrefix)
 				workload := CreatePodOwnedByReplicaSet(ctx, k8sClient, TestNamespaceName, name)
-				createdObjects = append(createdObjects, workload)
+				createdObjectsInstrumentationWebhookTest = append(createdObjectsInstrumentationWebhookTest, workload)
 				workload = GetPod(ctx, k8sClient, TestNamespaceName, name)
 				VerifyUnmodifiedPod(workload)
 				VerifyNoEvents(ctx, clientset, TestNamespaceName)
@@ -165,7 +165,7 @@ var _ = Describe("The Dash0 instrumentation webhook", func() {
 			It("should not instrument a new replica set owned by a deployment", func() {
 				name := UniqueName(ReplicaSetNamePrefix)
 				workload := CreateReplicaSetOwnedByDeployment(ctx, k8sClient, TestNamespaceName, name)
-				createdObjects = append(createdObjects, workload)
+				createdObjectsInstrumentationWebhookTest = append(createdObjectsInstrumentationWebhookTest, workload)
 				workload = GetReplicaSet(ctx, k8sClient, TestNamespaceName, name)
 				VerifyUnmodifiedReplicaSet(workload)
 				VerifyInstrumentationViaHigherOrderWorkloadEvent(ctx, clientset, TestNamespaceName, name, testActor)
@@ -175,7 +175,7 @@ var _ = Describe("The Dash0 instrumentation webhook", func() {
 		DescribeTable("when an uninstrumented workload has opted out of instrumentation", func(config WorkloadTestConfig) {
 			name := UniqueName(config.WorkloadNamePrefix)
 			workload := config.CreateFn(ctx, k8sClient, TestNamespaceName, name)
-			createdObjects = append(createdObjects, workload.Get())
+			createdObjectsInstrumentationWebhookTest = append(createdObjectsInstrumentationWebhookTest, workload.Get())
 			workload = config.GetFn(ctx, k8sClient, TestNamespaceName, name)
 			config.VerifyFn(workload)
 			VerifyNoEvents(ctx, clientset, TestNamespaceName)
@@ -235,7 +235,7 @@ var _ = Describe("The Dash0 instrumentation webhook", func() {
 				name := UniqueName(DeploymentNamePrefix)
 				workload := DeploymentWithMoreBellsAndWhistles(TestNamespaceName, name)
 				Expect(k8sClient.Create(ctx, workload)).Should(Succeed())
-				createdObjects = append(createdObjects, workload)
+				createdObjectsInstrumentationWebhookTest = append(createdObjectsInstrumentationWebhookTest, workload)
 
 				workload = GetDeployment(ctx, k8sClient, TestNamespaceName, name)
 				VerifyModifiedDeployment(workload, PodSpecExpectations{
@@ -370,7 +370,7 @@ var _ = Describe("The Dash0 instrumentation webhook", func() {
 				name := UniqueName(DeploymentNamePrefix)
 				workload := DeploymentWithExistingDash0Artifacts(TestNamespaceName, name)
 				Expect(k8sClient.Create(ctx, workload)).Should(Succeed())
-				createdObjects = append(createdObjects, workload)
+				createdObjectsInstrumentationWebhookTest = append(createdObjectsInstrumentationWebhookTest, workload)
 
 				workload = GetDeployment(ctx, k8sClient, TestNamespaceName, name)
 				VerifyModifiedDeployment(workload, PodSpecExpectations{
@@ -466,7 +466,7 @@ var _ = Describe("The Dash0 instrumentation webhook", func() {
 		DescribeTable("when the opt-out label is added to an already instrumented workload", func(config WorkloadTestConfig) {
 			name := UniqueName(config.WorkloadNamePrefix)
 			workload := config.CreateFn(ctx, k8sClient, TestNamespaceName, name)
-			createdObjects = append(createdObjects, workload.Get())
+			createdObjectsInstrumentationWebhookTest = append(createdObjectsInstrumentationWebhookTest, workload.Get())
 
 			DeleteAllEvents(ctx, clientset, TestNamespaceName)
 			AddOptOutLabel(workload.GetObjectMeta())
@@ -519,7 +519,7 @@ var _ = Describe("The Dash0 instrumentation webhook", func() {
 		DescribeTable("when the opt-out label is removed from a workload that had previously opted out", func(config WorkloadTestConfig) {
 			name := UniqueName(config.WorkloadNamePrefix)
 			workload := config.CreateFn(ctx, k8sClient, TestNamespaceName, name)
-			createdObjects = append(createdObjects, workload.Get())
+			createdObjectsInstrumentationWebhookTest = append(createdObjectsInstrumentationWebhookTest, workload.Get())
 
 			DeleteAllEvents(ctx, clientset, TestNamespaceName)
 			RemoveOptOutLabel(workload.GetObjectMeta())
@@ -572,7 +572,7 @@ var _ = Describe("The Dash0 instrumentation webhook", func() {
 		DescribeTable("when dash0.com/enabled=true is set on a workload that had previously opted out", func(config WorkloadTestConfig) {
 			name := UniqueName(config.WorkloadNamePrefix)
 			workload := config.CreateFn(ctx, k8sClient, TestNamespaceName, name)
-			createdObjects = append(createdObjects, workload.Get())
+			createdObjectsInstrumentationWebhookTest = append(createdObjectsInstrumentationWebhookTest, workload.Get())
 
 			DeleteAllEvents(ctx, clientset, TestNamespaceName)
 			UpdateLabel(workload.GetObjectMeta(), "dash0.com/enable", "true")
@@ -625,7 +625,7 @@ var _ = Describe("The Dash0 instrumentation webhook", func() {
 		DescribeTable("when seeing the webhook-ignore-once label", func(config WorkloadTestConfig) {
 			name := UniqueName(config.WorkloadNamePrefix)
 			workload := config.ConfigureFn(TestNamespaceName, name)
-			createdObjects = append(createdObjects, workload.Get())
+			createdObjectsInstrumentationWebhookTest = append(createdObjectsInstrumentationWebhookTest, workload.Get())
 			AddLabel(workload.GetObjectMeta(), "dash0.com/webhook-ignore-once", "true")
 			CreateWorkload(ctx, k8sClient, workload.Get())
 
@@ -687,7 +687,7 @@ var _ = Describe("The Dash0 instrumentation webhook", func() {
 
 	Describe("when the Dash0 monitoring resource does not exist", func() {
 		It("should not instrument workloads", func() {
-			createdObjects = verifyThatDeploymentIsNotBeingInstrumented(createdObjects)
+			createdObjectsInstrumentationWebhookTest = verifyThatDeploymentIsNotBeingInstrumented(createdObjectsInstrumentationWebhookTest)
 		})
 	})
 
@@ -701,7 +701,7 @@ var _ = Describe("The Dash0 instrumentation webhook", func() {
 		})
 
 		It("should not instrument workloads", func() {
-			createdObjects = verifyThatDeploymentIsNotBeingInstrumented(createdObjects)
+			createdObjectsInstrumentationWebhookTest = verifyThatDeploymentIsNotBeingInstrumented(createdObjectsInstrumentationWebhookTest)
 		})
 	})
 
@@ -717,7 +717,7 @@ var _ = Describe("The Dash0 instrumentation webhook", func() {
 		})
 
 		It("should instrument workloads", func() {
-			createdObjects = verifyThatDeploymentIsInstrumented(createdObjects)
+			createdObjectsInstrumentationWebhookTest = verifyThatDeploymentIsInstrumented(createdObjectsInstrumentationWebhookTest)
 		})
 	})
 
@@ -733,7 +733,7 @@ var _ = Describe("The Dash0 instrumentation webhook", func() {
 		})
 
 		It("should not instrument workloads", func() {
-			createdObjects = verifyThatDeploymentIsNotBeingInstrumented(createdObjects)
+			createdObjectsInstrumentationWebhookTest = verifyThatDeploymentIsNotBeingInstrumented(createdObjectsInstrumentationWebhookTest)
 		})
 	})
 
@@ -749,7 +749,7 @@ var _ = Describe("The Dash0 instrumentation webhook", func() {
 		})
 
 		It("should instrument workloads", func() {
-			createdObjects = verifyThatDeploymentIsInstrumented(createdObjects)
+			createdObjectsInstrumentationWebhookTest = verifyThatDeploymentIsInstrumented(createdObjectsInstrumentationWebhookTest)
 		})
 	})
 })

--- a/test-resources/bin/test-scenario-03-rebuild-update-operator-no-cleanup.sh
+++ b/test-resources/bin/test-scenario-03-rebuild-update-operator-no-cleanup.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 
 cd "$(dirname "${BASH_SOURCE[0]}")"/../..
 
+operator_namespace=${OPERATOR_NAMESPACE:-operator-namespace}
 target_namespace=${1:-test-namespace}
 
 source test-resources/bin/util
@@ -20,7 +21,7 @@ echo "STEP $step_counter: rebuild images"
 build_all_images
 finish_step
 
-echo "STEP $step_counter: deploy the Dash0 operator using helm"
+echo "STEP $step_counter: update the Dash0 operator using helm"
 update_via_helm
 finish_step
 

--- a/test/util/monitoring_resource.go
+++ b/test/util/monitoring_resource.go
@@ -43,6 +43,26 @@ var (
 	}
 )
 
+func DefaultMonitoringResource() *dash0v1alpha1.Dash0Monitoring {
+	return &dash0v1alpha1.Dash0Monitoring{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      MonitoringResourceName,
+			Namespace: TestNamespaceName,
+		},
+		Spec: MonitoringResourceDefaultSpec,
+	}
+}
+
+func DefaultMonitoringResourceWithName(monitoringResourceName types.NamespacedName) *dash0v1alpha1.Dash0Monitoring {
+	return &dash0v1alpha1.Dash0Monitoring{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      monitoringResourceName.Name,
+			Namespace: monitoringResourceName.Namespace,
+		},
+		Spec: MonitoringResourceDefaultSpec,
+	}
+}
+
 func CreateDefaultMonitoringResource(
 	ctx context.Context,
 	k8sClient client.Client,
@@ -51,13 +71,7 @@ func CreateDefaultMonitoringResource(
 	return CreateMonitoringResource(
 		ctx,
 		k8sClient,
-		&dash0v1alpha1.Dash0Monitoring{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      monitoringResourceName.Name,
-				Namespace: monitoringResourceName.Namespace,
-			},
-			Spec: MonitoringResourceDefaultSpec,
-		},
+		DefaultMonitoringResourceWithName(monitoringResourceName),
 	)
 }
 
@@ -275,6 +289,14 @@ func LoadMonitoringResourceByName(
 	}
 
 	return monitoringResource
+}
+
+func VerifyMonitoringResourceDoesNotExist(
+	ctx context.Context,
+	k8sClient client.Client,
+	g Gomega,
+) {
+	VerifyMonitoringResourceByNameDoesNotExist(ctx, k8sClient, g, MonitoringResourceQualifiedName)
 }
 
 func VerifyMonitoringResourceByNameDoesNotExist(

--- a/test/util/operator_configuration_resource.go
+++ b/test/util/operator_configuration_resource.go
@@ -29,12 +29,6 @@ var (
 		Name: OperatorConfigurationResourceName,
 	}
 
-	OperatorConfigurationResourceWithoutSelfMonitoringWithoutAuth = dash0v1alpha1.Dash0OperatorConfigurationSpec{
-		SelfMonitoring: dash0v1alpha1.SelfMonitoring{
-			Enabled: ptr.To(false),
-		},
-	}
-
 	OperatorConfigurationResourceWithoutExport = dash0v1alpha1.Dash0OperatorConfigurationSpec{
 		SelfMonitoring: dash0v1alpha1.SelfMonitoring{
 			Enabled: ptr.To(false),
@@ -197,6 +191,36 @@ func CreateOperatorConfigurationResourceWithSpec(
 		&dash0v1alpha1.Dash0OperatorConfiguration{
 			ObjectMeta: OperatorConfigurationResourceDefaultObjectMeta,
 			Spec:       operatorConfigurationSpec,
+		})
+	Expect(err).ToNot(HaveOccurred())
+	return operatorConfigurationResource
+}
+
+func CreateOperatorConfigurationResourceWithName(
+	ctx context.Context,
+	k8sClient client.Client,
+	resourceName string,
+) *dash0v1alpha1.Dash0OperatorConfiguration {
+	operatorConfigurationResource, err := CreateOperatorConfigurationResource(
+		ctx,
+		k8sClient,
+		&dash0v1alpha1.Dash0OperatorConfiguration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: resourceName,
+			},
+			Spec: dash0v1alpha1.Dash0OperatorConfigurationSpec{
+				SelfMonitoring: dash0v1alpha1.SelfMonitoring{
+					Enabled: ptr.To(false),
+				},
+				Export: &dash0v1alpha1.Export{
+					Dash0: &dash0v1alpha1.Dash0Configuration{
+						Endpoint: EndpointDash0Test,
+						Authorization: dash0v1alpha1.Authorization{
+							Token: &AuthorizationTokenTest,
+						},
+					},
+				},
+			},
 		})
 	Expect(err).ToNot(HaveOccurred())
 	return operatorConfigurationResource


### PR DESCRIPTION
Previously resources (monitoring resource, operator configuration resource) could get stuck in a degraded resource state and reconciling them would not make them available again, even if all reasons for the degraded state had been removed. Now resource reconciliation will transition resources from degraded to available if possible.