### PR TITLE
fix(webhook): always re-apply modifications in instrumentation webhook

### DIFF
--- a/internal/instrumentation/instrumenter.go
+++ b/internal/instrumentation/instrumenter.go
@@ -601,8 +601,12 @@ func (i *Instrumenter) instrumentWorkload(
 	}
 
 	var requiredAction util.ModificationMode
+	addIgnoreOnceLabel := true
 	if util.WasInstrumentedButHasOptedOutNow(workloadMeta, namespaceInstrumentationConfig.InstrumentationLabelSelector) {
 		requiredAction = util.ModificationModeUninstrumentation
+		// The webhook will skip modifying this workload on the i.Update below anyway, since this workload is marked
+		// as opt-out. Therefore, adding the ignore-once label is not required.
+		addIgnoreOnceLabel = false
 	} else if workloads.InstrumentationIsUpToDate(workloadMeta, containers, i.ClusterInstrumentationConfig.Images, namespaceInstrumentationConfig) {
 		// No change necessary, this workload has already been instrumented and an opt-out label (which would need to
 		// trigger uninstrumentation) has not been added since it has been instrumented.
@@ -653,6 +657,9 @@ func (i *Instrumenter) instrumentWorkload(
 		}
 
 		if modificationResult.HasBeenModified {
+			if addIgnoreOnceLabel {
+				util.AddWebhookIgnoreOnceLabel(workloadMeta)
+			}
 			return i.Update(ctx, workload.asClientObject(), &client.UpdateOptions{FieldManager: util.FieldManager})
 		} else {
 			return nil

--- a/internal/webhooks/instrumentation_webhook.go
+++ b/internal/webhooks/instrumentation_webhook.go
@@ -257,14 +257,6 @@ func (h *InstrumentationWebhookHandler) handleCronJob(
 	) {
 		modificationResult := h.newWorkloadModifier(namespaceInstrumentationConfig, logger).RevertCronJob(cronJob)
 		return h.postProcessUninstrumentation(request, cronJob, modificationResult, logger)
-	} else if workloads.InstrumentationIsUpToDate(
-		&cronJob.ObjectMeta,
-		cronJob.Spec.JobTemplate.Spec.Template.Spec.Containers,
-		h.ClusterInstrumentationConfig.Images,
-		namespaceInstrumentationConfig,
-	) {
-		// deliberately not logging this, would be very noisy
-		return admission.Allowed(sameVersionNoModificationMessage)
 	} else {
 		modificationResult := h.newWorkloadModifier(namespaceInstrumentationConfig, logger).ModifyCronJob(cronJob)
 		return h.postProcessInstrumentation(request, cronJob, modificationResult, false, logger)
@@ -301,14 +293,6 @@ func (h *InstrumentationWebhookHandler) handleDaemonSet(
 	) {
 		modificationResult := h.newWorkloadModifier(namespaceInstrumentationConfig, logger).RevertDaemonSet(daemonSet)
 		return h.postProcessUninstrumentation(request, daemonSet, modificationResult, logger)
-	} else if workloads.InstrumentationIsUpToDate(
-		&daemonSet.ObjectMeta,
-		daemonSet.Spec.Template.Spec.Containers,
-		h.ClusterInstrumentationConfig.Images,
-		namespaceInstrumentationConfig,
-	) {
-		// deliberately not logging this, would be very noisy
-		return admission.Allowed(sameVersionNoModificationMessage)
 	} else {
 		modificationResult := h.newWorkloadModifier(namespaceInstrumentationConfig, logger).ModifyDaemonSet(daemonSet)
 		return h.postProcessInstrumentation(request, daemonSet, modificationResult, false, logger)
@@ -345,14 +329,6 @@ func (h *InstrumentationWebhookHandler) handleDeployment(
 	) {
 		modificationResult := h.newWorkloadModifier(namespaceInstrumentationConfig, logger).RevertDeployment(deployment)
 		return h.postProcessUninstrumentation(request, deployment, modificationResult, logger)
-	} else if workloads.InstrumentationIsUpToDate(
-		&deployment.ObjectMeta,
-		deployment.Spec.Template.Spec.Containers,
-		h.ClusterInstrumentationConfig.Images,
-		namespaceInstrumentationConfig,
-	) {
-		// deliberately not logging this, would be very noisy
-		return admission.Allowed(sameVersionNoModificationMessage)
 	} else {
 		modificationResult := h.newWorkloadModifier(namespaceInstrumentationConfig, logger).ModifyDeployment(deployment)
 		return h.postProcessInstrumentation(request, deployment, modificationResult, false, logger)
@@ -391,14 +367,6 @@ func (h *InstrumentationWebhookHandler) handleJob(
 		// not listening to updates for jobs. We cannot uninstrument jobs if the user adds an opt-out label after the
 		// job has been already instrumented, since jobs are immutable.
 		return h.postProcessUninstrumentation(request, job, workloads.NewNotModifiedImmutableWorkloadCannotBeRevertedResult(), logger)
-	} else if workloads.InstrumentationIsUpToDate(
-		&job.ObjectMeta,
-		job.Spec.Template.Spec.Containers,
-		h.ClusterInstrumentationConfig.Images,
-		namespaceInstrumentationConfig,
-	) {
-		// This should not happen either.
-		return admission.Allowed(sameVersionNoModificationMessage)
 	} else {
 		modificationResult := h.newWorkloadModifier(namespaceInstrumentationConfig, logger).ModifyJob(job)
 		return h.postProcessInstrumentation(request, job, modificationResult, false, logger)
@@ -438,14 +406,6 @@ func (h *InstrumentationWebhookHandler) handlePod(
 		// after the pod has been already instrumented, since we cannot restart ownerless pods, which makes them
 		// effectively immutable.
 		return h.postProcessUninstrumentation(request, pod, workloads.NewNotModifiedImmutableWorkloadCannotBeRevertedResult(), logger)
-	} else if workloads.InstrumentationIsUpToDate(
-		&pod.ObjectMeta,
-		pod.Spec.Containers,
-		h.ClusterInstrumentationConfig.Images,
-		namespaceInstrumentationConfig,
-	) {
-		// This should not happen either.
-		return admission.Allowed(sameVersionNoModificationMessage)
 	} else {
 		modificationResult := h.newWorkloadModifier(namespaceInstrumentationConfig, logger).ModifyPod(pod)
 		return h.postProcessInstrumentation(request, pod, modificationResult, true, logger)
@@ -482,14 +442,6 @@ func (h *InstrumentationWebhookHandler) handleReplicaSet(
 	) {
 		modificationResult := h.newWorkloadModifier(namespaceInstrumentationConfig, logger).RevertReplicaSet(replicaSet)
 		return h.postProcessUninstrumentation(request, replicaSet, modificationResult, logger)
-	} else if workloads.InstrumentationIsUpToDate(
-		&replicaSet.ObjectMeta,
-		replicaSet.Spec.Template.Spec.Containers,
-		h.ClusterInstrumentationConfig.Images,
-		namespaceInstrumentationConfig,
-	) {
-		// deliberately not logging this, would be very noisy
-		return admission.Allowed(sameVersionNoModificationMessage)
 	} else {
 		modificationResult := h.newWorkloadModifier(namespaceInstrumentationConfig, logger).ModifyReplicaSet(replicaSet)
 		return h.postProcessInstrumentation(request, replicaSet, modificationResult, false, logger)
@@ -526,14 +478,6 @@ func (h *InstrumentationWebhookHandler) handleStatefulSet(
 	) {
 		modificationResult := h.newWorkloadModifier(namespaceInstrumentationConfig, logger).RevertStatefulSet(statefulSet)
 		return h.postProcessUninstrumentation(request, statefulSet, modificationResult, logger)
-	} else if workloads.InstrumentationIsUpToDate(
-		&statefulSet.ObjectMeta,
-		statefulSet.Spec.Template.Spec.Containers,
-		h.ClusterInstrumentationConfig.Images,
-		namespaceInstrumentationConfig,
-	) {
-		// deliberately not logging this, would be very noisy
-		return admission.Allowed(sameVersionNoModificationMessage)
 	} else {
 		modificationResult := h.newWorkloadModifier(namespaceInstrumentationConfig, logger).ModifyStatefulSet(statefulSet)
 		return h.postProcessInstrumentation(request, statefulSet, modificationResult, false, logger)

--- a/internal/webhooks/instrumentation_webhook_test.go
+++ b/internal/webhooks/instrumentation_webhook_test.go
@@ -104,14 +104,14 @@ var _ = Describe("The Dash0 instrumentation webhook", func() {
 				namespace string,
 				name string,
 			) *corev1.Pod {
-				pod := CreateBasicPod(ctx, k8sClient, namespace, name)
+				pod := BasicPod(namespace, name)
 				pod.ObjectMeta.OwnerReferences = []metav1.OwnerReference{{
 					Name:       "strimzi-podset-name",
 					APIVersion: "core.strimzi.io/v1beta2",
 					Kind:       "StrimziPodSet",
 					UID:        "35b829cb-78dc-4544-b7a9-5a8e51b7f322",
 				}}
-				UpdateWorkload(ctx, k8sClient, pod)
+				CreateWorkload(ctx, k8sClient, pod)
 				return pod
 			}),
 			GetFn: WrapPodFnAsTestableWorkload(GetPod),
@@ -131,14 +131,14 @@ var _ = Describe("The Dash0 instrumentation webhook", func() {
 				k8sClient client.Client,
 				namespace string,
 				name string) *appsv1.ReplicaSet {
-				rs := CreateBasicReplicaSet(ctx, k8sClient, namespace, name)
+				rs := BasicReplicaSet(namespace, name)
 				rs.OwnerReferences = []metav1.OwnerReference{{
 					Name:       "owner-name",
 					APIVersion: "api/v1beta2",
 					Kind:       "Kind",
 					UID:        "35b829cb-78dc-4544-b7a9-5a8e51b7f322",
 				}}
-				UpdateWorkload(ctx, k8sClient, rs)
+				CreateWorkload(ctx, k8sClient, rs)
 				return rs
 			}),
 			GetFn: WrapReplicaSetFnAsTestableWorkload(GetReplicaSet),


### PR DESCRIPTION
Previously, the webhook would check whether a workload had already been instrumented by the same operator version, and, if so, would not modify the workload again. The same logic is used when instrumenting existing workloads.

However, in the webhook, this conditional application of modifications is actually detrimental. In particular, if the workload is modified in a way that makes it invalid in combination with the Dash0 workload modifications, the update is rejected.

Example: The user deletes all volumes from the workload. This will result in an invalid state because the pods still have the dash0-instrumentation volume mounts.

Instead of ignoring that request in the instrumentation_webhook, which then leads to Kubernetes ultimately rejecting the workload update, the better strategy is to always re-apply our modifications.

Furthermore, the only reason for not applying the modifications again is to not restart pods, when modifying _existing_ workloads. But this aspect is irrelevant in the webhook (which only is triggered when workloads are modified anyway).

We already made this change a month ago, in 7890dcdd3c476dddd0d1400fd5862462bf331386, but needed to revert it with e4665b68c180c64b513651ee3b81ccdcbfc33b11 due to a conflict with how we handled OTEL_EXPORTER_OTLP_ENDPOINT/OTEL_EXPORTER_OTLP_PROTOCOL modifications. In particular, workload_modifier.go would always overwrite the _ENDPOINT with our collector's HTTP endpoint (and set the _PROTOCOL accordingly), even if the container already defines the _ENDPOINT. This is problematic for containers that implicitly use a gRPC export and ignore OTEL_EXPORTER_OTLP_PROTOCOL.

This issue was hidden by our previous webhook modification logic, i.e. an IaC system would re-apply its idea of OTEL_EXPORTER_OTLP_ENDPOINT on the workload after the operator's modifications, and telemetry would flow correctly. This self-healing broke with 7890dcdd3c476dddd0d1400fd5862462bf331386.

Now, with the changes from https://github.com/dash0hq/dash0-operator/pull/690, we can restore the webhook behavior change from 7890dcdd3c476dddd0d1400fd5862462bf331386, which is correct on its own and also needed for the scenarios described above.

This reverts commit e4665b68c180c64b513651ee3b81ccdcbfc33b11.