### PR TITLE
fix(webhook): revert webhook behavior back to the logic before 0.88.0

### DIFF
--- a/internal/instrumentation/instrumenter.go
+++ b/internal/instrumentation/instrumenter.go
@@ -568,12 +568,8 @@ func (i *Instrumenter) instrumentWorkload(
 	}
 
 	var requiredAction util.ModificationMode
-	addIgnoreOnceLabel := true
 	if util.WasInstrumentedButHasOptedOutNow(workloadMeta, namespaceInstrumentationConfig.InstrumentationLabelSelector) {
 		requiredAction = util.ModificationModeUninstrumentation
-		// The webhook will skip modifying this workload on the i.Update below anyway, since this workload is marked
-		// as opt-out. Therefore, adding the ignore-once label is not required.
-		addIgnoreOnceLabel = false
 	} else if workloads.InstrumentationIsUpToDate(workloadMeta, containers, i.ClusterInstrumentationConfig.Images, namespaceInstrumentationConfig) {
 		// No change necessary, this workload has already been instrumented and an opt-out label (which would need to
 		// trigger uninstrumentation) has not been added since it has been instrumented.
@@ -624,9 +620,6 @@ func (i *Instrumenter) instrumentWorkload(
 		}
 
 		if modificationResult.HasBeenModified {
-			if addIgnoreOnceLabel {
-				util.AddWebhookIgnoreOnceLabel(workloadMeta)
-			}
 			return i.Update(ctx, workload.asClientObject(), &client.UpdateOptions{FieldManager: util.FieldManager})
 		} else {
 			return nil

--- a/internal/webhooks/instrumentation_webhook.go
+++ b/internal/webhooks/instrumentation_webhook.go
@@ -257,6 +257,14 @@ func (h *InstrumentationWebhookHandler) handleCronJob(
 	) {
 		modificationResult := h.newWorkloadModifier(namespaceInstrumentationConfig, logger).RevertCronJob(cronJob)
 		return h.postProcessUninstrumentation(request, cronJob, modificationResult, logger)
+	} else if workloads.InstrumentationIsUpToDate(
+		&cronJob.ObjectMeta,
+		cronJob.Spec.JobTemplate.Spec.Template.Spec.Containers,
+		h.ClusterInstrumentationConfig.Images,
+		namespaceInstrumentationConfig,
+	) {
+		// deliberately not logging this, would be very noisy
+		return admission.Allowed(sameVersionNoModificationMessage)
 	} else {
 		modificationResult := h.newWorkloadModifier(namespaceInstrumentationConfig, logger).ModifyCronJob(cronJob)
 		return h.postProcessInstrumentation(request, cronJob, modificationResult, false, logger)
@@ -293,6 +301,14 @@ func (h *InstrumentationWebhookHandler) handleDaemonSet(
 	) {
 		modificationResult := h.newWorkloadModifier(namespaceInstrumentationConfig, logger).RevertDaemonSet(daemonSet)
 		return h.postProcessUninstrumentation(request, daemonSet, modificationResult, logger)
+	} else if workloads.InstrumentationIsUpToDate(
+		&daemonSet.ObjectMeta,
+		daemonSet.Spec.Template.Spec.Containers,
+		h.ClusterInstrumentationConfig.Images,
+		namespaceInstrumentationConfig,
+	) {
+		// deliberately not logging this, would be very noisy
+		return admission.Allowed(sameVersionNoModificationMessage)
 	} else {
 		modificationResult := h.newWorkloadModifier(namespaceInstrumentationConfig, logger).ModifyDaemonSet(daemonSet)
 		return h.postProcessInstrumentation(request, daemonSet, modificationResult, false, logger)
@@ -329,6 +345,14 @@ func (h *InstrumentationWebhookHandler) handleDeployment(
 	) {
 		modificationResult := h.newWorkloadModifier(namespaceInstrumentationConfig, logger).RevertDeployment(deployment)
 		return h.postProcessUninstrumentation(request, deployment, modificationResult, logger)
+	} else if workloads.InstrumentationIsUpToDate(
+		&deployment.ObjectMeta,
+		deployment.Spec.Template.Spec.Containers,
+		h.ClusterInstrumentationConfig.Images,
+		namespaceInstrumentationConfig,
+	) {
+		// deliberately not logging this, would be very noisy
+		return admission.Allowed(sameVersionNoModificationMessage)
 	} else {
 		modificationResult := h.newWorkloadModifier(namespaceInstrumentationConfig, logger).ModifyDeployment(deployment)
 		return h.postProcessInstrumentation(request, deployment, modificationResult, false, logger)
@@ -367,6 +391,14 @@ func (h *InstrumentationWebhookHandler) handleJob(
 		// not listening to updates for jobs. We cannot uninstrument jobs if the user adds an opt-out label after the
 		// job has been already instrumented, since jobs are immutable.
 		return h.postProcessUninstrumentation(request, job, workloads.NewNotModifiedImmutableWorkloadCannotBeRevertedResult(), logger)
+	} else if workloads.InstrumentationIsUpToDate(
+		&job.ObjectMeta,
+		job.Spec.Template.Spec.Containers,
+		h.ClusterInstrumentationConfig.Images,
+		namespaceInstrumentationConfig,
+	) {
+		// This should not happen either.
+		return admission.Allowed(sameVersionNoModificationMessage)
 	} else {
 		modificationResult := h.newWorkloadModifier(namespaceInstrumentationConfig, logger).ModifyJob(job)
 		return h.postProcessInstrumentation(request, job, modificationResult, false, logger)
@@ -406,6 +438,14 @@ func (h *InstrumentationWebhookHandler) handlePod(
 		// after the pod has been already instrumented, since we cannot restart ownerless pods, which makes them
 		// effectively immutable.
 		return h.postProcessUninstrumentation(request, pod, workloads.NewNotModifiedImmutableWorkloadCannotBeRevertedResult(), logger)
+	} else if workloads.InstrumentationIsUpToDate(
+		&pod.ObjectMeta,
+		pod.Spec.Containers,
+		h.ClusterInstrumentationConfig.Images,
+		namespaceInstrumentationConfig,
+	) {
+		// This should not happen either.
+		return admission.Allowed(sameVersionNoModificationMessage)
 	} else {
 		modificationResult := h.newWorkloadModifier(namespaceInstrumentationConfig, logger).ModifyPod(pod)
 		return h.postProcessInstrumentation(request, pod, modificationResult, true, logger)
@@ -442,6 +482,14 @@ func (h *InstrumentationWebhookHandler) handleReplicaSet(
 	) {
 		modificationResult := h.newWorkloadModifier(namespaceInstrumentationConfig, logger).RevertReplicaSet(replicaSet)
 		return h.postProcessUninstrumentation(request, replicaSet, modificationResult, logger)
+	} else if workloads.InstrumentationIsUpToDate(
+		&replicaSet.ObjectMeta,
+		replicaSet.Spec.Template.Spec.Containers,
+		h.ClusterInstrumentationConfig.Images,
+		namespaceInstrumentationConfig,
+	) {
+		// deliberately not logging this, would be very noisy
+		return admission.Allowed(sameVersionNoModificationMessage)
 	} else {
 		modificationResult := h.newWorkloadModifier(namespaceInstrumentationConfig, logger).ModifyReplicaSet(replicaSet)
 		return h.postProcessInstrumentation(request, replicaSet, modificationResult, false, logger)
@@ -478,6 +526,14 @@ func (h *InstrumentationWebhookHandler) handleStatefulSet(
 	) {
 		modificationResult := h.newWorkloadModifier(namespaceInstrumentationConfig, logger).RevertStatefulSet(statefulSet)
 		return h.postProcessUninstrumentation(request, statefulSet, modificationResult, logger)
+	} else if workloads.InstrumentationIsUpToDate(
+		&statefulSet.ObjectMeta,
+		statefulSet.Spec.Template.Spec.Containers,
+		h.ClusterInstrumentationConfig.Images,
+		namespaceInstrumentationConfig,
+	) {
+		// deliberately not logging this, would be very noisy
+		return admission.Allowed(sameVersionNoModificationMessage)
 	} else {
 		modificationResult := h.newWorkloadModifier(namespaceInstrumentationConfig, logger).ModifyStatefulSet(statefulSet)
 		return h.postProcessInstrumentation(request, statefulSet, modificationResult, false, logger)

--- a/internal/webhooks/instrumentation_webhook_test.go
+++ b/internal/webhooks/instrumentation_webhook_test.go
@@ -104,14 +104,14 @@ var _ = Describe("The Dash0 instrumentation webhook", func() {
 				namespace string,
 				name string,
 			) *corev1.Pod {
-				pod := BasicPod(namespace, name)
+				pod := CreateBasicPod(ctx, k8sClient, namespace, name)
 				pod.ObjectMeta.OwnerReferences = []metav1.OwnerReference{{
 					Name:       "strimzi-podset-name",
 					APIVersion: "core.strimzi.io/v1beta2",
 					Kind:       "StrimziPodSet",
 					UID:        "35b829cb-78dc-4544-b7a9-5a8e51b7f322",
 				}}
-				CreateWorkload(ctx, k8sClient, pod)
+				UpdateWorkload(ctx, k8sClient, pod)
 				return pod
 			}),
 			GetFn: WrapPodFnAsTestableWorkload(GetPod),
@@ -131,14 +131,14 @@ var _ = Describe("The Dash0 instrumentation webhook", func() {
 				k8sClient client.Client,
 				namespace string,
 				name string) *appsv1.ReplicaSet {
-				rs := BasicReplicaSet(namespace, name)
+				rs := CreateBasicReplicaSet(ctx, k8sClient, namespace, name)
 				rs.OwnerReferences = []metav1.OwnerReference{{
 					Name:       "owner-name",
 					APIVersion: "api/v1beta2",
 					Kind:       "Kind",
 					UID:        "35b829cb-78dc-4544-b7a9-5a8e51b7f322",
 				}}
-				CreateWorkload(ctx, k8sClient, rs)
+				UpdateWorkload(ctx, k8sClient, rs)
 				return rs
 			}),
 			GetFn: WrapReplicaSetFnAsTestableWorkload(GetReplicaSet),

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -275,52 +275,6 @@ var _ = Describe("Dash0 Operator", Ordered, ContinueOnFailure, func() {
 						true,
 					)
 				})
-
-				It("should revert/repair invalid workload changes", func() {
-					By("installing the Node.js deployment")
-					Expect(installNodeJsDeployment(applicationUnderTestNamespace)).To(Succeed())
-
-					// Verify that it is stil possible to make changes to the workload that would (as a side effect)
-					// make the workload invalid in combination with our workload modifications. This ensures that we
-					// are not blocking legitimate modifications accidentally.
-					By("attempt to remove the dash0-instrumentation volume")
-					jsonPatch := `
-[{
-  "op": "replace",
-  "path": "/spec/template/spec/volumes",
-  "value": null
-}]
-`
-					Expect(
-						runAndIgnoreOutput(
-							exec.Command(
-								"kubectl",
-								"patch",
-								"--namespace",
-								applicationUnderTestNamespace,
-								workloadTypeDeployment.workloadTypeString,
-								workloadName(runtimeTypeNodeJs, workloadTypeDeployment),
-								"--type=json",
-								"-p",
-								jsonPatch,
-							))).To(Succeed())
-
-					// Verify the dash0-instrumentation volume is actually still there, that is, that the webhook brings
-					// the workload back into a valid state by applying the (otherwise idempotent) workload
-					// modifications again.
-					volumeName, err := run(
-						exec.Command(
-							"kubectl",
-							"get",
-							"--namespace",
-							applicationUnderTestNamespace,
-							workloadTypeDeployment.workloadTypeString,
-							workloadName(runtimeTypeNodeJs, workloadTypeDeployment),
-							"-o=jsonpath='{.spec.template.spec.volumes[0].name}'",
-						))
-					Expect(err).ToNot(HaveOccurred())
-					Expect(volumeName).To(Equal("'dash0-instrumentation'"))
-				})
 			})
 
 			Describe("self-monitoring log collection", func() {


### PR DESCRIPTION
That is, if a workload is already instrumented by the same controller version, do not re-apply workload modifications.

The reverted change was detrimental for workloads that
- define OTEL_EXPORTER_OTLP_ENDPOINT on their own
- send telemetry via GRPC
- do not honor OTEL_EXPORTER_OTLP_PROTOCOL

In particular, this could lead to the operator overwriting OTEL_EXPORTER_OTLP_ENDPOINT in scenarios where it effectively would not override this before, and make the workload try to send OTel telemetry via GRPC to the collector's HTTP port.

This reverts commit a895347bf9af9d6f05458082a292ae51d6016aee, that is, "fix(webhook): always re-apply modifications in instrumentation webhook".