### PR TITLE
fix: ensure namespaced collector resources are watched

### DIFF
--- a/internal/startup/operator_manager_startup.go
+++ b/internal/startup/operator_manager_startup.go
@@ -886,6 +886,7 @@ func startDash0Controllers(
 	collectorReconciler := collectors.NewCollectorReconciler(
 		k8sClient,
 		collectorManager,
+		envVars.operatorNamespace,
 		envVars.oTelCollectorNamePrefix,
 	)
 	if err := collectorReconciler.SetupWithManager(mgr); err != nil {


### PR DESCRIPTION
## Overview

The `operatorNamespace` field in the collector controller was always empty and as a consequence the predicates for watching namespaced collector resources did not work.

## Main changes

- sets `operatorNamespace` in the constructor
- updates the name predicates so they work for both namespace- and cluster-scoped resources
- adds `GenerationChangedPredicate` and `LabelChangedPredicate` for resources that otherwise trigger the reconciliation continuously

## Testing

Running the test scenarios and deleting/updating different collector resources should now trigger a reconciliation.