### PR TITLE
fix(collectors): prepend scheme to self-monitoring logs endpoint

### DIFF
--- a/internal/collectors/otelcolresources/collector_config_maps_test.go
+++ b/internal/collectors/otelcolresources/collector_config_maps_test.go
@@ -2217,7 +2217,7 @@ var _ = Describe("The OpenTelemetry Collector ConfigMaps", func() {
 			Expect(ok).To(BeTrue())
 			otlpExporter := readOtlpExporterFromSelfMonitoringLogsPipeline(selfMonitoringLogsPipeline)
 			Expect(otlpExporter["protocol"]).To(Equal(common.ProtocolGrpc))
-			Expect(otlpExporter["endpoint"]).To(Equal(EndpointDash0Test))
+			Expect(otlpExporter["endpoint"]).To(Equal(EndpointDash0WithProtocolTest))
 			headersRaw := otlpExporter["headers"]
 			Expect(headersRaw).ToNot(BeNil())
 			headers, ok := headersRaw.(map[string]interface{})
@@ -2246,7 +2246,7 @@ var _ = Describe("The OpenTelemetry Collector ConfigMaps", func() {
 		Expect(ok).To(BeTrue())
 		otlpExporter := readOtlpExporterFromSelfMonitoringLogsPipeline(selfMonitoringLogsPipeline)
 		Expect(otlpExporter["protocol"]).To(Equal(common.ProtocolGrpc))
-		Expect(otlpExporter["endpoint"]).To(Equal(EndpointGrpcTest))
+		Expect(otlpExporter["endpoint"]).To(Equal(EndpointGrpcWithProtocolTest))
 		headersRaw := otlpExporter["headers"]
 		Expect(headersRaw).ToNot(BeNil())
 		headers, ok := headersRaw.(map[string]interface{})

--- a/internal/selfmonitoringapiaccess/self_monitoring_and_api_access.go
+++ b/internal/selfmonitoringapiaccess/self_monitoring_and_api_access.go
@@ -449,7 +449,7 @@ func convertDash0ExportConfigurationToCollectorLogSelfMonitoringPipelineString(d
 	pipeline := collectorLogSelfMonitoringPrelude +
 		fmt.Sprintf(`
                 protocol: grpc
-                endpoint: %s`, dash0Export.Endpoint)
+                endpoint: %s`, prependProtocol(dash0Export.Endpoint, "https://"))
 	pipeline = addInsecureFlagIfNecessary(pipeline, dash0Export.Endpoint)
 	pipeline += fmt.Sprintf(`
                 headers:
@@ -473,7 +473,7 @@ func convertGrpcExportConfigurationToCollectorLogSelfMonitoringPipelineString(gr
 		fmt.Sprintf(`
                 protocol: grpc
                 endpoint: %s`,
-			grpcExport.Endpoint,
+			prependProtocol(grpcExport.Endpoint, "dns://"),
 		)
 	pipeline = addInsecureFlagIfNecessary(pipeline, grpcExport.Endpoint)
 	pipeline = appendHeadersToCollectorLogSelfMonitoringPipelineString(pipeline, grpcExport.Headers)

--- a/internal/selfmonitoringapiaccess/self_monitoring_and_api_access_test.go
+++ b/internal/selfmonitoringapiaccess/self_monitoring_and_api_access_test.go
@@ -419,7 +419,7 @@ var _ = Describe("self monitoring and API access", Ordered, func() {
             exporter:
               otlp:
                 protocol: grpc
-                endpoint: endpoint.dash0.com:4317
+                endpoint: https://endpoint.dash0.com:4317
                 headers:
                   Authorization: "Bearer ${env:SELF_MONITORING_AUTH_TOKEN}"
 `
@@ -431,7 +431,7 @@ var _ = Describe("self monitoring and API access", Ordered, func() {
             exporter:
               otlp:
                 protocol: grpc
-                endpoint: endpoint.dash0.com:4317
+                endpoint: https://endpoint.dash0.com:4317
                 headers:
                   Authorization: "Bearer ${env:SELF_MONITORING_AUTH_TOKEN}"
                   Dash0-Dataset: "test-dataset"
@@ -540,7 +540,7 @@ var _ = Describe("self monitoring and API access", Ordered, func() {
             exporter:
               otlp:
                 protocol: grpc
-                endpoint: endpoint.backend.com:4317
+                endpoint: dns://endpoint.backend.com:4317
 `,
 				},
 			),
@@ -576,7 +576,7 @@ var _ = Describe("self monitoring and API access", Ordered, func() {
             exporter:
               otlp:
                 protocol: grpc
-                endpoint: endpoint.backend.com:4317
+                endpoint: dns://endpoint.backend.com:4317
                 headers:
                   Key1: "Value1"
                   Key2: "Value2"


### PR DESCRIPTION
Until release v0.127.0/v1.33.0 of the OpenTelemetry collector, specifying the export endpoint for the collector's internal telemetry/self-monitoring
(that is,
service.telemetry.logs.processors[batch].exporter.otlp.endpoint) as "ingress.eu-west-1.aws.dash0-dev.com:4317" (without a scheme prefix) worked perfectly fine. Starting with collector release v0.128.0/v1.34.0 this stopped working and the endpoint now needs a scheme prefix.

The issue would manifest as logs like the following in the collector logs (both daemonset and deployment collector pods):
```
warn grpc@v1.73.0/clientconn.go:1414 [core] [Channel #1 SubChannel #5]grpc:
  addrConn.createTransport failed to connect to {Addr: "34.240.90.89:4317",
  ServerName: "ingress.eu-west-1.aws.dash0-dev.com:4317",
  BalancerAttributes: {"<%!p(pickfirstleaf.managedByPickfirstKeyType={})>": "<%!p(bool=true)>" }}.
  Err: connection error: desc = "error reading server preface: EOF"
  {"resource": {
    "k8s.cluster.name": "...",
    "k8s.cluster.uid": "...",
    "k8s.container.name": "opentelemetry-collector",
    "k8s.daemonset.name": "dash0-operator-opentelemetry-collector-agent-daemonset",
    "k8s.daemonset.uid": "feb2ae4c-1078-4d68-ad8d-1b735c4d98c6",
    "k8s.namespace.name": "operator-namespace",
    "k8s.node.name": "...",
    "k8s.pod.name": "dash0-operator-opentelemetry-collector-agent-daemonset-vpbs5",
    "k8s.pod.uid": "2e8ff749-6efb-417e-9b96-aaea264de8d0",
    "service.instance.id": "faa3d250-1be4-4625-addb-d20f7330184e",
    "service.name": "dash0-operator-collector",
    "service.version": "dash0"},
    "grpc_log": true}
```