### PR TITLE
chore(instrumentation): move to Node.js package @dash0/opentelemetry

### DIFF
--- a/images/instrumentation/Dockerfile
+++ b/images/instrumentation/Dockerfile
@@ -29,7 +29,7 @@ FROM node:22.15.0-alpine3.21 AS build-node.js
 RUN mkdir -p /dash0-init-container/instrumentation/node.js
 WORKDIR /dash0-init-container/instrumentation/node.js
 COPY node.js/package* .
-COPY node.js/dash0hq-opentelemetry-*.tgz .
+COPY node.js/dash0-opentelemetry-*.tgz .
 RUN NPM_CONFIG_UPDATE_NOTIFIER=false \
   npm ci \
   --ignore-scripts \

--- a/images/instrumentation/injector/src/node_js.zig
+++ b/images/instrumentation/injector/src/node_js.zig
@@ -10,7 +10,7 @@ const types = @import("types.zig");
 const testing = std.testing;
 
 pub const node_options_env_var_name = "NODE_OPTIONS";
-const dash0_nodejs_otel_sdk_distribution = "/__dash0__/instrumentation/node.js/node_modules/@dash0hq/opentelemetry";
+const dash0_nodejs_otel_sdk_distribution = "/__dash0__/instrumentation/node.js/node_modules/@dash0/opentelemetry";
 const require_dash0_nodejs_otel_sdk_distribution = "--require " ++ dash0_nodejs_otel_sdk_distribution;
 const injection_happened_msg = "injecting the Dash0 Node.js OpenTelemetry distribution";
 
@@ -62,7 +62,7 @@ fn getModifiedNodeOptionsValue(original_value_optional: ?[:0]const u8) ?types.Nu
 test "getModifiedNodeOptionsValue: should return --require if original value is unset" {
     const modifiedNodeOptionsValue = getModifiedNodeOptionsValue(null);
     try testing.expectEqualStrings(
-        "--require /__dash0__/instrumentation/node.js/node_modules/@dash0hq/opentelemetry",
+        "--require /__dash0__/instrumentation/node.js/node_modules/@dash0/opentelemetry",
         std.mem.span(modifiedNodeOptionsValue orelse "-"),
     );
 }
@@ -71,7 +71,7 @@ test "getModifiedNodeOptionsValue: should prepend --require if original value ex
     const original_value: [:0]const u8 = "--abort-on-uncaught-exception"[0.. :0];
     const modified_node_options_value = getModifiedNodeOptionsValue(original_value);
     try testing.expectEqualStrings(
-        "--require /__dash0__/instrumentation/node.js/node_modules/@dash0hq/opentelemetry --abort-on-uncaught-exception",
+        "--require /__dash0__/instrumentation/node.js/node_modules/@dash0/opentelemetry --abort-on-uncaught-exception",
         std.mem.span(modified_node_options_value orelse "-"),
     );
 }

--- a/images/instrumentation/injector/test/scripts/create-inaccessible-sdk-dummy-files.sh
+++ b/images/instrumentation/injector/test/scripts/create-inaccessible-sdk-dummy-files.sh
@@ -4,8 +4,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Add an inaccessible dummy Dash0 OTel SDKs/distros.
-mkdir -p /__dash0__/instrumentation/node.js/node_modules/@dash0hq/opentelemetry
-touch /__dash0__/instrumentation/node.js/node_modules/@dash0hq/opentelemetry/index.js
+mkdir -p /__dash0__/instrumentation/node.js/node_modules/@dash0/opentelemetry
+touch /__dash0__/instrumentation/node.js/node_modules/@dash0/opentelemetry/index.js
 mkdir -p /__dash0__/instrumentation/jvm && touch /__dash0__/instrumentation/jvm/opentelemetry-javaagent.jar
 chmod -R 600 /__dash0__/instrumentation
 

--- a/images/instrumentation/injector/test/scripts/create-sdk-dummy-files.sh
+++ b/images/instrumentation/injector/test/scripts/create-sdk-dummy-files.sh
@@ -4,8 +4,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Add dummy Dash0 OTel SDKs/distros which actually do nothing but make the file check in the injector pass.
-mkdir -p /__dash0__/instrumentation/node.js/node_modules/@dash0hq/opentelemetry
-touch /__dash0__/instrumentation/node.js/node_modules/@dash0hq/opentelemetry/index.js
+mkdir -p /__dash0__/instrumentation/node.js/node_modules/@dash0/opentelemetry
+touch /__dash0__/instrumentation/node.js/node_modules/@dash0/opentelemetry/index.js
 mkdir -p /__dash0__/instrumentation/jvm
 touch /__dash0__/instrumentation/jvm/opentelemetry-javaagent.jar
 

--- a/images/instrumentation/injector/test/scripts/default.tests
+++ b/images/instrumentation/injector/test/scripts/default.tests
@@ -19,23 +19,23 @@ run_test_case \
   "getenv: overrides NODE_OPTIONS if it is not present" \
   "app" \
   "node index.js node_options" \
-  "NODE_OPTIONS: --require /__dash0__/instrumentation/node.js/node_modules/@dash0hq/opentelemetry"
+  "NODE_OPTIONS: --require /__dash0__/instrumentation/node.js/node_modules/@dash0/opentelemetry"
 run_test_case \
   "getenv: ask for NODE_OPTIONS (unset) twice" \
   "app" \
   "node index.js node_options_twice" \
-  "NODE_OPTIONS: --require /__dash0__/instrumentation/node.js/node_modules/@dash0hq/opentelemetry; NODE_OPTIONS: --require /__dash0__/instrumentation/node.js/node_modules/@dash0hq/opentelemetry"
+  "NODE_OPTIONS: --require /__dash0__/instrumentation/node.js/node_modules/@dash0/opentelemetry; NODE_OPTIONS: --require /__dash0__/instrumentation/node.js/node_modules/@dash0/opentelemetry"
 run_test_case \
   "getenv: prepends to NODE_OPTIONS if it is present" \
   "app" \
   "node index.js node_options" \
-  "NODE_OPTIONS: --require /__dash0__/instrumentation/node.js/node_modules/@dash0hq/opentelemetry --no-deprecation" \
+  "NODE_OPTIONS: --require /__dash0__/instrumentation/node.js/node_modules/@dash0/opentelemetry --no-deprecation" \
   "NODE_OPTIONS=--no-deprecation"
 run_test_case \
   "getenv: ask for NODE_OPTIONS (set) twice" \
   "app" \
   "node index.js node_options_twice" \
-  "NODE_OPTIONS: --require /__dash0__/instrumentation/node.js/node_modules/@dash0hq/opentelemetry --no-deprecation; NODE_OPTIONS: --require /__dash0__/instrumentation/node.js/node_modules/@dash0hq/opentelemetry --no-deprecation" \
+  "NODE_OPTIONS: --require /__dash0__/instrumentation/node.js/node_modules/@dash0/opentelemetry --no-deprecation; NODE_OPTIONS: --require /__dash0__/instrumentation/node.js/node_modules/@dash0/opentelemetry --no-deprecation" \
   "NODE_OPTIONS=--no-deprecation"
 
 # JAVA_TOOL_OPTIONS

--- a/images/instrumentation/node.js/.gitignore
+++ b/images/instrumentation/node.js/.gitignore
@@ -1,1 +1,1 @@
-dash0hq-opentelemetry-*.tgz
+dash0-opentelemetry-*.tgz

--- a/images/instrumentation/node.js/build.sh
+++ b/images/instrumentation/node.js/build.sh
@@ -4,12 +4,12 @@ set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
 if [[ "${USE_LOCAL_SOURCES_FOR_NODEJS_DISTRIBUTION:-}" = "true" ]]; then
-  echo "Node.js: using the local sources for @dash0hq/opentelemetry"
-  rm -f dash0hq-opentelemetry-*.tgz
+  echo "Node.js: using the local sources for @dash0/opentelemetry"
+  rm -f dash0-opentelemetry-*.tgz
   pushd ../../../../opentelemetry-js-distribution > /dev/null
   npm pack
   popd > /dev/null
-  cp ../../../../opentelemetry-js-distribution/dash0hq-opentelemetry-*.tgz .
+  cp ../../../../opentelemetry-js-distribution/dash0-opentelemetry-*.tgz .
 
   NPM_CONFIG_UPDATE_NOTIFIER=false \
     npm install \
@@ -18,8 +18,8 @@ if [[ "${USE_LOCAL_SOURCES_FOR_NODEJS_DISTRIBUTION:-}" = "true" ]]; then
     --omit=dev \
     --no-audit \
     --no-fund=true \
-    dash0hq-opentelemetry-*.tgz
+    dash0-opentelemetry-*.tgz
 else
-  rm -f dash0hq-opentelemetry-*.tgz
+  rm -f dash0-opentelemetry-*.tgz
   rm -rf node_modules
 fi

--- a/images/instrumentation/node.js/package-lock.json
+++ b/images/instrumentation/node.js/package-lock.json
@@ -5,13 +5,13 @@
   "packages": {
     "": {
       "dependencies": {
-        "@dash0hq/opentelemetry": "2.0.7"
+        "@dash0/opentelemetry": "3.0.0"
       }
     },
-    "node_modules/@dash0hq/opentelemetry": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@dash0hq/opentelemetry/-/opentelemetry-2.0.7.tgz",
-      "integrity": "sha512-l480Rqo5hYrn/FOGigeDOPfSrJJa0K+nkGOAMX4+AtkfQ/hC9mQXtmMU7q8QRRxroKsvvayAcqLviXU9tkTtmA==",
+    "node_modules/@dash0/opentelemetry": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@dash0/opentelemetry/-/opentelemetry-3.0.0.tgz",
+      "integrity": "sha512-Vx3SzjAI2PiMHXmRstKcvSBhGTU7f51XGw3pn7XzLhQI92IOspwLs2vja/rSwMmf/8TYlRBUx3F81lnlTHFphg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",

--- a/images/instrumentation/node.js/package.json
+++ b/images/instrumentation/node.js/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "@dash0hq/opentelemetry": "2.0.7"
+    "@dash0/opentelemetry": "3.0.0"
   }
 }

--- a/images/instrumentation/test/node/test-cases/node-options-already-set/index.js
+++ b/images/instrumentation/test/node/test-cases/node-options-already-set/index.js
@@ -5,7 +5,7 @@ const process = require('node:process');
 
 if (
   process.env['NODE_OPTIONS'] !==
-  '--require /__dash0__/instrumentation/node.js/node_modules/@dash0hq/opentelemetry --no-deprecation'
+  '--require /__dash0__/instrumentation/node.js/node_modules/@dash0/opentelemetry --no-deprecation'
 ) {
   console.error(`Unexpected value for NODE_OPTIONS: ${process.env['NODE_OPTIONS']}`);
   process.exit(1);

--- a/images/instrumentation/test/node/test-cases/node-options-unset/index.js
+++ b/images/instrumentation/test/node/test-cases/node-options-unset/index.js
@@ -4,7 +4,7 @@
 const process = require('node:process');
 
 if (
-  process.env['NODE_OPTIONS'] !== '--require /__dash0__/instrumentation/node.js/node_modules/@dash0hq/opentelemetry'
+  process.env['NODE_OPTIONS'] !== '--require /__dash0__/instrumentation/node.js/node_modules/@dash0/opentelemetry'
 ) {
   console.error(`Unexpected value for NODE_OPTIONS: ${process.env['NODE_OPTIONS']}`);
   process.exit(1);

--- a/images/instrumentation/test/node/test-cases/verify-distro-is-loaded/index.js
+++ b/images/instrumentation/test/node/test-cases/verify-distro-is-loaded/index.js
@@ -6,9 +6,9 @@ const process = require('node:process');
 const loadedModules = Object.keys(require.cache);
 if (
   !loadedModules.includes(
-    '/__dash0__/instrumentation/node.js/node_modules/@dash0hq/opentelemetry/dist/src/1.x/init.js',
+    '/__dash0__/instrumentation/node.js/node_modules/@dash0/opentelemetry/dist/src/1.x/init.js',
   ) &&
-  !loadedModules.includes('/__dash0__/instrumentation/node.js/node_modules/@dash0hq/opentelemetry/dist/src/2.x/init.js')
+  !loadedModules.includes('/__dash0__/instrumentation/node.js/node_modules/@dash0/opentelemetry/dist/src/2.x/init.js')
 ) {
   console.error(`It looks like the Dash0 Node.js OpenTelemetry distribution has not been loaded.`);
   process.exit(1);


### PR DESCRIPTION
The Dash0 Node.js OpenTelemetry is now under a new organization/scope, moving from @dash0hq/opentelemetry to @dash0/opentelemetry.