### PR TITLE
feat(collector): add option to disable watching collector resources

### DIFF
--- a/helm-chart/dash0-operator/templates/operator/deployment-and-webhooks.yaml
+++ b/helm-chart/dash0-operator/templates/operator/deployment-and-webhooks.yaml
@@ -221,7 +221,11 @@ spec:
         {{- end }}
         {{- if .Values.operator.instrumentation.debug }}
         - name: DASH0_INSTRUMENTATION_DEBUG
-          value: {{ .Values.operator.instrumentation.debug  | toString | quote }}
+          value: {{ .Values.operator.instrumentation.debug | toString | quote }}
+        {{- end }}
+        {{- if .Values.operator.disableCollectorResourceWatches }}
+        - name: DASH0_DISABLE_COLLECTOR_RESOURCE_WATCHES
+          value: {{ .Values.operator.disableCollectorResourceWatches | toString | quote }}
         {{- end }}
         {{- if .Values.operator.collectors.debugVerbosityDetailed }}
         - name: OTEL_COLLECTOR_DEBUG_VERBOSITY_DETAILED

--- a/helm-chart/dash0-operator/tests/operator/deployment-and-webhooks_test.yaml
+++ b/helm-chart/dash0-operator/tests/operator/deployment-and-webhooks_test.yaml
@@ -212,6 +212,7 @@ tests:
           delayAfterEachWorkloadMillis: 13
           delayAfterEachNamespaceMillis: 123
           debug: true
+        disableCollectorResourceWatches: true
         collectors:
           debugVerbosityDetailed: true
           sendBatchMaxSize: 32768
@@ -413,48 +414,54 @@ tests:
           value: "true"
       - equal:
           path: spec.template.spec.containers[0].env[20].name
-          value: OTEL_COLLECTOR_DEBUG_VERBOSITY_DETAILED
+          value: DASH0_DISABLE_COLLECTOR_RESOURCE_WATCHES
       - equal:
           path: spec.template.spec.containers[0].env[20].value
           value: "true"
       - equal:
           path: spec.template.spec.containers[0].env[21].name
-          value: OTEL_COLLECTOR_SEND_BATCH_MAX_SIZE
+          value: OTEL_COLLECTOR_DEBUG_VERBOSITY_DETAILED
       - equal:
           path: spec.template.spec.containers[0].env[21].value
-          value: "32768"
+          value: "true"
       - equal:
           path: spec.template.spec.containers[0].env[22].name
-          value: K8S_POD_UID
+          value: OTEL_COLLECTOR_SEND_BATCH_MAX_SIZE
       - equal:
-          path: spec.template.spec.containers[0].env[22].valueFrom.fieldRef.fieldPath
-          value: metadata.uid
+          path: spec.template.spec.containers[0].env[22].value
+          value: "32768"
       - equal:
           path: spec.template.spec.containers[0].env[23].name
-          value: K8S_NODE_IP
+          value: K8S_POD_UID
       - equal:
           path: spec.template.spec.containers[0].env[23].valueFrom.fieldRef.fieldPath
-          value: status.hostIP
+          value: metadata.uid
       - equal:
           path: spec.template.spec.containers[0].env[24].name
-          value: K8S_NODE_NAME
+          value: K8S_NODE_IP
       - equal:
           path: spec.template.spec.containers[0].env[24].valueFrom.fieldRef.fieldPath
-          value: spec.nodeName
+          value: status.hostIP
       - equal:
           path: spec.template.spec.containers[0].env[25].name
-          value: K8S_POD_IP
+          value: K8S_NODE_NAME
       - equal:
           path: spec.template.spec.containers[0].env[25].valueFrom.fieldRef.fieldPath
-          value: status.podIP
+          value: spec.nodeName
       - equal:
           path: spec.template.spec.containers[0].env[26].name
-          value: K8S_POD_NAME
+          value: K8S_POD_IP
       - equal:
           path: spec.template.spec.containers[0].env[26].valueFrom.fieldRef.fieldPath
+          value: status.podIP
+      - equal:
+          path: spec.template.spec.containers[0].env[27].name
+          value: K8S_POD_NAME
+      - equal:
+          path: spec.template.spec.containers[0].env[27].valueFrom.fieldRef.fieldPath
           value: metadata.name
       - notExists:
-          path: spec.template.spec.containers[0].env[27].name
+          path: spec.template.spec.containers[0].env[28].name
       - equal:
           path: spec.template.spec.containers[0].resources.limits.cpu
           value: 123m

--- a/helm-chart/dash0-operator/values.yaml
+++ b/helm-chart/dash0-operator/values.yaml
@@ -372,6 +372,18 @@ operator:
     # If set to true, it enables verbose output from the init container and the injector.
     debug: false
 
+  # If set to true, the operator manager will not watch the resources of the OpenTelemetry collectors it manages. By
+  # default, the operator watches all collector resources (config maps, deployment, daemonset etc.) and reconciles them
+  # if they are changed or deleted externally. This is generally the expected behavior of an operator in relation to the
+  # resources it manages. For troubleshooting purposes, this can be disabled temporarily, allowing quick one-off edits
+  # of the collector config maps.
+  # Note that even if the watches are disabled, other events will still trigger a reconciliation of the collector
+  # resources (for example changing the operator configuration resource, changing, adding or deleting monitoring
+  # resources, and updating the operator to a new version).
+  # The default is false, do not override this unless explicitly instructed by Dash0 support. Remove the override after
+  # the collector troubleshooting is finished.
+  disableCollectorResourceWatches: false
+
   # Settings related to the collectors managed by the operator.
   collectors:
     # If set to true, adds a debug exporter with "verbosity: detailed" to the collectors managed by the operator.


### PR DESCRIPTION
When watching the collector resources (config maps, deployment, daemonset etc.) is disabled, the operator will not reconcile these resources when they are changed or deleted externally.

Exposing this setting is useful for troubleshooting the OpenTelemetry collector in a cluster, for example by changing its config map on the fly.

The setting is not intended for normal operations and should only be enabled for troubleshooting.