### PR TITLE
fix: recheck string length after dropping registry part

### DIFF
--- a/internal/util/labels.go
+++ b/internal/util/labels.go
@@ -186,6 +186,8 @@ func ImageRefToLabel(imageRef string) string {
 		if lastSlash != -1 {
 			imageRef = imageRef[lastSlash+1:]
 		}
+	}
+	if len(imageRef) > maxLen {
 		imageRef = imageRef[:maxLen]
 	}
 

--- a/internal/util/labels_test.go
+++ b/internal/util/labels_test.go
@@ -70,5 +70,17 @@ var _ = Describe("labels", func() {
 			)
 			Expect(labelFromLongImageName).To(HaveLen(62))
 		})
+
+		It("should truncate long image names and leave the repo and tag unchanged if those parts are < 63 chars", func() {
+			labelFromLongImageName := ImageRefToLabel(
+				"some.very.long.registry.that.needs.to.be.truncated.io/dash0hq/operator-controller@latest",
+			)
+			Expect(labelFromLongImageName).To(
+				Equal(
+					"operator-controller_latest",
+				),
+			)
+			Expect(len(labelFromLongImageName)).To(BeNumerically("<", 63))
+		})
 	})
 })


### PR DESCRIPTION
The current code would panic with `runtime error: slice bounds out of range` when the string length is < 63 chars after dropping the registry part. We should only truncate the remaining string if it's necessary.