### PR TITLE
feat(collectors): enable inodes & container restarts metrics

### DIFF
--- a/internal/collectors/otelcolresources/daemonset.config.yaml.template
+++ b/internal/collectors/otelcolresources/daemonset.config.yaml.template
@@ -74,15 +74,6 @@ receivers:
         enabled: true
       k8s.pod.memory_request_utilization:
         enabled: true
-      # With metric_groups including "volume" (see above), volume metrics will be collected. Disable the inode-related
-      # metrics, and only leave k8s.volume.available and k8s.volume.capacity enabled (they are enabled by default if
-      # the metric group volume is explicitly enabled via metric_groups).
-      k8s.volume.inodes:
-        enabled: false
-      k8s.volume.inodes.free:
-        enabled: false
-      k8s.volume.inodes.used:
-        enabled: false
 
 {{- end }}{{/* if .KubeletStatsReceiverConfig.Enabled */}}
 

--- a/internal/collectors/otelcolresources/deployment.config.yaml.template
+++ b/internal/collectors/otelcolresources/deployment.config.yaml.template
@@ -6,8 +6,8 @@ extensions:
 receivers:
   k8s_cluster:
     metrics:
-      k8s.container.restarts:
-        enabled: false
+      k8s.container.status.reason:
+        enabled: true
       k8s.namespace.phase:
         enabled: false
 

--- a/test/e2e/k8s_cluster_receiver_metrics.txt
+++ b/test/e2e/k8s_cluster_receiver_metrics.txt
@@ -6,6 +6,8 @@ k8s.container.ephemeralstorage_request
 k8s.container.memory_limit
 k8s.container.memory_request
 k8s.container.ready
+k8s.container.restarts
+k8s.container.status.reason
 k8s.container.storage_limit
 k8s.container.storage_request
 k8s.cronjob.active_jobs

--- a/test/e2e/kubeletstats_receiver_metrics.txt
+++ b/test/e2e/kubeletstats_receiver_metrics.txt
@@ -53,3 +53,6 @@ k8s.pod.network.io
 k8s.pod.uptime
 k8s.volume.available
 k8s.volume.capacity
+k8s.volume.inodes
+k8s.volume.inodes.free
+k8s.volume.inodes.used


### PR DESCRIPTION
New metrics:
- kubeletstats receiver:
  - k8s.volume.inodes
  - k8s.volume.inodes.free
  - k8s.volume.inodes.used
- k8scluster receiver:
  - k8s.container.restarts
  - k8s.container.status.reason