### PR TITLE
fix(injector): merge OTEL_RESOURCE_ATTRIBUTES into JAVA_TOOL_OPTIONS

### DIFF
--- a/images/instrumentation/Dockerfile
+++ b/images/instrumentation/Dockerfile
@@ -12,7 +12,7 @@ RUN source /dash0-init-container/zig-version && \
 COPY injector /dash0-init-container
 WORKDIR /dash0-init-container
 ARG TARGETARCH
-RUN zig build -Dcpu-arch=${TARGETARCH} --summary all
+RUN zig build -Dcpu-arch=${TARGETARCH} --prominent-compile-errors --summary none
 
 # injector_build_end - do not remove this line (see images/instrumentation/injector/test/scripts/test-all.sh)
 
@@ -25,7 +25,7 @@ RUN ./mvnw dependency:copy-dependencies \
   && cp pom.xml ./build/pom.xml
 
 # build Node.js artifacts
-FROM node:22.15.0-alpine3.21 AS build-node.js
+FROM node:22.15.0-alpine3.21 AS build-node-js
 RUN mkdir -p /dash0-init-container/instrumentation/node.js
 WORKDIR /dash0-init-container/instrumentation/node.js
 COPY node.js/package* .
@@ -56,7 +56,7 @@ COPY --from=build-injector /dash0-init-container/dash0_injector.so /dash0-init-c
 COPY --from=build-dotnet /glibc /dash0-init-container/instrumentation/dotnet/glibc
 COPY --from=build-dotnet /musl /dash0-init-container/instrumentation/dotnet/musl
 COPY --from=build-jvm /dash0-init-container/instrumentation/jvm/build /dash0-init-container/instrumentation/jvm
-COPY --from=build-node.js /dash0-init-container/instrumentation/node.js /dash0-init-container/instrumentation/node.js
+COPY --from=build-node-js /dash0-init-container/instrumentation/node.js /dash0-init-container/instrumentation/node.js
 
 WORKDIR /
 CMD ["/copy-instrumentation.sh"]

--- a/images/instrumentation/injector/src/root.zig
+++ b/images/instrumentation/injector/src/root.zig
@@ -86,7 +86,8 @@ fn getEnvValue(name: [:0]const u8) ?types.NullTerminatedString {
         }
     } else if (std.mem.eql(u8, name, jvm.java_tool_options_env_var_name)) {
         if (!modified_java_tool_options_value_calculated) {
-            modified_java_tool_options_value = jvm.checkOTelJavaAgentJarAndGetModifiedJavaToolOptionsValue(original_value);
+            modified_java_tool_options_value =
+                jvm.checkOTelJavaAgentJarAndGetModifiedJavaToolOptionsValue(original_value);
             modified_java_tool_options_value_calculated = true;
         }
         if (modified_java_tool_options_value) |updated_value| {

--- a/images/instrumentation/injector/src/test_util.zig
+++ b/images/instrumentation/injector/src/test_util.zig
@@ -18,7 +18,7 @@ pub fn clearStdCEnviron() anyerror![*:null]?[*:0]u8 {
     return original_environ;
 }
 
-/// Sets the given key value pairs as the only content of std.c.environ. Everything else in std.c.environ is discarded.
+/// Sets the given key-value pairs as the only content of std.c.environ. Everything else in std.c.environ is discarded.
 /// The original content before making any changes is returned. The caller is expected to reset std.c.environ to
 /// the return value of this function when the test is done, for example by calling
 /// `defer resetStdCEnviron(original_environ);` directly after calling this function (where original_environ is the

--- a/images/instrumentation/injector/test/README.md
+++ b/images/instrumentation/injector/test/README.md
@@ -18,11 +18,18 @@ Usage
   Can be combined with `LIBC_FLAVORS` and other flags.
 * `LIBC_FLAVORS=glibc,musl scripts/test-all.sh` to run tests for a subset of libc flavors.
   Can be combined with `ARCHITECTURES` and other flags.
-* `TEST_CASES=twice,mapped scripts/test-all.sh` to only run tests cases whose names contain one of the
-  provided strings.
+* `TEST_SETS=default,sdk-cannot-be-accessed` to only run a subset of test sets  The test set names are the different
+  `scripts/*.tests` files. Can be combined with `ARCHITECTURES`, `LIBC_FLAVORS` etc.
+* `TEST_CASES="getenv: overrides NODE_OPTIONS if it is not present" scripts/test-all.sh` to only run tests cases whose
+  names _exactly match_ one of the provided strings.
+  The test cases are listed in the different test sets, i.e. the `scripts/*.tests` files.
+  Can be combined with `ARCHITECTURES`, `LIBC_FLAVORS` etc., cannot be combined with `TEST_CASES_CONTAINING`.
+* `TEST_CASES_CONTAINING=OTEL_RESOURCE_ATTRIBUTES,OTEL_RESOURCE_ATTRIBUTES scripts/test-all.sh` to only run tests cases
+  whose names _contain_ one of the provided strings as a substring.
   The test cases are listed in the different `scripts/*.tests` files.
-  Can be combined with `ARCHITECTURES`, `LIBC_FLAVORS` etc.
+  Can be combined with `ARCHITECTURES`, `LIBC_FLAVORS` etc., cannot be combined with `TEST_CASES`.
 * `INSTRUMENTATION_IMAGE=... scripts/test-all.sh` use an existing local or remote instrumentation image.
+* Set `VERBOSE=true` to always include the output from running the test case. Otherwise, the output is only
+  printed to stdout when a test case fails.
 * `MISSING_ENVIRON_SYMBOL_TESTS=true` also run tests with a binary that does not provide an `__environ` symbol.
   These are currently off by default.
-

--- a/images/instrumentation/injector/test/docker/Dockerfile-test
+++ b/images/instrumentation/injector/test/docker/Dockerfile-test
@@ -4,6 +4,21 @@
 ARG base_image="node:22.15.0-bookworm-slim"
 FROM ${base_image}
 
+
+ARG arch_under_test
+RUN if [ -z "$arch_under_test" ]; then \
+      echo "Error: build argument arch_under_test is required but not set."; \
+      exit 1; \
+    fi
+ENV ARCH_UNDER_TEST=${arch_under_test}
+
+ARG libc_under_test
+RUN if [ -z "libc_under_test" ]; then \
+      echo "Error: build argument libc_under_test is required but not set."; \
+      exit 1; \
+    fi
+ENV LIBC_UNDER_TEST=${libc_under_test}
+
 ARG injector_binary
 RUN if [ -z "$injector_binary" ]; then \
       echo "Error: build argument injector_binary is required but not set."; \
@@ -37,18 +52,6 @@ COPY bin/${injector_binary} /dash0-init-container/injector/dash0_injector.so
 
 RUN ${create_sdk_dummy_files_script}
 
-ARG arch_under_test
-RUN if [ -z "$arch_under_test" ]; then \
-      echo "Error: build argument arch_under_test is required but not set."; \
-      exit 1; \
-    fi
-ENV ARCH_UNDER_TEST=${arch_under_test}
-ARG libc_under_test
-RUN if [ -z "libc_under_test" ]; then \
-      echo "Error: build argument libc_under_test is required but not set."; \
-      exit 1; \
-    fi
-ENV LIBC_UNDER_TEST=${libc_under_test}
 
 USER node
 CMD ["scripts/run-tests-within-container.sh"]

--- a/images/instrumentation/injector/test/scripts/default.tests
+++ b/images/instrumentation/injector/test/scripts/default.tests
@@ -51,11 +51,30 @@ run_test_case \
   "JAVA_TOOL_OPTIONS: -some-option -javaagent:/__dash0__/instrumentation/jvm/opentelemetry-javaagent.jar -Dotel.resource.attributes=k8s.namespace.name=my-namespace,k8s.pod.name=my-pod,k8s.pod.uid=275ecb36-5aa8-4c2a-9c47-d8bb681b9aff,k8s.container.name=test-app" \
   "JAVA_TOOL_OPTIONS=-some-option"
 run_test_case \
-  "getenv: merges existing -Dotel.resource.attributes" \
+  "getenv: merges existing -Dotel.resource.attributes in JAVA_TOOL_OPTIONS" \
   "app" \
   "node index.js java_tool_options" \
   "JAVA_TOOL_OPTIONS: -Dotel.resource.attributes=my.attr1=value1,my.attr2=value2,k8s.namespace.name=my-namespace,k8s.pod.name=my-pod,k8s.pod.uid=275ecb36-5aa8-4c2a-9c47-d8bb681b9aff,k8s.container.name=test-app -javaagent:/__dash0__/instrumentation/jvm/opentelemetry-javaagent.jar" \
   "JAVA_TOOL_OPTIONS=-Dotel.resource.attributes=my.attr1=value1,my.attr2=value2"
+run_test_case \
+  "getenv: merges existing OTEL_RESOURCE_ATTRIBUTES if JAVA_TOOL_OPTIONS is not set" \
+  "app" \
+  "node index.js java_tool_options" \
+  "JAVA_TOOL_OPTIONS: -javaagent:/__dash0__/instrumentation/jvm/opentelemetry-javaagent.jar -Dotel.resource.attributes=my.attr1=value1,my.attr2=value2,k8s.namespace.name=my-namespace,k8s.pod.name=my-pod,k8s.pod.uid=275ecb36-5aa8-4c2a-9c47-d8bb681b9aff,k8s.container.name=test-app" \
+  "OTEL_RESOURCE_ATTRIBUTES=my.attr1=value1,my.attr2=value2"
+run_test_case \
+  "getenv: merges existing OTEL_RESOURCE_ATTRIBUTES if JAVA_TOOL_OPTIONS is set but does not have -Dotel.resource.attributes" \
+  "app" \
+  "node index.js java_tool_options" \
+  "JAVA_TOOL_OPTIONS: -some-option -javaagent:/__dash0__/instrumentation/jvm/opentelemetry-javaagent.jar -Dotel.resource.attributes=my.attr1=value1,my.attr2=value2,k8s.namespace.name=my-namespace,k8s.pod.name=my-pod,k8s.pod.uid=275ecb36-5aa8-4c2a-9c47-d8bb681b9aff,k8s.container.name=test-app" \
+  "OTEL_RESOURCE_ATTRIBUTES=my.attr1=value1,my.attr2=value2 JAVA_TOOL_OPTIONS=-some-option"
+# The Java OTel SDK will ignore OTEL_RESOURCE_ATTRIBUTES if JAVA_TOOL_OPTIONS and has -Dotel.resource.attributes is set, so we replicate this behavior.R
+run_test_case \
+  "getenv: do not merge existing OTEL_RESOURCE_ATTRIBUTES if JAVA_TOOL_OPTIONS and has -Dotel.resource.attributes" \
+  "app" \
+  "node index.js java_tool_options" \
+  "JAVA_TOOL_OPTIONS: -Dotel.resource.attributes=my.attr3=value3,my.attr4=value4,k8s.namespace.name=my-namespace,k8s.pod.name=my-pod,k8s.pod.uid=275ecb36-5aa8-4c2a-9c47-d8bb681b9aff,k8s.container.name=test-app -javaagent:/__dash0__/instrumentation/jvm/opentelemetry-javaagent.jar" \
+  "OTEL_RESOURCE_ATTRIBUTES=my.attr1=value1,my.attr2=value2 JAVA_TOOL_OPTIONS=-Dotel.resource.attributes=my.attr3=value3,my.attr4=value4"
 
 # OTEL_RESOURCE_ATTRIBUTES
 run_test_case \

--- a/images/instrumentation/injector/test/scripts/run-tests-for-container.sh
+++ b/images/instrumentation/injector/test/scripts/run-tests-for-container.sh
@@ -80,7 +80,9 @@ docker run \
   --env EXPECTED_CPU_ARCHITECTURE="$expected_cpu_architecture" \
   --env TEST_SET="$TEST_SET" \
   --env TEST_CASES="$TEST_CASES" \
+  --env TEST_CASES_CONTAINING="$TEST_CASES_CONTAINING" \
   --env MISSING_ENVIRON_SYMBOL_TESTS="${MISSING_ENVIRON_SYMBOL_TESTS:-}" \
+  --env VERBOSE="${VERBOSE:-}" \
   "$image_name" \
   $docker_run_extra_arguments
 { set +x; } 2> /dev/null

--- a/images/instrumentation/injector/watch-zig-build.sh
+++ b/images/instrumentation/injector/watch-zig-build.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright 2025 Dash0 Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+fd -e zig | entr ./zig-build.sh

--- a/images/instrumentation/injector/watch-zig-test.sh
+++ b/images/instrumentation/injector/watch-zig-test.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright 2025 Dash0 Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+fd -e zig | entr ./zig-test.sh

--- a/images/instrumentation/injector/zig-build.sh
+++ b/images/instrumentation/injector/zig-build.sh
@@ -7,12 +7,16 @@
 # cd images/instrumentation/injector
 # fd | entr ./zig-build.sh
 # ...to get fast feedback on compile errors when working on the Zig code.
+# See also: ./watch-zig-build.sh
+# The point is that `zig build` does not print anything when there have been no changes since the last successful build,
+# which makes it hard to tell (when using entr) whether the build is still ongoing or there simply was nothing to do.
+# This script will simply print a message indicating the successful build to circumvent this.
 
 set -euo pipefail
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
-if zig build; then
+if zig build --prominent-compile-errors --summary none; then
   echo "$(date) build successful"
   echo
 else

--- a/images/instrumentation/injector/zig-test.sh
+++ b/images/instrumentation/injector/zig-test.sh
@@ -7,12 +7,16 @@
 # cd images/instrumentation/injector
 # fd | entr ./zig-test.sh
 # ...to get fast feedback on test errors when working on the Zig code.
+# See also: ./watch-zig-test.sh
+# The point is that `zig build test` does not print anything when there have been no changes since the last successful
+# build, which makes it hard to tell (when using entr) whether the build is still ongoing or there simply was nothing
+# to do. This script will simply print a message indicating the successful build to circumvent this.
 
 set -euo pipefail
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
-if zig build test; then
+if zig build test --prominent-compile-errors --summary none; then
   echo "$(date) tests successful"
   echo
 else

--- a/images/instrumentation/test/.gitignore
+++ b/images/instrumentation/test/.gitignore
@@ -1,3 +1,5 @@
 node_modules/
 .containers_to_be_deleted_at_end
 .container_images_to_be_deleted_at_end
+*.class
+*.jar

--- a/images/instrumentation/test/cleanup.sh
+++ b/images/instrumentation/test/cleanup.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright 2025 Dash0 Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+find . -type f -name \*.o -delete
+find . -type f -name \*.class -delete
+find . -type f -name \*.jar -delete
+

--- a/images/instrumentation/test/jvm/test-cases/otel-resource-attributes-env-var-already-set/Main.java
+++ b/images/instrumentation/test/jvm/test-cases/otel-resource-attributes-env-var-already-set/Main.java
@@ -3,15 +3,11 @@ import static com.dash0.injector.testutils.TestUtils.*;
 public class Main {
 
     public static void main(String[] args) {
-        // The injector will not override the environment variable OTEL_RESOURCE_ATTRIBUTES, but that is ignored by the
-        // OTel Java SDK anyway.
-        verifyEnvVar("OTEL_RESOURCE_ATTRIBUTES", "key1=value1,key2=value2");
-
         // The injector will inject -Dotel.resource.attributes into JAVA_TOOL_OPTIONS, independent of the
         // OTEL_RESOURCE_ATTRIBUTES environment variable.
         verifyProperty(
                 "otel.resource.attributes",
-                "k8s.namespace.name=namespace,k8s.pod.name=pod_name,k8s.pod.uid=pod_uid,k8s.container.name=container_name"
+                "key1=value1,key2=value2,k8s.namespace.name=namespace,k8s.pod.name=pod_name,k8s.pod.uid=pod_uid,k8s.container.name=container_name"
         );
     }
 }

--- a/internal/startup/auto_operator_configuration_handler.go
+++ b/internal/startup/auto_operator_configuration_handler.go
@@ -47,6 +47,10 @@ type AutoOperatorConfigurationResourceHandler struct {
 
 const (
 	operatorConfigurationAutoResourceName = "dash0-operator-configuration-auto-resource"
+
+	argoCdAyncOptionsAnnotationKey    = "argocd.argoproj.io/sync-options"
+	argoCdCompareOptionsAnnotationKey = "argocd.argoproj.io/compare-options"
+	managedByHelmAnnotationKey        = "dash0.com/managed-by-helm"
 )
 
 // CreateOrUpdateOperatorConfigurationResource creates or updates the Dash0 operator configuration resource. The
@@ -271,8 +275,14 @@ func convertValuesToResource(operatorConfigurationValues *OperatorConfigurationV
 				// * The docs for preventing this on a resource level are here:
 				//   https://argo-cd.readthedocs.io/en/stable/user-guide/sync-options/#no-prune-resources
 				//   https://argo-cd.readthedocs.io/en/stable/user-guide/compare-options/#ignoring-resources-that-are-extraneous
-				"argocd.argoproj.io/sync-options":    "Prune=false",
-				"argocd.argoproj.io/compare-options": "IgnoreExtraneous",
+				argoCdAyncOptionsAnnotationKey:    "Prune=false",
+				argoCdCompareOptionsAnnotationKey: "IgnoreExtraneous",
+				managedByHelmAnnotationKey: "DO NOT EDIT THIS RESOURCE. This operator configuration resource is " +
+					"managed by the operator Helm chart (Helm values operator.dash0Export.*), manual modifications " +
+					"to this resource (i.e. via kubectl or k9s) will be overwritten when the operator manager is " +
+					"restarted or the operator is updated to a new version. See " +
+					"https://github.com/dash0hq/dash0-operator/blob/main/helm-chart/dash0-operator/README.md#" +
+					"notes-on-creating-the-operator-configuration-resource-via-helm.",
 			},
 		},
 		Spec: dash0v1alpha1.Dash0OperatorConfigurationSpec{

--- a/internal/startup/auto_operator_configuration_handler_test.go
+++ b/internal/startup/auto_operator_configuration_handler_test.go
@@ -92,9 +92,15 @@ var _ = Describe("Create an operator configuration resource at startup", Ordered
 			}, &operatorConfiguration)
 			g.Expect(err).ToNot(HaveOccurred())
 
-			g.Expect(operatorConfiguration.Annotations).To(HaveLen(2))
+			g.Expect(operatorConfiguration.Annotations).To(HaveLen(3))
 			g.Expect(operatorConfiguration.Annotations["argocd.argoproj.io/sync-options"]).To(Equal("Prune=false"))
 			g.Expect(operatorConfiguration.Annotations["argocd.argoproj.io/compare-options"]).To(Equal("IgnoreExtraneous"))
+			g.Expect(operatorConfiguration.Annotations[managedByHelmAnnotationKey]).To(Equal(
+				"DO NOT EDIT THIS RESOURCE. This operator configuration resource is managed by the operator Helm " +
+					"chart (Helm values operator.dash0Export.*), manual modifications to this resource (i.e. via " +
+					"kubectl or k9s) will be overwritten when the operator manager is restarted or the operator is " +
+					"updated to a new version. See https://github.com/dash0hq/dash0-operator/blob/main/helm-chart/" +
+					"dash0-operator/README.md#notes-on-creating-the-operator-configuration-resource-via-helm."))
 
 			spec := operatorConfiguration.Spec
 			export := spec.Export
@@ -126,7 +132,7 @@ var _ = Describe("Create an operator configuration resource at startup", Ordered
 			}, &operatorConfiguration)
 			g.Expect(err).ToNot(HaveOccurred())
 
-			g.Expect(operatorConfiguration.Annotations).To(HaveLen(2))
+			g.Expect(operatorConfiguration.Annotations).To(HaveLen(3))
 			g.Expect(operatorConfiguration.Annotations["argocd.argoproj.io/sync-options"]).To(Equal("Prune=false"))
 			g.Expect(operatorConfiguration.Annotations["argocd.argoproj.io/compare-options"]).To(Equal("IgnoreExtraneous"))
 
@@ -159,7 +165,7 @@ var _ = Describe("Create an operator configuration resource at startup", Ordered
 			}, &operatorConfiguration)
 			g.Expect(err).ToNot(HaveOccurred())
 
-			g.Expect(operatorConfiguration.Annotations).To(HaveLen(2))
+			g.Expect(operatorConfiguration.Annotations).To(HaveLen(3))
 			g.Expect(operatorConfiguration.Annotations["argocd.argoproj.io/sync-options"]).To(Equal("Prune=false"))
 			g.Expect(operatorConfiguration.Annotations["argocd.argoproj.io/compare-options"]).To(Equal("IgnoreExtraneous"))
 
@@ -186,7 +192,7 @@ var _ = Describe("Create an operator configuration resource at startup", Ordered
 			}, &operatorConfiguration)
 			g.Expect(err).ToNot(HaveOccurred())
 
-			g.Expect(operatorConfiguration.Annotations).To(HaveLen(2))
+			g.Expect(operatorConfiguration.Annotations).To(HaveLen(3))
 			g.Expect(operatorConfiguration.Annotations["argocd.argoproj.io/sync-options"]).To(Equal("Prune=false"))
 			g.Expect(operatorConfiguration.Annotations["argocd.argoproj.io/compare-options"]).To(Equal("IgnoreExtraneous"))
 
@@ -213,7 +219,7 @@ var _ = Describe("Create an operator configuration resource at startup", Ordered
 			}, &operatorConfiguration)
 			g.Expect(err).ToNot(HaveOccurred())
 
-			g.Expect(operatorConfiguration.Annotations).To(HaveLen(2))
+			g.Expect(operatorConfiguration.Annotations).To(HaveLen(3))
 			g.Expect(operatorConfiguration.Annotations["argocd.argoproj.io/sync-options"]).To(Equal("Prune=false"))
 			g.Expect(operatorConfiguration.Annotations["argocd.argoproj.io/compare-options"]).To(Equal("IgnoreExtraneous"))
 
@@ -244,9 +250,10 @@ var _ = Describe("Create an operator configuration resource at startup", Ordered
 			g.Expect(list.Items).To(HaveLen(1))
 			operatorConfiguration := list.Items[0]
 			g.Expect(operatorConfiguration.Name).To(Equal(operatorConfigurationAutoResourceName))
-			g.Expect(operatorConfiguration.Annotations).To(HaveLen(2))
+			g.Expect(operatorConfiguration.Annotations).To(HaveLen(3))
 			g.Expect(operatorConfiguration.Annotations["argocd.argoproj.io/sync-options"]).To(Equal("Prune=false"))
 			g.Expect(operatorConfiguration.Annotations["argocd.argoproj.io/compare-options"]).To(Equal("IgnoreExtraneous"))
+
 			export := operatorConfiguration.Spec.Export
 			g.Expect(export).ToNot(BeNil())
 			dash0Export := export.Dash0
@@ -285,7 +292,7 @@ var _ = Describe("Create an operator configuration resource at startup", Ordered
 			g.Expect(list.Items).To(HaveLen(1))
 			operatorConfiguration := list.Items[0]
 			g.Expect(operatorConfiguration.Name).To(Equal(operatorConfigurationAutoResourceName))
-			g.Expect(operatorConfiguration.Annotations).To(HaveLen(2))
+			g.Expect(operatorConfiguration.Annotations).To(HaveLen(3))
 			g.Expect(operatorConfiguration.Annotations["argocd.argoproj.io/sync-options"]).To(Equal("Prune=false"))
 			g.Expect(operatorConfiguration.Annotations["argocd.argoproj.io/compare-options"]).To(Equal("IgnoreExtraneous"))
 			export := operatorConfiguration.Spec.Export


### PR DESCRIPTION
OpenTelemetry resource attributes can be set for the JVM via the
OTEL_RESOURCE_ATTRIBUTES environment variable or by adding the system
property -Dotel.resource.attributes to the JAVA_TOOL_OPTIONS environment
variable. The Java OTel SDK will ignore OTEL_RESOURCE_ATTRIBUTES if
-Dotel.resource.attributes is set.

The Dash0 injector will add -Dotel.resource.attributes to
JAVA_TOOL_OPTIONS to add useful Kubernetes-related resource attributes
like pod uid, pod name etc. This can accidentally discard user-provided
values from OTEL_RESOURCE_ATTRIBUTES.

This fix makes the injector merge the values from
OTEL_RESOURCE_ATTRIBUTES into -Dotel.resource.attributes in situations
where this is appropriate.