### PR TITLE
fix(collectors): set resourcedetection.*.node_from_env_var explicitly

### DIFF
--- a/internal/collectors/otelcolresources/daemonset.config.yaml.template
+++ b/internal/collectors/otelcolresources/daemonset.config.yaml.template
@@ -382,6 +382,10 @@ processors:
     - aks
     - k8snode
     timeout: 2s
+    eks:
+      node_from_env_var: K8S_NODE_NAME
+    k8snode:
+      node_from_env_var: K8S_NODE_NAME
     system:
       resource_attributes:
         host.name:


### PR DESCRIPTION
node_from_env_var: K8S_NODE_NAME is already the default for the k8snode detector, but there is no default for the eks detector, which can lead to the warning "can't get K8s Instance Metadata; node name is empty" being emitted on EKS clusters.

Setting an explicit value for the eks detector should fix that, setting it for k8snode explicitly is purely for consistency.