### PR TITLE
Update PVC documentation with the access mode

### DIFF
--- a/helm-chart/dash0-operator/README.md
+++ b/helm-chart/dash0-operator/README.md
@@ -790,6 +790,9 @@ operator:
         claimName: offset-storage-claim
 ```
 
+**Important:** Since this volume is needed by a Daemonset run by the Dash0 operator, the PersistentVolumeClaim needs
+to be set with the `ReadWriteOnce` access mode.
+
 Using a volume instead of the default config map approach is also helpful if you have webhooks in your cluster which
 process every config map update.
 One known example is the

--- a/helm-chart/dash0-operator/README.md
+++ b/helm-chart/dash0-operator/README.md
@@ -791,7 +791,7 @@ operator:
 ```
 
 **Important:** Since this volume is needed by a Daemonset run by the Dash0 operator, the PersistentVolumeClaim needs
-to be set with the `ReadWriteOnce` access mode.
+to be set with the `ReadWriteMany` access mode.
 
 Using a volume instead of the default config map approach is also helpful if you have webhooks in your cluster which
 process every config map update.


### PR DESCRIPTION
Document that the persistent volume claim for the file offset must be set in access mode `ReadWriteMany`