### PR TITLE
fix(chart): set GOMEMLIMIT for operator manager

### DIFF
--- a/helm-chart/dash0-operator/templates/NOTES.txt
+++ b/helm-chart/dash0-operator/templates/NOTES.txt
@@ -1,3 +1,6 @@
+{{- if and (eq .Values.operator.managerContainerResources.gomemlimit "205MiB") (ne .Values.operator.managerContainerResources.limits.memory "256Mi") }}
+WARNING: You have set a custom memory limit for the operator manager (operator.managerContainerResources.limits.memory: {{ .Values.operator.managerContainerResources.limits.memory }}), but you have not set the container's GOMEMLIMIT (operator.managerContainerResources.gomemlimit: {{ .Values.operator.managerContainerResources.gomemlimit }}). This is probably a configuration error. The recommended setting for operator.managerContainerResources.gomemlimit is 80% of operator.managerContainerResources.limits.memory.
+{{- end }}
 {{- if .Release.IsInstall }}
 The Dash0 operator has been installed successfully from the chart {{ .Chart.Name }}.
 {{- else }}

--- a/helm-chart/dash0-operator/templates/operator/deployment-and-webhooks.yaml
+++ b/helm-chart/dash0-operator/templates/operator/deployment-and-webhooks.yaml
@@ -159,6 +159,8 @@ spec:
         - --instrumentation-delay-after-each-namespace-millis={{ default .Values.operator.instrumentation.delayAfterEachNamespaceMillis .Values.operator.instrumentationDelayAfterEachNamespaceMillis }}
 {{- end }}
         env:
+        - name: GOMEMLIMIT
+          value: {{ .Values.operator.managerContainerResources.gomemlimit | quote }}
         - name: DASH0_OPERATOR_NAMESPACE
           valueFrom:
             fieldRef:
@@ -266,7 +268,7 @@ spec:
           name: webhook-server
           protocol: TCP
         resources:
-          {{- toYaml .Values.operator.managerContainerResources | nindent 10 }}
+          {{- unset (.Values.operator.managerContainerResources | mustDeepCopy) "gomemlimit" | toYaml | nindent 10 }}
         {{ include "dash0-operator.restrictiveContainerSecurityContext" dict | nindent 8 }}
         volumeMounts:
         - name: certificates

--- a/helm-chart/dash0-operator/templates/operator/post-install-hook.yaml
+++ b/helm-chart/dash0-operator/templates/operator/post-install-hook.yaml
@@ -57,8 +57,11 @@ spec:
           args:
             - "--auto-operator-configuration-resource-available-check"
           {{ include "dash0-operator.restrictiveContainerSecurityContext" dict | nindent 10 }}
+          env:
+            - name: GOMEMLIMIT
+              value: {{ .Values.operator.managerContainerResources.gomemlimit }}
           resources:
-            {{- toYaml .Values.operator.managerContainerResources | nindent 12 }}
+            {{- unset (.Values.operator.managerContainerResources | mustDeepCopy) "gomemlimit" | toYaml | nindent 12 }}
       {{- with .Values.operator.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/helm-chart/dash0-operator/templates/operator/pre-delete-hook.yaml
+++ b/helm-chart/dash0-operator/templates/operator/pre-delete-hook.yaml
@@ -53,8 +53,11 @@ spec:
           args:
             - "--uninstrument-all"
           {{ include "dash0-operator.restrictiveContainerSecurityContext" dict | nindent 10 }}
+          env:
+            - name: GOMEMLIMIT
+              value: {{ .Values.operator.managerContainerResources.gomemlimit }}
           resources:
-            {{- toYaml .Values.operator.managerContainerResources | nindent 12 }}
+            {{- unset (.Values.operator.managerContainerResources | mustDeepCopy) "gomemlimit" | toYaml | nindent 12 }}
       {{- with .Values.operator.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/helm-chart/dash0-operator/tests/operator/__snapshot__/deployment-and-webhooks_test.yaml.snap
+++ b/helm-chart/dash0-operator/tests/operator/__snapshot__/deployment-and-webhooks_test.yaml.snap
@@ -54,6 +54,8 @@ deployment should match snapshot (default values):
               command:
                 - /manager
               env:
+                - name: GOMEMLIMIT
+                  value: 205MiB
                 - name: DASH0_OPERATOR_NAMESPACE
                   valueFrom:
                     fieldRef:
@@ -212,6 +214,8 @@ deployment should match snapshot when using cert-manager:
               command:
                 - /manager
               env:
+                - name: GOMEMLIMIT
+                  value: 205MiB
                 - name: DASH0_OPERATOR_NAMESPACE
                   valueFrom:
                     fieldRef:

--- a/helm-chart/dash0-operator/tests/operator/__snapshot__/post-install-hook_test.yaml.snap
+++ b/helm-chart/dash0-operator/tests/operator/__snapshot__/post-install-hook_test.yaml.snap
@@ -47,6 +47,9 @@ post-install hook job should match snapshot:
                 - --auto-operator-configuration-resource-available-check
               command:
                 - /manager
+              env:
+                - name: GOMEMLIMIT
+                  value: 205MiB
               image: ghcr.io/dash0hq/operator-controller:0.0.0
               imagePullPolicy: null
               name: post-install-job

--- a/helm-chart/dash0-operator/tests/operator/__snapshot__/pre-delete-hook_test.yaml.snap
+++ b/helm-chart/dash0-operator/tests/operator/__snapshot__/pre-delete-hook_test.yaml.snap
@@ -47,6 +47,9 @@ pre-delete hook job should match snapshot:
                 - --uninstrument-all
               command:
                 - /manager
+              env:
+                - name: GOMEMLIMIT
+                  value: 205MiB
               image: ghcr.io/dash0hq/operator-controller:0.0.0
               imagePullPolicy: null
               name: pre-delete-job

--- a/helm-chart/dash0-operator/tests/operator/deployment-and-webhooks_test.yaml
+++ b/helm-chart/dash0-operator/tests/operator/deployment-and-webhooks_test.yaml
@@ -21,73 +21,73 @@ tests:
           path: spec.template.spec.containers[0].image
           value: ghcr.io/dash0hq/operator-controller:99.100.101
       - equal:
-          path: spec.template.spec.containers[0].env[5].name
+          path: spec.template.spec.containers[0].env[6].name
           value: DASH0_OPERATOR_IMAGE
       - equal:
-          path: spec.template.spec.containers[0].env[5].value
+          path: spec.template.spec.containers[0].env[6].value
           value: ghcr.io/dash0hq/operator-controller:99.100.101
       - equal:
-          path: spec.template.spec.containers[0].env[6].name
+          path: spec.template.spec.containers[0].env[7].name
           value: DASH0_INIT_CONTAINER_IMAGE
       - equal:
-          path: spec.template.spec.containers[0].env[6].value
+          path: spec.template.spec.containers[0].env[7].value
           value: ghcr.io/dash0hq/instrumentation:99.100.101
       - equal:
-          path: spec.template.spec.containers[0].env[7].name
+          path: spec.template.spec.containers[0].env[8].name
           value: DASH0_COLLECTOR_IMAGE
       - equal:
-          path: spec.template.spec.containers[0].env[7].value
+          path: spec.template.spec.containers[0].env[8].value
           value: ghcr.io/dash0hq/collector:99.100.101
       - equal:
-          path: spec.template.spec.containers[0].env[9].name
+          path: spec.template.spec.containers[0].env[10].name
           value: DASH0_CONFIGURATION_RELOADER_IMAGE
       - equal:
-          path: spec.template.spec.containers[0].env[9].value
+          path: spec.template.spec.containers[0].env[10].value
           value: ghcr.io/dash0hq/configuration-reloader:99.100.101
       - equal:
-          path: spec.template.spec.containers[0].env[10].name
+          path: spec.template.spec.containers[0].env[11].name
           value: DASH0_FILELOG_OFFSET_SYNC_IMAGE
       - equal:
-          path: spec.template.spec.containers[0].env[10].value
+          path: spec.template.spec.containers[0].env[11].value
           value: ghcr.io/dash0hq/filelog-offset-sync:99.100.101
       - equal:
-          path: spec.template.spec.containers[0].env[11].name
+          path: spec.template.spec.containers[0].env[12].name
           value: DASH0_FILELOG_OFFSET_VOLUME_OWNERSHIP_IMAGE
       - equal:
-          path: spec.template.spec.containers[0].env[11].value
+          path: spec.template.spec.containers[0].env[12].value
           value: ghcr.io/dash0hq/filelog-offset-volume-ownership:99.100.101
       - equal:
-          path: spec.template.spec.containers[0].env[12].name
+          path: spec.template.spec.containers[0].env[13].name
           value: K8S_POD_UID
       - equal:
-          path: spec.template.spec.containers[0].env[12].valueFrom.fieldRef.fieldPath
+          path: spec.template.spec.containers[0].env[13].valueFrom.fieldRef.fieldPath
           value: metadata.uid
       - equal:
-          path: spec.template.spec.containers[0].env[13].name
+          path: spec.template.spec.containers[0].env[14].name
           value: K8S_NODE_IP
       - equal:
-          path: spec.template.spec.containers[0].env[13].valueFrom.fieldRef.fieldPath
+          path: spec.template.spec.containers[0].env[14].valueFrom.fieldRef.fieldPath
           value: status.hostIP
       - equal:
-          path: spec.template.spec.containers[0].env[14].name
+          path: spec.template.spec.containers[0].env[15].name
           value: K8S_NODE_NAME
       - equal:
-          path: spec.template.spec.containers[0].env[14].valueFrom.fieldRef.fieldPath
+          path: spec.template.spec.containers[0].env[15].valueFrom.fieldRef.fieldPath
           value: spec.nodeName
       - equal:
-          path: spec.template.spec.containers[0].env[15].name
+          path: spec.template.spec.containers[0].env[16].name
           value: K8S_POD_IP
       - equal:
-          path: spec.template.spec.containers[0].env[15].valueFrom.fieldRef.fieldPath
+          path: spec.template.spec.containers[0].env[16].valueFrom.fieldRef.fieldPath
           value: status.podIP
       - equal:
-          path: spec.template.spec.containers[0].env[16].name
+          path: spec.template.spec.containers[0].env[17].name
           value: K8S_POD_NAME
       - equal:
-          path: spec.template.spec.containers[0].env[16].valueFrom.fieldRef.fieldPath
+          path: spec.template.spec.containers[0].env[17].valueFrom.fieldRef.fieldPath
           value: metadata.name
       - notExists:
-          path: spec.template.spec.containers[0].env[17].name
+          path: spec.template.spec.containers[0].env[18].name
 
   - it: secret should contain ca and cert
     documentSelector:
@@ -202,6 +202,7 @@ tests:
             cpu: 123m
             memory: 456Mi
             ephemeral-storage: 789Mi
+          gomemlimit: 345MiB
           requests:
             cpu: 5m
             memory: 32Mi
@@ -301,189 +302,195 @@ tests:
           path: spec.template.spec.containers[0].args[8]
       - equal:
           path: spec.template.spec.containers[0].env[0].name
-          value: DASH0_OPERATOR_NAMESPACE
+          value: GOMEMLIMIT
+      - equal:
+          path: spec.template.spec.containers[0].env[0].value
+          value: 345MiB
       - equal:
           path: spec.template.spec.containers[0].env[1].name
-          value: DASH0_DEPLOYMENT_NAME
-      - equal:
-          path: spec.template.spec.containers[0].env[1].value
-          value: dash0-operator-controller
+          value: DASH0_OPERATOR_NAMESPACE
       - equal:
           path: spec.template.spec.containers[0].env[2].name
-          value: DASH0_WEBHOOK_SERVICE_NAME
+          value: DASH0_DEPLOYMENT_NAME
       - equal:
           path: spec.template.spec.containers[0].env[2].value
-          value: custom-webhook-service-name
+          value: dash0-operator-controller
       - equal:
           path: spec.template.spec.containers[0].env[3].name
-          value: OTEL_COLLECTOR_NAME_PREFIX
+          value: DASH0_WEBHOOK_SERVICE_NAME
       - equal:
           path: spec.template.spec.containers[0].env[3].value
-          value: RELEASE-NAME
+          value: custom-webhook-service-name
       - equal:
           path: spec.template.spec.containers[0].env[4].name
-          value: OTEL_TARGET_ALLOCATOR_NAME_PREFIX
+          value: OTEL_COLLECTOR_NAME_PREFIX
       - equal:
           path: spec.template.spec.containers[0].env[4].value
           value: RELEASE-NAME
       - equal:
           path: spec.template.spec.containers[0].env[5].name
-          value: DASH0_OPERATOR_IMAGE
+          value: OTEL_TARGET_ALLOCATOR_NAME_PREFIX
       - equal:
           path: spec.template.spec.containers[0].env[5].value
-          value: custom-operator-image:1.2.3
+          value: RELEASE-NAME
       - equal:
           path: spec.template.spec.containers[0].env[6].name
-          value: DASH0_INIT_CONTAINER_IMAGE
+          value: DASH0_OPERATOR_IMAGE
       - equal:
           path: spec.template.spec.containers[0].env[6].value
-          value: custom-init-container-image:4.5.6
+          value: custom-operator-image:1.2.3
       - equal:
           path: spec.template.spec.containers[0].env[7].name
-          value: DASH0_INIT_CONTAINER_IMAGE_PULL_POLICY
+          value: DASH0_INIT_CONTAINER_IMAGE
       - equal:
           path: spec.template.spec.containers[0].env[7].value
-          value: Always
+          value: custom-init-container-image:4.5.6
       - equal:
           path: spec.template.spec.containers[0].env[8].name
-          value: DASH0_COLLECTOR_IMAGE
+          value: DASH0_INIT_CONTAINER_IMAGE_PULL_POLICY
       - equal:
           path: spec.template.spec.containers[0].env[8].value
-          value: custom-collector-image:7.8.9
+          value: Always
       - equal:
           path: spec.template.spec.containers[0].env[9].name
-          value: DASH0_COLLECTOR_IMAGE_PULL_POLICY
+          value: DASH0_COLLECTOR_IMAGE
       - equal:
           path: spec.template.spec.containers[0].env[9].value
-          value: Never
+          value: custom-collector-image:7.8.9
       - equal:
           path: spec.template.spec.containers[0].env[10].name
-          value: DASH0_TARGET_ALLOCATOR_IMAGE
+          value: DASH0_COLLECTOR_IMAGE_PULL_POLICY
       - equal:
           path: spec.template.spec.containers[0].env[10].value
-          value: custom-ta-image:8.9.10
+          value: Never
       - equal:
           path: spec.template.spec.containers[0].env[11].name
-          value: DASH0_TARGET_ALLOCATOR_IMAGE_PULL_POLICY
+          value: DASH0_TARGET_ALLOCATOR_IMAGE
       - equal:
           path: spec.template.spec.containers[0].env[11].value
-          value: Never
+          value: custom-ta-image:8.9.10
       - equal:
           path: spec.template.spec.containers[0].env[12].name
-          value: DASH0_CONFIGURATION_RELOADER_IMAGE
+          value: DASH0_TARGET_ALLOCATOR_IMAGE_PULL_POLICY
       - equal:
           path: spec.template.spec.containers[0].env[12].value
-          value: custom-configuration-reloader-image:10.11.12
-      - equal:
-          path: spec.template.spec.containers[0].env[13].name
-          value: DASH0_CONFIGURATION_RELOADER_IMAGE_PULL_POLICY
-      - equal:
-          path: spec.template.spec.containers[0].env[13].value
-          value: Always
-      - equal:
-          path: spec.template.spec.containers[0].env[14].name
-          value: DASH0_FILELOG_OFFSET_SYNC_IMAGE
-      - equal:
-          path: spec.template.spec.containers[0].env[14].value
-          value: custom-filelog-offset-sync-image:13.14.15
-      - equal:
-          path: spec.template.spec.containers[0].env[15].name
-          value: DASH0_FILELOG_OFFSET_SYNC_IMAGE_PULL_POLICY
-      - equal:
-          path: spec.template.spec.containers[0].env[15].value
           value: Never
       - equal:
-          path: spec.template.spec.containers[0].env[16].name
-          value: DASH0_FILELOG_OFFSET_VOLUME_OWNERSHIP_IMAGE
+          path: spec.template.spec.containers[0].env[13].name
+          value: DASH0_CONFIGURATION_RELOADER_IMAGE
       - equal:
-          path: spec.template.spec.containers[0].env[16].value
-          value: custom-filelog-offset-volume-ownership-image:16.17.18
+          path: spec.template.spec.containers[0].env[13].value
+          value: custom-configuration-reloader-image:10.11.12
       - equal:
-          path: spec.template.spec.containers[0].env[17].name
-          value: DASH0_FILELOG_OFFSET_VOLUME_OWNERSHIP_IMAGE_PULL_POLICY
+          path: spec.template.spec.containers[0].env[14].name
+          value: DASH0_CONFIGURATION_RELOADER_IMAGE_PULL_POLICY
       - equal:
-          path: spec.template.spec.containers[0].env[17].value
+          path: spec.template.spec.containers[0].env[14].value
           value: Always
       - equal:
+          path: spec.template.spec.containers[0].env[15].name
+          value: DASH0_FILELOG_OFFSET_SYNC_IMAGE
+      - equal:
+          path: spec.template.spec.containers[0].env[15].value
+          value: custom-filelog-offset-sync-image:13.14.15
+      - equal:
+          path: spec.template.spec.containers[0].env[16].name
+          value: DASH0_FILELOG_OFFSET_SYNC_IMAGE_PULL_POLICY
+      - equal:
+          path: spec.template.spec.containers[0].env[16].value
+          value: Never
+      - equal:
+          path: spec.template.spec.containers[0].env[17].name
+          value: DASH0_FILELOG_OFFSET_VOLUME_OWNERSHIP_IMAGE
+      - equal:
+          path: spec.template.spec.containers[0].env[17].value
+          value: custom-filelog-offset-volume-ownership-image:16.17.18
+      - equal:
           path: spec.template.spec.containers[0].env[18].name
-          value: DASH0_DEVELOPMENT_MODE
+          value: DASH0_FILELOG_OFFSET_VOLUME_OWNERSHIP_IMAGE_PULL_POLICY
       - equal:
           path: spec.template.spec.containers[0].env[18].value
-          value: "true"
+          value: Always
       - equal:
           path: spec.template.spec.containers[0].env[19].name
-          value: DASH0_PPROF_PORT
+          value: DASH0_DEVELOPMENT_MODE
       - equal:
           path: spec.template.spec.containers[0].env[19].value
-          value: "1234"
-      - equal:
-          path: spec.template.spec.containers[0].env[20].name
-          value: DASH0_INSTRUMENTATION_DEBUG
-      - equal:
-          path: spec.template.spec.containers[0].env[20].value
           value: "true"
       - equal:
+          path: spec.template.spec.containers[0].env[20].name
+          value: DASH0_PPROF_PORT
+      - equal:
+          path: spec.template.spec.containers[0].env[20].value
+          value: "1234"
+      - equal:
           path: spec.template.spec.containers[0].env[21].name
-          value: DASH0_DISABLE_COLLECTOR_RESOURCE_WATCHES
+          value: DASH0_INSTRUMENTATION_DEBUG
       - equal:
           path: spec.template.spec.containers[0].env[21].value
           value: "true"
       - equal:
           path: spec.template.spec.containers[0].env[22].name
-          value: OTEL_COLLECTOR_DEBUG_VERBOSITY_DETAILED
+          value: DASH0_DISABLE_COLLECTOR_RESOURCE_WATCHES
       - equal:
           path: spec.template.spec.containers[0].env[22].value
           value: "true"
       - equal:
           path: spec.template.spec.containers[0].env[23].name
-          value: OTEL_COLLECTOR_SEND_BATCH_MAX_SIZE
+          value: OTEL_COLLECTOR_DEBUG_VERBOSITY_DETAILED
       - equal:
           path: spec.template.spec.containers[0].env[23].value
-          value: "32768"
-      - equal:
-          path: spec.template.spec.containers[0].env[24].name
-          value: OTEL_COLLECTOR_K8SATTRIBUTES_DISABLE_REPLICASET_INFORMER
-      - equal:
-          path: spec.template.spec.containers[0].env[24].value
           value: "true"
       - equal:
+          path: spec.template.spec.containers[0].env[24].name
+          value: OTEL_COLLECTOR_SEND_BATCH_MAX_SIZE
+      - equal:
+          path: spec.template.spec.containers[0].env[24].value
+          value: "32768"
+      - equal:
           path: spec.template.spec.containers[0].env[25].name
-          value: OTEL_COLLECTOR_ENABLE_PPROF_EXTENSION
+          value: OTEL_COLLECTOR_K8SATTRIBUTES_DISABLE_REPLICASET_INFORMER
       - equal:
           path: spec.template.spec.containers[0].env[25].value
           value: "true"
       - equal:
           path: spec.template.spec.containers[0].env[26].name
-          value: K8S_POD_UID
+          value: OTEL_COLLECTOR_ENABLE_PPROF_EXTENSION
       - equal:
-          path: spec.template.spec.containers[0].env[26].valueFrom.fieldRef.fieldPath
-          value: metadata.uid
+          path: spec.template.spec.containers[0].env[26].value
+          value: "true"
       - equal:
           path: spec.template.spec.containers[0].env[27].name
-          value: K8S_NODE_IP
+          value: K8S_POD_UID
       - equal:
           path: spec.template.spec.containers[0].env[27].valueFrom.fieldRef.fieldPath
-          value: status.hostIP
+          value: metadata.uid
       - equal:
           path: spec.template.spec.containers[0].env[28].name
-          value: K8S_NODE_NAME
+          value: K8S_NODE_IP
       - equal:
           path: spec.template.spec.containers[0].env[28].valueFrom.fieldRef.fieldPath
-          value: spec.nodeName
+          value: status.hostIP
       - equal:
           path: spec.template.spec.containers[0].env[29].name
-          value: K8S_POD_IP
+          value: K8S_NODE_NAME
       - equal:
           path: spec.template.spec.containers[0].env[29].valueFrom.fieldRef.fieldPath
-          value: status.podIP
+          value: spec.nodeName
       - equal:
           path: spec.template.spec.containers[0].env[30].name
-          value: K8S_POD_NAME
+          value: K8S_POD_IP
       - equal:
           path: spec.template.spec.containers[0].env[30].valueFrom.fieldRef.fieldPath
+          value: status.podIP
+      - equal:
+          path: spec.template.spec.containers[0].env[31].name
+          value: K8S_POD_NAME
+      - equal:
+          path: spec.template.spec.containers[0].env[31].valueFrom.fieldRef.fieldPath
           value: metadata.name
       - notExists:
-          path: spec.template.spec.containers[0].env[31].name
+          path: spec.template.spec.containers[0].env[32].name
       - equal:
           path: spec.template.spec.containers[0].resources.limits.cpu
           value: 123m
@@ -792,79 +799,79 @@ tests:
       - notExists:
           path: spec.template.spec.containers[0].imagePullPolicy
       - equal:
-          path: spec.template.spec.containers[0].env[5].name
+          path: spec.template.spec.containers[0].env[6].name
           value: DASH0_OPERATOR_IMAGE
       - equal:
-          path: spec.template.spec.containers[0].env[5].value
+          path: spec.template.spec.containers[0].env[6].value
           value: ghcr.io/dash0hq/operator-controller@sha256:e05496f5bcc3c2caf7d2a2944bfc084872d69dd1e9c365a521719c5bbcf4430c
       - equal:
-          path: spec.template.spec.containers[0].env[6].name
+          path: spec.template.spec.containers[0].env[7].name
           value: DASH0_INIT_CONTAINER_IMAGE
       - equal:
-          path: spec.template.spec.containers[0].env[6].value
+          path: spec.template.spec.containers[0].env[7].value
           value: ghcr.io/dash0hq/instrumentation@sha256:1e8c25853217c7393dbd95e17fe2117bb31b39478bbea4479cc5e7c1257dda01
       - equal:
-          path: spec.template.spec.containers[0].env[7].name
+          path: spec.template.spec.containers[0].env[8].name
           value: DASH0_COLLECTOR_IMAGE
       - equal:
-          path: spec.template.spec.containers[0].env[7].value
+          path: spec.template.spec.containers[0].env[8].value
           value: ghcr.io/dash0hq/collector@sha256:3e8c25853217c7393dbd95e17fe2117bb31b39478bbea4479cc5e7c1257dda03
       - equal:
-          path: spec.template.spec.containers[0].env[8].name
+          path: spec.template.spec.containers[0].env[9].name
           value: DASH0_TARGET_ALLOCATOR_IMAGE
       - equal:
-          path: spec.template.spec.containers[0].env[8].value
+          path: spec.template.spec.containers[0].env[9].value
           value: ghcr.io/open-telemetry/opentelemetry-operator/target-allocator@sha256:f3ec1cd500980f4fe5491a102b4a73a9eb3c5bd21bd3ef986c74f97de35a35dc
       - equal:
-          path: spec.template.spec.containers[0].env[9].name
+          path: spec.template.spec.containers[0].env[10].name
           value: DASH0_CONFIGURATION_RELOADER_IMAGE
       - equal:
-          path: spec.template.spec.containers[0].env[9].value
+          path: spec.template.spec.containers[0].env[10].value
           value: ghcr.io/dash0hq/configuration-reloader@sha256:4e8c25853217c7393dbd95e17fe2117bb31b39478bbea4479cc5e7c1257dda04
       - equal:
-          path: spec.template.spec.containers[0].env[10].name
+          path: spec.template.spec.containers[0].env[11].name
           value: DASH0_FILELOG_OFFSET_SYNC_IMAGE
       - equal:
-          path: spec.template.spec.containers[0].env[10].value
+          path: spec.template.spec.containers[0].env[11].value
           value: ghcr.io/dash0hq/filelog-offset-sync@sha256:5e8c25853217c7393dbd95e17fe2117bb31b39478bbea4479cc5e7c1257dda05
       - equal:
-          path: spec.template.spec.containers[0].env[11].name
+          path: spec.template.spec.containers[0].env[12].name
           value: DASH0_FILELOG_OFFSET_VOLUME_OWNERSHIP_IMAGE
       - equal:
-          path: spec.template.spec.containers[0].env[11].value
+          path: spec.template.spec.containers[0].env[12].value
           value: ghcr.io/dash0hq/filelog-offset-volume-ownership@sha256:6e8c25853217c7393dbd95e17fe2117bb31b39478bbea4479cc5e7c1257dda06
       - equal:
-          path: spec.template.spec.containers[0].env[12].name
+          path: spec.template.spec.containers[0].env[13].name
           value: K8S_POD_UID
       - equal:
-          path: spec.template.spec.containers[0].env[12].valueFrom.fieldRef.fieldPath
+          path: spec.template.spec.containers[0].env[13].valueFrom.fieldRef.fieldPath
           value: metadata.uid
       - equal:
-          path: spec.template.spec.containers[0].env[13].name
+          path: spec.template.spec.containers[0].env[14].name
           value: K8S_NODE_IP
       - equal:
-          path: spec.template.spec.containers[0].env[13].valueFrom.fieldRef.fieldPath
+          path: spec.template.spec.containers[0].env[14].valueFrom.fieldRef.fieldPath
           value: status.hostIP
       - equal:
-          path: spec.template.spec.containers[0].env[14].name
+          path: spec.template.spec.containers[0].env[15].name
           value: K8S_NODE_NAME
       - equal:
-          path: spec.template.spec.containers[0].env[14].valueFrom.fieldRef.fieldPath
+          path: spec.template.spec.containers[0].env[15].valueFrom.fieldRef.fieldPath
           value: spec.nodeName
       - equal:
-          path: spec.template.spec.containers[0].env[15].name
+          path: spec.template.spec.containers[0].env[16].name
           value: K8S_POD_IP
       - equal:
-          path: spec.template.spec.containers[0].env[15].valueFrom.fieldRef.fieldPath
+          path: spec.template.spec.containers[0].env[16].valueFrom.fieldRef.fieldPath
           value: status.podIP
       - equal:
-          path: spec.template.spec.containers[0].env[16].name
+          path: spec.template.spec.containers[0].env[17].name
           value: K8S_POD_NAME
       - equal:
-          path: spec.template.spec.containers[0].env[16].valueFrom.fieldRef.fieldPath
+          path: spec.template.spec.containers[0].env[17].valueFrom.fieldRef.fieldPath
           value: metadata.name
       - notExists:
-          path: spec.template.spec.containers[0].env[17].name
+          path: spec.template.spec.containers[0].env[18].name
 
   - it: deployment should support changing repositories for images
     chart:
@@ -897,79 +904,79 @@ tests:
       - notExists:
           path: spec.template.spec.containers[0].imagePullPolicy
       - equal:
-          path: spec.template.spec.containers[0].env[5].name
+          path: spec.template.spec.containers[0].env[6].name
           value: DASH0_OPERATOR_IMAGE
       - equal:
-          path: spec.template.spec.containers[0].env[5].value
+          path: spec.template.spec.containers[0].env[6].value
           value: customrepo.io/repo/custom-operator-controller:99.100.101
       - equal:
-          path: spec.template.spec.containers[0].env[6].name
+          path: spec.template.spec.containers[0].env[7].name
           value: DASH0_INIT_CONTAINER_IMAGE
       - equal:
-          path: spec.template.spec.containers[0].env[6].value
+          path: spec.template.spec.containers[0].env[7].value
           value: customrepo.io/repo/custom-instrumentation:99.100.101
       - equal:
-          path: spec.template.spec.containers[0].env[7].name
+          path: spec.template.spec.containers[0].env[8].name
           value: DASH0_COLLECTOR_IMAGE
       - equal:
-          path: spec.template.spec.containers[0].env[7].value
+          path: spec.template.spec.containers[0].env[8].value
           value: customrepo.io/repo/custom-collector:99.100.101
       - equal:
-          path: spec.template.spec.containers[0].env[8].name
+          path: spec.template.spec.containers[0].env[9].name
           value: DASH0_TARGET_ALLOCATOR_IMAGE
       - equal:
-          path: spec.template.spec.containers[0].env[8].value
+          path: spec.template.spec.containers[0].env[9].value
           value: customrepo.io/repo/custom-target-allocator:latest
       - equal:
-          path: spec.template.spec.containers[0].env[9].name
+          path: spec.template.spec.containers[0].env[10].name
           value: DASH0_CONFIGURATION_RELOADER_IMAGE
       - equal:
-          path: spec.template.spec.containers[0].env[9].value
+          path: spec.template.spec.containers[0].env[10].value
           value: customrepo.io/repo/custom-configuration-reloader:99.100.101
       - equal:
-          path: spec.template.spec.containers[0].env[10].name
+          path: spec.template.spec.containers[0].env[11].name
           value: DASH0_FILELOG_OFFSET_SYNC_IMAGE
       - equal:
-          path: spec.template.spec.containers[0].env[10].value
+          path: spec.template.spec.containers[0].env[11].value
           value: customrepo.io/repo/custom-filelog-offset-sync:99.100.101
       - equal:
-          path: spec.template.spec.containers[0].env[11].name
+          path: spec.template.spec.containers[0].env[12].name
           value: DASH0_FILELOG_OFFSET_VOLUME_OWNERSHIP_IMAGE
       - equal:
-          path: spec.template.spec.containers[0].env[11].value
+          path: spec.template.spec.containers[0].env[12].value
           value: customrepo.io/repo/custom-filelog-offset-volume-ownership:99.100.101
       - equal:
-          path: spec.template.spec.containers[0].env[12].name
+          path: spec.template.spec.containers[0].env[13].name
           value: K8S_POD_UID
       - equal:
-          path: spec.template.spec.containers[0].env[12].valueFrom.fieldRef.fieldPath
+          path: spec.template.spec.containers[0].env[13].valueFrom.fieldRef.fieldPath
           value: metadata.uid
       - equal:
-          path: spec.template.spec.containers[0].env[13].name
+          path: spec.template.spec.containers[0].env[14].name
           value: K8S_NODE_IP
       - equal:
-          path: spec.template.spec.containers[0].env[13].valueFrom.fieldRef.fieldPath
+          path: spec.template.spec.containers[0].env[14].valueFrom.fieldRef.fieldPath
           value: status.hostIP
       - equal:
-          path: spec.template.spec.containers[0].env[14].name
+          path: spec.template.spec.containers[0].env[15].name
           value: K8S_NODE_NAME
       - equal:
-          path: spec.template.spec.containers[0].env[14].valueFrom.fieldRef.fieldPath
+          path: spec.template.spec.containers[0].env[15].valueFrom.fieldRef.fieldPath
           value: spec.nodeName
       - equal:
-          path: spec.template.spec.containers[0].env[15].name
+          path: spec.template.spec.containers[0].env[16].name
           value: K8S_POD_IP
       - equal:
-          path: spec.template.spec.containers[0].env[15].valueFrom.fieldRef.fieldPath
+          path: spec.template.spec.containers[0].env[16].valueFrom.fieldRef.fieldPath
           value: status.podIP
       - equal:
-          path: spec.template.spec.containers[0].env[16].name
+          path: spec.template.spec.containers[0].env[17].name
           value: K8S_POD_NAME
       - equal:
-          path: spec.template.spec.containers[0].env[16].valueFrom.fieldRef.fieldPath
+          path: spec.template.spec.containers[0].env[17].valueFrom.fieldRef.fieldPath
           value: metadata.name
       - notExists:
-          path: spec.template.spec.containers[0].env[17].name
+          path: spec.template.spec.containers[0].env[18].name
 
   - it: mutating webhook should have caBundle set
     documentSelector:

--- a/helm-chart/dash0-operator/values.yaml
+++ b/helm-chart/dash0-operator/values.yaml
@@ -243,6 +243,10 @@ operator:
       cpu: 500m
       memory: 256Mi
       ephemeral-storage: 500Mi
+    # The GOMEMLIMIT environment variable value for the operator manager container, the recommended value is 80% of
+    # managerContainerResources.limits.memory. Note that valid units are different from Kubernetes resources, use
+    # MiB or GiB (see https://pkg.go.dev/runtime#hdr-Environment_Variables).
+    gomemlimit: 205MiB
     requests:
       cpu: 50m
       memory: 128Mi
@@ -475,7 +479,8 @@ operator:
         memory: 500Mi
         # ephemeral-storage: (no ephemeral-storage limit by default)
       # The GOMEMLIMIT environment variable value for the collector container, the recommended value is 80% of
-      # daemonSetCollectorContainerResources.limits.memory.
+      # daemonSetCollectorContainerResources.limits.memory. Note that valid units are different from Kubernetes
+      # resource settings, use MiB or GiB (see https://pkg.go.dev/runtime#hdr-Environment_Variables).
       gomemlimit: 400MiB
       requests:
         # cpu: (no cpu request by default)
@@ -490,7 +495,8 @@ operator:
         memory: 24Mi
         # ephemeral-storage: (no ephemeral-storage limit by default)
       # The GOMEMLIMIT environment variable value for the configuration reloader container, the recommended value is 80%
-      # of daemonSetConfigurationReloaderContainerResources.limits.memory.
+      # of daemonSetConfigurationReloaderContainerResources.limits.memory. Note that valid units are different from
+      # Kubernetes resource settings, use MiB or GiB (see https://pkg.go.dev/runtime#hdr-Environment_Variables).
       gomemlimit: 18MiB
       requests:
         # cpu: (no cpu request by default)
@@ -505,7 +511,8 @@ operator:
         memory: 32Mi
         # ephemeral-storage: (no ephemeral-storage limit by default)
       # The GOMEMLIMIT environment variable value for the filelog offset sync container, the recommended value is 80%
-      # of daemonSetFileLogOffsetSyncContainerResources.limits.memory.
+      # of daemonSetFileLogOffsetSyncContainerResources.limits.memory. Note that valid units are different from
+      # Kubernetes resource settings, use MiB or GiB (see https://pkg.go.dev/runtime#hdr-Environment_Variables).
       gomemlimit: 24MiB
       requests:
         # cpu: (no cpu request by default)
@@ -555,7 +562,8 @@ operator:
         memory: 500Mi
         # ephemeral-storage: (no ephemeral-storage limit by default)
       # The GOMEMLIMIT environment variable value for the collector container, the recommended value is 80% of
-      # deploymentCollectorContainerResources.limits.memory.
+      # deploymentCollectorContainerResources.limits.memory. Note that valid units are different from Kubernetes
+      # resource settings, use MiB or GiB (see https://pkg.go.dev/runtime#hdr-Environment_Variables).
       gomemlimit: 400MiB
       requests:
         # cpu: (no cpu request by default)
@@ -570,7 +578,8 @@ operator:
         memory: 24Mi
         # ephemeral-storage: (no ephemeral-storage limit by default)
       # The GOMEMLIMIT environment variable value for the configuration reloader container, the recommended value is 80%
-      # of deploymentConfigurationReloaderContainerResources.limits.memory.
+      # of deploymentConfigurationReloaderContainerResources.limits.memory. Note that valid units are different from
+      # Kubernetes resource settings, use MiB or GiB (see https://pkg.go.dev/runtime#hdr-Environment_Variables).
       gomemlimit: 18MiB
       requests:
         # cpu: (no cpu request by default)


### PR DESCRIPTION
This introduces a new configuration value for setting GOMEMLIMIT for the operator manager container, along with the Kubernetes resource limits. The default value is ~80% of the default Kubernetes memory limit for the container.

The setting is a necessity to make Go's garbage collection behave reasonable and prevent the container getting OOM-killed when larger chunks of memory are allocated in a short time, for example when instrumenting all existing workloads in a namespace for a namespace that has a lot of workloads of the same kind.