### PR TITLE
fix(chart): apply tolerations, priority class and affinity to hooks

### DIFF
--- a/helm-chart/dash0-operator/templates/operator/post-install-hook.yaml
+++ b/helm-chart/dash0-operator/templates/operator/post-install-hook.yaml
@@ -26,6 +26,21 @@ spec:
         app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
         helm.sh/chart: {{ include "dash0-operator.chartNameWithVersion" . }}
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: "dash0.com/enable"
+                    operator: "NotIn"
+                    values: ["false"]
+{{- if .Values.operator.tolerations }}
+      tolerations:
+        {{- toYaml .Values.operator.tolerations | nindent 8 }}
+{{- end }}
+{{- if .Values.operator.managerPriorityClassName }}
+      priorityClassName: {{ .Values.operator.managerPriorityClassName }}
+{{- end }}
       restartPolicy: OnFailure
       containers:
         - name: post-install-job

--- a/helm-chart/dash0-operator/templates/operator/pre-delete-hook.yaml
+++ b/helm-chart/dash0-operator/templates/operator/pre-delete-hook.yaml
@@ -23,6 +23,21 @@ spec:
         helm.sh/chart: {{ include "dash0-operator.chartNameWithVersion" . }}
     spec:
       restartPolicy: OnFailure
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: "dash0.com/enable"
+                    operator: "NotIn"
+                    values: ["false"]
+{{- if .Values.operator.tolerations }}
+      tolerations:
+        {{- toYaml .Values.operator.tolerations | nindent 8 }}
+{{- end }}
+{{- if .Values.operator.managerPriorityClassName }}
+      priorityClassName: {{ .Values.operator.managerPriorityClassName }}
+{{- end }}
       containers:
         - name: pre-delete-job
           image: {{ include "dash0-operator.image" . | quote }}

--- a/helm-chart/dash0-operator/tests/operator/__snapshot__/post-install-hook_test.yaml.snap
+++ b/helm-chart/dash0-operator/tests/operator/__snapshot__/post-install-hook_test.yaml.snap
@@ -28,6 +28,15 @@ post-install hook job should match snapshot:
             helm.sh/chart: dash0-operator-0.0.0
           name: RELEASE-NAME-post-install-job
         spec:
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: dash0.com/enable
+                        operator: NotIn
+                        values:
+                          - "false"
           automountServiceAccountToken: true
           containers:
             - command:

--- a/helm-chart/dash0-operator/tests/operator/__snapshot__/pre-delete-hook_test.yaml.snap
+++ b/helm-chart/dash0-operator/tests/operator/__snapshot__/pre-delete-hook_test.yaml.snap
@@ -28,6 +28,15 @@ pre-delete hook job should match snapshot:
             helm.sh/chart: dash0-operator-0.0.0
           name: RELEASE-NAME-pre-delete-job
         spec:
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: dash0.com/enable
+                        operator: NotIn
+                        values:
+                          - "false"
           automountServiceAccountToken: true
           containers:
             - command:

--- a/helm-chart/dash0-operator/tests/operator/post-install-hook_test.yaml
+++ b/helm-chart/dash0-operator/tests/operator/post-install-hook_test.yaml
@@ -37,3 +37,35 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+
+  - it: should render tolerations and priority class
+    set:
+      operator:
+        dash0Export:
+          enabled: true
+          endpoint: https://ingress.dash0.com
+          token: "very-secret-dash0-auth-token"
+          apiEndpoint: https://api.dash0.com
+        tolerations:
+          - key: key1
+            operator: Equal
+            value: value1
+            effect: NoSchedule
+          - key: key2
+            operator: Exists
+            effect: NoSchedule
+        managerPriorityClassName: operator-manager-priority-class
+    asserts:
+      - equal:
+          path: spec.template.spec.tolerations
+          value:
+            - key: key1
+              operator: Equal
+              value: value1
+              effect: NoSchedule
+            - key: key2
+              operator: Exists
+              effect: NoSchedule
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: operator-manager-priority-class

--- a/helm-chart/dash0-operator/tests/operator/pre-delete-hook_test.yaml
+++ b/helm-chart/dash0-operator/tests/operator/pre-delete-hook_test.yaml
@@ -14,3 +14,30 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].image
           value: ghcr.io/dash0hq/operator-controller:99.100.101
+
+  - it: should render tolerations and priority class
+    set:
+      operator:
+        tolerations:
+          - key: key1
+            operator: Equal
+            value: value1
+            effect: NoSchedule
+          - key: key2
+            operator: Exists
+            effect: NoSchedule
+        managerPriorityClassName: operator-manager-priority-class
+    asserts:
+      - equal:
+          path: spec.template.spec.tolerations
+          value:
+            - key: key1
+              operator: Equal
+              value: value1
+              effect: NoSchedule
+            - key: key2
+              operator: Exists
+              effect: NoSchedule
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: operator-manager-priority-class


### PR DESCRIPTION
In particular, these are now also applied to the post-install and the pre-delete Helm hook jobs. Without the tolerations for example, the operator would be scheduled on tainted nodes, but the post-install hook pod not, so helm install --wait would wait forever.