### PR TITLE
fix(workloads): make sure DASH0_NODE_IP is listed first

### DIFF
--- a/internal/collectors/otelcolresources/desired_state.go
+++ b/internal/collectors/otelcolresources/desired_state.go
@@ -73,8 +73,6 @@ type NamespacedTransform struct {
 }
 
 const (
-	EnvVarDash0NodeIp = "DASH0_NODE_IP"
-
 	OtlpGrpcHostPort = 40317
 	OtlpHttpHostPort = 40318
 	// ^ We deliberately do not use the default grpc/http ports as host ports. If there is another OTel collector

--- a/internal/startup/operator_manager_startup.go
+++ b/internal/startup/operator_manager_startup.go
@@ -1133,7 +1133,7 @@ func determineCollectorBaseUrl(forceOTelCollectorServiceUrl bool, isIPv6Cluster 
 			envVars.operatorNamespace)
 	oTelCollectorNodeLocalBaseUrl := fmt.Sprintf(
 		oTelCollectorNodeLocalBaseUrlPattern,
-		otelcolresources.EnvVarDash0NodeIp,
+		util.EnvVarDash0NodeIp,
 		otelcolresources.OtlpHttpHostPort,
 	)
 

--- a/internal/util/constants.go
+++ b/internal/util/constants.go
@@ -28,6 +28,8 @@ const (
 	AppKubernetesIoManagedByLabel = "app.kubernetes.io/managed-by"
 	AppKubernetesIoVersionLabel   = "app.kubernetes.io/version"
 	KubernetesIoOs                = "kubernetes.io/os"
+
+	EnvVarDash0NodeIp = "DASH0_NODE_IP"
 )
 
 func RenderAuthorizationHeader(authToken string) string {

--- a/test/util/resources.go
+++ b/test/util/resources.go
@@ -955,10 +955,6 @@ func simulateInstrumentedPodSpec(podSpec *corev1.PodSpec, meta *metav1.ObjectMet
 	}}
 	container.Env = []corev1.EnvVar{
 		{
-			Name:  "LD_PRELOAD",
-			Value: "/__dash0__/dash0_injector.so",
-		},
-		{
 			Name:      "DASH0_NODE_IP",
 			ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.hostIP"}},
 		},
@@ -973,6 +969,10 @@ func simulateInstrumentedPodSpec(podSpec *corev1.PodSpec, meta *metav1.ObjectMet
 		{
 			Name:  "OTEL_EXPORTER_OTLP_PROTOCOL",
 			Value: common.ProtocolHttpProtobuf,
+		},
+		{
+			Name:  "LD_PRELOAD",
+			Value: "/__dash0__/dash0_injector.so",
 		},
 		{
 			Name: "DASH0_NAMESPACE_NAME",


### PR DESCRIPTION
In cases where workloads already define OTEL_EXPORTER_OTLP_ENDPOINT and then are mutated via the webhook again, the resulting env var array of a container could list OTEL_EXPORTER_OTLP_ENDPOINT before DASH0_NODE_IP; but since OTEL_EXPORTER_OTLP_ENDPOINT references DASH0_NODE_IP, this is an error.