### PR TITLE
test(e2e): increase Helm timeout for test apps

### DIFF
--- a/test/e2e/applications_under_test.go
+++ b/test/e2e/applications_under_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	testAppHelmInstallTimeout = "60s"
+	testAppHelmInstallTimeout = "120s"
 )
 
 var (


### PR DESCRIPTION
In some cases, the JVM workload need a little more than 60 seconds for downloading the image, initializing the pods and starting up.