### PR TITLE
chore(chart): add imagePullSecrets to helm hooks

### DIFF
--- a/helm-chart/dash0-operator/Chart.yaml
+++ b/helm-chart/dash0-operator/Chart.yaml
@@ -19,5 +19,7 @@ sources:
 maintainers:
   - name: Bastian Krol
     email: bastian.krol@dash0.com
+  - name: Petra Bierleutgeb
+    email: petra.bierleutgeb@dash0.com
 icon: https://www.dash0.com/shared/logo_colors_128x128.png
 appVersion: "0.0.0" # note: will be replaced when building a release

--- a/helm-chart/dash0-operator/templates/operator/post-install-hook.yaml
+++ b/helm-chart/dash0-operator/templates/operator/post-install-hook.yaml
@@ -55,6 +55,10 @@ spec:
           {{ include "dash0-operator.restrictiveContainerSecurityContext" dict | nindent 10 }}
           resources:
             {{- toYaml .Values.operator.managerContainerResources | nindent 12 }}
+      {{- with .Values.operator.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       securityContext:
         runAsNonRoot: true
       serviceAccountName: {{ template "dash0-operator.serviceAccountName" . }}

--- a/helm-chart/dash0-operator/templates/operator/pre-delete-hook.yaml
+++ b/helm-chart/dash0-operator/templates/operator/pre-delete-hook.yaml
@@ -51,6 +51,10 @@ spec:
           {{ include "dash0-operator.restrictiveContainerSecurityContext" dict | nindent 10 }}
           resources:
             {{- toYaml .Values.operator.managerContainerResources | nindent 12 }}
+      {{- with .Values.operator.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       securityContext:
         runAsNonRoot: true
       serviceAccountName: {{ template "dash0-operator.serviceAccountName" . }}

--- a/helm-chart/dash0-operator/tests/operator/deployment-and-webhooks_test.yaml
+++ b/helm-chart/dash0-operator/tests/operator/deployment-and-webhooks_test.yaml
@@ -1085,3 +1085,22 @@ tests:
       - exists:
           path: spec.template.metadata.labels["dash0.com/cert-digest"]
         not: true
+
+  - it: should consider the provided imagePullSecrets
+    set:
+      operator:
+        dash0Export:
+          enabled: true
+          endpoint: https://ingress.dash0.com
+          token: "very-secret-dash0-auth-token"
+          apiEndpoint: https://api.dash0.com
+        imagePullSecrets:
+          - name: secret-for-private-reg
+    documentSelector:
+      path: metadata.name
+      value: dash0-operator-controller
+    asserts:
+      - equal:
+          path: spec.template.spec.imagePullSecrets
+          value:
+            - name: secret-for-private-reg

--- a/helm-chart/dash0-operator/tests/operator/post-install-hook_test.yaml
+++ b/helm-chart/dash0-operator/tests/operator/post-install-hook_test.yaml
@@ -69,3 +69,19 @@ tests:
       - equal:
           path: spec.template.spec.priorityClassName
           value: operator-manager-priority-class
+
+  - it: should consider the provided imagePullSecrets
+    set:
+      operator:
+        dash0Export:
+          enabled: true
+          endpoint: https://ingress.dash0.com
+          token: "very-secret-dash0-auth-token"
+          apiEndpoint: https://api.dash0.com
+        imagePullSecrets:
+          - name: secret-for-private-reg
+    asserts:
+      - equal:
+          path: spec.template.spec.imagePullSecrets
+          value:
+            - name: secret-for-private-reg

--- a/helm-chart/dash0-operator/tests/operator/pre-delete-hook_test.yaml
+++ b/helm-chart/dash0-operator/tests/operator/pre-delete-hook_test.yaml
@@ -41,3 +41,19 @@ tests:
       - equal:
           path: spec.template.spec.priorityClassName
           value: operator-manager-priority-class
+
+  - it: should consider the provided imagePullSecrets
+    set:
+      operator:
+        dash0Export:
+          enabled: true
+          endpoint: https://ingress.dash0.com
+          token: "very-secret-dash0-auth-token"
+          apiEndpoint: https://api.dash0.com
+        imagePullSecrets:
+          - name: secret-for-private-reg
+    asserts:
+      - equal:
+          path: spec.template.spec.imagePullSecrets
+          value:
+            - name: secret-for-private-reg


### PR DESCRIPTION
When using a controller image from a private registry, the helm hooks would fail to pull the image because the `imagePullSecrets` from the values file were not used there.