### PR TITLE
test: add script to create a large number of Kubernetes entities

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,6 +64,10 @@ jobs:
         run: |
           go version
 
+      - name: shellcheck version
+        run: |
+          shellcheck --version
+
       - uses: mlugg/setup-zig@fa65c4058643678a4e4a9a60513944a7d8d35440
         with:
           # keep in sync with images/instrumentation/injector/zig-version, if possible

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -195,7 +195,7 @@ Moving beyond the quickstart instructions, here are more details on the test scr
       as resource attributes.
       This defaults to `$TELEMETRY_COLLECTION_ENABLED`, which in turn defaults to "true".
     * `COLLECTOR_ENABLE_PPROF`: Set to "true" to enable the pprof extension in the collector containers.
-      See <helm-chart/dash0-operator/README.md#create-heap-dumps> for instructions for creating heap dumps.
+      See <helm-chart/dash0-operator/README.md#create-heap-profiles> for instructions for creating heap profiles.
     * `DASH0_API_ENDPOINT`: The endpoint for API requests (for synchronizing Perses dashboards, Prometheus check rules,
       synthetic checks and views). It is recommended to set this in `test-resources/.env`.
     * `DASH0_AUTHORIZATION_TOKEN`: The authorization token for sending telemetry to the Dash0 ingress endpoint and
@@ -256,7 +256,7 @@ Moving beyond the quickstart instructions, here are more details on the test scr
     * `OPERATOR_HELM_CHART`: The name of the Helm chart to use for deploying the operator. Defaults to the local Helm
       chart sources in `helm-chart/dash0-operator`.
     * `OPERATOR_MANAGER_PPROF_PORT`: Set this to a numeric value to enable pprof in the operator manager container.
-      See <helm-chart/dash0-operator/README.md#create-heap-dumps> for instructions for creating heap dumps.
+      See <helm-chart/dash0-operator/README.md#create-heap-profiles> for instructions for creating heap profiles.
     * `OTEL_COLLECTOR_DEBUG_VERBOSITY_DETAILED`: Add a debug exporter to the OTel collectors with `verbosity: detailed`.
     * `OTEL_COLLECTOR_SEND_BATCH_MAX_SIZE`: Set the `send_batch_max_size parameter` of the batch processor of the
       collectors managed by the operator. There is usually no need to configure this. The value must be greater than or

--- a/Makefile
+++ b/Makefile
@@ -178,7 +178,7 @@ ifdef GINKGO_FOCUS
 else
 	go run github.com/onsi/ginkgo/v2/ginkgo -v test/e2e
 endif
-	
+
 GOLANGCI_LINT = $(shell pwd)/bin/golangci-lint
 GOLANGCI_LINT_VERSION ?= v2.5.0
 golangci-lint-install:

--- a/helm-chart/dash0-operator/README.md
+++ b/helm-chart/dash0-operator/README.md
@@ -2281,11 +2281,11 @@ The `hostmetrics` receiver will be disabled when using Docker as the container r
 
 ## Troubleshooting
 
-### Create Heap Dumps
+### Create Heap Profiles
 
 The instructions in this section are mainly meant to be used in a shared troubleshooting session with Dash0 support.
 
-_To get a heap dump from the operator manager container:_
+_To get a heap profile from the operator manager container:_
 1. Deploy the operator manager with the additional Helm value `operator.pprofPort=1777`.
 2. Take note of the namespace the operator is deployed in (default: `dash0-system`).
 3. Run `kubectl get pod -n <operator-namespace> -l app.kubernetes.io/component=controller` to get the name of the
@@ -2304,7 +2304,7 @@ _To get a heap dump from the operator manager container:_
 7. Exit the `kubectl debug` shell.
 8. Redeploy the operator without the Helm setting `operator.pprofPort=1777`.
 
-_To get a heap dump from a OpenTelemetry collector daemonset container:_
+_To get a heap profile from a OpenTelemetry collector daemonset container:_
 1. Deploy the operator manager with the additional Helm value `operator.collectors.enablePprofExtension=true`.
 2. Take note of the namespace the operator is deployed in (default: `dash0-system`).
 3. Run `kubectl top pod -n <operator-namespace> -l app.kubernetes.io/component=agent-collector` to get the name of a
@@ -2323,6 +2323,6 @@ _To get a heap dump from a OpenTelemetry collector daemonset container:_
 7. Exit the `kubectl debug` shell.
 8. Redeploy the operator without the Helm setting `operator.collectors.enablePprofExtension=true`.
 
-_To get a heap dump from a OpenTelemetry collector deployment container:_
+_To get a heap profile from a OpenTelemetry collector deployment container:_
 * Follow the same steps as for the collector daemonset, but use
   `-l app.kubernetes.io/component=cluster-metrics-collector` in step (3.).

--- a/test-resources/many-k8s-entities/.gitignore
+++ b/test-resources/many-k8s-entities/.gitignore
@@ -1,0 +1,1 @@
+*deployment.yaml

--- a/test-resources/many-k8s-entities/README.md
+++ b/test-resources/many-k8s-entities/README.md
@@ -1,0 +1,46 @@
+Operator and Collector Memory Usage
+===================================
+
+The script `create-many-deployments-and-replicasets.sh` can be used to quickly create a larger number of Kubernetes
+objects, and to investigate how memory consumption of the operator manager and the OTel collectors it manages behaves
+in relation to that.
+
+The script continuosly creates deployments with multiple revisions (hence more replicasets) in one namespace, each with
+replicas=0. This can be used to
+a) test the impact of a high numbers of deployments/replicasets on the OTel collector, and
+b) test the impact of a high numbers of deployments/replicasets on the operator manager.
+
+The script has a couple of settings (`target_ctx`, `target_namespace`, `max_deployments`, `revisions_per_deployment`,
+`max_number_of_replicasets`) that can be tuned to create a specific scenario.
+
+To clean up, simply delete the namespace "operator-k8s-api-load-test" (will take a while).
+
+Note that the speed of creating deployments/replicasets is mainly limited by the duration of the `kubectl apply` call.
+
+If you want to create objects faster, start this script multiple times in parallel, each time with a different prefix,
+like so:
+```
+./create-many-deployments-and-replicasets.sh aaa
+./create-many-deployments-and-replicasets.sh bbb
+./create-many-deployments-and-replicasets.sh ccc
+./create-many-deployments-and-replicasets.sh ddd
+```
+
+The limit set via `max_number_of_replicasets` is respected across parallel script invocations.
+
+To inspect the operator manager's heap, you can deploy it with pprof enabled:
+```
+operator:
+  pprofPort: 1777
+  collectors:
+    # Optional, this is useful to not have the collector pods go OOM due to high number of replicasets, if you want
+    # to focus your testing on the operator manager.
+    disableReplicasetInformer: true
+```
+
+Then run
+`kubectl --namespace operator-namespace port-forward $(kubectl get pods --namespace operator-namespace -l app.kubernetes.io/name=dash0-operator -l app.kubernetes.io/component=controller -o jsonpath="{.items[0].metadata.name}") 1777:1777` and use `curl http://localhost:1777/debug/pprof/` to talk
+to pprof and `curl http://localhost:1777/debug/pprof/heap > operator_manager.out` to get a heap profile.
+Alternatively, attach a debug container as outlined in
+<https://github.com/dash0hq/dash0-operator/blob/main/helm-chart/dash0-operator/README.md#create-heap-profiles>
+

--- a/test-resources/many-k8s-entities/create-many-deployments-and-replicasets.sh
+++ b/test-resources/many-k8s-entities/create-many-deployments-and-replicasets.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright 2025 Dash0 Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# See ./README.md for documentation.
+
+set -eu
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+prefix="${1:-}"
+if [[ -n "$prefix" ]]; then
+  prefix="${prefix}-"
+fi
+
+# Kubernetes context to use
+target_ctx=dash0-operator-test-bk
+
+# Kubernetes namespace to use
+target_namespace=operator-k8s-api-load-test
+
+# number of different deployment names to be used
+max_deployments=200
+
+# number of replicaset revisions to create per deployment. The script will create
+# $max_deployments * $revisions_per_deployment replicasets, but limited by $max_number_of_replicasets.
+revisions_per_deployment=50
+
+# The script will stop once >= $max_number_of_replicasets replicasets exist in the target namespace.
+# (The check is independent of whether the replicasets have been created by this script.)
+max_number_of_replicasets=10000
+
+# Checking the number of existing replicasets after each kubect apply is costly and slows down the script, so
+# the number is only checked after every $check_number_every_nth_iteration loop iteration. This might lead to
+# creating a slightly higher number than specified by $max_number_of_replicasets, but getting exact number of
+# replicasets is not really relevant.
+check_number_every_nth_iteration=100
+
+kubectl --context "$target_ctx" create ns "$target_namespace" || true
+
+iteration=0
+for _ in $(seq 1 $revisions_per_deployment); do
+  for deployment_idx in $(seq 1 $max_deployments); do
+    # echo "deployment: $deployment_idx, revision: $revision, random_annotation: $random_annotation"
+    name="${prefix}test-deployment-${deployment_idx}"
+    selector="${name}-app"
+    manifest_filename="${prefix}deployment.yaml"
+    # shellcheck disable=SC2002
+    random_annotation=$(cat /dev/urandom | LC_ALL=C tr -dc 'a-zA-Z0-9' | fold -w 10 | head -n 1)
+    # shellcheck disable=SC2002
+    cat \
+      deployment.yaml.template | \
+      NAME="$name" \
+      SELECTOR="$selector" \
+      RANDOM_ANNOTATION="$random_annotation" \
+      envsubst > \
+      "$manifest_filename"
+    kubectl --context "$target_ctx" apply -n "$target_namespace" -f "$manifest_filename" || true
+
+    echo $iteration
+    ((++iteration))
+    if [[ $iteration -ge $check_number_every_nth_iteration ]]; then
+      iteration=0
+      number_of_replicasets=$(kubectl --context "$target_ctx" get replicasets -n "$target_namespace" --no-headers | wc -l)
+      if [[ $number_of_replicasets -ge $max_number_of_replicasets ]]; then
+        echo "$number_of_replicasets now exist in the namespace $target_namespace"
+        exit 0
+      fi
+    fi
+  done
+done
+

--- a/test-resources/many-k8s-entities/deployment.yaml.template
+++ b/test-resources/many-k8s-entities/deployment.yaml.template
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: $NAME
+  labels:
+    app: $SELECTOR
+spec:
+  replicas: 0
+  selector:
+    matchLabels:
+      app: $SELECTOR
+  template:
+    metadata:
+      labels:
+        app: $SELECTOR
+      annotations:
+        random: "$RANDOM_ANNOTATION"
+        largeAnnotation: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium. Integer tincidunt. Cras dapibus. Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. Aenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante, dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra nulla ut metus varius laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel augue. Curabitur ullamcorper ultricies nisi. Nam eget dui. Etiam rhoncus. Maecenas tempus, tellus eget condimentum rhoncus, sem quam semper libero, sit amet adipiscing sem neque sed ipsum. Nam quam nunc, blandit vel, luctus pulvinar, hendrerit id, lorem. Maecenas nec odio et ante tincidunt tempus. Donec vitae sapien ut libero venenatis faucibus. Nullam quis ante. Etiam sit amet orci eget eros faucibus tincidunt. Duis leo. Sed fringilla mauris sit amet nibh. Donec sodales sagittis magna. Sed consequat, leo eget bibendum sodales, augue velit cursus nunc, quis gravida magna mi a libero. Fusce vulputate eleifend sapien. Vestibulum purus quam, scelerisque ut, mollis sed, nonummy id, metus. Nullam accumsan lorem in dui. Cras ultricies mi eu turpis hendrerit fringilla. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; In ac dui quis mi consectetuer lacinia. Nam pretium turpis et arcu. Duis arcu tortor, suscipit eget, imperdiet nec, imperdiet iaculis, ipsum. Sed aliquam ultrices mauris. Integer ante arcu, accumsan a, consectetuer eget, posuere ut, mauris. Praesent adipiscing. Phasellus ullamcorper ipsum rutrum nunc. Nunc nonummy metus. Vestibulum volutpat pretium libero. Cras id dui. Aenean ut eros et nisl sagittis vestibulum. Nullam nulla eros, ultricies sit amet, nonummy id, imperdiet feugiat, pede. Sed lectus. Donec mollis hendrerit risus. Phasellus nec sem in justo pellentesque facilisis. Etiam imperdiet imperdiet orci. Nunc nec neque. Phasellus leo dolor, tempus non, auctor et, hendrerit quis, nisi. Curabitur ligula sapien, tincidunt non, euismod vitae, posuere imperdiet, leo. Maecenas malesuada. Praesent congue erat at massa. Sed cursus turpis vitae tortor. Donec posuere vulputate arcu. Phasellus accumsan cursus velit. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Sed aliquam, nisi quis porttitor congue, elit erat euismod orci, ac placerat dolor lectus quis orci. Phasellus consectetuer vestibulum elit. Aenean tellus metus, bibendum sed, posuere ac, mattis non, nunc. Vestibulum fringilla pede sit amet augue. In turpis. Pellentesque posuere. Praesent turpis. Aenean posuere, tortor sed cursus feugiat, nunc augue blandit nunc, eu sollicitudin urna dolor sagittis lacus. Donec elit libero, sodales nec, volutpat a, suscipit non, turpis. Nullam sagittis. Suspendisse pulvinar, augue ac venenatis condimentum, sem libero volutpat nibh, nec pellentesque velit pede quis nunc. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Fusce id purus. Ut varius tincidunt libero. Phasellus dolor. Maecenas vestibulum mollis diam. Pellentesque ut neque. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. In dui magna, posuere eget, vestibulum et, tempor auctor, justo. In ac felis quis tortor malesuada pretium. Pellentesque auctor neque nec urna. Proin sapien ipsum, porta a, auctor quis, euismod ut, mi. Aenean viverra rhoncus pede. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Ut non enim eleifend felis pretium feugiat. Vivamus quis mi. Phasellus a est. Phasellus magna. In hac habitasse platea dictumst. Curabitur at lacus ac velit ornare lobortis. Cura"
+    spec:
+      containers:
+        - name: container
+          image: stefanprodan/podinfo
+


### PR DESCRIPTION
This can be used to test the resource consumption of the operator (and the collectors it manages) in relation to the number of Kubernetes entities and their rate of change.