### PR TITLE
chore: update locations in sample synthetic check

### DIFF
--- a/test-resources/customresources/dash0syntheticcheck/dash0syntheticcheck.yaml
+++ b/test-resources/customresources/dash0syntheticcheck/dash0syntheticcheck.yaml
@@ -44,8 +44,8 @@ spec:
   schedule:
     interval: 1m
     locations:
-      - gcp-europe-west3
-      - gcp-us-west1
+      - de-frankfurt
+      - us-oregon
     strategy: all_locations
   display:
     name: Google.com


### PR DESCRIPTION
Replace deprecated technical gcp locations by user facing synthetic check locations in the sample synthetic check config

ref: https://www.dash0.com/documentation/dash0/synthetic-monitoring#synthetic-checks

<img width="955" height="327" alt="image" src="https://github.com/user-attachments/assets/d30e41d0-74e5-4a6e-a7bf-58ef9b2172b8" />

