### PR TITLE
fix(collectors): disable processor.resourcedetection.propagateerrors

### DIFF
--- a/internal/collectors/otelcolresources/desired_state.go
+++ b/internal/collectors/otelcolresources/desired_state.go
@@ -1018,7 +1018,10 @@ func assembleDaemonSetCollectorContainer(
 
 	collectorContainer := corev1.Container{
 		Name: openTelemetryCollector,
-		Args: []string{"--config=file:" + collectorConfigurationFilePath},
+		Args: []string{
+			"--config=file:" + collectorConfigurationFilePath,
+			"--feature-gates=-processor.resourcedetection.propagateerrors",
+		},
 		SecurityContext: &corev1.SecurityContext{
 			AllowPrivilegeEscalation: ptr.To(false),
 			ReadOnlyRootFilesystem:   ptr.To(false),

--- a/internal/collectors/otelcolresources/desired_state_test.go
+++ b/internal/collectors/otelcolresources/desired_state_test.go
@@ -128,8 +128,9 @@ var _ = Describe("The desired state of the OpenTelemetry Collector resources", f
 		Expect(daemonSetCollectorContainer.ImagePullPolicy).To(Equal(corev1.PullAlways))
 		Expect(daemonSetCollectorContainer.Resources.Limits.Memory().String()).To(Equal("500Mi"))
 		Expect(daemonSetCollectorContainer.Resources.Requests.Memory().String()).To(Equal("500Mi"))
-		Expect(daemonSetCollectorContainerArgs).To(HaveLen(1))
+		Expect(daemonSetCollectorContainerArgs).To(HaveLen(2))
 		Expect(daemonSetCollectorContainerArgs[0]).To(Equal("--config=file:/etc/otelcol/conf/config.yaml"))
+		Expect(daemonSetCollectorContainerArgs[1]).To(Equal("--feature-gates=-processor.resourcedetection.propagateerrors"))
 		Expect(daemonSetCollectorContainer.VolumeMounts).To(HaveLen(6))
 		Expect(daemonSetCollectorContainer.VolumeMounts).To(
 			ContainElement(MatchVolumeMount("opentelemetry-collector-configmap", "/etc/otelcol/conf")))


### PR DESCRIPTION
Release 0.142.0 flipped the default for this feature gate from off-by-default to on-by-default. This can lead to collectors failing to start on EKS, with the error being
```
Error: cannot start pipelines: failed to start "resourcedetection" processor: can't get K8s Instance Metadata; node name is empty
```
This error was logged in previous releases as well, but it did not lead to the collector crashing.

Disabling this feature gate restores the previous behavior (before updating the resource detection processor to 0.142.0).