### PR TITLE
test(e2e): make collector configuration update less flaky

### DIFF
--- a/test/e2e/collector.go
+++ b/test/e2e/collector.go
@@ -196,19 +196,6 @@ func verifyConfigMapDoesNotContainStrings(operatorNamespace string, configMapNam
 	)
 }
 
-func verifyCollectorContainerLogContainsStrings(
-	operatorNamespace string,
-	containerName string,
-	timeout time.Duration,
-	needles ...string,
-) {
-	verifyCommandOutputContainsStrings(
-		getLogsViaKubectl(operatorNamespace, collectorDaemonSetNameQualified, containerName),
-		timeout,
-		needles...,
-	)
-}
-
 func findMostRecentCollectorReadyLogLine(g Gomega) time.Time {
 	allCollectorReadyLogLines := getMatchingLogLinesFomCollectorContainerLog(
 		g,

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1605,28 +1605,12 @@ trace_statements:
 				By("verify that the config map has been updated by the controller")
 				verifyDaemonSetCollectorConfigMapContainsString(operatorNamespace, newEndpoint)
 
-				By("verify that the configuration reloader says to have triggered a config change")
-				verifyCollectorContainerLogContainsStrings(
-					operatorNamespace,
-					"configuration-reloader",
-					10*time.Second,
-					"Triggering a collector update due to changes to the config files",
-				)
-
-				By("verify that the collector appears to have reloaded its configuration")
-				verifyCollectorContainerLogContainsStrings(
-					operatorNamespace,
-					"opentelemetry-collector",
-					20*time.Second,
-					"Received signal from OS",
-					"Config updated, restart service",
-				)
-
 				By("verify that the collector has restarted and has become ready once more")
 				Eventually(func(g Gomega) {
 					secondCollectorReadyTimeStamp := findMostRecentCollectorReadyLogLine(g)
 					g.Expect(secondCollectorReadyTimeStamp).To(BeTemporally(">", firstCollectorReadyTimeStamp))
-				}, 30*time.Second, time.Second).Should(Succeed())
+				}, 2*time.Minute, time.Second).Should(Succeed())
+
 			})
 		})
 


### PR DESCRIPTION
The test was overly specific, and flaky as a result. Instead of only verifying the final outcome of the config update (new config map content, collector restart), it tried to check for the intermittent steps (in particular, it tried to find log messages of the "old" collector pod immediately before the restart). Actually seeing these was timing-dependent, and it was possible for the e2e test suite to miss them; e.g. if the collector pod was terminated and removed between two executions of kubectl get logs.