### PR TITLE
ci: add dependabot config for docker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -46,11 +46,11 @@ updates:
       - "/images/collector"
       - "/images/configreloader"
       - "/images/filelogoffsetsync"
-      # - "/images/filelogoffsetvolumeownership"
+      - "/images/filelogoffsetvolumeownership"
       - "/images/instrumentation"
     schedule:
       interval: "daily"
-      time: "07:20"
+      time: "07:15"
       timezone: "Europe/Berlin"
 
   # -----------------------

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,6 +39,20 @@ updates:
     schedule:
       interval: "daily"
 
+  # Docker
+  - package-ecosystem: "docker"
+    directories:
+      - "/"
+      - "/images/collector"
+      - "/images/configreloader"
+      - "/images/filelogoffsetsync"
+      # - "/images/filelogoffsetvolumeownership"
+      - "/images/instrumentation"
+    schedule:
+      interval: "daily"
+      time: "07:20"
+      timezone: "Europe/Berlin"
+
   # -----------------------
   # -- Test applications --
   # -----------------------


### PR DESCRIPTION
Small PR to add automatic version updates for Docker.

Note: I didn't add a config for Helm, since it only checks the chart dependencies and not the images used in the templates/manifests. Since we currently don't depend on any other charts, that check wouldn't provide any value.