### PR TITLE
feat(workloads): do not attempt to instrument non-Linux workloads

### DIFF
--- a/internal/collectors/otelcolresources/desired_state.go
+++ b/internal/collectors/otelcolresources/desired_state.go
@@ -100,8 +100,7 @@ const (
 	fileLogOffsetSync = "filelog-offset-sync"
 
 	// label keys
-	dash0OptOutLabelKey    = "dash0.com/enable"
-	nodeOsSelectorLabelKey = "kubernetes.io/os"
+	dash0OptOutLabelKey = "dash0.com/enable"
 
 	// label values
 	appKubernetesIoNameValue      = openTelemetryCollector
@@ -588,7 +587,7 @@ func assembleCollectorDaemonSet(config *oTelColConfig, extraConfig util.ExtraCon
 									Values:   []string{"false"},
 								},
 								{
-									Key:      nodeOsSelectorLabelKey,
+									Key:      util.KubernetesIoOs,
 									Operator: corev1.NodeSelectorOpIn,
 									Values:   []string{"linux"},
 								},
@@ -1298,7 +1297,7 @@ func assembleCollectorDeployment(
 									Values:   []string{"false"},
 								},
 								{
-									Key:      nodeOsSelectorLabelKey,
+									Key:      util.KubernetesIoOs,
 									Operator: corev1.NodeSelectorOpIn,
 									Values:   []string{"linux"},
 								},

--- a/internal/util/constants.go
+++ b/internal/util/constants.go
@@ -27,6 +27,7 @@ const (
 	AppKubernetesIoComponentLabel = "app.kubernetes.io/component"
 	AppKubernetesIoManagedByLabel = "app.kubernetes.io/managed-by"
 	AppKubernetesIoVersionLabel   = "app.kubernetes.io/version"
+	KubernetesIoOs                = "kubernetes.io/os"
 )
 
 func RenderAuthorizationHeader(authToken string) string {


### PR DESCRIPTION
While we cannot always predict the target OS of a workload in advance
with 100% accuracy, there are at least some good heuristics which we can
make use of:
- pod.spec.os.name != linux
- pod.spec.nodeSelector: kubernetes.io/os=windows
- pod.spec.affinities.nodeAffinities.requiredDuringSchedulingIgnoredDuringExecution.matchExpression
  for the kubernetes.io/os label and operator In/NotIn

Workloads for which the pod spec contains any of the above will not be
instrumented by the operator.

fixes #547