### PR TITLE
ci: add scanSeverity option, ignore <= MEDIUM for collector image

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -160,6 +160,7 @@ jobs:
           imageUrl: https://github.com/dash0hq/dash0-operator/tree/main/images/instrumentation
           context: images/instrumentation
           scan: 'true'
+          scanSeverity: 'UNKNOWN,HIGH,CRITICAL'
 
       - name: build collector image
         uses: ./.github/actions/build-image


### PR DESCRIPTION
This fixes the breaking build due to the Trivy action complaining about the following low and medium severity vulnerabilities:
- CVE-2024-58251
- CVE-2025-46394

Both are currently not fixable as there is no more recent busybox image, both are utterly irrelevant in this context.