### PR TITLE
feat(collector): enable pprof extension on demand

### DIFF
--- a/helm-chart/dash0-operator/templates/operator/deployment-and-webhooks.yaml
+++ b/helm-chart/dash0-operator/templates/operator/deployment-and-webhooks.yaml
@@ -235,6 +235,10 @@ spec:
         - name: OTEL_COLLECTOR_SEND_BATCH_MAX_SIZE
           value: {{ .Values.operator.collectors.sendBatchMaxSize | quote }}
         {{- end }}
+        {{- if .Values.operator.collectors.enablePprofExtension }}
+        - name: OTEL_COLLECTOR_ENABLE_PPROF_EXTENSION
+          value: {{ .Values.operator.collectors.enablePprofExtension | toString | quote }}
+        {{- end }}
         - name: K8S_POD_UID
           valueFrom:
             fieldRef:

--- a/helm-chart/dash0-operator/tests/operator/deployment-and-webhooks_test.yaml
+++ b/helm-chart/dash0-operator/tests/operator/deployment-and-webhooks_test.yaml
@@ -218,6 +218,7 @@ tests:
           sendBatchMaxSize: 32768
           forceUseServiceUrl: true
           disableHostPorts: true
+          enablePprofExtension: true
 
     asserts:
       - equal:
@@ -432,36 +433,42 @@ tests:
           value: "32768"
       - equal:
           path: spec.template.spec.containers[0].env[23].name
-          value: K8S_POD_UID
+          value: OTEL_COLLECTOR_ENABLE_PPROF_EXTENSION
       - equal:
-          path: spec.template.spec.containers[0].env[23].valueFrom.fieldRef.fieldPath
-          value: metadata.uid
+          path: spec.template.spec.containers[0].env[23].value
+          value: "true"
       - equal:
           path: spec.template.spec.containers[0].env[24].name
-          value: K8S_NODE_IP
+          value: K8S_POD_UID
       - equal:
           path: spec.template.spec.containers[0].env[24].valueFrom.fieldRef.fieldPath
-          value: status.hostIP
+          value: metadata.uid
       - equal:
           path: spec.template.spec.containers[0].env[25].name
-          value: K8S_NODE_NAME
+          value: K8S_NODE_IP
       - equal:
           path: spec.template.spec.containers[0].env[25].valueFrom.fieldRef.fieldPath
-          value: spec.nodeName
+          value: status.hostIP
       - equal:
           path: spec.template.spec.containers[0].env[26].name
-          value: K8S_POD_IP
+          value: K8S_NODE_NAME
       - equal:
           path: spec.template.spec.containers[0].env[26].valueFrom.fieldRef.fieldPath
-          value: status.podIP
+          value: spec.nodeName
       - equal:
           path: spec.template.spec.containers[0].env[27].name
-          value: K8S_POD_NAME
+          value: K8S_POD_IP
       - equal:
           path: spec.template.spec.containers[0].env[27].valueFrom.fieldRef.fieldPath
+          value: status.podIP
+      - equal:
+          path: spec.template.spec.containers[0].env[28].name
+          value: K8S_POD_NAME
+      - equal:
+          path: spec.template.spec.containers[0].env[28].valueFrom.fieldRef.fieldPath
           value: metadata.name
       - notExists:
-          path: spec.template.spec.containers[0].env[28].name
+          path: spec.template.spec.containers[0].env[29].name
       - equal:
           path: spec.template.spec.containers[0].resources.limits.cpu
           value: 123m

--- a/helm-chart/dash0-operator/values.yaml
+++ b/helm-chart/dash0-operator/values.yaml
@@ -404,6 +404,11 @@ operator:
     # Implies forceUseServiceUrl: true.
     disableHostPorts: false
 
+    # If set to true, the pprof extension will be enabled for both collectors.
+    # The default is false, do not override this unless explicitly instructed by Dash0 support. Remove the override
+    # after the collector troubleshooting is finished.
+    enablePprofExtension: false
+
     # A reference to a persistent volume to use for the filelog offset sync. Specify this is you have a cluster
     # with more than pods 100 pods active at the same time. By default, the filelog offset sync will use a config map
     # for its peristent storage, but ConfigMaps are limited to 1 MB in size. If you have around 100 pods running in

--- a/images/collector/src/builder/config.yaml
+++ b/images/collector/src/builder/config.yaml
@@ -9,6 +9,7 @@ dist:
 extensions:
   - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.141.0"
   - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/filestorage v0.141.0"
+  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension v0.141.0"
 providers:
   - gomod: "go.opentelemetry.io/collector/confmap/provider/envprovider v1.47.0"
   - gomod: "go.opentelemetry.io/collector/confmap/provider/fileprovider v1.47.0"

--- a/internal/collectors/otelcolresources/collector_config_maps.go
+++ b/internal/collectors/otelcolresources/collector_config_maps.go
@@ -94,6 +94,7 @@ type collectorConfigurationTemplateValues struct {
 	SelfMonitoringLogsConfig                         string
 	DevelopmentMode                                  bool
 	DebugVerbosityDetailed                           bool
+	EnableProfExtension                              bool
 }
 
 type OtlpExporter struct {
@@ -230,6 +231,7 @@ func assembleCollectorConfigMap(
 				SelfMonitoringLogsConfig:                         selfMonitoringLogsConfig,
 				DevelopmentMode:                                  config.DevelopmentMode,
 				DebugVerbosityDetailed:                           config.DebugVerbosityDetailed,
+				EnableProfExtension:                              config.EnableProfExtension,
 			})
 		if err != nil {
 			return nil, fmt.Errorf("cannot render the collector configuration template: %w", err)

--- a/internal/collectors/otelcolresources/daemonset.config.yaml.template
+++ b/internal/collectors/otelcolresources/daemonset.config.yaml.template
@@ -22,6 +22,9 @@ extensions:
   file_storage/filelogreceiver_offsets:
     directory: /var/otelcol/filelogreceiver_offsets
     timeout: 1s
+  {{- if .EnableProfExtension }}
+  pprof: {}
+  {{- end }}
 
 
 connectors:
@@ -660,6 +663,9 @@ service:
   extensions:
   - health_check
   - file_storage/filelogreceiver_offsets
+  {{- if .EnableProfExtension }}
+  - pprof
+  {{- end }}
   pipelines:
     traces/downstream:
       receivers:

--- a/internal/collectors/otelcolresources/deployment.config.yaml.template
+++ b/internal/collectors/otelcolresources/deployment.config.yaml.template
@@ -1,6 +1,9 @@
 extensions:
   health_check:
     endpoint: "{{ .SelfIpReference }}:13133"
+  {{- if .EnableProfExtension }}
+  pprof: {}
+  {{- end }}
 
 
 receivers:
@@ -189,6 +192,9 @@ exporters:
 service:
   extensions:
   - health_check
+  {{- if .EnableProfExtension }}
+  - pprof
+  {{- end }}
 
   pipelines:
 

--- a/internal/collectors/otelcolresources/desired_state.go
+++ b/internal/collectors/otelcolresources/desired_state.go
@@ -51,6 +51,7 @@ type oTelColConfig struct {
 	OffsetStorageVolume                              *corev1.Volume
 	DevelopmentMode                                  bool
 	DebugVerbosityDetailed                           bool
+	EnableProfExtension                              bool
 }
 
 func (c *oTelColConfig) usesOffsetStorageVolume() bool {

--- a/internal/collectors/otelcolresources/otelcol_resources.go
+++ b/internal/collectors/otelcolresources/otelcol_resources.go
@@ -164,6 +164,7 @@ func (m *OTelColResourceManager) CreateOrUpdateOpenTelemetryCollectorResources(
 		IsGkeAutopilot:         m.collectorConfig.IsGkeAutopilot,
 		DevelopmentMode:        m.collectorConfig.DevelopmentMode,
 		DebugVerbosityDetailed: m.collectorConfig.DebugVerbosityDetailed,
+		EnableProfExtension:    m.collectorConfig.EnableProfExtension,
 	}
 	if extraConfig.CollectorFilelogOffsetStorageVolume != nil {
 		config.OffsetStorageVolume = extraConfig.CollectorFilelogOffsetStorageVolume
@@ -366,6 +367,7 @@ func (m *OTelColResourceManager) DeleteResources(
 		IsGkeAutopilot:                                   m.collectorConfig.IsGkeAutopilot,
 		DevelopmentMode:                                  m.collectorConfig.DevelopmentMode,
 		DebugVerbosityDetailed:                           m.collectorConfig.DebugVerbosityDetailed,
+		EnableProfExtension:                              m.collectorConfig.EnableProfExtension,
 	}
 	if extraConfig.CollectorFilelogOffsetStorageVolume != nil {
 		config.OffsetStorageVolume = extraConfig.CollectorFilelogOffsetStorageVolume

--- a/internal/startup/operator_manager_startup.go
+++ b/internal/startup/operator_manager_startup.go
@@ -79,6 +79,7 @@ type environmentVariables struct {
 	instrumentationDebug                        bool
 	debugVerbosityDetailed                      bool
 	disableCollectorResourceWatches             bool
+	enablePprofExtension                        bool
 }
 
 type commandLineArguments struct {
@@ -137,6 +138,7 @@ const (
 	disableCollectorResourceWatchesEnvVarName = "DASH0_DISABLE_COLLECTOR_RESOURCE_WATCHES"
 	debugVerbosityDetailedEnvVarName          = "OTEL_COLLECTOR_DEBUG_VERBOSITY_DETAILED"
 	sendBatchMaxSizeEnvVarName                = "OTEL_COLLECTOR_SEND_BATCH_MAX_SIZE"
+	enablePprofExtensionEnvVarName            = "OTEL_COLLECTOR_ENABLE_PPROF_EXTENSION"
 
 	//nolint
 	mandatoryEnvVarMissingMessageTemplate = "cannot start the Dash0 operator, the mandatory environment variable \"%s\" is missing"
@@ -604,6 +606,9 @@ func readEnvironmentVariables(logger *logr.Logger) error {
 		}
 	}
 
+	enablePprofExtensionRaw, isSet := os.LookupEnv(enablePprofExtensionEnvVarName)
+	enablePprofExtension := isSet && strings.ToLower(enablePprofExtensionRaw) == envVarValueTrue
+
 	envVars = environmentVariables{
 		operatorNamespace:                           operatorNamespace,
 		deploymentName:                              deploymentName,
@@ -630,6 +635,7 @@ func readEnvironmentVariables(logger *logr.Logger) error {
 		instrumentationDebug:            instrumentationDebug,
 		debugVerbosityDetailed:          debugVerbosityDetailed,
 		disableCollectorResourceWatches: disableCollectorResourceWatches,
+		enablePprofExtension:            enablePprofExtension,
 	}
 
 	return nil
@@ -776,6 +782,8 @@ func startOperatorManager(
 		developmentMode,
 		"verbosity detailed",
 		envVars.debugVerbosityDetailed,
+		"enable pprof extension",
+		envVars.enablePprofExtension,
 		"instrumentation debug",
 		envVars.instrumentationDebug,
 		"watch collector resources",
@@ -911,6 +919,7 @@ func startDash0Controllers(
 		IsGkeAutopilot:            cliArgs.isGkeAutopilot,
 		DevelopmentMode:           developmentMode,
 		DebugVerbosityDetailed:    envVars.debugVerbosityDetailed,
+		EnableProfExtension:       envVars.enablePprofExtension,
 	}
 	oTelColResourceManager := otelcolresources.NewOTelColResourceManager(
 		k8sClient,

--- a/internal/util/types.go
+++ b/internal/util/types.go
@@ -53,6 +53,7 @@ type CollectorConfig struct {
 	IsGkeAutopilot            bool
 	DevelopmentMode           bool
 	DebugVerbosityDetailed    bool
+	EnableProfExtension       bool
 }
 
 type TargetAllocatorConfig struct {


### PR DESCRIPTION
This adds a new option to the Helm values to enable the pprof extension both in the daemonset collector pods as well as in the collector deployment. This can be enabled temporarily to troubleshoot the collector's memory consumption.