### PR TITLE
test: use kind with port-mapping for test scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -261,7 +261,8 @@ PHONY: test-app-images
 test-app-images: \
   test-app-image-dotnet \
   test-app-image-jvm \
-  test-app-image-nodejs ## Build all test application container images. If IMAGE_PLATFORMS is set, it will be passed as --platform to the build.
+  test-app-image-nodejs \
+	test-app-image-python ## Build all test application container images. If IMAGE_PLATFORMS is set, it will be passed as --platform to the build.
 
 .PHONY: test-app-image-dotnet
 test-app-image-dotnet: ## Build the .NET test application.

--- a/test-resources/bin/lib/constants
+++ b/test-resources/bin/lib/constants
@@ -15,6 +15,7 @@ project_root="$(dirname "${BASH_SOURCE[0]}")"/../../..
 
 # various other paths, relative to project_root
 scripts_bin="test-resources/bin"
+scripts_lib="test-resources/bin/lib"
 
 # local registry (note: these are currently not configurable to avoid the need for templating in kind-config.yaml)
 local_reg_name='kind-registry'

--- a/test-resources/bin/lib/util
+++ b/test-resources/bin/lib/util
@@ -104,7 +104,7 @@ install_nginx_ingress() {
   if ! kubectl wait --namespace ingress-nginx --for=condition=ready pod --selector=app.kubernetes.io/component=controller --timeout=5s; then
     echo "deploying ingress-nginx..."
     echo
-    kubectl apply -f https://kind.sigs.k8s.io/examples/ingress/deploy-ingress-nginx.yaml
+    kubectl apply -k test-resources/nginx
     echo
     echo "waiting for ingress-nginx..."
     kubectl wait \
@@ -672,7 +672,7 @@ deploy_application_under_monitoring() {
       "test-resources/jvm/spring-boot/dash0-operator-test-app-jvm" \
       "test-app-jvm" \
       "${target_namespace}" \
-      "${kind}"
+      "${kind}" \
       "$test_app_jvm_image_repository" \
       "$test_app_jvm_image_tag" \
       "$test_app_jvm_image_pull_policy"
@@ -701,7 +701,7 @@ deploy_application_under_monitoring() {
       "test-resources/dotnet/dash0-operator-test-app-dotnet" \
       "test-app-dotnet" \
       "${target_namespace}" \
-      "${kind}"
+      "${kind}" \
       "$test_app_dotnet_image_repository" \
       "$test_app_dotnet_image_tag" \
       "$test_app_dotnet_image_pull_policy"

--- a/test-resources/dotnet/dash0-operator-test-app-dotnet/templates/_helpers.tpl
+++ b/test-resources/dotnet/dash0-operator-test-app-dotnet/templates/_helpers.tpl
@@ -24,7 +24,7 @@ spec:
   ports:
     - port: {{ .port }}
       targetPort: {{ .targetPort }}
-  type: LoadBalancer
+  type: ClusterIP
 {{- end }}
 
 {{/*

--- a/test-resources/dotnet/dash0-operator-test-app-dotnet/templates/daemonset.yaml
+++ b/test-resources/dotnet/dash0-operator-test-app-dotnet/templates/daemonset.yaml
@@ -22,7 +22,7 @@ spec:
         test.label/key: "label-value"
       annotations:
         prometheus.io/scrape: "true"
-        prometheus.io/port: "{{ .Values.daemonset.port }}"
+        prometheus.io/port: "{{ .Values.daemonset.targetPort }}"
         test.annotation/key: "annotation value"
     spec:
       containers:
@@ -30,7 +30,7 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           env:
             - name: PORT
-              value: "{{ .Values.daemonset.port }}"
+              value: "{{ .Values.daemonset.targetPort }}"
             # See https://opentelemetry.io/docs/zero-code/dotnet/instrumentations/#instrumentation-options
             - name: OTEL_DOTNET_EXPERIMENTAL_ASPNETCORE_DISABLE_URL_QUERY_REDACTION
               value: "true"
@@ -39,14 +39,14 @@ spec:
             - name: OTEL_DOTNET_EXPERIMENTAL_HTTPCLIENT_DISABLE_URL_QUERY_REDACTION
               value: "true"
           ports:
-            - containerPort: {{ .Values.daemonset.port }}
+            - containerPort: {{ .Values.daemonset.targetPort }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           readinessProbe:
             httpGet:
               path: /ready
-              port: {{ .Values.daemonset.port }}
+              port: {{ .Values.daemonset.targetPort }}
             initialDelaySeconds: 1
             periodSeconds: 1
 {{- end }}

--- a/test-resources/dotnet/dash0-operator-test-app-dotnet/templates/deployment.yaml
+++ b/test-resources/dotnet/dash0-operator-test-app-dotnet/templates/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         test.label/key: "label-value"
       annotations:
         prometheus.io/scrape: "true"
-        prometheus.io/port: "{{ .Values.deployment.port }}"
+        prometheus.io/port: "{{ .Values.deployment.targetPort }}"
         test.annotation/key: "annotation value"
     spec:
       containers:
@@ -32,7 +32,7 @@ spec:
           env:
             - name: PORT
               # See https://opentelemetry.io/docs/zero-code/dotnet/instrumentations/#instrumentation-options
-              value: "{{ .Values.deployment.port }}"
+              value: "{{ .Values.deployment.targetPort }}"
             - name: OTEL_DOTNET_EXPERIMENTAL_ASPNETCORE_DISABLE_URL_QUERY_REDACTION
               value: "true"
             - name: OTEL_DOTNET_EXPERIMENTAL_ASPNET_DISABLE_URL_QUERY_REDACTION
@@ -40,14 +40,14 @@ spec:
             - name: OTEL_DOTNET_EXPERIMENTAL_HTTPCLIENT_DISABLE_URL_QUERY_REDACTION
               value: "true"
           ports:
-            - containerPort: {{ .Values.deployment.port }}
+            - containerPort: {{ .Values.deployment.targetPort }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           readinessProbe:
             httpGet:
               path: /ready
-              port: {{ .Values.deployment.port }}
+              port: {{ .Values.deployment.targetPort }}
             initialDelaySeconds: 1
             periodSeconds: 1
 {{- end }}

--- a/test-resources/dotnet/dash0-operator-test-app-dotnet/templates/pod.yaml
+++ b/test-resources/dotnet/dash0-operator-test-app-dotnet/templates/pod.yaml
@@ -14,7 +14,7 @@ metadata:
     {{- end }}
   annotations:
     prometheus.io/scrape: "true"
-    prometheus.io/port: "{{ .Values.pod.port }}"
+    prometheus.io/port: "{{ .Values.pod.targetPort }}"
     test.annotation/key: "annotation value"
 spec:
   containers:
@@ -23,7 +23,7 @@ spec:
       env:
         - name: PORT
           # See https://opentelemetry.io/docs/zero-code/dotnet/instrumentations/#instrumentation-options
-          value: "{{ .Values.pod.port }}"
+          value: "{{ .Values.pod.targetPort }}"
         - name: OTEL_DOTNET_EXPERIMENTAL_ASPNETCORE_DISABLE_URL_QUERY_REDACTION
           value: "true"
         - name: OTEL_DOTNET_EXPERIMENTAL_ASPNET_DISABLE_URL_QUERY_REDACTION
@@ -31,14 +31,14 @@ spec:
         - name: OTEL_DOTNET_EXPERIMENTAL_HTTPCLIENT_DISABLE_URL_QUERY_REDACTION
           value: "true"
       ports:
-        - containerPort: {{ .Values.pod.port }}
+        - containerPort: {{ .Values.pod.targetPort }}
       resources:
         {{- toYaml .Values.resources | nindent 8 }}
       imagePullPolicy: {{ .Values.image.pullPolicy }}
       readinessProbe:
         httpGet:
           path: /ready
-          port: {{ .Values.pod.port }}
+          port: {{ .Values.pod.targetPort }}
         initialDelaySeconds: 1
         periodSeconds: 1
 {{- end }}

--- a/test-resources/dotnet/dash0-operator-test-app-dotnet/templates/replicaset.yaml
+++ b/test-resources/dotnet/dash0-operator-test-app-dotnet/templates/replicaset.yaml
@@ -23,7 +23,7 @@ spec:
         test.label/key: "label-value"
       annotations:
         prometheus.io/scrape: "true"
-        prometheus.io/port: "{{ .Values.replicaset.port }}"
+        prometheus.io/port: "{{ .Values.replicaset.targetPort }}"
         test.annotation/key: "annotation value"
     spec:
       containers:
@@ -31,7 +31,7 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           env:
             - name: PORT
-              value: "{{ .Values.replicaset.port }}"
+              value: "{{ .Values.replicaset.targetPort }}"
               # See https://opentelemetry.io/docs/zero-code/dotnet/instrumentations/#instrumentation-options
             - name: OTEL_DOTNET_EXPERIMENTAL_ASPNETCORE_DISABLE_URL_QUERY_REDACTION
               value: "true"
@@ -40,14 +40,14 @@ spec:
             - name: OTEL_DOTNET_EXPERIMENTAL_HTTPCLIENT_DISABLE_URL_QUERY_REDACTION
               value: "true"
           ports:
-            - containerPort: {{ .Values.replicaset.port }}
+            - containerPort: {{ .Values.replicaset.targetPort }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           readinessProbe:
             httpGet:
               path: /ready
-              port: {{ .Values.replicaset.port }}
+              port: {{ .Values.replicaset.targetPort }}
             initialDelaySeconds: 1
             periodSeconds: 1
 {{- end }}

--- a/test-resources/dotnet/dash0-operator-test-app-dotnet/templates/statefulset.yaml
+++ b/test-resources/dotnet/dash0-operator-test-app-dotnet/templates/statefulset.yaml
@@ -23,7 +23,7 @@ spec:
         test.label/key: "label-value"
       annotations:
         prometheus.io/scrape: "true"
-        prometheus.io/port: "{{ .Values.statefulset.port }}"
+        prometheus.io/port: "{{ .Values.statefulset.targetPort }}"
         test.annotation/key: "annotation value"
     spec:
       terminationGracePeriodSeconds: 3
@@ -33,7 +33,7 @@ spec:
           env:
             - name: PORT
               # See https://opentelemetry.io/docs/zero-code/dotnet/instrumentations/#instrumentation-options
-              value: "{{ .Values.statefulset.port }}"
+              value: "{{ .Values.statefulset.targetPort }}"
             - name: OTEL_DOTNET_EXPERIMENTAL_ASPNETCORE_DISABLE_URL_QUERY_REDACTION
               value: "true"
             - name: OTEL_DOTNET_EXPERIMENTAL_ASPNET_DISABLE_URL_QUERY_REDACTION
@@ -41,14 +41,14 @@ spec:
             - name: OTEL_DOTNET_EXPERIMENTAL_HTTPCLIENT_DISABLE_URL_QUERY_REDACTION
               value: "true"
           ports:
-            - containerPort: {{ .Values.statefulset.port }}
+            - containerPort: {{ .Values.statefulset.targetPort }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           readinessProbe:
             httpGet:
               path: /ready
-              port: {{ .Values.statefulset.port }}
+              port: {{ .Values.statefulset.targetPort }}
             initialDelaySeconds: 1
             periodSeconds: 1
 {{- end }}

--- a/test-resources/jvm/spring-boot/Dockerfile
+++ b/test-resources/jvm/spring-boot/Dockerfile
@@ -1,13 +1,27 @@
 # SPDX-FileCopyrightText: Copyright 2025 Dash0 Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-ARG JDK_VERSION=24
+ARG JDK_VERSION=25
 
-FROM eclipse-temurin:${JDK_VERSION}-jdk-alpine
+FROM eclipse-temurin:${JDK_VERSION}-jdk-noble
 
-COPY . .
-COPY .m2 /m2
+RUN groupadd -r appuser && useradd -r -g appuser -m -s /bin/bash appuser
 
-RUN JAVA_HOME=$(which java | xargs dirname | xargs dirname) "./mvnw" "-gs" "/m2/settings.xml" package
+WORKDIR /app
 
-ENTRYPOINT [ "java", "-jar", "/target/app.jar" ]
+COPY --chmod=755 mvnw ./
+COPY --chmod=644 pom.xml ./
+COPY --chmod=755 .mvn ./.mvn
+COPY --chmod=755 src ./src
+
+COPY --chmod=755 --chown=appuser:appuser .m2 /home/appuser/.m2
+RUN chown -R appuser:appuser /app
+
+USER appuser
+
+RUN JAVA_HOME=$(which java | xargs dirname | xargs dirname) \
+    ./mvnw -gs /home/appuser/.m2/settings.xml \
+    -Dmaven.repo.local=/home/appuser/.m2/repository \
+    package
+
+ENTRYPOINT ["java", "-jar", "/app/target/app.jar"]

--- a/test-resources/jvm/spring-boot/dash0-operator-test-app-jvm/templates/_helpers.tpl
+++ b/test-resources/jvm/spring-boot/dash0-operator-test-app-jvm/templates/_helpers.tpl
@@ -24,7 +24,7 @@ spec:
   ports:
     - port: {{ .port }}
       targetPort: {{ .targetPort }}
-  type: LoadBalancer
+  type: ClusterIP
 {{- end }}
 
 {{/*

--- a/test-resources/jvm/spring-boot/dash0-operator-test-app-jvm/templates/daemonset.yaml
+++ b/test-resources/jvm/spring-boot/dash0-operator-test-app-jvm/templates/daemonset.yaml
@@ -22,7 +22,7 @@ spec:
         test.label/key: "label-value"
       annotations:
         prometheus.io/scrape: "true"
-        prometheus.io/port: "{{ .Values.daemonset.port }}"
+        prometheus.io/port: "{{ .Values.daemonset.targetPort }}"
         test.annotation/key: "annotation value"
     spec:
       containers:
@@ -30,16 +30,16 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           env:
             - name: PORT
-              value: "{{ .Values.daemonset.port }}"
+              value: "{{ .Values.daemonset.targetPort }}"
           ports:
-            - containerPort: {{ .Values.daemonset.port }}
+            - containerPort: {{ .Values.daemonset.targetPort }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           readinessProbe:
             httpGet:
               path: /ready
-              port: {{ .Values.daemonset.port }}
+              port: {{ .Values.daemonset.targetPort }}
             initialDelaySeconds: 1
             periodSeconds: 1
 {{- end }}

--- a/test-resources/jvm/spring-boot/dash0-operator-test-app-jvm/templates/deployment.yaml
+++ b/test-resources/jvm/spring-boot/dash0-operator-test-app-jvm/templates/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         test.label/key: "label-value"
       annotations:
         prometheus.io/scrape: "true"
-        prometheus.io/port: "{{ .Values.deployment.port }}"
+        prometheus.io/port: "{{ .Values.deployment.targetPort }}"
         test.annotation/key: "annotation value"
     spec:
       containers:
@@ -31,16 +31,16 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           env:
             - name: PORT
-              value: "{{ .Values.deployment.port }}"
+              value: "{{ .Values.deployment.targetPort }}"
           ports:
-            - containerPort: {{ .Values.deployment.port }}
+            - containerPort: {{ .Values.deployment.targetPort }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           readinessProbe:
             httpGet:
               path: /ready
-              port: {{ .Values.deployment.port }}
+              port: {{ .Values.deployment.targetPort }}
             initialDelaySeconds: 1
             periodSeconds: 1
 {{- end }}

--- a/test-resources/jvm/spring-boot/dash0-operator-test-app-jvm/templates/pod.yaml
+++ b/test-resources/jvm/spring-boot/dash0-operator-test-app-jvm/templates/pod.yaml
@@ -14,7 +14,7 @@ metadata:
     {{- end }}
   annotations:
     prometheus.io/scrape: "true"
-    prometheus.io/port: "{{ .Values.pod.port }}"
+    prometheus.io/port: "{{ .Values.pod.targetPort }}"
     test.annotation/key: "annotation value"
 spec:
   containers:
@@ -22,16 +22,16 @@ spec:
       image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
       env:
         - name: PORT
-          value: "{{ .Values.pod.port }}"
+          value: "{{ .Values.pod.targetPort }}"
       ports:
-        - containerPort: {{ .Values.pod.port }}
+        - containerPort: {{ .Values.pod.targetPort }}
       resources:
         {{- toYaml .Values.resources | nindent 8 }}
       imagePullPolicy: {{ .Values.image.pullPolicy }}
       readinessProbe:
         httpGet:
           path: /ready
-          port: {{ .Values.pod.port }}
+          port: {{ .Values.pod.targetPort }}
         initialDelaySeconds: 1
         periodSeconds: 1
 {{- end }}

--- a/test-resources/jvm/spring-boot/dash0-operator-test-app-jvm/templates/replicaset.yaml
+++ b/test-resources/jvm/spring-boot/dash0-operator-test-app-jvm/templates/replicaset.yaml
@@ -23,7 +23,7 @@ spec:
         test.label/key: "label-value"
       annotations:
         prometheus.io/scrape: "true"
-        prometheus.io/port: "{{ .Values.replicaset.port }}"
+        prometheus.io/port: "{{ .Values.replicaset.targetPort }}"
         test.annotation/key: "annotation value"
     spec:
       containers:
@@ -31,16 +31,16 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           env:
             - name: PORT
-              value: "{{ .Values.replicaset.port }}"
+              value: "{{ .Values.replicaset.targetPort }}"
           ports:
-            - containerPort: {{ .Values.replicaset.port }}
+            - containerPort: {{ .Values.replicaset.targetPort }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           readinessProbe:
             httpGet:
               path: /ready
-              port: {{ .Values.replicaset.port }}
+              port: {{ .Values.replicaset.targetPort }}
             initialDelaySeconds: 1
             periodSeconds: 1
 {{- end }}

--- a/test-resources/jvm/spring-boot/dash0-operator-test-app-jvm/templates/statefulset.yaml
+++ b/test-resources/jvm/spring-boot/dash0-operator-test-app-jvm/templates/statefulset.yaml
@@ -23,7 +23,7 @@ spec:
         test.label/key: "label-value"
       annotations:
         prometheus.io/scrape: "true"
-        prometheus.io/port: "{{ .Values.statefulset.port }}"
+        prometheus.io/port: "{{ .Values.statefulset.targetPort }}"
         test.annotation/key: "annotation value"
     spec:
       terminationGracePeriodSeconds: 3
@@ -32,16 +32,16 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           env:
             - name: PORT
-              value: "{{ .Values.statefulset.port }}"
+              value: "{{ .Values.statefulset.targetPort }}"
           ports:
-            - containerPort: {{ .Values.statefulset.port }}
+            - containerPort: {{ .Values.statefulset.targetPort }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           readinessProbe:
             httpGet:
               path: /ready
-              port: {{ .Values.statefulset.port }}
+              port: {{ .Values.statefulset.targetPort }}
             initialDelaySeconds: 1
             periodSeconds: 1
 {{- end }}

--- a/test-resources/kind-config-lr.yaml
+++ b/test-resources/kind-config-lr.yaml
@@ -31,6 +31,15 @@ nodes:
       - hostPath: /Users/username/dash0/code/dash0-operator/test-resources/e2e/volumes/filelog-offsets
         containerPath: /offset-storage
   - role: worker
+    extraPortMappings:
+      - containerPort: 80
+        hostPort: 8080
+        protocol: TCP
+      - containerPort: 443
+        hostPort: 4443
+        protocol: TCP
+    labels:
+      nginx-ingress: "true"
     extraMounts:
       - hostPath: /Users/username/dash0/code/dash0-operator/test-resources/e2e/volumes/otlp-sink
         containerPath: /tmp/telemetry

--- a/test-resources/nginx/kustomization.yaml
+++ b/test-resources/nginx/kustomization.yaml
@@ -1,0 +1,27 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - https://kind.sigs.k8s.io/examples/ingress/deploy-ingress-nginx.yaml
+
+patches:
+  - target:
+      kind: Deployment
+      name: ingress-nginx-controller
+    patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: ingress-nginx-controller
+      spec:
+        template:
+          spec:
+            affinity:
+              nodeAffinity:
+                preferredDuringSchedulingIgnoredDuringExecution:
+                  - weight: 100
+                    preference:
+                      matchExpressions:
+                        - key: nginx-ingress
+                          operator: In
+                          values: ["true"] 

--- a/test-resources/node.js/express/dash0-operator-test-app-nodejs/templates/_helpers.tpl
+++ b/test-resources/node.js/express/dash0-operator-test-app-nodejs/templates/_helpers.tpl
@@ -24,7 +24,7 @@ spec:
   ports:
     - port: {{ .port }}
       targetPort: {{ .targetPort }}
-  type: LoadBalancer
+  type: ClusterIP
 {{- end }}
 
 {{/*

--- a/test-resources/node.js/express/dash0-operator-test-app-nodejs/templates/daemonset.yaml
+++ b/test-resources/node.js/express/dash0-operator-test-app-nodejs/templates/daemonset.yaml
@@ -22,7 +22,7 @@ spec:
         test.label/key: "label-value"
       annotations:
         prometheus.io/scrape: "true"
-        prometheus.io/port: "{{ .Values.daemonset.port }}"
+        prometheus.io/port: "{{ .Values.daemonset.targetPort }}"
         test.annotation/key: "annotation value"
     spec:
       containers:
@@ -30,16 +30,16 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           env:
             - name: PORT
-              value: "{{ .Values.daemonset.port }}"
+              value: "{{ .Values.daemonset.targetPort }}"
           ports:
-            - containerPort: {{ .Values.daemonset.port }}
+            - containerPort: {{ .Values.daemonset.targetPort }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           readinessProbe:
             httpGet:
               path: /ready
-              port: {{ .Values.daemonset.port }}
+              port: {{ .Values.daemonset.targetPort }}
             initialDelaySeconds: 1
             periodSeconds: 1
 {{- end }}

--- a/test-resources/node.js/express/dash0-operator-test-app-nodejs/templates/deployment.yaml
+++ b/test-resources/node.js/express/dash0-operator-test-app-nodejs/templates/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         test.label/key: "label-value"
       annotations:
         prometheus.io/scrape: "true"
-        prometheus.io/port: "{{ .Values.deployment.port }}"
+        prometheus.io/port: "{{ .Values.deployment.targetPort }}"
         test.annotation/key: "annotation value"
     spec:
       containers:
@@ -31,18 +31,18 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           env:
             - name: PORT
-              value: "{{ .Values.deployment.port }}"
+              value: "{{ .Values.deployment.targetPort }}"
             # - name: CREATE_TARGET_INFO_METRIC
             #   value: "true"
           ports:
-            - containerPort: {{ .Values.deployment.port }}
+            - containerPort: {{ .Values.deployment.targetPort }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           readinessProbe:
             httpGet:
               path: /ready
-              port: {{ .Values.deployment.port }}
+              port: {{ .Values.deployment.targetPort }}
             initialDelaySeconds: 1
             periodSeconds: 1
           # For testing k8s.volume.* metrics with a volume:

--- a/test-resources/node.js/express/dash0-operator-test-app-nodejs/templates/pod.yaml
+++ b/test-resources/node.js/express/dash0-operator-test-app-nodejs/templates/pod.yaml
@@ -14,7 +14,7 @@ metadata:
     {{- end }}
   annotations:
     prometheus.io/scrape: "true"
-    prometheus.io/port: "{{ .Values.pod.port }}"
+    prometheus.io/port: "{{ .Values.pod.targetPort }}"
     test.annotation/key: "annotation value"
 spec:
   containers:
@@ -22,16 +22,16 @@ spec:
       image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
       env:
         - name: PORT
-          value: "{{ .Values.pod.port }}"
+          value: "{{ .Values.pod.targetPort }}"
       ports:
-        - containerPort: {{ .Values.pod.port }}
+        - containerPort: {{ .Values.pod.targetPort }}
       resources:
         {{- toYaml .Values.resources | nindent 8 }}
       imagePullPolicy: {{ .Values.image.pullPolicy }}
       readinessProbe:
         httpGet:
           path: /ready
-          port: {{ .Values.pod.port }}
+          port: {{ .Values.pod.targetPort }}
         initialDelaySeconds: 1
         periodSeconds: 1
 {{- end }}

--- a/test-resources/node.js/express/dash0-operator-test-app-nodejs/templates/replicaset.yaml
+++ b/test-resources/node.js/express/dash0-operator-test-app-nodejs/templates/replicaset.yaml
@@ -23,7 +23,7 @@ spec:
         test.label/key: "label-value"
       annotations:
         prometheus.io/scrape: "true"
-        prometheus.io/port: "{{ .Values.replicaset.port }}"
+        prometheus.io/port: "{{ .Values.replicaset.targetPort }}"
         test.annotation/key: "annotation value"
     spec:
       containers:
@@ -31,16 +31,16 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           env:
             - name: PORT
-              value: "{{ .Values.replicaset.port }}"
+              value: "{{ .Values.replicaset.targetPort }}"
           ports:
-            - containerPort: {{ .Values.replicaset.port }}
+            - containerPort: {{ .Values.replicaset.targetPort }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           readinessProbe:
             httpGet:
               path: /ready
-              port: {{ .Values.replicaset.port }}
+              port: {{ .Values.replicaset.targetPort }}
             initialDelaySeconds: 1
             periodSeconds: 1
 {{- end }}

--- a/test-resources/node.js/express/dash0-operator-test-app-nodejs/templates/statefulset.yaml
+++ b/test-resources/node.js/express/dash0-operator-test-app-nodejs/templates/statefulset.yaml
@@ -23,7 +23,7 @@ spec:
         test.label/key: "label-value"
       annotations:
         prometheus.io/scrape: "true"
-        prometheus.io/port: "{{ .Values.statefulset.port }}"
+        prometheus.io/port: "{{ .Values.statefulset.targetPort }}"
         test.annotation/key: "annotation value"
     spec:
       terminationGracePeriodSeconds: 3
@@ -32,16 +32,16 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           env:
             - name: PORT
-              value: "{{ .Values.statefulset.port }}"
+              value: "{{ .Values.statefulset.targetPort }}"
           ports:
-            - containerPort: {{ .Values.statefulset.port }}
+            - containerPort: {{ .Values.statefulset.targetPort }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           readinessProbe:
             httpGet:
               path: /ready
-              port: {{ .Values.statefulset.port }}
+              port: {{ .Values.statefulset.targetPort }}
             initialDelaySeconds: 1
             periodSeconds: 1
 {{- end }}

--- a/test-resources/python/flask/dash0-operator-test-app-python/templates/_helpers.tpl
+++ b/test-resources/python/flask/dash0-operator-test-app-python/templates/_helpers.tpl
@@ -24,7 +24,7 @@ spec:
   ports:
     - port: {{ .port }}
       targetPort: {{ .targetPort }}
-  type: LoadBalancer
+  type: ClusterIP
 {{- end }}
 
 {{/*

--- a/test-resources/python/flask/dash0-operator-test-app-python/templates/daemonset.yaml
+++ b/test-resources/python/flask/dash0-operator-test-app-python/templates/daemonset.yaml
@@ -22,7 +22,7 @@ spec:
         test.label/key: "label-value"
       annotations:
         prometheus.io/scrape: "true"
-        prometheus.io/port: "{{ .Values.daemonset.port }}"
+        prometheus.io/port: "{{ .Values.daemonset.targetPort }}"
         test.annotation/key: "annotation value"
     spec:
       containers:
@@ -30,16 +30,16 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           env:
             - name: PORT
-              value: "{{ .Values.daemonset.port }}"
+              value: "{{ .Values.daemonset.targetPort }}"
           ports:
-            - containerPort: {{ .Values.daemonset.port }}
+            - containerPort: {{ .Values.daemonset.targetPort }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           readinessProbe:
             httpGet:
               path: /ready
-              port: {{ .Values.daemonset.port }}
+              port: {{ .Values.daemonset.targetPort }}
             initialDelaySeconds: 1
             periodSeconds: 1
 {{- end }}

--- a/test-resources/python/flask/dash0-operator-test-app-python/templates/deployment.yaml
+++ b/test-resources/python/flask/dash0-operator-test-app-python/templates/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         test.label/key: "label-value"
       annotations:
         prometheus.io/scrape: "true"
-        prometheus.io/port: "{{ .Values.deployment.port }}"
+        prometheus.io/port: "{{ .Values.deployment.targetPort }}"
         test.annotation/key: "annotation value"
     spec:
       containers:
@@ -31,16 +31,16 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           env:
             - name: PORT
-              value: "{{ .Values.deployment.port }}"
+              value: "{{ .Values.deployment.targetPort }}"
           ports:
-            - containerPort: {{ .Values.deployment.port }}
+            - containerPort: {{ .Values.deployment.targetPort }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           readinessProbe:
             httpGet:
               path: /ready
-              port: {{ .Values.deployment.port }}
+              port: {{ .Values.deployment.targetPort }}
             initialDelaySeconds: 1
             periodSeconds: 1
 {{- end }}

--- a/test-resources/python/flask/dash0-operator-test-app-python/templates/pod.yaml
+++ b/test-resources/python/flask/dash0-operator-test-app-python/templates/pod.yaml
@@ -14,7 +14,7 @@ metadata:
     {{- end }}
   annotations:
     prometheus.io/scrape: "true"
-    prometheus.io/port: "{{ .Values.pod.port }}"
+    prometheus.io/port: "{{ .Values.pod.targetPort }}"
     test.annotation/key: "annotation value"
 spec:
   containers:
@@ -22,16 +22,16 @@ spec:
       image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
       env:
         - name: PORT
-          value: "{{ .Values.pod.port }}"
+          value: "{{ .Values.pod.targetPort }}"
       ports:
-        - containerPort: {{ .Values.pod.port }}
+        - containerPort: {{ .Values.pod.targetPort }}
       resources:
         {{- toYaml .Values.resources | nindent 8 }}
       imagePullPolicy: {{ .Values.image.pullPolicy }}
       readinessProbe:
         httpGet:
           path: /ready
-          port: {{ .Values.pod.port }}
+          port: {{ .Values.pod.targetPort }}
         initialDelaySeconds: 1
         periodSeconds: 1
 {{- end }}

--- a/test-resources/python/flask/dash0-operator-test-app-python/templates/replicaset.yaml
+++ b/test-resources/python/flask/dash0-operator-test-app-python/templates/replicaset.yaml
@@ -23,7 +23,7 @@ spec:
         test.label/key: "label-value"
       annotations:
         prometheus.io/scrape: "true"
-        prometheus.io/port: "{{ .Values.replicaset.port }}"
+        prometheus.io/port: "{{ .Values.replicaset.targetPort }}"
         test.annotation/key: "annotation value"
     spec:
       containers:
@@ -31,16 +31,16 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           env:
             - name: PORT
-              value: "{{ .Values.replicaset.port }}"
+              value: "{{ .Values.replicaset.targetPort }}"
           ports:
-            - containerPort: {{ .Values.replicaset.port }}
+            - containerPort: {{ .Values.replicaset.targetPort }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           readinessProbe:
             httpGet:
               path: /ready
-              port: {{ .Values.replicaset.port }}
+              port: {{ .Values.replicaset.targetPort }}
             initialDelaySeconds: 1
             periodSeconds: 1
 {{- end }}

--- a/test-resources/python/flask/dash0-operator-test-app-python/templates/statefulset.yaml
+++ b/test-resources/python/flask/dash0-operator-test-app-python/templates/statefulset.yaml
@@ -23,7 +23,7 @@ spec:
         test.label/key: "label-value"
       annotations:
         prometheus.io/scrape: "true"
-        prometheus.io/port: "{{ .Values.statefulset.port }}"
+        prometheus.io/port: "{{ .Values.statefulset.targetPort }}"
         test.annotation/key: "annotation value"
     spec:
       terminationGracePeriodSeconds: 3
@@ -32,16 +32,16 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           env:
             - name: PORT
-              value: "{{ .Values.statefulset.port }}"
+              value: "{{ .Values.statefulset.targetPort }}"
           ports:
-            - containerPort: {{ .Values.statefulset.port }}
+            - containerPort: {{ .Values.statefulset.targetPort }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           readinessProbe:
             httpGet:
               path: /ready
-              port: {{ .Values.statefulset.port }}
+              port: {{ .Values.statefulset.targetPort }}
             initialDelaySeconds: 1
             periodSeconds: 1
 {{- end }}


### PR DESCRIPTION
## The main changes in this PR are

- adds a port mapping to the worker node in the kind-config
- adds a label to this node so the nginx controller can be scheduled on the right node
- patches the nginx deployment with a `preferredDuringSchedulingIgnoredDuringExecution` using the label from above
- changes the (default) service type of the test apps from `LoadBalancer` to `ClusterIP`, since the apps will be accessible via the nginx ingress

## Minor changes/fixes:

- the Helm templates for the test apps used `port` instead of `targetPort` - since those are currently always the same in our test setup, this hasn't caused any issues so far, but it would fail when using different ports
- `helm install`ing the jvm and .net apps didn't work because of a missing `\`
- the new python test app was missing in the `test-app-images` target in the makefile

## How to test

After creating the cluster and running the test scenario as usual (e.g. setting the required env vars and running `create_cluster_and_registry.sh` and `test-scenario-01-aum-operator-cr.sh`), the test application can be reached via nginx on the port defined by the port-mapping (`8080`) and the path defined in the ingress resource. E.g.:

- `curl localhost:8080/deployment/nodejs/dash0-k8s-operator-test`
- `curl localhost:8080/deployment/python/dash0-k8s-operator-test`
-...
