### PR TITLE
feat: add nodeSelector for Linux nodes conditionally

### DIFF
--- a/helm-chart/dash0-operator/templates/operator/deployment-and-webhooks.yaml
+++ b/helm-chart/dash0-operator/templates/operator/deployment-and-webhooks.yaml
@@ -292,6 +292,10 @@ spec:
       - name: config-volume
         configMap:
           name: {{ template "dash0-operator.extraConfigMapName" . }}
+      {{- if not .Values.operator.applyLinuxNodeSelector }}
+      nodeSelector:
+        kubernetes.io/os: linux
+      {{- end }}
 
 {{/*
 ---------------

--- a/helm-chart/dash0-operator/templates/operator/deployment-and-webhooks.yaml
+++ b/helm-chart/dash0-operator/templates/operator/deployment-and-webhooks.yaml
@@ -292,7 +292,7 @@ spec:
       - name: config-volume
         configMap:
           name: {{ template "dash0-operator.extraConfigMapName" . }}
-      {{- if not .Values.operator.applyLinuxNodeSelector }}
+      {{- if not .Values.operator.applyPodLinuxNodeSelector }}
       nodeSelector:
         kubernetes.io/os: linux
       {{- end }}

--- a/helm-chart/dash0-operator/values.yaml
+++ b/helm-chart/dash0-operator/values.yaml
@@ -184,6 +184,9 @@ operator:
   #   annotation2: "value 2"
   podAnnotations: {}
 
+  # if working on a multi-platform cluster, you can turn on a linux node selector for the operator manager pod(s)
+  applyPodLinuxNodeSelector: false
+
   # resources for the operator manager container
   managerContainerResources:
     limits:


### PR DESCRIPTION
This PR proposes adding a conditional value (defaulted to false for backward compatibility) with node selectors for Linux.

On multi-platform clusters we need this selector to stop allocating the operator pods to non-Linux nodes.

The other option would be to add a generic pod spec "extras" field in the values but looking at the other values in this chart there doesn't seem to be a convention to add something like that.