### PR TITLE
chore: remove GO111MODULE=on

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -390,7 +390,7 @@ $(KUSTOMIZE): $(LOCALBIN)
 		echo "$(LOCALBIN)/kustomize version is not expected $(KUSTOMIZE_VERSION). Removing it before installing."; \
 		rm -rf $(LOCALBIN)/kustomize; \
 	fi
-	test -s $(LOCALBIN)/kustomize || GOBIN=$(LOCALBIN) GO111MODULE=on go install sigs.k8s.io/kustomize/kustomize/v5@$(KUSTOMIZE_VERSION)
+	test -s $(LOCALBIN)/kustomize || GOBIN=$(LOCALBIN) go install sigs.k8s.io/kustomize/kustomize/v5@$(KUSTOMIZE_VERSION)
 
 .PHONY: controller-gen
 controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary. If wrong version is installed, it will be overwritten.
@@ -478,7 +478,7 @@ catalog-push: ## Push a catalog image.
 
 .PHONY: husky-install
 husky-install:
-	test -s $(HUSKY) || GOBIN=$(LOCALBIN) GO111MODULE=on go install github.com/automation-co/husky@latest
+	test -s $(HUSKY) || GOBIN=$(LOCALBIN) go install github.com/automation-co/husky@latest
 
 .PHONY: husky-setup-hooks
 husky-setup-hooks: husky-install

--- a/test/e2e/run_command.go
+++ b/test/e2e/run_command.go
@@ -40,7 +40,6 @@ func run(cmd *exec.Cmd, logCommandArgs ...bool) (string, error) {
 		e2ePrint("chdir dir: %s\n", err)
 	}
 
-	cmd.Env = append(os.Environ(), "GO111MODULE=on")
 	command := strings.Join(cmd.Args, " ")
 	if logCommand {
 		e2ePrint("running: %s\n", command)


### PR DESCRIPTION
This is the default value since Go 1.16.