### PR TITLE
SUP-450: fix action enum definition in views CRD

### DIFF
--- a/helm-chart/dash0-operator/templates/operator/custom-resource-definition-views.yaml
+++ b/helm-chart/dash0-operator/templates/operator/custom-resource-definition-views.yaml
@@ -459,12 +459,12 @@ spec:
                     actions:
                       description: Outlines possible actions that matching views can
                         take with this view.
-                      enum:
-                      - views:read
-                      - views:write
-                      - views:delete
                       items:
                         type: string
+                        enum:
+                        - views:read
+                        - views:write
+                        - views:delete
                       type: array
                     role:
                       description: Use role identifiers such as `admin` and `basic_member`

--- a/helm-chart/dash0-operator/tests/operator/__snapshot__/custom-resource-definition-views_test.yaml.snap
+++ b/helm-chart/dash0-operator/tests/operator/__snapshot__/custom-resource-definition-views_test.yaml.snap
@@ -429,11 +429,11 @@ custom resource definition for views should match snapshot:
                         properties:
                           actions:
                             description: Outlines possible actions that matching views can take with this view.
-                            enum:
-                              - views:read
-                              - views:write
-                              - views:delete
                             items:
+                              enum:
+                                - views:read
+                                - views:write
+                                - views:delete
                               type: string
                             type: array
                           role:


### PR DESCRIPTION
Customer tried to create a k8s custom resource from a view yaml exported from Dash0 UI:
```
apiVersion: operator.dash0.com/v1alpha1
kind: Dash0View
metadata:
  annotations: {}
  labels:
    dash0.com/dataset: prod
    dash0.com/id: eecc930d-124d-4b95-a371-a000c3382470
    dash0.com/source: userdefined
    dash0.com/version: "1"
  name: idp-view
spec:
  display:
    description: All logs displayed with a general-purpose layout.
    name: IDP View
  filter:
    - key: some.key
      operator: is_one_of
      values:
        - ip
        - idp
  groupBy:
    - otel.log.severity.range
  implicitFilter: []
  permissions:
    - actions:
        - views:read
        - views:write
        - views:delete
      userId: <redacted>
    - actions:
        - views:read
        - views:write
        - views:delete
      teamId: <redacted>
  table:
    columns:
      - colSize: min-content
        key: otel.log.severity.range
        label: Severity
      - colSize: min-content
        key: otel.log.time
        label: Time
      - key: dash0.resource.id
        label: Resource
      - key: otel.log.body
        label: Body
      - colSize: min-content
        key: dash0.trace.context
    sort:
      - direction: descending
        key: otel.log.time
  type: logs
  visualizations:
    - metric: logs_total
      renderers: []
      yAxisScale: linear
```

And got error 
```
* spec.permissions[0].actions: Unsupported value: []interface {}{"views:read", "views:write", "views:delete"}: supported values: "views:read", "views:write", "views:delete"
* spec.permissions[1].actions: Unsupported value: []interface {}{"views:read", "views:write", "views:delete"}: supported values: "views:read", "views:write", "views:delete" 
```

I think there's a bug in the view CRD, the `actions` enums need to be defined under `items`