### PR TITLE
chore(deps): update kube-rbac-proxy to v0.20.0

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -15,7 +15,7 @@ spec:
           capabilities:
             drop:
             - "ALL"
-        image: quay.io/brancz/kube-rbac-proxy:v0.19.1
+        image: quay.io/brancz/kube-rbac-proxy:v0.20.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/helm-chart/dash0-operator/templates/_helpers.tpl
+++ b/helm-chart/dash0-operator/templates/_helpers.tpl
@@ -111,6 +111,9 @@ securityContext:
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: true
   runAsNonRoot: true
+{{- if .userId }}
+  runAsUser: {{ .userId }}
+{{- end }}
   capabilities:
     drop:
     - ALL

--- a/helm-chart/dash0-operator/templates/operator/deployment-and-webhooks.yaml
+++ b/helm-chart/dash0-operator/templates/operator/deployment-and-webhooks.yaml
@@ -241,7 +241,7 @@ spec:
           protocol: TCP
         resources:
           {{- toYaml .Values.operator.managerContainerResources | nindent 10 }}
-        {{ include "dash0-operator.restrictiveContainerSecurityContext" . | nindent 8 }}
+        {{ include "dash0-operator.restrictiveContainerSecurityContext" dict | nindent 8 }}
         volumeMounts:
         - name: certificates
           mountPath: /tmp/k8s-webhook-server/serving-certs
@@ -274,12 +274,12 @@ spec:
           protocol: TCP
         resources:
           {{- toYaml .Values.operator.kubeRbacProxyContainerResources | nindent 10 }}
-        {{ include "dash0-operator.restrictiveContainerSecurityContext" . | nindent 8 }}
+        {{ include "dash0-operator.restrictiveContainerSecurityContext" (dict "userId" 65532) | nindent 8 }}
       {{- with .Values.operator.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{ include "dash0-operator.restrictivePodSecurityContext" . | nindent 6 }}
+      {{ include "dash0-operator.restrictivePodSecurityContext" dict | nindent 6 }}
       serviceAccountName: {{ template "dash0-operator.serviceAccountName" . }}
       automountServiceAccountToken: true
       terminationGracePeriodSeconds: 10

--- a/helm-chart/dash0-operator/templates/operator/post-install-hook.yaml
+++ b/helm-chart/dash0-operator/templates/operator/post-install-hook.yaml
@@ -34,7 +34,7 @@ spec:
           command:
             - /manager
             - "--auto-operator-configuration-resource-available-check"
-          {{ include "dash0-operator.restrictiveContainerSecurityContext" . | nindent 10 }}
+          {{ include "dash0-operator.restrictiveContainerSecurityContext" dict | nindent 10 }}
           resources:
             {{- toYaml .Values.operator.managerContainerResources | nindent 12 }}
       securityContext:

--- a/helm-chart/dash0-operator/templates/operator/pre-delete-hook.yaml
+++ b/helm-chart/dash0-operator/templates/operator/pre-delete-hook.yaml
@@ -30,7 +30,7 @@ spec:
           command:
             - /manager
             - "--uninstrument-all"
-          {{ include "dash0-operator.restrictiveContainerSecurityContext" . | nindent 10 }}
+          {{ include "dash0-operator.restrictiveContainerSecurityContext" dict | nindent 10 }}
           resources:
             {{- toYaml .Values.operator.managerContainerResources | nindent 12 }}
       securityContext:

--- a/helm-chart/dash0-operator/tests/operator/__snapshot__/deployment-and-webhooks_test.yaml.snap
+++ b/helm-chart/dash0-operator/tests/operator/__snapshot__/deployment-and-webhooks_test.yaml.snap
@@ -139,7 +139,7 @@ deployment should match snapshot (default values):
                 - --upstream=http://127.0.0.1:8080/
                 - --logtostderr=true
                 - --v=0
-              image: quay.io/brancz/kube-rbac-proxy:v0.19.1
+              image: quay.io/brancz/kube-rbac-proxy:v0.20.0
               name: kube-rbac-proxy
               ports:
                 - containerPort: 8443
@@ -161,6 +161,7 @@ deployment should match snapshot (default values):
                     - ALL
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
+                runAsUser: 65532
                 seccompProfile:
                   type: RuntimeDefault
           securityContext:
@@ -317,7 +318,7 @@ deployment should match snapshot when using cert-manager:
                 - --upstream=http://127.0.0.1:8080/
                 - --logtostderr=true
                 - --v=0
-              image: quay.io/brancz/kube-rbac-proxy:v0.19.1
+              image: quay.io/brancz/kube-rbac-proxy:v0.20.0
               name: kube-rbac-proxy
               ports:
                 - containerPort: 8443
@@ -339,6 +340,7 @@ deployment should match snapshot when using cert-manager:
                     - ALL
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
+                runAsUser: 65532
                 seccompProfile:
                   type: RuntimeDefault
           securityContext:

--- a/helm-chart/dash0-operator/tests/operator/deployment-and-webhooks_test.yaml
+++ b/helm-chart/dash0-operator/tests/operator/deployment-and-webhooks_test.yaml
@@ -837,7 +837,7 @@ tests:
           path: spec.template.spec.containers[0].imagePullPolicy
       - equal:
           path: spec.template.spec.containers[1].image
-          value: customrepo.io/repo/custom-kube-rbac-proxy:v0.19.1
+          value: customrepo.io/repo/custom-kube-rbac-proxy:v0.20.0
       - equal:
           path: spec.template.spec.containers[0].env[4].name
           value: DASH0_OPERATOR_IMAGE

--- a/helm-chart/dash0-operator/values.yaml
+++ b/helm-chart/dash0-operator/values.yaml
@@ -267,7 +267,7 @@ operator:
     # setups that do not use Dash0's official kube RBAC proxy image.
     repository: "quay.io/brancz/kube-rbac-proxy"
     # overrides the image tag
-    tag: "v0.19.1"
+    tag: "v0.20.0"
     # pull image by digest instead of tag; if this is set, the tag value will be ignored
     digest:
     # override the default image pull policy


### PR DESCRIPTION
Turns out the runAsNonRoot issue we saw with v0.20.0 earlier is a Docker Desktop issue. It does not reproduce on kind, for example. And there is a workaround for Docker Desktop: pass an explicit user ID in the container security context.

For context, without setting the explicit user ID, K8s on Docker Desktop fails to start any pod with a kube-rbac-proxy container with:
    Error: container has runAsNonRoot and image will run as root
    (pod: "...", container: kube-rbac-proxy)

For reference, the underlying issue that makes this workaround necessary is tracked here:
https://github.com/docker/for-mac/issues/7723