### PR TITLE
chore(deps): update kube-rbac-proxy to v0.19.1

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -15,7 +15,7 @@ spec:
           capabilities:
             drop:
             - "ALL"
-        image: quay.io/brancz/kube-rbac-proxy:v0.20.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.19.1
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/helm-chart/dash0-operator/tests/operator/__snapshot__/deployment-and-webhooks_test.yaml.snap
+++ b/helm-chart/dash0-operator/tests/operator/__snapshot__/deployment-and-webhooks_test.yaml.snap
@@ -137,7 +137,7 @@ deployment should match snapshot (default values):
                 - --upstream=http://127.0.0.1:8080/
                 - --logtostderr=true
                 - --v=0
-              image: quay.io/brancz/kube-rbac-proxy:v0.20.0
+              image: quay.io/brancz/kube-rbac-proxy:v0.19.1
               name: kube-rbac-proxy
               ports:
                 - containerPort: 8443
@@ -313,7 +313,7 @@ deployment should match snapshot when using cert-manager:
                 - --upstream=http://127.0.0.1:8080/
                 - --logtostderr=true
                 - --v=0
-              image: quay.io/brancz/kube-rbac-proxy:v0.20.0
+              image: quay.io/brancz/kube-rbac-proxy:v0.19.1
               name: kube-rbac-proxy
               ports:
                 - containerPort: 8443

--- a/helm-chart/dash0-operator/tests/operator/deployment-and-webhooks_test.yaml
+++ b/helm-chart/dash0-operator/tests/operator/deployment-and-webhooks_test.yaml
@@ -805,7 +805,7 @@ tests:
           path: spec.template.spec.containers[0].imagePullPolicy
       - equal:
           path: spec.template.spec.containers[1].image
-          value: customrepo.io/repo/custom-kube-rbac-proxy:v0.20.0
+          value: customrepo.io/repo/custom-kube-rbac-proxy:v0.19.1
       - equal:
           path: spec.template.spec.containers[0].env[4].name
           value: DASH0_OPERATOR_IMAGE

--- a/helm-chart/dash0-operator/values.yaml
+++ b/helm-chart/dash0-operator/values.yaml
@@ -267,7 +267,7 @@ operator:
     # setups that do not use Dash0's official kube RBAC proxy image.
     repository: "quay.io/brancz/kube-rbac-proxy"
     # overrides the image tag
-    tag: "v0.20.0"
+    tag: "v0.19.1"
     # pull image by digest instead of tag; if this is set, the tag value will be ignored
     digest:
     # override the default image pull policy


### PR DESCRIPTION
Updates the `kube-rbac-proxy` image to `v0.19.1`.

Note: not updating to `v0.20.0` for now because during testing we noticed an error (`container has runAsNonRoot and image will run as root`) that we need to further investigate.