### PR TITLE
test(e2e): fix ingress path for apps under test

### DIFF
--- a/test-resources/dotnet/daemonset.yaml
+++ b/test-resources/dotnet/daemonset.yaml
@@ -78,7 +78,7 @@ spec:
   rules:
   - http:
       paths:
-      - path: /daemonset(/|$)(.*)
+      - path: /daemonset/.net(/|$)(.*)
         pathType: ImplementationSpecific
         backend:
           service:

--- a/test-resources/dotnet/deployment.yaml
+++ b/test-resources/dotnet/deployment.yaml
@@ -79,7 +79,7 @@ spec:
   rules:
   - http:
       paths:
-      - path: /deployment(/|$)(.*)
+      - path: /deployment/.net(/|$)(.*)
         pathType: ImplementationSpecific
         backend:
           service:

--- a/test-resources/dotnet/pod.yaml
+++ b/test-resources/dotnet/pod.yaml
@@ -70,7 +70,7 @@ spec:
   rules:
   - http:
       paths:
-      - path: /pod(/|$)(.*)
+      - path: /pod/.net(/|$)(.*)
         pathType: ImplementationSpecific
         backend:
           service:

--- a/test-resources/dotnet/replicaset.yaml
+++ b/test-resources/dotnet/replicaset.yaml
@@ -79,7 +79,7 @@ spec:
   rules:
   - http:
       paths:
-      - path: /replicaset(/|$)(.*)
+      - path: /replicaset/.net(/|$)(.*)
         pathType: ImplementationSpecific
         backend:
           service:

--- a/test-resources/dotnet/statefulset.yaml
+++ b/test-resources/dotnet/statefulset.yaml
@@ -82,7 +82,7 @@ spec:
   rules:
   - http:
       paths:
-      - path: /statefulset(/|$)(.*)
+      - path: /statefulset/.net(/|$)(.*)
         pathType: ImplementationSpecific
         backend:
           service:

--- a/test-resources/jvm/spring-boot/daemonset.yaml
+++ b/test-resources/jvm/spring-boot/daemonset.yaml
@@ -69,7 +69,7 @@ spec:
   rules:
   - http:
       paths:
-      - path: /daemonset(/|$)(.*)
+      - path: /daemonset/jvm(/|$)(.*)
         pathType: ImplementationSpecific
         backend:
           service:

--- a/test-resources/jvm/spring-boot/deployment.yaml
+++ b/test-resources/jvm/spring-boot/deployment.yaml
@@ -70,7 +70,7 @@ spec:
   rules:
   - http:
       paths:
-      - path: /deployment(/|$)(.*)
+      - path: /deployment/jvm(/|$)(.*)
         pathType: ImplementationSpecific
         backend:
           service:

--- a/test-resources/jvm/spring-boot/pod.yaml
+++ b/test-resources/jvm/spring-boot/pod.yaml
@@ -61,7 +61,7 @@ spec:
   rules:
   - http:
       paths:
-      - path: /pod(/|$)(.*)
+      - path: /pod/jvm(/|$)(.*)
         pathType: ImplementationSpecific
         backend:
           service:

--- a/test-resources/jvm/spring-boot/replicaset.yaml
+++ b/test-resources/jvm/spring-boot/replicaset.yaml
@@ -70,7 +70,7 @@ spec:
   rules:
   - http:
       paths:
-      - path: /replicaset(/|$)(.*)
+      - path: /replicaset/jvm(/|$)(.*)
         pathType: ImplementationSpecific
         backend:
           service:

--- a/test-resources/jvm/spring-boot/statefulset.yaml
+++ b/test-resources/jvm/spring-boot/statefulset.yaml
@@ -73,7 +73,7 @@ spec:
   rules:
   - http:
       paths:
-      - path: /statefulset(/|$)(.*)
+      - path: /statefulset/jvm(/|$)(.*)
         pathType: ImplementationSpecific
         backend:
           service:

--- a/test-resources/node.js/express/daemonset.opt-out.yaml
+++ b/test-resources/node.js/express/daemonset.opt-out.yaml
@@ -77,7 +77,7 @@ spec:
   rules:
   - http:
       paths:
-      - path: /daemonset(/|$)(.*)
+      - path: /daemonset/node.js(/|$)(.*)
         pathType: ImplementationSpecific
         backend:
           service:

--- a/test-resources/node.js/express/daemonset.yaml
+++ b/test-resources/node.js/express/daemonset.yaml
@@ -73,7 +73,7 @@ spec:
   rules:
   - http:
       paths:
-      - path: /daemonset(/|$)(.*)
+      - path: /daemonset/node.js(/|$)(.*)
         pathType: ImplementationSpecific
         backend:
           service:

--- a/test-resources/node.js/express/deployment.yaml
+++ b/test-resources/node.js/express/deployment.yaml
@@ -95,7 +95,7 @@ spec:
   rules:
   - http:
       paths:
-      - path: /deployment(/|$)(.*)
+      - path: /deployment/node.js(/|$)(.*)
         pathType: ImplementationSpecific
         backend:
           service:

--- a/test-resources/node.js/express/pod.yaml
+++ b/test-resources/node.js/express/pod.yaml
@@ -65,7 +65,7 @@ spec:
   rules:
   - http:
       paths:
-      - path: /pod(/|$)(.*)
+      - path: /pod/node.js(/|$)(.*)
         pathType: ImplementationSpecific
         backend:
           service:

--- a/test-resources/node.js/express/replicaset.yaml
+++ b/test-resources/node.js/express/replicaset.yaml
@@ -74,7 +74,7 @@ spec:
   rules:
   - http:
       paths:
-      - path: /replicaset(/|$)(.*)
+      - path: /replicaset/node.js(/|$)(.*)
         pathType: ImplementationSpecific
         backend:
           service:

--- a/test-resources/node.js/express/statefulset.yaml
+++ b/test-resources/node.js/express/statefulset.yaml
@@ -77,7 +77,7 @@ spec:
   rules:
   - http:
       paths:
-      - path: /statefulset(/|$)(.*)
+      - path: /statefulset/node.js(/|$)(.*)
         pathType: ImplementationSpecific
         backend:
           service:

--- a/test-resources/python/flask/daemonset.yaml
+++ b/test-resources/python/flask/daemonset.yaml
@@ -69,7 +69,7 @@ spec:
   rules:
   - http:
       paths:
-      - path: /daemonset(/|$)(.*)
+      - path: /daemonset/python(/|$)(.*)
         pathType: ImplementationSpecific
         backend:
           service:

--- a/test-resources/python/flask/deployment.yaml
+++ b/test-resources/python/flask/deployment.yaml
@@ -70,7 +70,7 @@ spec:
   rules:
   - http:
       paths:
-      - path: /deployment(/|$)(.*)
+      - path: /deployment/python(/|$)(.*)
         pathType: ImplementationSpecific
         backend:
           service:

--- a/test-resources/python/flask/pod.yaml
+++ b/test-resources/python/flask/pod.yaml
@@ -61,7 +61,7 @@ spec:
   rules:
   - http:
       paths:
-      - path: /pod(/|$)(.*)
+      - path: /pod/python(/|$)(.*)
         pathType: ImplementationSpecific
         backend:
           service:

--- a/test-resources/python/flask/replicaset.yaml
+++ b/test-resources/python/flask/replicaset.yaml
@@ -70,7 +70,7 @@ spec:
   rules:
   - http:
       paths:
-      - path: /replicaset(/|$)(.*)
+      - path: /replicaset/python(/|$)(.*)
         pathType: ImplementationSpecific
         backend:
           service:

--- a/test-resources/python/flask/statefulset.yaml
+++ b/test-resources/python/flask/statefulset.yaml
@@ -73,7 +73,7 @@ spec:
   rules:
   - http:
       paths:
-      - path: /statefulset(/|$)(.*)
+      - path: /statefulset/python(/|$)(.*)
         pathType: ImplementationSpecific
         backend:
           service:

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -39,6 +39,7 @@ var (
 var _ = Describe("Dash0 Operator", Ordered, func() {
 
 	BeforeAll(func() {
+		By("running BeforeAll hook of test suite root")
 		// Do not truncate string diff output.
 		gomegaformat.MaxLength = 0
 
@@ -81,9 +82,11 @@ var _ = Describe("Dash0 Operator", Ordered, func() {
 		deployThirdPartyCrds()
 
 		stopPodCrashOrOOMKillDetection = failOnPodCrashOrOOMKill()
+		By("finished BeforeAll hook of test suite root")
 	})
 
 	AfterAll(func() {
+		By("running AfterAll hook of test suite root")
 		stopPodCrashOrOOMKillDetection <- true
 		uninstallOtlpSink(workingDir)
 		removeAllTemporaryManifests()
@@ -101,13 +104,16 @@ var _ = Describe("Dash0 Operator", Ordered, func() {
 		if kubeContextHasBeenChanged {
 			revertKubernetesContext(originalKubeContext)
 		}
+		By("finished AfterAll hook of test suite root")
 	})
 
 	BeforeEach(func() {
+		By("running BeforeEach hook of test suite root")
 		createDirAndDeleteOldCollectedLogs()
 	})
 
 	AfterEach(func() {
+		By("running AfterEach hook of test suite root")
 		removeAllTestApplications(applicationUnderTestNamespace)
 	})
 

--- a/test/e2e/kind.go
+++ b/test/e2e/kind.go
@@ -104,6 +104,7 @@ func deployIngressController() {
 }
 
 func undeployNginxIngressController() {
+	By("removing nginx ingress controller")
 	Expect(runAndIgnoreOutput(exec.Command(
 		"kubectl",
 		"delete",

--- a/test/e2e/otlp_sink.go
+++ b/test/e2e/otlp_sink.go
@@ -94,6 +94,7 @@ func createDirAndDeleteOldExportedTelemetry() {
 }
 
 func uninstallOtlpSink(workingDir string) {
+	By("removing otlp-sink")
 	originalManifest := fmt.Sprintf(
 		"%s/test-resources/otlp-sink/otlp-sink.yaml",
 		workingDir,
@@ -109,5 +110,4 @@ func uninstallOtlpSink(workingDir string) {
 				originalManifest,
 				"--wait",
 			))).To(Succeed())
-
 }

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -57,6 +57,7 @@ func sendRequest(g Gomega, runtime runtimeType, workloadType workloadType, route
 	httpPathWithQuery := fmt.Sprintf("%s?%s", route, query)
 	executeHttpRequest(
 		g,
+		runtime.runtimeTypeLabel,
 		workloadType.workloadTypeString,
 		getPort(runtime, workloadType),
 		httpPathWithQuery,
@@ -68,6 +69,7 @@ func sendRequest(g Gomega, runtime runtimeType, workloadType workloadType, route
 func sendReadyProbe(g Gomega, runtime runtimeType, workloadType workloadType) {
 	executeHttpRequest(
 		g,
+		runtime.runtimeTypeLabel,
 		workloadType.workloadTypeString,
 		getPort(runtime, workloadType),
 		"/ready",
@@ -78,6 +80,7 @@ func sendReadyProbe(g Gomega, runtime runtimeType, workloadType workloadType) {
 
 func executeHttpRequest(
 	g Gomega,
+	runtimeTypeLabel string,
 	workloadTypeString string,
 	port int,
 	httpPathWithQuery string,
@@ -86,7 +89,13 @@ func executeHttpRequest(
 ) {
 	url := fmt.Sprintf("http://localhost:%d%s", port, httpPathWithQuery)
 	if isKindCluster() {
-		url = fmt.Sprintf("http://%s/%s%s", kindClusterIngressIp, workloadTypeString, httpPathWithQuery)
+		url = fmt.Sprintf(
+			"http://%s/%s/%s%s",
+			kindClusterIngressIp,
+			workloadTypeString,
+			strings.ToLower(runtimeTypeLabel),
+			httpPathWithQuery,
+		)
 	}
 	httpClient := http.Client{
 		Timeout: 500 * time.Millisecond,


### PR DESCRIPTION
When running the e2e tests on kind where http requests from the test suite to the apps under test is routed via an K8s ingress, and when running multiple apps under test with the same workload type in parallel, the ingress path definitions would conflict, i.e. both the Node.js deployment and the JVM deployment would register /deployment(/|$)(.*) as their path. Since some test cases run multiple apps in parallel, the path needs to be unique. Including the runtime of the app under test fixes this.