### PR TITLE
test: fix Java test application after upgrade to Spring Boot 4

### DIFF
--- a/test-resources/jvm/spring-boot/src/main/java/com/dash0/app_under_test/Controller.java
+++ b/test-resources/jvm/spring-boot/src/main/java/com/dash0/app_under_test/Controller.java
@@ -1,7 +1,7 @@
 package com.dash0.app_under_test;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ObjectNode;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;


### PR DESCRIPTION
This is a follow up to commit 6ef8a6cbb03e20146b45a88e91c011b28e735150. Package names have changed with Spring Boot 4, and in particular with the implicit update from Jackson 2 to Jackson 3.

See also:

https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-4.0-Migration-Guide#upgrading-jackson