### PR TITLE
chore: improve image label

### DIFF
--- a/internal/util/labels_test.go
+++ b/internal/util/labels_test.go
@@ -12,20 +12,20 @@ var _ = Describe("labels", func() {
 
 	Describe("converting labels", func() {
 		It("should leave normal characters untouched", func() {
-			Expect(ImageNameToLabel("instrumentation")).To(Equal("instrumentation"))
+			Expect(ImageRefToLabel("instrumentation")).To(Equal("instrumentation"))
 		})
 
 		It("should convert : to _", func() {
-			Expect(ImageNameToLabel("instrumentation:latest")).To(Equal("instrumentation_latest"))
+			Expect(ImageRefToLabel("instrumentation:latest")).To(Equal("instrumentation_latest"))
 		})
 
 		It("should convert / to _", func() {
-			Expect(ImageNameToLabel("ghcr.io/dash0hq/operator-controller:0.3.0")).To(Equal("ghcr.io_dash0hq_operator-controller_0.3.0"))
+			Expect(ImageRefToLabel("ghcr.io/dash0hq/operator-controller:0.3.0")).To(Equal("ghcr.io_dash0hq_operator-controller_0.3.0"))
 		})
 
 		It("should convert @ to _", func() {
 			Expect(
-				ImageNameToLabel(
+				ImageRefToLabel(
 					"ghcr.io/dash0hq/operator-controller@sha256:123",
 				),
 			).To(
@@ -36,15 +36,39 @@ var _ = Describe("labels", func() {
 		})
 
 		It("should truncate long image names", func() {
-			labelFromLongImageName := ImageNameToLabel(
+			labelFromLongImageName := ImageRefToLabel(
 				"ghcr.io/dash0hq/operator-controller@sha256:68d83fa12931ba8c085d8804f5a60d0b3df68494903a7a5b6506928e0bcd3c6b",
 			)
 			Expect(labelFromLongImageName).To(
 				Equal(
-					"ghcr.io_dash0hq_operator-controller_sha256_68d83fa12931ba8c085d",
+					"operator-controller_sha256_68d83fa12931ba8c085d8804f5a60d0b3df6",
 				),
 			)
 			Expect(labelFromLongImageName).To(HaveLen(63))
+		})
+
+		It("should truncate long image names when registry part contains port", func() {
+			labelFromLongImageName := ImageRefToLabel(
+				"ghcr.io:8080/dash0hq/operator-controller@sha256:68d83fa12931ba8c085d8804f5a60d0b3df68494903a7a5b6506928e0bc",
+			)
+			Expect(labelFromLongImageName).To(
+				Equal(
+					"operator-controller_sha256_68d83fa12931ba8c085d8804f5a60d0b3df6",
+				),
+			)
+			Expect(labelFromLongImageName).To(HaveLen(63))
+		})
+
+		It("should truncate long image names and ensure the label value does not end with an invalid character", func() {
+			labelFromLongImageName := ImageRefToLabel(
+				"ghcr.io/dash0hq/operator-controller@sha256:68d83fa12931ba8c085d8804f5a60d0b3df-68494903a7a5b6506928e0bcd3c6b",
+			)
+			Expect(labelFromLongImageName).To(
+				Equal(
+					"operator-controller_sha256_68d83fa12931ba8c085d8804f5a60d0b3df",
+				),
+			)
+			Expect(labelFromLongImageName).To(HaveLen(62))
 		})
 	})
 })

--- a/test/e2e/labels.go
+++ b/test/e2e/labels.go
@@ -63,9 +63,9 @@ func expectedImageLabel(image ImageSpec, defaultImageName string) (string, bool)
 	// If the repository has been unset explicitly via the respective environment variable, the default image from the
 	// helm chart will be used, so we need to test against that.
 	if image.repository == "" {
-		return util.ImageNameToLabel(defaultImageName), false
+		return util.ImageRefToLabel(defaultImageName), false
 	}
-	return util.ImageNameToLabel(renderFullyQualifiedImageName(image)), true
+	return util.ImageRefToLabel(renderFullyQualifiedImageName(image)), true
 }
 
 func renderFullyQualifiedImageName(image ImageSpec) string {


### PR DESCRIPTION
- Improved truncation logic for long image refs: previously the image ref was truncated after the first 63 characters, which could result in the interesting parts (image repo and tag) being dropped in case of a lengthy registry part. The new logic removes the registry part before truncating to 63 characters.
- Sometimes the truncated string would start or end with a non-alphanumeric character and would therefore not conform to the k8s label spec. In these cases, the invalid character(s) are now dropped.