### PR TITLE
feat(collectors): use custom image for filelog offset volume ownership

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -183,6 +183,17 @@ jobs:
           context: images
           file: images/filelogoffsetsync/Dockerfile
 
+      - name: build filelog offset volume ownership image
+        uses: ./.github/actions/build-image
+        with:
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          imageName: filelog-offset-volume-ownership
+          imageTitle: Dash0 Kubernetes Filelog Offset Volume Ownership
+          imageDescription: the filelog offset volume ownership init container for the Dash0 operator for Kubernetes
+          imageUrl: https://github.com/dash0hq/dash0-operator/tree/main
+          context: images
+          file: images/filelogoffsetvolumeownership/Dockerfile
+
   publish_helm_chart_dry_run:
     name: Publish Helm Chart (Dry Run)
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,10 @@ After that, you can deploy the operator to your cluster:
     CONFIGURATION_RELOADER_IMG_PULL_POLICY=""
     FILELOG_OFFSET_SYNC_IMG_REPOSITORY=ghcr.io/dash0hq/filelog-offset-sync \
     FILELOG_OFFSET_SYNC_IMG_TAG=main-dev \
-    FILELOG_OFFSET_SYNC_IMG_PULL_POLICY=""
+    FILELOG_OFFSET_SYNC_IMG_PULL_POLICY="" \
+    FILELOG_OFFSET_VOLUME_OWNERSHIP_IMG_REPOSITORY=ghcr.io/dash0hq/filelog-offset-volume-ownership \
+    FILELOG_OFFSET_VOLUME_OWNERSHIP_IMG_TAG=main-dev \
+    FILELOG_OFFSET_VOLUME_OWNERSHIP_IMG_PULL_POLICY=""
   ```
 * The custom resource definition will automatically be installed when deploying the operator. However, you can also do
   that separately via kustomize if required via `make install`.
@@ -92,6 +95,8 @@ CONTROLLER_IMG_REPOSITORY=ghcr.io/dash0hq/operator-controller \
   CONFIGURATION_RELOADER_IMG_TAG=main-dev \
   FILELOG_OFFSET_SYNC_IMG_REPOSITORY=ghcr.io/dash0hq/filelog-offset-sync \
   FILELOG_OFFSET_SYNC_IMG_TAG=main-dev \
+  FILELOG_OFFSET_VOLUME_OWNERSHIP_IMG_REPOSITORY=ghcr.io/dash0hq/filelog-offset-volume-ownership \
+  FILELOG_OFFSET_VOLUME_OWNERSHIP_IMG_TAG=main-dev \
   make test-e2e
 ```
 
@@ -302,6 +307,10 @@ If you want to report telemetry to a Dash0 backend, set `DASH0_AUTHORIZATION_TOK
     * `FILELOG_OFFSET_SYNC_IMG_TAG`
     * `FILELOG_OFFSET_SYNC_IMG_DIGEST`
     * `FILELOG_OFFSET_SYNC_IMG_PULL_POLICY`
+    * `FILELOG_OFFSET_VOLUME_OWNERSHIP_IMG_REPOSITORY`
+    * `FILELOG_OFFSET_VOLUME_OWNERSHIP_IMG_TAG`
+    * `FILELOG_OFFSET_VOLUME_OWNERSHIP_IMG_DIGEST`
+    * `FILELOG_OFFSET_VOLUME_OWNERSHIP_IMG_PULL_POLICY`
 * To run the scenario with the images that have been built from the main branch and pushed to ghcr.io most recently:
     ```
     CONTROLLER_IMG_REPOSITORY=ghcr.io/dash0hq/operator-controller \
@@ -314,6 +323,8 @@ If you want to report telemetry to a Dash0 backend, set `DASH0_AUTHORIZATION_TOK
       CONFIGURATION_RELOADER_IMG_TAG=main-dev \
       FILELOG_OFFSET_SYNC_IMG_REPOSITORY=ghcr.io/dash0hq/filelog-offset-sync \
       FILELOG_OFFSET_SYNC_IMG_TAG=main-dev \
+      FILELOG_OFFSET_VOLUME_OWNERSHIP_IMG_REPOSITORY=ghcr.io/dash0hq/filelog-offset-volume-ownership \
+      FILELOG_OFFSET_VOLUME_OWNERSHIP_IMG_TAG=main-dev \
       test-resources/bin/test-scenario-01-aum-operator-cr.sh
     ```
    * To run the scenario with the helm chart from the official remote repository and the default images referenced in

--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,11 @@ FILELOG_OFFSET_SYNC_IMG_TAG ?= latest
 FILELOG_OFFSET_SYNC_IMG ?= $(FILELOG_OFFSET_SYNC_IMG_REPOSITORY):$(FILELOG_OFFSET_SYNC_IMG_TAG)
 FILELOG_OFFSET_SYNC_IMG_PULL_POLICY ?= Never
 
+FILELOG_OFFSET_VOLUME_OWNERSHIP_IMG_REPOSITORY ?= filelog-offset-volume-ownership
+FILELOG_OFFSET_VOLUME_OWNERSHIP_IMG_TAG ?= latest
+FILELOG_OFFSET_VOLUME_OWNERSHIP_IMG ?= $(FILELOG_OFFSET_VOLUME_OWNERSHIP_IMG_REPOSITORY):$(FILELOG_OFFSET_VOLUME_OWNERSHIP_IMG_TAG)
+FILELOG_OFFSET_VOLUME_OWNERSHIP_IMG_PULL_POLICY ?= Never
+
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.28.3
 
@@ -280,7 +285,8 @@ docker-build: \
   docker-build-instrumentation \
   docker-build-collector \
   docker-build-config-reloader \
-  docker-build-filelog-offset-sync ## Build all container images.
+  docker-build-filelog-offset-sync \
+  docker-build-filelog-offset-volume-ownership
 
 define build_container_image
 $(eval $@_IMAGE_REPOSITORY = $(1))
@@ -323,6 +329,10 @@ docker-build-config-reloader: ## Build the config reloader container image.
 docker-build-filelog-offset-sync: ## Build the filelog offset sync container image.
 	@$(call build_container_image,$(FILELOG_OFFSET_SYNC_IMG_REPOSITORY),$(FILELOG_OFFSET_SYNC_IMG_TAG),images,images/filelogoffsetsync/Dockerfile)
 
+.PHONY: docker-build-filelog-offset-volume-ownership
+docker-build-filelog-offset-volume-ownership: ## Build the filelog offset volume ownership container image.
+	@$(call build_container_image,$(FILELOG_OFFSET_VOLUME_OWNERSHIP_IMG_REPOSITORY),$(FILELOG_OFFSET_VOLUME_OWNERSHIP_IMG_TAG),images,images/filelogoffsetvolumeownership/Dockerfile)
+
 ifndef ignore-not-found
   ignore-not-found = false
 endif
@@ -356,6 +366,9 @@ deploy-via-helm: ## Deploy the controller via helm to the K8s cluster specified 
 		--set operator.filelogOffsetSyncImage.repository=$(FILELOG_OFFSET_SYNC_IMG_REPOSITORY) \
 		--set operator.filelogOffsetSyncImage.tag=$(FILELOG_OFFSET_SYNC_IMG_TAG) \
 		--set operator.filelogOffsetSyncImage.pullPolicy=$(FILELOG_OFFSET_SYNC_IMG_PULL_POLICY) \
+		--set operator.filelogOffsetVolumeOwnershipImage.repository=$(FILELOG_OFFSET_VOLUME_OWNERSHIP_IMG_REPOSITORY) \
+		--set operator.filelogOffsetVolumeOwnershipImage.tag=$(FILELOG_OFFSET_VOLUME_OWNERSHIP_IMG_TAG) \
+		--set operator.filelogOffsetVolumeOwnershipImage.pullPolicy=$(FILELOG_OFFSET_VOLUME_OWNERSHIP_IMG_PULL_POLICY) \
 		--set operator.developmentMode=true \
 		dash0-operator \
 		$(OPERATOR_HELM_CHART)

--- a/helm-chart/dash0-operator/templates/_helpers.tpl
+++ b/helm-chart/dash0-operator/templates/_helpers.tpl
@@ -93,6 +93,11 @@ helm.sh/chart: {{ include "dash0-operator.chartNameWithVersion" . }}
 {{- include "dash0-operator.imageRef" (dict "image" .Values.operator.filelogOffsetSyncImage "context" .) -}}
 {{- end }}
 
+{{/* the filelog offset volume ownership image */}}
+{{- define "dash0-operator.filelogOffsetVolumeOwnershipImage" -}}
+{{- include "dash0-operator.imageRef" (dict "image" .Values.operator.filelogOffsetVolumeOwnershipImage "context" .) -}}
+{{- end }}
+
 {{- define "dash0-operator.imageRef" -}}
 {{- if .image.digest -}}
 {{- printf "%s@%s" .image.repository .image.digest }}

--- a/helm-chart/dash0-operator/templates/operator/deployment-and-webhooks.yaml
+++ b/helm-chart/dash0-operator/templates/operator/deployment-and-webhooks.yaml
@@ -193,6 +193,12 @@ spec:
         - name: DASH0_FILELOG_OFFSET_SYNC_IMAGE_PULL_POLICY
           value: {{ .Values.operator.filelogOffsetSyncImage.pullPolicy }}
         {{- end }}
+        - name: DASH0_FILELOG_OFFSET_VOLUME_OWNERSHIP_IMAGE
+          value: {{ include "dash0-operator.filelogOffsetVolumeOwnershipImage" . | quote }}
+        {{- if .Values.operator.filelogOffsetVolumeOwnershipImage.pullPolicy }}
+        - name: DASH0_FILELOG_OFFSET_VOLUME_OWNERSHIP_IMAGE_PULL_POLICY
+          value: {{ .Values.operator.filelogOffsetVolumeOwnershipImage.pullPolicy }}
+        {{- end }}
         {{- if .Values.operator.developmentMode }}
         - name: DASH0_DEVELOPMENT_MODE
           value: {{ .Values.operator.developmentMode | toString | quote }}

--- a/helm-chart/dash0-operator/tests/operator/__snapshot__/deployment-and-webhooks_test.yaml.snap
+++ b/helm-chart/dash0-operator/tests/operator/__snapshot__/deployment-and-webhooks_test.yaml.snap
@@ -69,6 +69,8 @@ deployment should match snapshot (default values):
                   value: ghcr.io/dash0hq/configuration-reloader:0.0.0
                 - name: DASH0_FILELOG_OFFSET_SYNC_IMAGE
                   value: ghcr.io/dash0hq/filelog-offset-sync:0.0.0
+                - name: DASH0_FILELOG_OFFSET_VOLUME_OWNERSHIP_IMAGE
+                  value: ghcr.io/dash0hq/filelog-offset-volume-ownership:0.0.0
                 - name: K8S_POD_UID
                   valueFrom:
                     fieldRef:
@@ -245,6 +247,8 @@ deployment should match snapshot when using cert-manager:
                   value: ghcr.io/dash0hq/configuration-reloader:0.0.0
                 - name: DASH0_FILELOG_OFFSET_SYNC_IMAGE
                   value: ghcr.io/dash0hq/filelog-offset-sync:0.0.0
+                - name: DASH0_FILELOG_OFFSET_VOLUME_OWNERSHIP_IMAGE
+                  value: ghcr.io/dash0hq/filelog-offset-volume-ownership:0.0.0
                 - name: K8S_POD_UID
                   valueFrom:
                     fieldRef:

--- a/helm-chart/dash0-operator/tests/operator/deployment-and-webhooks_test.yaml
+++ b/helm-chart/dash0-operator/tests/operator/deployment-and-webhooks_test.yaml
@@ -52,36 +52,42 @@ tests:
           value: ghcr.io/dash0hq/filelog-offset-sync:99.100.101
       - equal:
           path: spec.template.spec.containers[0].env[9].name
-          value: K8S_POD_UID
+          value: DASH0_FILELOG_OFFSET_VOLUME_OWNERSHIP_IMAGE
       - equal:
-          path: spec.template.spec.containers[0].env[9].valueFrom.fieldRef.fieldPath
-          value: metadata.uid
+          path: spec.template.spec.containers[0].env[9].value
+          value: ghcr.io/dash0hq/filelog-offset-volume-ownership:99.100.101
       - equal:
           path: spec.template.spec.containers[0].env[10].name
-          value: K8S_NODE_IP
+          value: K8S_POD_UID
       - equal:
           path: spec.template.spec.containers[0].env[10].valueFrom.fieldRef.fieldPath
-          value: status.hostIP
+          value: metadata.uid
       - equal:
           path: spec.template.spec.containers[0].env[11].name
-          value: K8S_NODE_NAME
+          value: K8S_NODE_IP
       - equal:
           path: spec.template.spec.containers[0].env[11].valueFrom.fieldRef.fieldPath
-          value: spec.nodeName
+          value: status.hostIP
       - equal:
           path: spec.template.spec.containers[0].env[12].name
-          value: K8S_POD_IP
+          value: K8S_NODE_NAME
       - equal:
           path: spec.template.spec.containers[0].env[12].valueFrom.fieldRef.fieldPath
-          value: status.podIP
+          value: spec.nodeName
       - equal:
           path: spec.template.spec.containers[0].env[13].name
-          value: K8S_POD_NAME
+          value: K8S_POD_IP
       - equal:
           path: spec.template.spec.containers[0].env[13].valueFrom.fieldRef.fieldPath
+          value: status.podIP
+      - equal:
+          path: spec.template.spec.containers[0].env[14].name
+          value: K8S_POD_NAME
+      - equal:
+          path: spec.template.spec.containers[0].env[14].valueFrom.fieldRef.fieldPath
           value: metadata.name
       - notExists:
-          path: spec.template.spec.containers[0].env[14].name
+          path: spec.template.spec.containers[0].env[15].name
 
   - it: secret should contain ca and cert
     documentSelector:
@@ -183,6 +189,10 @@ tests:
           repository: custom-filelog-offset-sync-image
           tag: "13.14.15"
           pullPolicy: Never
+        filelogOffsetVolumeOwnershipImage:
+          repository: custom-filelog-offset-volume-ownership-image
+          tag: "16.17.18"
+          pullPolicy: Always
         managerContainerResources:
           limits:
             cpu: 123m
@@ -363,60 +373,72 @@ tests:
           value: Never
       - equal:
           path: spec.template.spec.containers[0].env[13].name
-          value: DASH0_DEVELOPMENT_MODE
+          value: DASH0_FILELOG_OFFSET_VOLUME_OWNERSHIP_IMAGE
       - equal:
           path: spec.template.spec.containers[0].env[13].value
-          value: "true"
+          value: custom-filelog-offset-volume-ownership-image:16.17.18
       - equal:
           path: spec.template.spec.containers[0].env[14].name
-          value: DASH0_INSTRUMENTATION_DEBUG
+          value: DASH0_FILELOG_OFFSET_VOLUME_OWNERSHIP_IMAGE_PULL_POLICY
       - equal:
           path: spec.template.spec.containers[0].env[14].value
-          value: "true"
+          value: Always
       - equal:
           path: spec.template.spec.containers[0].env[15].name
-          value: OTEL_COLLECTOR_DEBUG_VERBOSITY_DETAILED
+          value: DASH0_DEVELOPMENT_MODE
       - equal:
           path: spec.template.spec.containers[0].env[15].value
           value: "true"
       - equal:
           path: spec.template.spec.containers[0].env[16].name
-          value: OTEL_COLLECTOR_SEND_BATCH_MAX_SIZE
+          value: DASH0_INSTRUMENTATION_DEBUG
       - equal:
           path: spec.template.spec.containers[0].env[16].value
-          value: "32768"
+          value: "true"
       - equal:
           path: spec.template.spec.containers[0].env[17].name
-          value: K8S_POD_UID
+          value: OTEL_COLLECTOR_DEBUG_VERBOSITY_DETAILED
       - equal:
-          path: spec.template.spec.containers[0].env[17].valueFrom.fieldRef.fieldPath
-          value: metadata.uid
+          path: spec.template.spec.containers[0].env[17].value
+          value: "true"
       - equal:
           path: spec.template.spec.containers[0].env[18].name
-          value: K8S_NODE_IP
+          value: OTEL_COLLECTOR_SEND_BATCH_MAX_SIZE
       - equal:
-          path: spec.template.spec.containers[0].env[18].valueFrom.fieldRef.fieldPath
-          value: status.hostIP
+          path: spec.template.spec.containers[0].env[18].value
+          value: "32768"
       - equal:
           path: spec.template.spec.containers[0].env[19].name
-          value: K8S_NODE_NAME
+          value: K8S_POD_UID
       - equal:
           path: spec.template.spec.containers[0].env[19].valueFrom.fieldRef.fieldPath
-          value: spec.nodeName
+          value: metadata.uid
       - equal:
           path: spec.template.spec.containers[0].env[20].name
-          value: K8S_POD_IP
+          value: K8S_NODE_IP
       - equal:
           path: spec.template.spec.containers[0].env[20].valueFrom.fieldRef.fieldPath
-          value: status.podIP
+          value: status.hostIP
       - equal:
           path: spec.template.spec.containers[0].env[21].name
-          value: K8S_POD_NAME
+          value: K8S_NODE_NAME
       - equal:
           path: spec.template.spec.containers[0].env[21].valueFrom.fieldRef.fieldPath
+          value: spec.nodeName
+      - equal:
+          path: spec.template.spec.containers[0].env[22].name
+          value: K8S_POD_IP
+      - equal:
+          path: spec.template.spec.containers[0].env[22].valueFrom.fieldRef.fieldPath
+          value: status.podIP
+      - equal:
+          path: spec.template.spec.containers[0].env[23].name
+          value: K8S_POD_NAME
+      - equal:
+          path: spec.template.spec.containers[0].env[23].valueFrom.fieldRef.fieldPath
           value: metadata.name
       - notExists:
-          path: spec.template.spec.containers[0].env[22].name
+          path: spec.template.spec.containers[0].env[24].name
       - equal:
           path: spec.template.spec.containers[0].resources.limits.cpu
           value: 123m
@@ -697,13 +719,15 @@ tests:
         initContainerImage:
           digest: sha256:1e8c25853217c7393dbd95e17fe2117bb31b39478bbea4479cc5e7c1257dda01
         kubeRbacProxyImage:
-          digest: sha256:5e8c25853217c7393dbd95e17fe2117bb31b39478bbea4479cc5e7c1257dda05
-        collectorImage:
           digest: sha256:2e8c25853217c7393dbd95e17fe2117bb31b39478bbea4479cc5e7c1257dda02
-        configurationReloaderImage:
+        collectorImage:
           digest: sha256:3e8c25853217c7393dbd95e17fe2117bb31b39478bbea4479cc5e7c1257dda03
-        filelogOffsetSyncImage:
+        configurationReloaderImage:
           digest: sha256:4e8c25853217c7393dbd95e17fe2117bb31b39478bbea4479cc5e7c1257dda04
+        filelogOffsetSyncImage:
+          digest: sha256:5e8c25853217c7393dbd95e17fe2117bb31b39478bbea4479cc5e7c1257dda05
+        filelogOffsetVolumeOwnershipImage:
+          digest: sha256:6e8c25853217c7393dbd95e17fe2117bb31b39478bbea4479cc5e7c1257dda06
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
@@ -712,7 +736,7 @@ tests:
           path: spec.template.spec.containers[0].imagePullPolicy
       - equal:
           path: spec.template.spec.containers[1].image
-          value: quay.io/brancz/kube-rbac-proxy@sha256:5e8c25853217c7393dbd95e17fe2117bb31b39478bbea4479cc5e7c1257dda05
+          value: quay.io/brancz/kube-rbac-proxy@sha256:2e8c25853217c7393dbd95e17fe2117bb31b39478bbea4479cc5e7c1257dda02
       - equal:
           path: spec.template.spec.containers[0].env[4].name
           value: DASH0_OPERATOR_IMAGE
@@ -730,51 +754,57 @@ tests:
           value: DASH0_COLLECTOR_IMAGE
       - equal:
           path: spec.template.spec.containers[0].env[6].value
-          value: ghcr.io/dash0hq/collector@sha256:2e8c25853217c7393dbd95e17fe2117bb31b39478bbea4479cc5e7c1257dda02
+          value: ghcr.io/dash0hq/collector@sha256:3e8c25853217c7393dbd95e17fe2117bb31b39478bbea4479cc5e7c1257dda03
       - equal:
           path: spec.template.spec.containers[0].env[7].name
           value: DASH0_CONFIGURATION_RELOADER_IMAGE
       - equal:
           path: spec.template.spec.containers[0].env[7].value
-          value: ghcr.io/dash0hq/configuration-reloader@sha256:3e8c25853217c7393dbd95e17fe2117bb31b39478bbea4479cc5e7c1257dda03
+          value: ghcr.io/dash0hq/configuration-reloader@sha256:4e8c25853217c7393dbd95e17fe2117bb31b39478bbea4479cc5e7c1257dda04
       - equal:
           path: spec.template.spec.containers[0].env[8].name
           value: DASH0_FILELOG_OFFSET_SYNC_IMAGE
       - equal:
           path: spec.template.spec.containers[0].env[8].value
-          value: ghcr.io/dash0hq/filelog-offset-sync@sha256:4e8c25853217c7393dbd95e17fe2117bb31b39478bbea4479cc5e7c1257dda04
+          value: ghcr.io/dash0hq/filelog-offset-sync@sha256:5e8c25853217c7393dbd95e17fe2117bb31b39478bbea4479cc5e7c1257dda05
       - equal:
           path: spec.template.spec.containers[0].env[9].name
-          value: K8S_POD_UID
+          value: DASH0_FILELOG_OFFSET_VOLUME_OWNERSHIP_IMAGE
       - equal:
-          path: spec.template.spec.containers[0].env[9].valueFrom.fieldRef.fieldPath
-          value: metadata.uid
+          path: spec.template.spec.containers[0].env[9].value
+          value: ghcr.io/dash0hq/filelog-offset-volume-ownership@sha256:6e8c25853217c7393dbd95e17fe2117bb31b39478bbea4479cc5e7c1257dda06
       - equal:
           path: spec.template.spec.containers[0].env[10].name
-          value: K8S_NODE_IP
+          value: K8S_POD_UID
       - equal:
           path: spec.template.spec.containers[0].env[10].valueFrom.fieldRef.fieldPath
-          value: status.hostIP
+          value: metadata.uid
       - equal:
           path: spec.template.spec.containers[0].env[11].name
-          value: K8S_NODE_NAME
+          value: K8S_NODE_IP
       - equal:
           path: spec.template.spec.containers[0].env[11].valueFrom.fieldRef.fieldPath
-          value: spec.nodeName
+          value: status.hostIP
       - equal:
           path: spec.template.spec.containers[0].env[12].name
-          value: K8S_POD_IP
+          value: K8S_NODE_NAME
       - equal:
           path: spec.template.spec.containers[0].env[12].valueFrom.fieldRef.fieldPath
-          value: status.podIP
+          value: spec.nodeName
       - equal:
           path: spec.template.spec.containers[0].env[13].name
-          value: K8S_POD_NAME
+          value: K8S_POD_IP
       - equal:
           path: spec.template.spec.containers[0].env[13].valueFrom.fieldRef.fieldPath
+          value: status.podIP
+      - equal:
+          path: spec.template.spec.containers[0].env[14].name
+          value: K8S_POD_NAME
+      - equal:
+          path: spec.template.spec.containers[0].env[14].valueFrom.fieldRef.fieldPath
           value: metadata.name
       - notExists:
-          path: spec.template.spec.containers[0].env[14].name
+          path: spec.template.spec.containers[0].env[15].name
 
   - it: deployment should support changing repositories for images
     chart:
@@ -797,6 +827,8 @@ tests:
           repository: customrepo.io/repo/custom-configuration-reloader
         filelogOffsetSyncImage:
           repository: customrepo.io/repo/custom-filelog-offset-sync
+        filelogOffsetVolumeOwnershipImage:
+          repository: customrepo.io/repo/custom-filelog-offset-volume-ownership
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
@@ -838,36 +870,42 @@ tests:
           value: customrepo.io/repo/custom-filelog-offset-sync:99.100.101
       - equal:
           path: spec.template.spec.containers[0].env[9].name
-          value: K8S_POD_UID
+          value: DASH0_FILELOG_OFFSET_VOLUME_OWNERSHIP_IMAGE
       - equal:
-          path: spec.template.spec.containers[0].env[9].valueFrom.fieldRef.fieldPath
-          value: metadata.uid
+          path: spec.template.spec.containers[0].env[9].value
+          value: customrepo.io/repo/custom-filelog-offset-volume-ownership:99.100.101
       - equal:
           path: spec.template.spec.containers[0].env[10].name
-          value: K8S_NODE_IP
+          value: K8S_POD_UID
       - equal:
           path: spec.template.spec.containers[0].env[10].valueFrom.fieldRef.fieldPath
-          value: status.hostIP
+          value: metadata.uid
       - equal:
           path: spec.template.spec.containers[0].env[11].name
-          value: K8S_NODE_NAME
+          value: K8S_NODE_IP
       - equal:
           path: spec.template.spec.containers[0].env[11].valueFrom.fieldRef.fieldPath
-          value: spec.nodeName
+          value: status.hostIP
       - equal:
           path: spec.template.spec.containers[0].env[12].name
-          value: K8S_POD_IP
+          value: K8S_NODE_NAME
       - equal:
           path: spec.template.spec.containers[0].env[12].valueFrom.fieldRef.fieldPath
-          value: status.podIP
+          value: spec.nodeName
       - equal:
           path: spec.template.spec.containers[0].env[13].name
-          value: K8S_POD_NAME
+          value: K8S_POD_IP
       - equal:
           path: spec.template.spec.containers[0].env[13].valueFrom.fieldRef.fieldPath
+          value: status.podIP
+      - equal:
+          path: spec.template.spec.containers[0].env[14].name
+          value: K8S_POD_NAME
+      - equal:
+          path: spec.template.spec.containers[0].env[14].valueFrom.fieldRef.fieldPath
           value: metadata.name
       - notExists:
-          path: spec.template.spec.containers[0].env[14].name
+          path: spec.template.spec.containers[0].env[15].name
 
   - it: mutating webhook should have caBundle set
     documentSelector:

--- a/helm-chart/dash0-operator/values.yaml
+++ b/helm-chart/dash0-operator/values.yaml
@@ -294,10 +294,25 @@ operator:
     # override the default image pull policy
     pullPolicy:
 
-  # the container image to use for the synchronizing of the offset files for the filelog receiver
+  # the container image to use for synchronizing the offset files for the filelog receiver to the filelog offset config
+  # map; will not be used if a filelog offset storage volume is provided via
+  # operator.collectors.filelogOffsetSyncStorageVolume
   # (there should usually be no reason to override this)
   filelogOffsetSyncImage:
     repository: "ghcr.io/dash0hq/filelog-offset-sync"
+    # overrides the image tag, which defaults to the chart appVersion.
+    tag:
+    # pull image by digest instead of tag; if this is set, the tag value will be ignored
+    digest:
+    # override the default image pull policy
+    pullPolicy:
+
+  # the container image to use for the init container which sets up the required file system ownership in the log file
+  # offset volume; will only be used if a host volume is provided for filelog offset storage via
+  # operator.collectors.filelogOffsetSyncStorageVolume
+  # (there should usually be no reason to override this)
+  filelogOffsetVolumeOwnershipImage:
+    repository: "ghcr.io/dash0hq/filelog-offset-volume-ownership"
     # overrides the image tag, which defaults to the chart appVersion.
     tag:
     # pull image by digest instead of tag; if this is set, the tag value will be ignored

--- a/images/filelogoffsetvolumeownership/Dockerfile
+++ b/images/filelogoffsetvolumeownership/Dockerfile
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright 2025 Dash0 Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Note: This basically just re-tags the busybox. We do this for consistency with other images. That is, all images used
+# by the collector pods are built in the same way, and stored in the same container registry. In particular, we avoid
+# using images from Dockerhub directly because of its pull rate limits.
+
+# Note: This container needs to run as root, since its purpose is to change file ownership settings in a mounted host
+# path volume; the path inside the volume is owned by root by default.
+
+FROM busybox:1.37.0-glibc

--- a/internal/collectors/collector_manager_test.go
+++ b/internal/collectors/collector_manager_test.go
@@ -841,6 +841,7 @@ var _ = Describe("The collector manager", Ordered, func() {
 			initContainers := podSpec.InitContainers
 			Expect(initContainers).To(HaveLen(1))
 			Expect(initContainers[0].Name).To(Equal("filelog-offset-volume-ownership"))
+			Expect(initContainers[0].Image).To(Equal(TestImages.FilelogOffsetVolumeOwnershipImage))
 			containers := podSpec.Containers
 			Expect(containers).To(HaveLen(2))
 

--- a/internal/collectors/otelcolresources/otelcol_resources.go
+++ b/internal/collectors/otelcolresources/otelcol_resources.go
@@ -60,11 +60,12 @@ var (
 	knownIrrelevantPatches = []string{bogusDeploymentPatch}
 
 	dummyImagesForDeletion = util.Images{
-		OperatorImage:              "ghcr.io/dash0hq/operator-controller:latest",
-		InitContainerImage:         "ghcr.io/dash0hq/instrumentation:latest",
-		CollectorImage:             "ghcr.io/dash0hq/collector:latest",
-		ConfigurationReloaderImage: "ghcr.io/dash0hq/configuration-reloader:latest",
-		FilelogOffsetSyncImage:     "ghcr.io/dash0hq/filelog-offset-sync:latest",
+		OperatorImage:                     "ghcr.io/dash0hq/operator-controller:latest",
+		InitContainerImage:                "ghcr.io/dash0hq/instrumentation:latest",
+		CollectorImage:                    "ghcr.io/dash0hq/collector:latest",
+		ConfigurationReloaderImage:        "ghcr.io/dash0hq/configuration-reloader:latest",
+		FilelogOffsetSyncImage:            "ghcr.io/dash0hq/filelog-offset-sync:latest",
+		FilelogOffsetVolumeOwnershipImage: "ghcr.io/dash0hq/filelog-offset-volume-ownership:latest",
 	}
 
 	httpClient     = &http.Client{}

--- a/internal/util/types.go
+++ b/internal/util/types.go
@@ -51,15 +51,17 @@ type CollectorConfig struct {
 	DebugVerbosityDetailed  bool
 }
 type Images struct {
-	OperatorImage                        string
-	InitContainerImage                   string
-	InitContainerImagePullPolicy         corev1.PullPolicy
-	CollectorImage                       string
-	CollectorImagePullPolicy             corev1.PullPolicy
-	ConfigurationReloaderImage           string
-	ConfigurationReloaderImagePullPolicy corev1.PullPolicy
-	FilelogOffsetSyncImage               string
-	FilelogOffsetSyncImagePullPolicy     corev1.PullPolicy
+	OperatorImage                               string
+	InitContainerImage                          string
+	InitContainerImagePullPolicy                corev1.PullPolicy
+	CollectorImage                              string
+	CollectorImagePullPolicy                    corev1.PullPolicy
+	ConfigurationReloaderImage                  string
+	ConfigurationReloaderImagePullPolicy        corev1.PullPolicy
+	FilelogOffsetSyncImage                      string
+	FilelogOffsetSyncImagePullPolicy            corev1.PullPolicy
+	FilelogOffsetVolumeOwnershipImage           string
+	FilelogOffsetVolumeOwnershipImagePullPolicy corev1.PullPolicy
 }
 
 func (i Images) GetOperatorVersion() string {

--- a/test-resources/bin/util
+++ b/test-resources/bin/util
@@ -106,6 +106,10 @@ determine_container_images() {
   filelog_offset_sync_img_tag="latest"
   filelog_offset_sync_img_digest=""
   filelog_offset_sync_img_pull_policy="Never"
+  filelog_offset_volume_ownership_img_repository="filelog-offset-volume-ownership"
+  filelog_offset_volume_ownership_img_tag="latest"
+  filelog_offset_volume_ownership_img_digest=""
+  filelog_offset_volume_ownership_img_pull_policy="Never"
 
   operator_helm_chart=${OPERATOR_HELM_CHART:-helm-chart/dash0-operator}
 
@@ -129,6 +133,9 @@ determine_container_images() {
     filelog_offset_sync_img_repository=""
     filelog_offset_sync_img_tag=""
     filelog_offset_sync_img_pull_policy=""
+    filelog_offset_volume_ownership_img_repository=""
+    filelog_offset_volume_ownership_img_tag=""
+    filelog_offset_volume_ownership_img_pull_policy=""
   fi
 
   if [[ -n "${CONTROLLER_IMG_REPOSITORY:-}" ]]; then
@@ -196,6 +203,19 @@ determine_container_images() {
     filelog_offset_sync_img_pull_policy="$FILELOG_OFFSET_SYNC_IMG_PULL_POLICY"
   fi
 
+  if [[ -n "${FILELOG_OFFSET_VOLUME_OWNERSHIP_IMG_REPOSITORY:-}" ]]; then
+    filelog_offset_volume_ownership_img_repository="$FILELOG_OFFSET_VOLUME_OWNERSHIP_IMG_REPOSITORY"
+  fi
+  if [[ -n "${FILELOG_OFFSET_VOLUME_OWNERSHIP_IMG_TAG:-}" ]]; then
+    filelog_offset_volume_ownership_img_tag="$FILELOG_OFFSET_VOLUME_OWNERSHIP_IMG_TAG"
+  fi
+  if [[ -n "${FILELOG_OFFSET_VOLUME_OWNERSHIP_IMG_DIGEST:-}" ]]; then
+    filelog_offset_volume_ownership_img_digest="$FILELOG_OFFSET_VOLUME_OWNERSHIP_IMG_DIGEST"
+  fi
+  if [[ -n "${FILELOG_OFFSET_VOLUME_OWNERSHIP_IMG_PULL_POLICY:-}" ]]; then
+    filelog_offset_volume_ownership_img_pull_policy="$FILELOG_OFFSET_VOLUME_OWNERSHIP_IMG_PULL_POLICY"
+  fi
+
   if [[ "$is_local_helm_chart" = "true" ]]; then
     # support using the local helm chart with remote images
     if [[ $(is_remote_image "$controller_img_repository") = "true" ]]; then
@@ -213,6 +233,9 @@ determine_container_images() {
     if [[ $(is_remote_image "$filelog_offset_sync_img_repository") = "true" ]]; then
       filelog_offset_sync_img_pull_policy=""
     fi
+    if [[ $(is_remote_image "$filelog_offset_volume_ownership_img_repository") = "true" ]]; then
+      filelog_offset_volume_ownership_img_pull_policy=""
+    fi
   fi
 }
 
@@ -226,6 +249,8 @@ build_all_images() {
     CONFIGURATION_RELOADER_IMG_TAG="$configuration_reloader_img_tag" \
     FILELOG_OFFSET_SYNC_IMG_REPOSITORY=$filelog_offset_sync_img_repository \
     FILELOG_OFFSET_SYNC_IMG_TAG="$filelog_offset_sync_img_tag" \
+    FILELOG_OFFSET_VOLUME_OWNERSHIP_IMG_REPOSITORY=$filelog_offset_volume_ownership_img_repository \
+    FILELOG_OFFSET_VOLUME_OWNERSHIP_IMG_TAG="$filelog_offset_volume_ownership_img_tag" \
     make docker-build
 
   if [[ "$is_kind_cluster" = "true" ]]; then
@@ -236,7 +261,8 @@ build_all_images() {
       instrumentation:latest \
       collector:latest \
       configuration-reloader:latest \
-      filelog-offset-sync:latest
+      filelog-offset-sync:latest \
+      filelog-offset-volume-ownership:latest
   fi
 }
 
@@ -408,6 +434,19 @@ run_helm() {
   fi
   if [[ -n "$filelog_offset_sync_img_pull_policy" ]]; then
     helm_install_command+=" --set operator.filelogOffsetSyncImage.pullPolicy=$filelog_offset_sync_img_pull_policy"
+  fi
+
+  if [[ -n "$filelog_offset_volume_ownership_img_repository" ]]; then
+    helm_install_command+=" --set operator.filelogOffsetVolumeOwnershipImage.repository=$filelog_offset_volume_ownership_img_repository"
+  fi
+  if [[ -n "$filelog_offset_volume_ownership_img_tag" ]]; then
+    helm_install_command+=" --set operator.filelogOffsetVolumeOwnershipImage.tag=$filelog_offset_volume_ownership_img_tag"
+  fi
+  if [[ -n "$filelog_offset_volume_ownership_img_digest" ]]; then
+    helm_install_command+=" --set operator.filelogOffsetVolumeOwnershipImage.digest=$filelog_offset_volume_ownership_img_digest"
+  fi
+  if [[ -n "$filelog_offset_volume_ownership_img_pull_policy" ]]; then
+    helm_install_command+=" --set operator.filelogOffsetVolumeOwnershipImage.pullPolicy=$filelog_offset_volume_ownership_img_pull_policy"
   fi
 
   # Deploy an operator configuration right away.

--- a/test/e2e/container_images.go
+++ b/test/e2e/container_images.go
@@ -22,11 +22,12 @@ type ImageSpec struct {
 }
 
 type Images struct {
-	operator              ImageSpec
-	instrumentation       ImageSpec
-	collector             ImageSpec
-	configurationReloader ImageSpec
-	fileLogOffsetSync     ImageSpec
+	operator                     ImageSpec
+	instrumentation              ImageSpec
+	collector                    ImageSpec
+	configurationReloader        ImageSpec
+	fileLogOffsetSync            ImageSpec
+	fileLogOffsetVolumeOwnership ImageSpec
 }
 
 const (
@@ -69,6 +70,13 @@ var (
 			dockerContext: "images",
 			dockerfile:    "images/filelogoffsetsync/Dockerfile",
 		},
+		fileLogOffsetVolumeOwnership: ImageSpec{
+			repository:    "filelog-offset-volume-ownership",
+			tag:           tagLatest,
+			pullPolicy:    "Never",
+			dockerContext: "images",
+			dockerfile:    "images/filelogoffsetvolumeownership/Dockerfile",
+		},
 	}
 
 	emptyImages = Images{
@@ -107,6 +115,13 @@ var (
 			dockerContext: localImages.fileLogOffsetSync.dockerContext,
 			dockerfile:    localImages.fileLogOffsetSync.dockerfile,
 		},
+		fileLogOffsetVolumeOwnership: ImageSpec{
+			repository:    "",
+			tag:           "",
+			pullPolicy:    "",
+			dockerContext: localImages.fileLogOffsetVolumeOwnership.dockerContext,
+			dockerfile:    localImages.fileLogOffsetVolumeOwnership.dockerfile,
+		},
 	}
 
 	images = localImages
@@ -118,6 +133,7 @@ func rebuildAllContainerImages() {
 	rebuildLocalImage(images.collector)
 	rebuildLocalImage(images.configurationReloader)
 	rebuildLocalImage(images.fileLogOffsetSync)
+	rebuildLocalImage(images.fileLogOffsetVolumeOwnership)
 }
 
 func rebuildLocalImage(imageSpec ImageSpec) {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1535,11 +1535,12 @@ trace_statements:
 				// image names that are used throughout the whole test suite (defined by environment variables).
 
 				initialAlternativeImages := Images{
-					operator:              deriveAlternativeImageForUpdateTest(images.operator),
-					instrumentation:       deriveAlternativeImageForUpdateTest(images.instrumentation),
-					collector:             deriveAlternativeImageForUpdateTest(images.collector),
-					configurationReloader: deriveAlternativeImageForUpdateTest(images.configurationReloader),
-					fileLogOffsetSync:     deriveAlternativeImageForUpdateTest(images.fileLogOffsetSync),
+					operator:                     deriveAlternativeImageForUpdateTest(images.operator),
+					instrumentation:              deriveAlternativeImageForUpdateTest(images.instrumentation),
+					collector:                    deriveAlternativeImageForUpdateTest(images.collector),
+					configurationReloader:        deriveAlternativeImageForUpdateTest(images.configurationReloader),
+					fileLogOffsetSync:            deriveAlternativeImageForUpdateTest(images.fileLogOffsetSync),
+					fileLogOffsetVolumeOwnership: deriveAlternativeImageForUpdateTest(images.fileLogOffsetVolumeOwnership),
 				}
 				deployOperatorWithDefaultAutoOperationConfiguration(
 					operatorNamespace,
@@ -1961,6 +1962,20 @@ func determineContainerImages() {
 		images.fileLogOffsetSync.pullPolicy,
 	)
 
+	images.fileLogOffsetVolumeOwnership.repository = getEnvOrDefault(
+		"FILELOG_OFFSET_VOLUME_OWNERSHIP_IMG_REPOSITORY",
+		images.fileLogOffsetVolumeOwnership.repository,
+	)
+	images.fileLogOffsetVolumeOwnership.tag =
+		getEnvOrDefault("FILELOG_OFFSET_VOLUME_OWNERSHIP_IMG_TAG", images.fileLogOffsetVolumeOwnership.tag)
+	images.fileLogOffsetVolumeOwnership.digest =
+		getEnvOrDefault("FILELOG_OFFSET_VOLUME_OWNERSHIP_IMG_DIGEST",
+			images.fileLogOffsetVolumeOwnership.digest)
+	images.fileLogOffsetVolumeOwnership.pullPolicy = getEnvOrDefault(
+		"FILELOG_OFFSET_VOLUME_OWNERSHIP_IMG_PULL_POLICY",
+		images.fileLogOffsetVolumeOwnership.pullPolicy,
+	)
+
 	if isLocalHelmChart() {
 		// support using the local helm chart with remote images
 		if isRemoteImage(images.operator) {
@@ -1977,6 +1992,10 @@ func determineContainerImages() {
 		}
 		if isRemoteImage(images.fileLogOffsetSync) {
 			images.fileLogOffsetSync.pullPolicy = getEnvOrDefault("FILELOG_OFFSET_SYNC_IMG_PULL_POLICY", "")
+		}
+		if isRemoteImage(images.fileLogOffsetVolumeOwnership) {
+			images.fileLogOffsetVolumeOwnership.pullPolicy =
+				getEnvOrDefault("FILELOG_OFFSET_VOLUME_OWNERSHIP_IMG_PULL_POLICY", "")
 		}
 	}
 }

--- a/test/e2e/operator.go
+++ b/test/e2e/operator.go
@@ -178,6 +178,15 @@ func addHelmParametersForImages(arguments []string, images Images) []string {
 	arguments = setIfNotEmpty(arguments, "operator.filelogOffsetSyncImage.pullPolicy",
 		images.fileLogOffsetSync.pullPolicy)
 
+	arguments = setIfNotEmpty(arguments, "operator.filelogOffsetVolumeOwnershipImage.repository",
+		images.fileLogOffsetVolumeOwnership.repository)
+	arguments = setIfNotEmpty(arguments, "operator.filelogOffsetVolumeOwnershipImage.tag",
+		images.fileLogOffsetVolumeOwnership.tag)
+	arguments = setIfNotEmpty(arguments, "operator.filelogOffsetVolumeOwnershipImage.digest",
+		images.fileLogOffsetVolumeOwnership.digest)
+	arguments = setIfNotEmpty(arguments, "operator.filelogOffsetVolumeOwnershipImage.pullPolicy",
+		images.fileLogOffsetVolumeOwnership.pullPolicy)
+
 	return arguments
 }
 

--- a/test/util/constants.go
+++ b/test/util/constants.go
@@ -32,12 +32,13 @@ const (
 	ReplicaSetNamePrefix  = "replicaset"
 	StatefulSetNamePrefix = "statefulset"
 
-	OperatorVersionTest            = "1.2.3"
-	OperatorImageTest              = "some-registry.com:1234/dash0hq/operator-controller:1.2.3"
-	InitContainerImageTest         = "some-registry.com:1234/dash0hq/instrumentation:4.5.6"
-	CollectorImageTest             = "some-registry.com:1234/dash0hq/collector:7.8.9"
-	ConfigurationReloaderImageTest = "some-registry.com:1234/dash0hq/configuration-reloader:10.11.12"
-	FilelogOffsetSyncImageTest     = "some-registry.com:1234/dash0hq/filelog-offset-sync:13.14.15"
+	OperatorVersionTest                   = "1.2.3"
+	OperatorImageTest                     = "some-registry.com:1234/dash0hq/operator-controller:1.2.3"
+	InitContainerImageTest                = "some-registry.com:1234/dash0hq/instrumentation:4.5.6"
+	CollectorImageTest                    = "some-registry.com:1234/dash0hq/collector:7.8.9"
+	ConfigurationReloaderImageTest        = "some-registry.com:1234/dash0hq/configuration-reloader:10.11.12"
+	FilelogOffsetSyncImageTest            = "some-registry.com:1234/dash0hq/filelog-offset-sync:13.14.15"
+	FilelogOffsetVolumeOwnershipImageTest = "some-registry.com:1234/dash0hq/filelog-offset-volume-ownership:16.17.18"
 
 	OTelCollectorNodeLocalBaseUrlTest = "http://$(DASH0_NODE_IP):40318"
 	OTelCollectorServiceBaseUrlTest   = //
@@ -69,15 +70,17 @@ var (
 	ArbitraryNumer int64 = 1302
 
 	TestImages = util.Images{
-		OperatorImage:                        OperatorImageTest,
-		InitContainerImage:                   InitContainerImageTest,
-		InitContainerImagePullPolicy:         corev1.PullAlways,
-		CollectorImage:                       CollectorImageTest,
-		CollectorImagePullPolicy:             corev1.PullAlways,
-		ConfigurationReloaderImage:           ConfigurationReloaderImageTest,
-		ConfigurationReloaderImagePullPolicy: corev1.PullAlways,
-		FilelogOffsetSyncImage:               FilelogOffsetSyncImageTest,
-		FilelogOffsetSyncImagePullPolicy:     corev1.PullAlways,
+		OperatorImage:                               OperatorImageTest,
+		InitContainerImage:                          InitContainerImageTest,
+		InitContainerImagePullPolicy:                corev1.PullAlways,
+		CollectorImage:                              CollectorImageTest,
+		CollectorImagePullPolicy:                    corev1.PullAlways,
+		ConfigurationReloaderImage:                  ConfigurationReloaderImageTest,
+		ConfigurationReloaderImagePullPolicy:        corev1.PullAlways,
+		FilelogOffsetSyncImage:                      FilelogOffsetSyncImageTest,
+		FilelogOffsetSyncImagePullPolicy:            corev1.PullAlways,
+		FilelogOffsetVolumeOwnershipImage:           FilelogOffsetVolumeOwnershipImageTest,
+		FilelogOffsetVolumeOwnershipImagePullPolicy: corev1.PullAlways,
 	}
 
 	OperatorManagerDeploymentUIDStr = "2f009c75-d69f-4b02-9d9d-fa17e76f5c1d"


### PR DESCRIPTION
When a host volume is used for storing filelog offsets, we attach an init container to set up the correct ownership in the volume. Previously, this was the busybox image directly from Dockerhub. This can cause issues with Dockerhub's pull rate limit. To avoid that, we build a custom image for this init container and make it configurable via Helm, consistent with all other container images used in the collector pods.