### PR TITLE
chore: use ubuntu-based temurin image to avoid issues with wget

### DIFF
--- a/images/instrumentation/Dockerfile
+++ b/images/instrumentation/Dockerfile
@@ -17,7 +17,7 @@ RUN zig build -Dcpu-arch=${TARGETARCH} --prominent-compile-errors --summary none
 # injector_build_end - do not remove this line (see images/instrumentation/injector/test/scripts/test-all.sh)
 
 # download OpenTelemetry Java agent
-FROM eclipse-temurin:25-jdk-alpine AS build-jvm
+FROM eclipse-temurin:25-jdk-noble AS build-jvm
 COPY jvm /dash0-init-container/instrumentation/jvm
 WORKDIR /dash0-init-container/instrumentation/jvm
 RUN ./mvnw dependency:copy-dependencies \


### PR DESCRIPTION
`alpine` comes with a minimal wget version that sometimes causes issues (see https://github.com/apache/maven-wrapper/issues/324 for example).

While I got a slightly different error (`connection refused`), switching to the ubuntu-based image solved the issue.

Given that we use caching, the additional 30mb shouldn't make a big difference.