### PR TITLE
ci: optionally scan images after build

### DIFF
--- a/.github/actions/build-image/action.yaml
+++ b/.github/actions/build-image/action.yaml
@@ -27,7 +27,7 @@ inputs:
   scan:
     description: "whether to scan the built image with Trivy"
     required: false
-    default: "false"
+    default: 'false'
 
 runs:
   using: "composite"
@@ -97,7 +97,7 @@ runs:
 
     # optionally scan the built container image with Trivy and upload the results
     - name: run Trivy vulnerability scanner
-      if: ${{ inputs.scan }}
+      if: ${{ inputs.scan == 'true' }}
       uses: aquasecurity/trivy-action@0.28.0
       with:
         image-ref: 'ghcr.io/dash0hq/${{ inputs.imageName }}:sha-${{ env.SHORT_SHA }}'
@@ -106,14 +106,14 @@ runs:
         exit-code: '1' # fail build if vulnerabilities are found
 
     - name: upload Trivy scan results to GitHub Security tab
-      if: ${{ always() && inputs.scan }}
+      if: ${{ always() && inputs.scan == 'true' }}
       uses: github/codeql-action/upload-sarif@v3
       with:
         sarif_file: 'trivy-results.sarif'
         category: ".github/workflows/ci.yaml:build_and_push_images/${{ inputs.imageName }}"
 
     - name: push container image
-      if: ${{ env.PUSH_ENABLED }}
+      if: ${{ env.PUSH_ENABLED == 'true' }}
       uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4
       with:
         context: ${{ inputs.context }}
@@ -123,4 +123,4 @@ runs:
         platforms: 'linux/amd64,linux/arm64'
         cache-from: type=gha,scope=${{ inputs.imageName }}
         cache-to: type=gha,mode=max,scope=${{ inputs.imageName }}
-        push: false # setting this to false during testing
+        push: ${{ env.PUSH_ENABLED }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -151,6 +151,7 @@ jobs:
           imageDescription: contains Dash0 OpenTelemetry distributions for multiple runtimes
           imageUrl: https://github.com/dash0hq/dash0-operator/tree/main/images/instrumentation
           context: images/instrumentation
+          scan: 'true'
 
       - name: build collector image
         uses: ./.github/actions/build-image
@@ -161,6 +162,7 @@ jobs:
           imageDescription: the OpenTelemetry collector for the Dash0 operator for Kubernetes
           imageUrl: https://github.com/dash0hq/dash0-operator/tree/main/images/collector
           context: images/collector
+          scan: 'true'
 
       - name: build configuration reloader image
         uses: ./.github/actions/build-image
@@ -172,6 +174,7 @@ jobs:
           imageUrl: https://github.com/dash0hq/dash0-operator/tree/main/images/configreloader
           context: images
           file: images/configreloader/Dockerfile
+          scan: 'true'
 
       - name: build filelog offset sync image
         uses: ./.github/actions/build-image
@@ -183,6 +186,7 @@ jobs:
           imageUrl: https://github.com/dash0hq/dash0-operator/tree/main
           context: images
           file: images/filelogoffsetsync/Dockerfile
+          scan: 'true'
 
       - name: build filelog offset volume ownership image
         uses: ./.github/actions/build-image
@@ -194,6 +198,7 @@ jobs:
           imageUrl: https://github.com/dash0hq/dash0-operator/tree/main
           context: images
           file: images/filelogoffsetvolumeownership/Dockerfile
+          scan: 'true'
 
   publish_helm_chart_dry_run:
     name: Publish Helm Chart (Dry Run)

--- a/images/collector/Dockerfile
+++ b/images/collector/Dockerfile
@@ -21,7 +21,7 @@ RUN CGO_ENABLED=0 \
     builder --config=builder/config.yaml && \
     chmod u+x /src/dist/dash0-operator-collector
 
-FROM alpine:3.21.2
+FROM alpine:3.22.2
 COPY src/image/entrypoint.sh /entrypoint.sh
 COPY --from=builder /src/dist/dash0-operator-collector otelcol
 USER 65532:65532


### PR DESCRIPTION
This PR adds https://github.com/aquasecurity/trivy-action to scan the built images with Trivy, so we detect vulnerabilities before publishing a release.

If vulnerabilities are found, the build will fail and the scan results can be found on https://github.com/dash0hq/dash0-operator/security/code-scanning (the pr/branch needs to be selected).