### PR TITLE
test(e2e): fix helm params for custom ta image

### DIFF
--- a/test/e2e/collect_logs_on_fail.go
+++ b/test/e2e/collect_logs_on_fail.go
@@ -47,7 +47,20 @@ func collectPodInfoAndLogs(specReport SpecReport) {
 	serializeToFile(specReport.Failure.Location, outputPath, "_failure-location.txt")
 	serializeToFile(specReport.Failure.FailureNodeLocation, outputPath, "_failure-node-location.txt")
 
-	for _, namespace := range []string{operatorNamespace,
+	executeCommandAndStoreOutput(
+		fmt.Sprintf("kubectl -n %s describe deployment dash0-operator-controller",
+			operatorNamespace), outputPath)
+	executeCommandAndStoreOutput(
+		fmt.Sprintf("kubectl -n %s describe daemonset e2e-tests-operator-hr-opentelemetry-collector-agent-daemonset",
+			operatorNamespace), outputPath)
+	executeCommandAndStoreOutput(
+		fmt.Sprintf("kubectl -n %s describe deployment e2e-tests-operator-hr-cluster-metrics-collector-deployment",
+			operatorNamespace), outputPath)
+	executeCommandAndStoreOutput(
+		fmt.Sprintf("kubectl -n %s describe deployment e2e-tests-operator-hr-opentelemetry-target-allocator-deployment",
+			operatorNamespace), outputPath)
+	for _, namespace := range []string{
+		operatorNamespace,
 		applicationUnderTestNamespace,
 		"otlp-sink",
 		"dash0-api",

--- a/test/e2e/operator.go
+++ b/test/e2e/operator.go
@@ -188,10 +188,10 @@ func addHelmParametersForImages(arguments []string, images Images) []string {
 	arguments = setIfNotEmpty(arguments, "operator.filelogOffsetVolumeOwnershipImage.pullPolicy",
 		images.fileLogOffsetVolumeOwnership.pullPolicy)
 
-	arguments = setIfNotEmpty(arguments, "operator.targetAllocator.repository", images.targetAllocator.repository)
-	arguments = setIfNotEmpty(arguments, "operator.targetAllocator.tag", images.targetAllocator.tag)
-	arguments = setIfNotEmpty(arguments, "operator.targetAllocator.digest", images.targetAllocator.digest)
-	arguments = setIfNotEmpty(arguments, "operator.targetAllocator.pullPolicy", images.targetAllocator.pullPolicy)
+	arguments = setIfNotEmpty(arguments, "operator.targetAllocatorImage.repository", images.targetAllocator.repository)
+	arguments = setIfNotEmpty(arguments, "operator.targetAllocatorImage.tag", images.targetAllocator.tag)
+	arguments = setIfNotEmpty(arguments, "operator.targetAllocatorImage.digest", images.targetAllocator.digest)
+	arguments = setIfNotEmpty(arguments, "operator.targetAllocatorImage.pullPolicy", images.targetAllocator.pullPolicy)
 
 	return arguments
 }


### PR DESCRIPTION
Plus: Also get a kubectl describe deployment/daemonset for the operator workloads on failure, not only a kubectl describe pods.