### PR TITLE
feat(deployment): custom kube rbac image option

### DIFF
--- a/helm-chart/dash0-operator/templates/_helpers.tpl
+++ b/helm-chart/dash0-operator/templates/_helpers.tpl
@@ -65,6 +65,15 @@ helm.sh/chart: {{ include "dash0-operator.chartNameWithVersion" . }}
 {{- include "dash0-operator.imageRef" (dict "image" .Values.operator.initContainerImage "context" .) -}}
 {{- end }}
 
+{{/* the kube rbac proxy image */}}
+{{- define "dash0-operator.kubeRbacProxyImage" -}}
+{{- if .Values.operator.kubeRbacProxyImage.digest -}}
+{{- printf "%s@%s" .Values.operator.kubeRbacProxyImage.repository .Values.operator.kubeRbacProxyImage.digest }}
+{{- else -}}
+{{- printf "%s:%s" .Values.operator.kubeRbacProxyImage.repository .Values.operator.kubeRbacProxyImage.tag }}
+{{- end }}
+{{- end }}
+
 {{/* the collector image */}}
 {{- define "dash0-operator.collectorImage" -}}
 {{- include "dash0-operator.imageRef" (dict "image" .Values.operator.collectorImage "context" .) -}}

--- a/helm-chart/dash0-operator/templates/operator/deployment-and-webhooks.yaml
+++ b/helm-chart/dash0-operator/templates/operator/deployment-and-webhooks.yaml
@@ -231,7 +231,7 @@ spec:
           initialDelaySeconds: 5
           periodSeconds: 10
       - name: kube-rbac-proxy
-        image: quay.io/brancz/kube-rbac-proxy:v0.18.0
+        image: {{ include "dash0-operator.kubeRbacProxyImage" . | quote }}
         args:
         - --secure-listen-address=0.0.0.0:8443
         - --upstream=http://127.0.0.1:8080/

--- a/helm-chart/dash0-operator/tests/operator/deployment-and-webhooks_test.yaml
+++ b/helm-chart/dash0-operator/tests/operator/deployment-and-webhooks_test.yaml
@@ -585,6 +585,8 @@ tests:
           digest: sha256:e05496f5bcc3c2caf7d2a2944bfc084872d69dd1e9c365a521719c5bbcf4430c
         initContainerImage:
           digest: sha256:1e8c25853217c7393dbd95e17fe2117bb31b39478bbea4479cc5e7c1257dda01
+        kubeRbacProxyImage:
+          digest: sha256:5e8c25853217c7393dbd95e17fe2117bb31b39478bbea4479cc5e7c1257dda05
         collectorImage:
           digest: sha256:2e8c25853217c7393dbd95e17fe2117bb31b39478bbea4479cc5e7c1257dda02
         configurationReloaderImage:
@@ -597,6 +599,9 @@ tests:
           value: ghcr.io/dash0hq/operator-controller@sha256:e05496f5bcc3c2caf7d2a2944bfc084872d69dd1e9c365a521719c5bbcf4430c
       - notExists:
           path: spec.template.spec.containers[0].imagePullPolicy
+      - equal:
+          path: spec.template.spec.containers[1].image
+          value: quay.io/brancz/kube-rbac-proxy@sha256:5e8c25853217c7393dbd95e17fe2117bb31b39478bbea4479cc5e7c1257dda05
       - equal:
           path: spec.template.spec.containers[0].env[4].name
           value: DASH0_OPERATOR_IMAGE
@@ -627,6 +632,99 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].env[8].value
           value: ghcr.io/dash0hq/filelog-offset-sync@sha256:4e8c25853217c7393dbd95e17fe2117bb31b39478bbea4479cc5e7c1257dda04
+      - equal:
+          path: spec.template.spec.containers[0].env[9].name
+          value: K8S_POD_UID
+      - equal:
+          path: spec.template.spec.containers[0].env[9].valueFrom.fieldRef.fieldPath
+          value: metadata.uid
+      - equal:
+          path: spec.template.spec.containers[0].env[10].name
+          value: K8S_NODE_IP
+      - equal:
+          path: spec.template.spec.containers[0].env[10].valueFrom.fieldRef.fieldPath
+          value: status.hostIP
+      - equal:
+          path: spec.template.spec.containers[0].env[11].name
+          value: K8S_NODE_NAME
+      - equal:
+          path: spec.template.spec.containers[0].env[11].valueFrom.fieldRef.fieldPath
+          value: spec.nodeName
+      - equal:
+          path: spec.template.spec.containers[0].env[12].name
+          value: K8S_POD_IP
+      - equal:
+          path: spec.template.spec.containers[0].env[12].valueFrom.fieldRef.fieldPath
+          value: status.podIP
+      - equal:
+          path: spec.template.spec.containers[0].env[13].name
+          value: K8S_POD_NAME
+      - equal:
+          path: spec.template.spec.containers[0].env[13].valueFrom.fieldRef.fieldPath
+          value: metadata.name
+      - notExists:
+          path: spec.template.spec.containers[0].env[14].name
+  
+  - it: deployment should support changing repositories for images
+    chart:
+      version: 4.5.6
+      appVersion: 99.100.101
+    documentSelector:
+      path: metadata.name
+      value: dash0-operator-controller
+    set:
+      operator:
+        image:
+          repository: customrepo.io/repo/custom-operator-controller
+        initContainerImage:
+          repository: customrepo.io/repo/custom-instrumentation
+        kubeRbacProxyImage:
+          repository: customrepo.io/repo/custom-kube-rbac-proxy
+        collectorImage:
+          repository: customrepo.io/repo/custom-collector
+        configurationReloaderImage:
+          repository: customrepo.io/repo/custom-configuration-reloader
+        filelogOffsetSyncImage:
+          repository: customrepo.io/repo/custom-filelog-offset-sync
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: customrepo.io/repo/custom-operator-controller:99.100.101
+      - notExists:
+          path: spec.template.spec.containers[0].imagePullPolicy
+      - equal:
+          path: spec.template.spec.containers[1].image
+          value: customrepo.io/repo/custom-kube-rbac-proxy:v0.18.0
+      - equal:
+          path: spec.template.spec.containers[0].env[4].name
+          value: DASH0_OPERATOR_IMAGE
+      - equal:
+          path: spec.template.spec.containers[0].env[4].value
+          value: customrepo.io/repo/custom-operator-controller:99.100.101
+      - equal:
+          path: spec.template.spec.containers[0].env[5].name
+          value: DASH0_INIT_CONTAINER_IMAGE
+      - equal:
+          path: spec.template.spec.containers[0].env[5].value
+          value: customrepo.io/repo/custom-instrumentation:99.100.101
+      - equal:
+          path: spec.template.spec.containers[0].env[6].name
+          value: DASH0_COLLECTOR_IMAGE
+      - equal:
+          path: spec.template.spec.containers[0].env[6].value
+          value: customrepo.io/repo/custom-collector:99.100.101
+      - equal:
+          path: spec.template.spec.containers[0].env[7].name
+          value: DASH0_CONFIGURATION_RELOADER_IMAGE
+      - equal:
+          path: spec.template.spec.containers[0].env[7].value
+          value: customrepo.io/repo/custom-configuration-reloader:99.100.101
+      - equal:
+          path: spec.template.spec.containers[0].env[8].name
+          value: DASH0_FILELOG_OFFSET_SYNC_IMAGE
+      - equal:
+          path: spec.template.spec.containers[0].env[8].value
+          value: customrepo.io/repo/custom-filelog-offset-sync:99.100.101
       - equal:
           path: spec.template.spec.containers[0].env[9].name
           value: K8S_POD_UID

--- a/helm-chart/dash0-operator/values.yaml
+++ b/helm-chart/dash0-operator/values.yaml
@@ -212,6 +212,18 @@ operator:
     # override the default image pull policy
     pullPolicy:
 
+  # the container image to use for the kube RBAC proxy
+  kubeRbacProxyImage:
+    # Use a different image for the kube RBAC proxy entirely. Note that Dash0 does not offer support for Dash0 operator
+    # setups that do not use Dash0's official kube RBAC proxy image.
+    repository: "quay.io/brancz/kube-rbac-proxy"
+    # overrides the image tag
+    tag: "v0.18.0"
+    # pull image by digest instead of tag; if this is set, the tag value will be ignored
+    digest:
+    # override the default image pull policy
+    pullPolicy:
+
   # the container image to use for the collector component (there should usually be no reason to override this)
   collectorImage:
     repository: "ghcr.io/dash0hq/collector"


### PR DESCRIPTION
For users (like us) that need to deploy the helm chart behind a firewall we need to be able to define custom images.

Added tests and otherwise tried to keep to conventions I've seen.