### PR TITLE
feat(collectors): enable Kubernetes volume metrics

### DIFF
--- a/internal/collectors/otelcolresources/daemonset.config.yaml.template
+++ b/internal/collectors/otelcolresources/daemonset.config.yaml.template
@@ -49,6 +49,11 @@ receivers:
 {{- /* Note: Even if we use K8s_NODE_IP for the endpoint, it is still correct to use K8S_NODE_NAME for 'node'. The node
       value will only be used as a resource attribute. */}}
     node: '${env:K8S_NODE_NAME}'
+    metric_groups:
+    - container
+    - pod
+    - node
+    - volume
     k8s_api_config:
       auth_type: serviceAccount
     metrics:
@@ -75,6 +80,15 @@ receivers:
         enabled: true
       k8s.pod.memory_request_utilization:
         enabled: true
+      # With metric_groups including "volume" (see above), volume metrics will be collected. Disable the inode-related
+      # metrics, and only leave k8s.volume.available and k8s.volume.capacity enabled (they are enabled by default if
+      # the metric group volume is explicitly enabled via metric_groups).
+      k8s.volume.inodes:
+        enabled: false
+      k8s.volume.inodes.free:
+        enabled: false
+      k8s.volume.inodes.used:
+        enabled: false
 
 {{- end }}{{/* if .KubeletStatsReceiverConfig.Enabled */}}
 

--- a/test/e2e/kubeletstats_receiver_metrics.txt
+++ b/test/e2e/kubeletstats_receiver_metrics.txt
@@ -56,6 +56,3 @@ k8s.pod.network.io
 k8s.pod.uptime
 k8s.volume.available
 k8s.volume.capacity
-k8s.volume.inodes
-k8s.volume.inodes.free
-k8s.volume.inodes.used


### PR DESCRIPTION
Add the following Kubernetes volume metrics for volumes in monitored
namespaces:
- k8s.volume.available
- k8s.volume.capacity

If you do not want to collect these metrics, they can be disabled via
filters in the Dash0 monitoring resource or via spam filters in Dash0.

Inode-related metrics are disabled at the moment, that is, the following
metrics are not collected:
- k8s.volume.inodes
- k8s.volume.inodes.free
- k8s.volume.inodes.used