### PR TITLE
test: update k8s binaries version in *_suite_test.go

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,7 @@ FILELOG_OFFSET_VOLUME_OWNERSHIP_IMG ?= $(FILELOG_OFFSET_VOLUME_OWNERSHIP_IMG_REP
 FILELOG_OFFSET_VOLUME_OWNERSHIP_IMG_PULL_POLICY ?= Never
 
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
+# Maintenance note: Keep this in sync with EnvtestK8sVersion in test/util/constants.go.
 ENVTEST_K8S_VERSION = 1.34.1
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)

--- a/internal/collectors/collectors_suite_test.go
+++ b/internal/collectors/collectors_suite_test.go
@@ -22,6 +22,8 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	. "github.com/dash0hq/dash0-operator/test/util"
 )
 
 var (
@@ -44,7 +46,7 @@ var _ = BeforeSuite(func() {
 		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
 		ErrorIfCRDPathMissing: true,
 		BinaryAssetsDirectory: filepath.Join("..", "..", "bin", "k8s",
-			fmt.Sprintf("1.28.3-%s-%s", runtime.GOOS, runtime.GOARCH)),
+			fmt.Sprintf("%s-%s-%s", EnvtestK8sVersion, runtime.GOOS, runtime.GOARCH)),
 	}
 
 	var err error

--- a/internal/collectors/otelcolresources/otelcol_resources_suite_test.go
+++ b/internal/collectors/otelcolresources/otelcol_resources_suite_test.go
@@ -51,7 +51,7 @@ var _ = BeforeSuite(func() {
 		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
 		ErrorIfCRDPathMissing: true,
 		BinaryAssetsDirectory: filepath.Join("..", "..", "..", "bin", "k8s",
-			fmt.Sprintf("1.28.3-%s-%s", runtime.GOOS, runtime.GOARCH)),
+			fmt.Sprintf("%s-%s-%s", EnvtestK8sVersion, runtime.GOOS, runtime.GOARCH)),
 	}
 
 	var err error

--- a/internal/controller/controller_suite_test.go
+++ b/internal/controller/controller_suite_test.go
@@ -27,6 +27,8 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/format"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
+
+	. "github.com/dash0hq/dash0-operator/test/util"
 )
 
 const (
@@ -58,7 +60,7 @@ var _ = BeforeSuite(func() {
 		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
 		ErrorIfCRDPathMissing: true,
 		BinaryAssetsDirectory: filepath.Join("..", "..", "bin", "k8s",
-			fmt.Sprintf("1.28.3-%s-%s", runtime.GOOS, runtime.GOARCH)),
+			fmt.Sprintf("%s-%s-%s", EnvtestK8sVersion, runtime.GOOS, runtime.GOARCH)),
 	}
 
 	var err error

--- a/internal/instrumentation/instrumentation_suite_test.go
+++ b/internal/instrumentation/instrumentation_suite_test.go
@@ -25,6 +25,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/format"
+
+	. "github.com/dash0hq/dash0-operator/test/util"
 )
 
 var (
@@ -50,7 +52,7 @@ var _ = BeforeSuite(func() {
 		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
 		ErrorIfCRDPathMissing: true,
 		BinaryAssetsDirectory: filepath.Join("..", "..", "bin", "k8s",
-			fmt.Sprintf("1.28.3-%s-%s", runtime.GOOS, runtime.GOARCH)),
+			fmt.Sprintf("%s-%s-%s", EnvtestK8sVersion, runtime.GOOS, runtime.GOARCH)),
 	}
 
 	var err error

--- a/internal/postinstall/post_install_suite_test.go
+++ b/internal/postinstall/post_install_suite_test.go
@@ -26,6 +26,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/format"
+
+	. "github.com/dash0hq/dash0-operator/test/util"
 )
 
 var (
@@ -64,7 +66,7 @@ var _ = BeforeSuite(func() {
 		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
 		ErrorIfCRDPathMissing: true,
 		BinaryAssetsDirectory: filepath.Join("..", "..", "bin", "k8s",
-			fmt.Sprintf("1.28.3-%s-%s", runtime.GOOS, runtime.GOARCH)),
+			fmt.Sprintf("%s-%s-%s", EnvtestK8sVersion, runtime.GOOS, runtime.GOARCH)),
 	}
 
 	var err error

--- a/internal/predelete/pre_delete_suite_test.go
+++ b/internal/predelete/pre_delete_suite_test.go
@@ -63,7 +63,7 @@ var _ = BeforeSuite(func() {
 		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
 		ErrorIfCRDPathMissing: true,
 		BinaryAssetsDirectory: filepath.Join("..", "..", "bin", "k8s",
-			fmt.Sprintf("1.28.3-%s-%s", runtime.GOOS, runtime.GOARCH)),
+			fmt.Sprintf("%s-%s-%s", EnvtestK8sVersion, runtime.GOOS, runtime.GOARCH)),
 	}
 
 	var err error

--- a/internal/resources/resources_suite_test.go
+++ b/internal/resources/resources_suite_test.go
@@ -26,6 +26,8 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/format"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
+
+	. "github.com/dash0hq/dash0-operator/test/util"
 )
 
 var (
@@ -51,7 +53,7 @@ var _ = BeforeSuite(func() {
 		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
 		ErrorIfCRDPathMissing: true,
 		BinaryAssetsDirectory: filepath.Join("..", "..", "bin", "k8s",
-			fmt.Sprintf("1.28.3-%s-%s", runtime.GOOS, runtime.GOARCH)),
+			fmt.Sprintf("%s-%s-%s", EnvtestK8sVersion, runtime.GOOS, runtime.GOARCH)),
 	}
 
 	var err error

--- a/internal/selfmonitoringapiaccess/selfmonitoringapiaccess_suite_test.go
+++ b/internal/selfmonitoringapiaccess/selfmonitoringapiaccess_suite_test.go
@@ -21,6 +21,8 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/format"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
+
+	. "github.com/dash0hq/dash0-operator/test/util"
 )
 
 var (
@@ -44,7 +46,7 @@ var _ = BeforeSuite(func() {
 		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
 		ErrorIfCRDPathMissing: true,
 		BinaryAssetsDirectory: filepath.Join("..", "..", "bin", "k8s",
-			fmt.Sprintf("1.28.3-%s-%s", runtime.GOOS, runtime.GOARCH)),
+			fmt.Sprintf("%s-%s-%s", EnvtestK8sVersion, runtime.GOOS, runtime.GOARCH)),
 	}
 
 	var err error

--- a/internal/startup/startup_suite_test.go
+++ b/internal/startup/startup_suite_test.go
@@ -22,6 +22,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/format"
+
+	. "github.com/dash0hq/dash0-operator/test/util"
 )
 
 var (
@@ -46,7 +48,7 @@ var _ = BeforeSuite(func() {
 		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
 		ErrorIfCRDPathMissing: true,
 		BinaryAssetsDirectory: filepath.Join("..", "..", "bin", "k8s",
-			fmt.Sprintf("1.28.3-%s-%s", runtime.GOOS, runtime.GOARCH)),
+			fmt.Sprintf("%s-%s-%s", EnvtestK8sVersion, runtime.GOOS, runtime.GOARCH)),
 	}
 
 	var err error

--- a/internal/webhooks/webhook_suite_test.go
+++ b/internal/webhooks/webhook_suite_test.go
@@ -80,7 +80,7 @@ var _ = BeforeSuite(func() {
 		},
 		ErrorIfCRDPathMissing: true,
 		BinaryAssetsDirectory: filepath.Join("..", "..", "bin", "k8s",
-			fmt.Sprintf("1.28.3-%s-%s", runtime.GOOS, runtime.GOARCH)),
+			fmt.Sprintf("%s-%s-%s", EnvtestK8sVersion, runtime.GOOS, runtime.GOARCH)),
 		WebhookInstallOptions: envtest.WebhookInstallOptions{
 			Paths: []string{filepath.Join("..", "..", "config", "webhook")},
 		},

--- a/test/util/constants.go
+++ b/test/util/constants.go
@@ -18,6 +18,10 @@ import (
 )
 
 const (
+	// EnvtestK8sVersion is the version of the binaries used by envtest. Maintenance note: Keep this in sync with
+	// ENVTEST_K8S_VERSION in the Makefile.
+	EnvtestK8sVersion = "1.34.1"
+
 	ClusterUidTest              = "cluster-uid-test"
 	ClusterNameTest             = "cluster-name-test"
 	TestNamespaceName           = "test-namespace"


### PR DESCRIPTION
This is a follow up to commit df473346b29255acca2ea0449d4b869f56e57b1e, specifically to this change:
https://github.com/dash0hq/dash0-operator/commit/df473346b29255acca2ea0449d4b869f56e57b1e#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R90

It seems that it is best to keep the ENVTEST_K8S_VERSION in the Makefile and the version referenced in the various *_suite_test.go files in sync. Running Go unit tests via make test does not depend on this, since the make targets make sure to set KUBEBUILDER_ASSETS correctly. (And KUBEBUILDER_ASSETS is interpreted by envtest, see
https://book.kubebuilder.io/reference/envtest.)

However, running Go unit tests via other means (for example directly via the IDE) can fail if the versions do not match.