### PR TITLE
chore: do not log failure to attach an event as an error

### DIFF
--- a/internal/controller/api_sync_common.go
+++ b/internal/controller/api_sync_common.go
@@ -642,6 +642,7 @@ func executeSingleHttpRequestWithRetryAndReadBody(
 			Factor:   1.5,
 		},
 		true,
+		true,
 		logger,
 	); err != nil {
 		return nil, err

--- a/internal/controller/monitoring_controller.go
+++ b/internal/controller/monitoring_controller.go
@@ -428,6 +428,7 @@ func (r *MonitoringReconciler) attachDanglingEvents(
 			},
 			backoff,
 			false,
+			false,
 			logger,
 		)
 

--- a/internal/postinstall/operator_post_install_handler.go
+++ b/internal/postinstall/operator_post_install_handler.go
@@ -83,6 +83,7 @@ func (h *OperatorPostInstallHandler) WaitForOperatorConfigurationResourceToBecom
 		},
 		h.retryBackoff,
 		false,
+		true,
 		h.logger,
 	); err != nil {
 		return fmt.Errorf(

--- a/internal/startup/auto_operator_configuration_handler.go
+++ b/internal/startup/auto_operator_configuration_handler.go
@@ -161,6 +161,7 @@ func (r *AutoOperatorConfigurationResourceHandler) createOrUpdateOperatorConfigu
 			Steps:    6,
 		},
 		true,
+		true,
 		logger,
 	)
 }

--- a/internal/startup/ready_check.go
+++ b/internal/startup/ready_check.go
@@ -108,6 +108,7 @@ func (c *ReadyCheckExecuter) pollWebhookServiceEndpoint(ctx context.Context, log
 		},
 		c.retryBackoff,
 		false,
+		true,
 		logger,
 	); err != nil {
 		e := fmt.Errorf("waiting for the webhook service endpoint has timed out (no more retries left): %v", err)

--- a/test/e2e/dash0_monitoring_resource.go
+++ b/test/e2e/dash0_monitoring_resource.go
@@ -136,6 +136,7 @@ func deployRenderedMonitoringResource(
 			Steps:    3,
 		},
 		true,
+		true,
 		&retryLogger,
 	)
 	Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
Attaching an event retrospectively to the associated Kubernetes resource fails if the workload in question is short-lived. Logging this as an error is too noisy.

The issue in question would be logged like this:
```
attaching dangling event to involved object failed after attempt 3/3, no more retries left.
...
"error": "could not update event.InvolvedObject:
could not load involved object ReplicaSet ...
ReplicaSet.apps ... not found"
```
with a stack trace pointing to `github.com/dash0hq/dash0-operator/internal/util.RetryWithCustomBackoff`

This will be logged on info level from now on, which is much more appropriate.