### PR TITLE
test(e2e): fix collection of kubectl output for test failures

### DIFF
--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -13,7 +13,7 @@ import (
 
 // run e2e tests using the Ginkgo runner.
 func TestE2E(t *testing.T) {
-	RegisterFailHandler(collectPodInfoAndLogsFailWrapper)
+	RegisterFailHandler(Fail)
 	_, _ = fmt.Fprint(GinkgoWriter, "Starting dash0-operator suite\n")
 	RunSpecs(t, "Dash0 operator end-to-end test suite")
 }

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -54,6 +54,9 @@ var _ = Describe("Dash0 Operator", Ordered, ContinueOnFailure, func() {
 		} else {
 			e2ePrint("%s not found, assuming required environment variables are set via other means\n", dotEnvFile)
 		}
+
+		createDirAndDeleteOldCollectedLogs()
+
 		e2eKubernetesContext = os.Getenv("E2E_KUBECTX")
 		verboseHttp = strings.ToLower(os.Getenv("E2E_VERBOSE_HTTP")) == "true"
 		if e2eKubernetesContext == "" {
@@ -118,9 +121,11 @@ var _ = Describe("Dash0 Operator", Ordered, ContinueOnFailure, func() {
 		By("finished AfterAll hook of test suite root")
 	})
 
-	BeforeEach(func() {
-		By("running BeforeEach hook of test suite root")
-		createDirAndDeleteOldCollectedLogs()
+	JustAfterEach(func() {
+		currentSpecReport := CurrentSpecReport()
+		if currentSpecReport.Failed() {
+			collectPodInfoAndLogs(currentSpecReport)
+		}
 	})
 
 	AfterEach(func() {


### PR DESCRIPTION
This is a follow up to 9fe289eaf864494cb1a7f85eda2146ad3a0577d2. Using Gingko's ContinueOnFailure was not compatible with the existing approach to collect diagnostic information in case of failing test cases (RegisterFailHandler with a custom handler). The new approach (JustAfterEach hook) is more idiomatic anyway.