### PR TITLE
fix(api-sync): remove dash0.com labels from metadata

### DIFF
--- a/internal/controller/api_sync_common_test.go
+++ b/internal/controller/api_sync_common_test.go
@@ -1,0 +1,120 @@
+// SPDX-FileCopyrightText: Copyright 2025 Dash0 Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("The API Sync", Ordered, func() {
+
+	type cleanUpMetadataTestConfig struct {
+		resource map[string]interface{}
+		expected map[string]interface{}
+	}
+
+	DescribeTable("cleans up resource metadata", func(testConfig cleanUpMetadataTestConfig) {
+		cleanUpMetadata(testConfig.resource)
+		Expect(testConfig.resource).To(Equal(testConfig.expected))
+	},
+		Entry("does nothing on empty resource", cleanUpMetadataTestConfig{
+			resource: map[string]interface{}{},
+			expected: map[string]interface{}{},
+		}),
+
+		Entry("removes managedFields", cleanUpMetadataTestConfig{
+			resource: map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"managedFields": []map[string]interface{}{},
+					"annotations": map[string]interface{}{
+						"dash0.com/folder-path": "/folder",
+					},
+					"labels": map[string]interface{}{
+						"label": "value",
+					},
+				},
+				"spec": map[string]interface{}{
+					"key": "value",
+				},
+			},
+			expected: map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"annotations": map[string]interface{}{
+						"dash0.com/folder-path": "/folder",
+					},
+					"labels": map[string]interface{}{
+						"label": "value",
+					},
+				},
+				"spec": map[string]interface{}{
+					"key": "value",
+				},
+			},
+		}),
+
+		Entry("removes last-applied-configuration annotation", cleanUpMetadataTestConfig{
+			resource: map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"annotations": map[string]interface{}{
+						"kubectl.kubernetes.io/last-applied-configuration": "{}",
+						"dash0.com/folder-path":                            "/folder",
+					},
+					"labels": map[string]interface{}{
+						"label": "value",
+					},
+				},
+				"spec": map[string]interface{}{
+					"key": "value",
+				},
+			},
+			expected: map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"annotations": map[string]interface{}{
+						"dash0.com/folder-path": "/folder",
+					},
+					"labels": map[string]interface{}{
+						"label": "value",
+					},
+				},
+				"spec": map[string]interface{}{
+					"key": "value",
+				},
+			},
+		}),
+
+		Entry("removes dash0.com labels", cleanUpMetadataTestConfig{
+			resource: map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"annotations": map[string]interface{}{
+						"dash0.com/folder-path": "/folder",
+					},
+					"labels": map[string]interface{}{
+						"label":             "value",
+						"dash0.com/dataset": "default",
+						"dash0.com/id":      "14cdf74a-3b1c-48a3-ab6a-b97910853760",
+						"dash0.com/source":  "userdefined",
+						"dash0.com/version": "1",
+					},
+				},
+				"spec": map[string]interface{}{
+					"key": "value",
+				},
+			},
+			expected: map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"annotations": map[string]interface{}{
+						"dash0.com/folder-path": "/folder",
+					},
+					"labels": map[string]interface{}{
+						"label": "value",
+					},
+				},
+				"spec": map[string]interface{}{
+					"key": "value",
+				},
+			},
+		}),
+	)
+})

--- a/test/e2e/dash0syntheticcheck.yaml.template
+++ b/test/e2e/dash0syntheticcheck.yaml.template
@@ -7,6 +7,10 @@ metadata:
 {{- if .Dash0ComEnabled }}
     dash0.com/enabled: {{ .Dash0ComEnabled | quote }}
 {{- end }}
+    dash0.com/dataset: default
+    dash0.com/id: 14cdf74a-3b1c-48a3-ab6a-b97910853760
+    dash0.com/source: userdefined
+    dash0.com/version: "1"
 spec:
   enabled: true
   notifications:

--- a/test/e2e/dash0view.yaml.template
+++ b/test/e2e/dash0view.yaml.template
@@ -2,40 +2,51 @@ apiVersion: operator.dash0.com/v1alpha1
 kind: Dash0View
 metadata:
   name: view-e2e-test
+  annotations:
+    dash0.com/folder-path: "/test-folder"
   labels:
     app.kubernetes.io/name: view-e2e-test
 {{- if .Dash0ComEnabled }}
     dash0.com/enabled: {{ .Dash0ComEnabled | quote }}
 {{- end }}
+    dash0.com/dataset: default
+    dash0.com/id: 14cdf74a-3b1c-48a3-ab6a-b97910853760
+    dash0.com/source: userdefined
+    dash0.com/version: "1"
 spec:
-  type: resources
+  type: logs
   display:
     name: E2E test view
     description: A test view for the e2e-test for synchronizing views with the Dash0 Operator.
-    folder: ["Test", "Operator"]
   filter:
     - key: service.name
-      operator: is
-      value:
-        stringValue: test-service
-    - key: http.status_code
+      operator: is_one_of
+      values:
+        - operator-manager
+        - dash0-operator-collector
+    - key: otel.log.severity.number
       operator: gte
-      value:
-        stringValue: "200"
+      value: "13"
   groupBy:
-    - service.name
-    - deployment.environment
+    - otel.log.severity.range
   table:
     columns:
-      - key: service.name
-        label: Service
-        colSize: "150px"
-      - key: http.status_code
-        label: Status Code
+      - colSize: min-content
+        key: otel.log.severity.range
+        label: Severity
+      - colSize: min-content
+        key: otel.log.time
+        label: Time
+      - key: dash0.resource.id
+        label: Resource
+      - key: otel.log.body
+        label: Body
+      - colSize: min-content
+        key: dash0.trace.context
     sort:
-      - key: service.name
-        direction: ascending
+      - direction: descending
+        key: otel.log.time
   visualizations:
-    - renderers:
-        - resources/services/red
+    - metric: logs_total
+      renderers: []
       yAxisScale: linear

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -527,7 +527,7 @@ var _ = Describe("Dash0 Operator", Ordered, ContinueOnFailure, func() {
 					Expect(req.Url).To(MatchRegexp(routeRegex))
 					Expect(req.Body).ToNot(BeNil())
 					Expect(*req.Body).To(ContainSubstring("This is a test synthetic check."))
-					Expect(*req.Body).ToNot(ContainSubstring("kubectl.kubernetes.io/last-applied-configuration"))
+					verifyApiSyncRequest(req)
 
 					setOptOutLabelInSyntheticCheck(applicationUnderTestNamespace, "false")
 					By("verifying the synthetic check has been deleted via the Dash0 API (after setting dash0.com/enable=false)\"")
@@ -542,7 +542,7 @@ var _ = Describe("Dash0 Operator", Ordered, ContinueOnFailure, func() {
 					Expect(req.Method).To(Equal("PUT"))
 					Expect(req.Url).To(MatchRegexp(routeRegex))
 					Expect(*req.Body).To(ContainSubstring("This is a test synthetic check."))
-					Expect(*req.Body).ToNot(ContainSubstring("kubectl.kubernetes.io/last-applied-configuration"))
+					verifyApiSyncRequest(req)
 
 					removeSyntheticCheckResource(applicationUnderTestNamespace)
 					By("verifying the synthetic check has been deleted via the Dash0 API (after removing the resource)")
@@ -567,7 +567,7 @@ var _ = Describe("Dash0 Operator", Ordered, ContinueOnFailure, func() {
 					Expect(req.Url).To(MatchRegexp(routeRegex))
 					Expect(req.Body).ToNot(BeNil())
 					Expect(*req.Body).To(ContainSubstring("\"name\":\"E2E test view\""))
-					Expect(*req.Body).ToNot(ContainSubstring("kubectl.kubernetes.io/last-applied-configuration"))
+					verifyApiSyncRequest(req)
 
 					setOptOutLabelInView(applicationUnderTestNamespace, "false")
 					By("verifying the view has been deleted via the Dash0 API (after setting dash0.com/enable=false)\"")
@@ -582,7 +582,7 @@ var _ = Describe("Dash0 Operator", Ordered, ContinueOnFailure, func() {
 					Expect(req.Method).To(Equal("PUT"))
 					Expect(req.Url).To(MatchRegexp(routeRegex))
 					Expect(*req.Body).To(ContainSubstring("\"name\":\"E2E test view\""))
-					Expect(*req.Body).ToNot(ContainSubstring("kubectl.kubernetes.io/last-applied-configuration"))
+					verifyApiSyncRequest(req)
 
 					removeViewResource(applicationUnderTestNamespace)
 					By("verifying the view has been deleted via the Dash0 API (after removing the resource)")
@@ -607,7 +607,7 @@ var _ = Describe("Dash0 Operator", Ordered, ContinueOnFailure, func() {
 					Expect(req.Url).To(MatchRegexp(routeRegex))
 					Expect(req.Body).ToNot(BeNil())
 					Expect(*req.Body).To(ContainSubstring("This is a test dashboard."))
-					Expect(*req.Body).ToNot(ContainSubstring("kubectl.kubernetes.io/last-applied-configuration"))
+					verifyApiSyncRequest(req)
 
 					setOptOutLabelInPersesDashboard(applicationUnderTestNamespace, "false")
 					By("verifying the dashboard has been deleted via the Dash0 API (after setting dash0.com/enable=false)\"")
@@ -621,7 +621,7 @@ var _ = Describe("Dash0 Operator", Ordered, ContinueOnFailure, func() {
 					Expect(req.Method).To(Equal("PUT"))
 					Expect(req.Url).To(MatchRegexp(routeRegex))
 					Expect(*req.Body).To(ContainSubstring("This is a test dashboard."))
-					Expect(*req.Body).ToNot(ContainSubstring("kubectl.kubernetes.io/last-applied-configuration"))
+					verifyApiSyncRequest(req)
 
 					removePersesDashboardResource(applicationUnderTestNamespace)
 					By("verifying the dashboard has been deleted via the Dash0 API (after removing the resource)")
@@ -663,7 +663,7 @@ var _ = Describe("Dash0 Operator", Ordered, ContinueOnFailure, func() {
 						regexIdx++
 						Expect(req.Body).ToNot(BeNil())
 						Expect(*req.Body).To(ContainSubstring(substrings[substringIdx]))
-						Expect(*req.Body).ToNot(ContainSubstring("kubectl.kubernetes.io/last-applied-configuration"))
+						verifyApiSyncRequest(req)
 						substringIdx++
 					}
 
@@ -693,7 +693,7 @@ var _ = Describe("Dash0 Operator", Ordered, ContinueOnFailure, func() {
 						Expect(req.Url).To(MatchRegexp(routeRegexes[regexIdx]))
 						regexIdx++
 						Expect(*req.Body).To(ContainSubstring(substrings[substringIdx]))
-						Expect(*req.Body).ToNot(ContainSubstring("kubectl.kubernetes.io/last-applied-configuration"))
+						verifyApiSyncRequest(req)
 						substringIdx++
 					}
 

--- a/test/e2e/persesdashboard.yaml.template
+++ b/test/e2e/persesdashboard.yaml.template
@@ -7,6 +7,10 @@ metadata:
 {{- if .Dash0ComEnabled }}
     dash0.com/enabled: {{ .Dash0ComEnabled | quote }}
 {{- end }}
+    dash0.com/dataset: default
+    dash0.com/id: 14cdf74a-3b1c-48a3-ab6a-b97910853760
+    dash0.com/source: userdefined
+    dash0.com/version: "1"
 spec:
   duration: 30m
   display:

--- a/test/e2e/prometheusrule.yaml.template
+++ b/test/e2e/prometheusrule.yaml.template
@@ -5,6 +5,10 @@ metadata:
   labels:
     prometheus: example
     role: alert-rules
+    dash0.com/dataset: default
+    dash0.com/id: 14cdf74a-3b1c-48a3-ab6a-b97910853760
+    dash0.com/source: userdefined
+    dash0.com/version: "1"
 spec:
   groups:
     - name: dash0/k8s

--- a/test/e2e/verify_api_sync.go
+++ b/test/e2e/verify_api_sync.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: Copyright 2025 Dash0 Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	. "github.com/onsi/gomega"
+)
+
+func verifyApiSyncRequest(req StoredRequest) {
+	Expect(*req.Body).ToNot(ContainSubstring("managedFields"))
+	Expect(*req.Body).ToNot(ContainSubstring("kubectl.kubernetes.io/last-applied-configuration"))
+	Expect(*req.Body).ToNot(ContainSubstring("dash0.com/dataset"))
+	Expect(*req.Body).ToNot(ContainSubstring("dash0.com/id"))
+	Expect(*req.Body).ToNot(ContainSubstring("dash0.com/source"))
+	Expect(*req.Body).ToNot(ContainSubstring("dash0.com/version"))
+}


### PR DESCRIPTION
Remove the following entries from metadata.labels when synchronizing resources to the Dash0 API:
- dash0.com/dataset
- dash0.com/id
- dash0.com/source
- dash0.com/version

These labels were part of the yaml downloaded from the Dash0 UI for a while (until January 2026), and are now omitted from the downloaded yaml. It is still necessary to explicitly remove them from the payload on the operator's side, since existing Dash0View/Dash0SyntheticCheck/... resources might already have those labels.

Reasons for not including the labels in the request to the API:
- The dataset is determined by the dataset setting in the Dash0 export of operator configuration resource (or the monitoring resource). It is sent to the backend via a query parameter in the URL, not in the payload.
- The id is an internal value, the operator only uses the "origin" to identify resources, never the internal id.
- The source is usually "userdefined" when downloading a resource from the UI, but there is a validation that forbids synchronizing objects with that source; furthermore the source can be determined by the backend on the basis of the resource's origin.
- The version is also an internal field managed by the backend.