### PR TITLE
feat(collectors): option to disable k8sattributes' replicaset informer

### DIFF
--- a/helm-chart/dash0-operator/templates/operator/deployment-and-webhooks.yaml
+++ b/helm-chart/dash0-operator/templates/operator/deployment-and-webhooks.yaml
@@ -233,6 +233,10 @@ spec:
         - name: OTEL_COLLECTOR_SEND_BATCH_MAX_SIZE
           value: {{ .Values.operator.collectors.sendBatchMaxSize | quote }}
         {{- end }}
+        {{- if .Values.operator.collectors.disableReplicasetInformer }}
+        - name: OTEL_COLLECTOR_K8SATTRIBUTES_DISABLE_REPLICASET_INFORMER
+          value: {{ .Values.operator.collectors.disableReplicasetInformer | toString | quote }}
+        {{- end }}
         {{- if .Values.operator.collectors.enablePprofExtension }}
         - name: OTEL_COLLECTOR_ENABLE_PPROF_EXTENSION
           value: {{ .Values.operator.collectors.enablePprofExtension | toString | quote }}

--- a/helm-chart/dash0-operator/tests/operator/deployment-and-webhooks_test.yaml
+++ b/helm-chart/dash0-operator/tests/operator/deployment-and-webhooks_test.yaml
@@ -221,6 +221,7 @@ tests:
           forceUseServiceUrl: true
           disableHostPorts: true
           enablePprofExtension: true
+          disableReplicasetInformer: true
 
     asserts:
       - equal:
@@ -441,42 +442,48 @@ tests:
           value: "32768"
       - equal:
           path: spec.template.spec.containers[0].env[24].name
-          value: OTEL_COLLECTOR_ENABLE_PPROF_EXTENSION
+          value: OTEL_COLLECTOR_K8SATTRIBUTES_DISABLE_REPLICASET_INFORMER
       - equal:
           path: spec.template.spec.containers[0].env[24].value
           value: "true"
       - equal:
           path: spec.template.spec.containers[0].env[25].name
-          value: K8S_POD_UID
+          value: OTEL_COLLECTOR_ENABLE_PPROF_EXTENSION
       - equal:
-          path: spec.template.spec.containers[0].env[25].valueFrom.fieldRef.fieldPath
-          value: metadata.uid
+          path: spec.template.spec.containers[0].env[25].value
+          value: "true"
       - equal:
           path: spec.template.spec.containers[0].env[26].name
-          value: K8S_NODE_IP
+          value: K8S_POD_UID
       - equal:
           path: spec.template.spec.containers[0].env[26].valueFrom.fieldRef.fieldPath
-          value: status.hostIP
+          value: metadata.uid
       - equal:
           path: spec.template.spec.containers[0].env[27].name
-          value: K8S_NODE_NAME
+          value: K8S_NODE_IP
       - equal:
           path: spec.template.spec.containers[0].env[27].valueFrom.fieldRef.fieldPath
-          value: spec.nodeName
+          value: status.hostIP
       - equal:
           path: spec.template.spec.containers[0].env[28].name
-          value: K8S_POD_IP
+          value: K8S_NODE_NAME
       - equal:
           path: spec.template.spec.containers[0].env[28].valueFrom.fieldRef.fieldPath
-          value: status.podIP
+          value: spec.nodeName
       - equal:
           path: spec.template.spec.containers[0].env[29].name
-          value: K8S_POD_NAME
+          value: K8S_POD_IP
       - equal:
           path: spec.template.spec.containers[0].env[29].valueFrom.fieldRef.fieldPath
+          value: status.podIP
+      - equal:
+          path: spec.template.spec.containers[0].env[30].name
+          value: K8S_POD_NAME
+      - equal:
+          path: spec.template.spec.containers[0].env[30].valueFrom.fieldRef.fieldPath
           value: metadata.name
       - notExists:
-          path: spec.template.spec.containers[0].env[30].name
+          path: spec.template.spec.containers[0].env[31].name
       - equal:
           path: spec.template.spec.containers[0].resources.limits.cpu
           value: 123m

--- a/helm-chart/dash0-operator/values.yaml
+++ b/helm-chart/dash0-operator/values.yaml
@@ -417,6 +417,11 @@ operator:
     # 8192, which is the default value for send_batch_size.
     sendBatchMaxSize: 0
 
+    # Disables the replicaset informer for the k8sattributes processor. This will lead to not collecting the resource
+    # attribute k8s.deployment.uid, and might lead to wrong values k8s.deployment.name in some edge cases.
+    # The default is false, do not override this unless explicitly instructed by Dash0 support.
+    disableReplicasetInformer: false
+
     # If set to true, instrumented workloads will be instructed to use the service URL of the OpenTelemetry collector
     # DaemonSet, instead of sending telemetry via a node-local route to the node's IP address and the collector's host
     # port. This can be useful if you employ mechanisms that block host ports, like certain Istio configurations.

--- a/internal/collectors/otelcolresources/collector_config_maps.go
+++ b/internal/collectors/otelcolresources/collector_config_maps.go
@@ -76,6 +76,7 @@ type collectorConfigurationTemplateValues struct {
 	SendBatchMaxSize                                 *uint32
 	KubernetesInfrastructureMetricsCollectionEnabled bool
 	CollectPodLabelsAndAnnotationsEnabled            bool
+	DisableReplicasetInformer                        bool
 	PrometheusCrdSupportEnabled                      bool
 	TargetAllocatorServiceName                       string
 	KubeletStatsReceiverConfig                       KubeletStatsReceiverConfig
@@ -213,6 +214,7 @@ func assembleCollectorConfigMap(
 				SendBatchMaxSize: config.SendBatchMaxSize,
 				KubernetesInfrastructureMetricsCollectionEnabled: config.KubernetesInfrastructureMetricsCollectionEnabled,
 				CollectPodLabelsAndAnnotationsEnabled:            config.CollectPodLabelsAndAnnotationsEnabled,
+				DisableReplicasetInformer:                        config.DisableReplicasetInformer,
 				PrometheusCrdSupportEnabled:                      config.PrometheusCrdSupportEnabled,
 				TargetAllocatorServiceName:                       targetAllocatorServiceName,
 				KubeletStatsReceiverConfig:                       config.KubeletStatsReceiverConfig,

--- a/internal/collectors/otelcolresources/daemonset.config.yaml.template
+++ b/internal/collectors/otelcolresources/daemonset.config.yaml.template
@@ -378,6 +378,9 @@ processors:
 
   k8sattributes:
     extract:
+      {{- if .DisableReplicasetInformer }}
+      deployment_name_from_replicaset: true
+      {{- end }}
       metadata:
       - k8s.cluster.uid
       - k8s.cronjob.name
@@ -385,7 +388,9 @@ processors:
       - k8s.daemonset.name
       - k8s.daemonset.uid
       - k8s.deployment.name
+      {{- if not .DisableReplicasetInformer }}
       - k8s.deployment.uid
+      {{- end }}
       - k8s.job.name
       - k8s.job.uid
       - k8s.namespace.name
@@ -751,7 +756,6 @@ service:
       - otlp
       processors:
       - memory_limiter
-      - k8sattributes
       exporters:
       - forward/logs
 
@@ -761,8 +765,6 @@ service:
       - filelog
       processors:
       - memory_limiter
-      - k8sattributes
-      - transform/logs/filelog_service_attributes
       exporters:
       - forward/logs
 {{- end }}
@@ -772,6 +774,8 @@ service:
       - forward/logs
       processors:
       - resourcedetection
+      - k8sattributes
+      - transform/logs/filelog_service_attributes
       {{- if .ClusterName }}
       - resource/clustername
       {{- end }}

--- a/internal/collectors/otelcolresources/deployment.config.yaml.template
+++ b/internal/collectors/otelcolresources/deployment.config.yaml.template
@@ -27,6 +27,9 @@ processors:
 
   k8sattributes:
     extract:
+      {{- if .DisableReplicasetInformer }}
+      deployment_name_from_replicaset: true
+      {{- end }}
       metadata:
       - k8s.cluster.uid
       - k8s.cronjob.name
@@ -34,7 +37,9 @@ processors:
       - k8s.daemonset.name
       - k8s.daemonset.uid
       - k8s.deployment.name
+      {{- if not .DisableReplicasetInformer }}
       - k8s.deployment.uid
+      {{- end }}
       - k8s.job.name
       - k8s.job.uid
       - k8s.namespace.name

--- a/internal/collectors/otelcolresources/desired_state.go
+++ b/internal/collectors/otelcolresources/desired_state.go
@@ -38,6 +38,7 @@ type oTelColConfig struct {
 	SelfMonitoringConfiguration                      selfmonitoringapiaccess.SelfMonitoringConfiguration
 	KubernetesInfrastructureMetricsCollectionEnabled bool
 	CollectPodLabelsAndAnnotationsEnabled            bool
+	DisableReplicasetInformer                        bool
 	PrometheusCrdSupportEnabled                      bool
 	TargetAllocatorNamePrefix                        string
 	KubeletStatsReceiverConfig                       KubeletStatsReceiverConfig

--- a/internal/collectors/otelcolresources/otelcol_resources.go
+++ b/internal/collectors/otelcolresources/otelcol_resources.go
@@ -145,6 +145,7 @@ func (m *OTelColResourceManager) CreateOrUpdateOpenTelemetryCollectorResources(
 		SelfMonitoringConfiguration: selfMonitoringConfiguration,
 		KubernetesInfrastructureMetricsCollectionEnabled: kubernetesInfrastructureMetricsCollectionEnabled,
 		CollectPodLabelsAndAnnotationsEnabled:            collectPodLabelsAndAnnotationsEnabled,
+		DisableReplicasetInformer:                        m.collectorConfig.DisableReplicasetInformer,
 		PrometheusCrdSupportEnabled:                      prometheusCrdSupportEnabled,
 		TargetAllocatorNamePrefix:                        m.collectorConfig.TargetAllocatorNamePrefix,
 		KubeletStatsReceiverConfig:                       kubeletStatsReceiverConfig,
@@ -360,6 +361,7 @@ func (m *OTelColResourceManager) DeleteResources(
 		// related resources, we always try to delete all collector resources (daemonset & deployment), no matter
 		// whether both sets have been created earlier or not.
 		KubernetesInfrastructureMetricsCollectionEnabled: true,
+		DisableReplicasetInformer:                        m.collectorConfig.DisableReplicasetInformer,
 		UseHostMetricsReceiver:                           !m.collectorConfig.IsDocker,        // irrelevant for deletion
 		DisableHostPorts:                                 m.collectorConfig.DisableHostPorts, // irrelevant for deletion
 		Images:                                           dummyImagesForDeletion,

--- a/internal/startup/operator_manager_startup.go
+++ b/internal/startup/operator_manager_startup.go
@@ -78,6 +78,7 @@ type environmentVariables struct {
 	nodeName                                    string
 	podIp                                       string
 	sendBatchMaxSize                            *uint32
+	disableReplicasetInformer                   bool
 	instrumentationDebug                        bool
 	debugVerbosityDetailed                      bool
 	disableCollectorResourceWatches             bool
@@ -141,6 +142,7 @@ const (
 	disableCollectorResourceWatchesEnvVarName = "DASH0_DISABLE_COLLECTOR_RESOURCE_WATCHES"
 	debugVerbosityDetailedEnvVarName          = "OTEL_COLLECTOR_DEBUG_VERBOSITY_DETAILED"
 	sendBatchMaxSizeEnvVarName                = "OTEL_COLLECTOR_SEND_BATCH_MAX_SIZE"
+	disableReplicasetInformerEnvVarName       = "OTEL_COLLECTOR_K8SATTRIBUTES_DISABLE_REPLICASET_INFORMER"
 	enablePprofExtensionEnvVarName            = "OTEL_COLLECTOR_ENABLE_PPROF_EXTENSION"
 
 	//nolint
@@ -623,6 +625,9 @@ func readEnvironmentVariables(logger *logr.Logger) error {
 		}
 	}
 
+	disableReplicasetInformerRaw, isSet := os.LookupEnv(disableReplicasetInformerEnvVarName)
+	disableReplicasetInformer := isSet && strings.ToLower(disableReplicasetInformerRaw) == envVarValueTrue
+
 	enablePprofExtensionRaw, isSet := os.LookupEnv(enablePprofExtensionEnvVarName)
 	enablePprofExtension := isSet && strings.ToLower(enablePprofExtensionRaw) == envVarValueTrue
 
@@ -649,6 +654,7 @@ func readEnvironmentVariables(logger *logr.Logger) error {
 		nodeName:                        nodeName,
 		podIp:                           podIp,
 		sendBatchMaxSize:                sendBatchMaxSize,
+		disableReplicasetInformer:       disableReplicasetInformer,
 		instrumentationDebug:            instrumentationDebug,
 		debugVerbosityDetailed:          debugVerbosityDetailed,
 		disableCollectorResourceWatches: disableCollectorResourceWatches,
@@ -927,6 +933,7 @@ func startDash0Controllers(
 		OTelCollectorNamePrefix:   envVars.oTelCollectorNamePrefix,
 		TargetAllocatorNamePrefix: envVars.targetAllocatorNamePrefix,
 		SendBatchMaxSize:          envVars.sendBatchMaxSize,
+		DisableReplicasetInformer: envVars.disableReplicasetInformer,
 		NodeIp:                    envVars.nodeIp,
 		NodeName:                  envVars.nodeName,
 		PseudoClusterUid:          pseudoClusterUid,

--- a/internal/util/types.go
+++ b/internal/util/types.go
@@ -44,6 +44,7 @@ type CollectorConfig struct {
 	// config of the prometheus_receiver
 	TargetAllocatorNamePrefix string
 	SendBatchMaxSize          *uint32
+	DisableReplicasetInformer bool
 	NodeIp                    string
 	NodeName                  string
 	PseudoClusterUid          types.UID


### PR DESCRIPTION
The k8sattributes processor makes the collector consumes a lot of memory at startup in clusters with an excessive amount of replicasets. This is due to how the processor uses a replicaset informer to derive k8s.deployment.name and k8s.deployment.uid for pods. Even in the daemonset collector, with filter.node_from_env_var being set, it needs to fetch all replicasets in the cluster.

This commit adds an option to the Helm chart to disable the replicaset informer within the k8sattributes processor. As a consequence, k8s.deployment.uid is then also removed from the list k8sattributes.extract.metadata, as this is required to actually make sure the costly replicaset informer is not used.

See here for an extensive discussion around the k8sattributes processor and the replicaset informer specifically:
- https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/23067
- https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/44407
- https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/44708
- https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/36234
- https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/42534

For now, this is only an option in the Helm chart. We can later add it as a Dash0OperatorConfiguration property, if needed. This depends on whether (and how fast) currently ongoing attempts to fix this issue upstream are successful.

Also: Get rid of one k8sattributes processor instance by moving it from the logs/otlp and the logs/filelog pipeline to the logs/downstream pipeline.