### PR TITLE
feat: add support for namespaced exporters

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -203,6 +203,12 @@ Moving beyond the quickstart instructions, here are more details on the test scr
       It is recommended to set this in `test-resources/.env`.
     * `DASH0_INGRESS_ENDPOINT`: The ingress endpoint where telemetry is sent.
       It is recommended to set this in `test-resources/.env`.
+    * `DASH0_NAMESPACED_DATASET`: Dataset used exclusively by the test script for namespaced exporters. It will be
+      placed in the monitoring resource of the test namespace to override the default config from the operator
+      configuration resource.
+    * `DASH0_NAMESPACED_AUTHORIZATION_TOKEN`: Token used exclusively by the test script for namespaced exporters. It
+      will be placed in the monitoring resource of the test namespace to override the default config from the operator
+      configuration resource.
     * `DEPLOY_APPLICATION_UNDER_MONITORING`: Set this to "false" to skip deploying a workload in the test namespace.
       This is assumed to be "true" by default.
     * `DEPLOY_NGINX_INGRESS`: Set this to "false" to skip deploying an nginx ingress to the cluster.

--- a/internal/collectors/collector_controller.go
+++ b/internal/collectors/collector_controller.go
@@ -136,8 +136,6 @@ func (r *CollectorReconciler) Reconcile(
 
 	hasBeenReconciled, err := r.collectorManager.ReconcileOpenTelemetryCollector(
 		ctx,
-		nil,
-		TriggeredByWatchEvent,
 	)
 	if err != nil {
 		logger.Error(err, "Failed to create/update collector resources.")

--- a/internal/collectors/collector_manager_test.go
+++ b/internal/collectors/collector_manager_test.go
@@ -75,51 +75,35 @@ var _ = Describe("The collector manager", Ordered, func() {
 	})
 
 	Describe("when validation checks fail", func() {
+		BeforeEach(func() {
+			CreateDefaultOperatorConfigurationResource(ctx, k8sClient)
+		})
+
+		AfterEach(func() {
+			DeleteAllOperatorConfigurationResources(ctx, k8sClient)
+		})
+
 		It("should fail if no endpoint is provided", func() {
-			monitoringResource := &dash0v1beta1.Dash0Monitoring{
-				Spec: dash0v1beta1.Dash0MonitoringSpec{
-					Export: &dash0common.Export{
-						Dash0: &dash0common.Dash0Configuration{
-							Authorization: dash0common.Authorization{
-								Token: &AuthorizationTokenTest,
-							},
-						},
+			operatorConfig := LoadOperatorConfigurationResourceOrFail(ctx, k8sClient, Default)
+			operatorConfig.Spec.Export = &dash0common.Export{
+				Dash0: &dash0common.Dash0Configuration{
+					Authorization: dash0common.Authorization{
+						Token: &AuthorizationTokenTest,
 					},
 				},
 			}
-			monitoringResource.EnsureResourceIsMarkedAsAvailable()
-			hasBeenReconciled, err := collectorManager.ReconcileOpenTelemetryCollector(
-				ctx,
-				monitoringResource,
-				TriggeredByDash0ResourceReconcile,
-			)
-			Expect(err).To(MatchError(
-				"cannot assemble the exporters for the configuration: no endpoint provided for the Dash0 exporter, unable to create the OpenTelemetry collector"))
-			Expect(hasBeenReconciled).To(BeFalse())
-			VerifyCollectorResourcesDoNotExist(ctx, k8sClient, operatorNamespace)
+			Expect(k8sClient.Update(ctx, operatorConfig)).To(HaveOccurred())
 		})
 
 		It("should fail if neither authorization token nor secret ref are provided for Dash0 exporter", func() {
-			monitoringResource := &dash0v1beta1.Dash0Monitoring{
-				Spec: dash0v1beta1.Dash0MonitoringSpec{
-					Export: &dash0common.Export{
-						Dash0: &dash0common.Dash0Configuration{
-							Endpoint:      EndpointDash0Test,
-							Authorization: dash0common.Authorization{},
-						},
-					},
+			operatorConfig := LoadOperatorConfigurationResourceOrFail(ctx, k8sClient, Default)
+			operatorConfig.Spec.Export = &dash0common.Export{
+				Dash0: &dash0common.Dash0Configuration{
+					Endpoint:      EndpointDash0Test,
+					Authorization: dash0common.Authorization{},
 				},
 			}
-			monitoringResource.EnsureResourceIsMarkedAsAvailable()
-			hasBeenReconciled, err := collectorManager.ReconcileOpenTelemetryCollector(
-				ctx,
-				monitoringResource,
-				TriggeredByDash0ResourceReconcile,
-			)
-			Expect(err).To(MatchError(
-				"neither token nor secretRef provided for the Dash0 exporter"))
-			Expect(hasBeenReconciled).To(BeFalse())
-			VerifyCollectorResourcesDoNotExist(ctx, k8sClient, operatorNamespace)
+			Expect(k8sClient.Update(ctx, operatorConfig)).To(HaveOccurred())
 		})
 	})
 
@@ -139,8 +123,6 @@ var _ = Describe("The collector manager", Ordered, func() {
 		It("should do nothing if there is no operator configuration resource and also no monitoring resource", func() {
 			hasBeenReconciled, err := collectorManager.ReconcileOpenTelemetryCollector(
 				ctx,
-				nil,
-				TriggeredByDash0ResourceReconcile,
 			)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(hasBeenReconciled).To(BeTrue())
@@ -154,46 +136,15 @@ var _ = Describe("The collector manager", Ordered, func() {
 			)
 			hasBeenReconciled, err := collectorManager.ReconcileOpenTelemetryCollector(
 				ctx,
-				nil,
-				TriggeredByDash0ResourceReconcile,
 			)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(hasBeenReconciled).To(BeTrue())
-			VerifyCollectorResources(ctx, k8sClient, operatorNamespace, EndpointDash0Test, AuthorizationTokenTest)
+			VerifyCollectorResources(ctx, k8sClient, operatorNamespace, EndpointDash0Test, AuthorizationDefaultEnvVar, AuthorizationTokenTest)
 		})
 
-		It("the operator configuration's export settings should have priority over the triggering monitoring source and the existing monitoring resources", func() {
-			CreateDefaultOperatorConfigurationResource(
-				ctx,
-				k8sClient,
-			)
-			monitoringResource := EnsureMonitoringResourceWithSpecExistsAndIsAvailable(
-				ctx,
-				k8sClient,
-				dash0v1beta1.Dash0MonitoringSpec{
-					Export: &dash0common.Export{
-						Dash0: &dash0common.Dash0Configuration{
-							Endpoint: EndpointDash0TestAlternative,
-							Authorization: dash0common.Authorization{
-								Token: &AuthorizationTokenTestAlternative,
-							},
-						},
-					},
-				},
-			)
-			createdObjectsCollectorManagerTest = append(createdObjectsCollectorManagerTest, monitoringResource)
-			hasBeenReconciled, err := collectorManager.ReconcileOpenTelemetryCollector(
-				ctx,
-				assembleMonitoringResource(EndpointDash0TestAlternative, AuthorizationTokenTestAlternative),
-				TriggeredByDash0ResourceReconcile,
-			)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(hasBeenReconciled).To(BeTrue())
-			VerifyCollectorResources(ctx, k8sClient, operatorNamespace, EndpointDash0Test, AuthorizationTokenTest)
-		})
-
-		It("should use the triggering monitoring resource's export settings if there is no operator configuration resource", func() {
-			// this monitoring resource is just created to verify that the triggering resource takes priority
+		It("should do nothing if there is no operator configuration resource even if there is a monitoring resource with export", func() {
+			// With the new implementation, an operator configuration is required for default exporters.
+			// Monitoring resources only provide namespaced exporters.
 			monitoringResource := EnsureMonitoringResourceWithSpecExistsAndIsAvailable(
 				ctx,
 				k8sClient,
@@ -212,28 +163,11 @@ var _ = Describe("The collector manager", Ordered, func() {
 
 			hasBeenReconciled, err := collectorManager.ReconcileOpenTelemetryCollector(
 				ctx,
-				assembleMonitoringResource(EndpointDash0Test, AuthorizationTokenTest),
-				TriggeredByDash0ResourceReconcile,
 			)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(hasBeenReconciled).To(BeTrue())
-			VerifyCollectorResources(ctx, k8sClient, operatorNamespace, EndpointDash0Test, AuthorizationTokenTest)
-		})
-
-		It("should use the export settings from an existing monitoring resource if there is no operator configuration resource and no triggering monitoring resource", func() {
-			monitoringResource := EnsureMonitoringResourceExistsAndIsAvailable(
-				ctx,
-				k8sClient,
-			)
-			createdObjectsCollectorManagerTest = append(createdObjectsCollectorManagerTest, monitoringResource)
-			hasBeenReconciled, err := collectorManager.ReconcileOpenTelemetryCollector(
-				ctx,
-				nil,
-				TriggeredByDash0ResourceReconcile,
-			)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(hasBeenReconciled).To(BeTrue())
-			VerifyCollectorResources(ctx, k8sClient, operatorNamespace, EndpointDash0Test, AuthorizationTokenTest)
+			// No collector resources should be created without an operator configuration
+			VerifyCollectorResourcesDoNotExist(ctx, k8sClient, operatorNamespace)
 		})
 
 		It("should do nothing if the operator configuration resource has telemetryCollection.enabled=false", func() {
@@ -248,53 +182,13 @@ var _ = Describe("The collector manager", Ordered, func() {
 			)
 			hasBeenReconciled, err := collectorManager.ReconcileOpenTelemetryCollector(
 				ctx,
-				nil,
-				TriggeredByDash0ResourceReconcile,
 			)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(hasBeenReconciled).To(BeTrue())
 			VerifyCollectorResourcesDoNotExist(ctx, k8sClient, operatorNamespace)
 		})
 
-		It("should do nothing if there is no operator configuration resource and the triggering monitoring resource has no export", func() {
-			monitoringResource := &dash0v1beta1.Dash0Monitoring{
-				Spec: dash0v1beta1.Dash0MonitoringSpec{},
-			}
-			monitoringResource.EnsureResourceIsMarkedAsAvailable()
-			hasBeenReconciled, err := collectorManager.ReconcileOpenTelemetryCollector(
-				ctx,
-				monitoringResource,
-				TriggeredByDash0ResourceReconcile,
-			)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(hasBeenReconciled).To(BeTrue())
-			VerifyCollectorResourcesDoNotExist(ctx, k8sClient, operatorNamespace)
-		})
-
-		It("should do nothing if there is no operator configuration resource and the triggering monitoring resource is not marked as available", func() {
-			monitoringResource := &dash0v1beta1.Dash0Monitoring{
-				Spec: dash0v1beta1.Dash0MonitoringSpec{
-					Export: &dash0common.Export{
-						Dash0: &dash0common.Dash0Configuration{
-							Endpoint: EndpointDash0TestAlternative,
-							Authorization: dash0common.Authorization{
-								Token: &AuthorizationTokenTestAlternative,
-							},
-						},
-					},
-				},
-			}
-			hasBeenReconciled, err := collectorManager.ReconcileOpenTelemetryCollector(
-				ctx,
-				monitoringResource,
-				TriggeredByDash0ResourceReconcile,
-			)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(hasBeenReconciled).To(BeTrue())
-			VerifyCollectorResourcesDoNotExist(ctx, k8sClient, operatorNamespace)
-		})
-
-		It("should do nothing if the operator configuration resource has no export and there is no monitoring resource", func() {
+		It("should do nothing if the operator configuration resource has no export", func() {
 			CreateOperatorConfigurationResourceWithSpec(
 				ctx,
 				k8sClient,
@@ -302,76 +196,6 @@ var _ = Describe("The collector manager", Ordered, func() {
 			)
 			hasBeenReconciled, err := collectorManager.ReconcileOpenTelemetryCollector(
 				ctx,
-				nil,
-				TriggeredByDash0ResourceReconcile,
-			)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(hasBeenReconciled).To(BeTrue())
-			VerifyCollectorResourcesDoNotExist(ctx, k8sClient, operatorNamespace)
-		})
-
-		It("should do nothing if the operator configuration resource has no export and the triggering monitoring resource has no export", func() {
-			CreateOperatorConfigurationResourceWithSpec(
-				ctx,
-				k8sClient,
-				dash0v1alpha1.Dash0OperatorConfigurationSpec{},
-			)
-			monitoringResource := &dash0v1beta1.Dash0Monitoring{
-				Spec: dash0v1beta1.Dash0MonitoringSpec{},
-			}
-			monitoringResource.EnsureResourceIsMarkedAsAvailable()
-			hasBeenReconciled, err := collectorManager.ReconcileOpenTelemetryCollector(
-				ctx,
-				monitoringResource,
-				TriggeredByDash0ResourceReconcile,
-			)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(hasBeenReconciled).To(BeTrue())
-			VerifyCollectorResourcesDoNotExist(ctx, k8sClient, operatorNamespace)
-		})
-
-		It("should do nothing if there is no operator configuration resource and neither the triggering nor the existing monitoring resource have an export", func() {
-			existingMonitoringResource := EnsureMonitoringResourceExists(
-				ctx,
-				k8sClient,
-			)
-			createdObjectsCollectorManagerTest = append(createdObjectsCollectorManagerTest, existingMonitoringResource)
-			triggeringMonitoringResource := &dash0v1beta1.Dash0Monitoring{
-				Spec: dash0v1beta1.Dash0MonitoringSpec{
-					Export: &dash0common.Export{
-						Dash0: &dash0common.Dash0Configuration{
-							Endpoint: EndpointDash0TestAlternative,
-							Authorization: dash0common.Authorization{
-								Token: &AuthorizationTokenTestAlternative,
-							},
-						},
-					},
-				},
-			}
-			hasBeenReconciled, err := collectorManager.ReconcileOpenTelemetryCollector(
-				ctx,
-				triggeringMonitoringResource,
-				TriggeredByDash0ResourceReconcile,
-			)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(hasBeenReconciled).To(BeTrue())
-			VerifyCollectorResourcesDoNotExist(ctx, k8sClient, operatorNamespace)
-		})
-
-		It("should do nothing if there is no operator configuration resource and neither the triggering nor the existing monitoring are marked as available", func() {
-			existingMonitoringResource := EnsureEmptyMonitoringResourceExistsAndIsAvailable(
-				ctx,
-				k8sClient,
-			)
-			createdObjectsCollectorManagerTest = append(createdObjectsCollectorManagerTest, existingMonitoringResource)
-			triggeringMonitoringResource := &dash0v1beta1.Dash0Monitoring{
-				Spec: dash0v1beta1.Dash0MonitoringSpec{},
-			}
-			triggeringMonitoringResource.EnsureResourceIsMarkedAsAvailable()
-			hasBeenReconciled, err := collectorManager.ReconcileOpenTelemetryCollector(
-				ctx,
-				triggeringMonitoringResource,
-				TriggeredByDash0ResourceReconcile,
 			)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(hasBeenReconciled).To(BeTrue())
@@ -382,6 +206,8 @@ var _ = Describe("The collector manager", Ordered, func() {
 	Describe("when updating OpenTelemetry collector resources", func() {
 
 		BeforeEach(func() {
+			// Create operator configuration resource - required for collector creation
+			CreateDefaultOperatorConfigurationResource(ctx, k8sClient)
 			// creating a valid monitoring resource beforehand, just so we get past the
 			// m.findAllMonitoringResources step.
 			resource := EnsureMonitoringResourceExistsAndIsAvailable(
@@ -389,6 +215,10 @@ var _ = Describe("The collector manager", Ordered, func() {
 				k8sClient,
 			)
 			createdObjectsCollectorManagerTest = append(createdObjectsCollectorManagerTest, resource)
+		})
+
+		AfterEach(func() {
+			DeleteAllOperatorConfigurationResources(ctx, k8sClient)
 		})
 
 		It("should update the resources", func() {
@@ -411,12 +241,10 @@ var _ = Describe("The collector manager", Ordered, func() {
 
 			hasBeenReconciled, err := collectorManager.ReconcileOpenTelemetryCollector(
 				ctx,
-				nil,
-				TriggeredByDash0ResourceReconcile,
 			)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(hasBeenReconciled).To(BeTrue())
-			VerifyCollectorResources(ctx, k8sClient, operatorNamespace, EndpointDash0Test, AuthorizationTokenTest)
+			VerifyCollectorResources(ctx, k8sClient, operatorNamespace, EndpointDash0Test, AuthorizationDefaultEnvVar, AuthorizationTokenTest)
 
 			// verify that all wrong properties that we have set up initially have been removed
 			cm := GetOTelColDaemonSetConfigMap(ctx, k8sClient, operatorNamespace)
@@ -453,22 +281,18 @@ var _ = Describe("The collector manager", Ordered, func() {
 			// Let the manager create the collector so there is something to delete.
 			_, err := collectorManager.ReconcileOpenTelemetryCollector(
 				ctx,
-				monitoringResource,
-				TriggeredByDash0ResourceReconcile,
 			)
 			Expect(err).ToNot(HaveOccurred())
-			VerifyCollectorResources(ctx, k8sClient, operatorNamespace, EndpointDash0Test, AuthorizationTokenTest)
+			VerifyCollectorResources(ctx, k8sClient, operatorNamespace, EndpointDash0Test, AuthorizationDefaultEnvVar, AuthorizationTokenTest)
 
 			hasBeenReconciled, err := collectorManager.ReconcileOpenTelemetryCollector(
 				ctx,
-				monitoringResource,
-				TriggeredByDash0ResourceReconcile,
 			)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(hasBeenReconciled).To(BeTrue())
 			// verify the collector is not deleted even if the monitoring resource provided as a parameter is the only
 			// one left, when there is still an operator configuration left,
-			VerifyCollectorResources(ctx, k8sClient, operatorNamespace, EndpointDash0Test, AuthorizationTokenTest)
+			VerifyCollectorResources(ctx, k8sClient, operatorNamespace, EndpointDash0Test, AuthorizationDefaultEnvVar, AuthorizationTokenTest)
 		})
 
 		It("should not delete the collector if there is an operator configuration resource and no monitoring resource exists", func() {
@@ -484,27 +308,28 @@ var _ = Describe("The collector manager", Ordered, func() {
 			)
 			_, err := collectorManager.ReconcileOpenTelemetryCollector(
 				ctx,
-				monitoringResource,
-				TriggeredByDash0ResourceReconcile,
 			)
 			Expect(err).ToNot(HaveOccurred())
-			VerifyCollectorResources(ctx, k8sClient, operatorNamespace, EndpointDash0Test, AuthorizationTokenTest)
+			VerifyCollectorResources(ctx, k8sClient, operatorNamespace, EndpointDash0Test, AuthorizationDefaultEnvVar, AuthorizationTokenTest)
 
 			Expect(k8sClient.Delete(ctx, monitoringResource)).To(Succeed())
 
 			hasBeenReconciled, err := collectorManager.ReconcileOpenTelemetryCollector(
 				ctx,
-				monitoringResource,
-				TriggeredByDash0ResourceReconcile,
 			)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(hasBeenReconciled).To(BeTrue())
 			// verify the collector is not deleted even if the last monitoring resource has been deleted, but there is
 			// still an operator configuration left,
-			VerifyCollectorResources(ctx, k8sClient, operatorNamespace, EndpointDash0Test, AuthorizationTokenTest)
+			VerifyCollectorResources(ctx, k8sClient, operatorNamespace, EndpointDash0Test, AuthorizationDefaultEnvVar, AuthorizationTokenTest)
 		})
 
-		It("should not delete the collector if there is no operator configuration resource but there are still monitoring resources", func() {
+		It("should not delete the collector if there is an operator configuration resource and multiple monitoring resources exist", func() {
+			CreateDefaultOperatorConfigurationResource(
+				ctx,
+				k8sClient,
+			)
+
 			// create multiple monitoring resources
 			firstName := types.NamespacedName{Namespace: TestNamespaceName, Name: "dash0-monitoring-test-resource-1"}
 			firstDash0MonitoringResource := EnsureMonitoringResourceExistsInNamespaceAndIsAvailable(ctx, k8sClient, firstName)
@@ -521,65 +346,17 @@ var _ = Describe("The collector manager", Ordered, func() {
 			// Let the manager create the collector so there is something to delete.
 			_, err := collectorManager.ReconcileOpenTelemetryCollector(
 				ctx,
-				secondDash0MonitoringResource,
-				TriggeredByDash0ResourceReconcile,
 			)
 			Expect(err).ToNot(HaveOccurred())
-			VerifyCollectorResources(ctx, k8sClient, operatorNamespace, EndpointDash0Test, AuthorizationTokenTest)
+			VerifyCollectorResources(ctx, k8sClient, operatorNamespace, EndpointDash0Test, AuthorizationDefaultEnvVar, AuthorizationTokenTest)
 
 			hasBeenReconciled, err := collectorManager.ReconcileOpenTelemetryCollector(
 				ctx,
-				secondDash0MonitoringResource,
-				TriggeredByDash0ResourceReconcile,
 			)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(hasBeenReconciled).To(BeTrue())
-			// since other monitoring resources still exist, the collector resources should not be deleted
-			VerifyCollectorResources(ctx, k8sClient, operatorNamespace, EndpointDash0Test, AuthorizationTokenTest)
-		})
-
-		It("should not delete the collector if there is no operator configuration resource, but if there one available resource with an export left", func() {
-			resourceName := types.NamespacedName{Namespace: TestNamespaceName, Name: "dash0-monitoring-test-resource-1"}
-			existingDash0MonitoringResource := EnsureMonitoringResourceExistsInNamespaceAndIsAvailable(ctx, k8sClient, resourceName)
-			createdObjectsCollectorManagerTest = append(createdObjectsCollectorManagerTest, existingDash0MonitoringResource)
-
-			// Let the manager create the collector so there is something to delete.
-			_, err := collectorManager.ReconcileOpenTelemetryCollector(
-				ctx,
-				existingDash0MonitoringResource,
-				TriggeredByDash0ResourceReconcile,
-			)
-			Expect(err).ToNot(HaveOccurred())
-			VerifyCollectorResources(ctx, k8sClient, operatorNamespace, EndpointDash0Test, AuthorizationTokenTest)
-
-			triggeringMonitoringResourceNotAvailable := &dash0v1beta1.Dash0Monitoring{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "some-other-namespace",
-					Name:      "name",
-					UID:       "3c0e72bb-26a7-40a4-bbdd-b1c978278fc5",
-				},
-				Spec: dash0v1beta1.Dash0MonitoringSpec{
-					Export: &dash0common.Export{
-						Dash0: &dash0common.Dash0Configuration{
-							Endpoint: EndpointDash0Test,
-							Authorization: dash0common.Authorization{
-								Token: &AuthorizationTokenTest,
-							},
-						},
-					},
-				},
-			}
-			hasBeenReconciled, err := collectorManager.ReconcileOpenTelemetryCollector(
-				ctx,
-				// Here the triggering monitoring resource has an export but is not marked as available, so it will not
-				// contribute towards retaining the collector resources; the existing monitoring resource created above
-				// has an export and is available, so ultimately, the collector resources are not deleted.
-				triggeringMonitoringResourceNotAvailable,
-				TriggeredByDash0ResourceReconcile,
-			)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(hasBeenReconciled).To(BeTrue())
-			VerifyCollectorResources(ctx, k8sClient, operatorNamespace, EndpointDash0Test, AuthorizationTokenTest)
+			// since operator configuration exists, the collector resources should not be deleted
+			VerifyCollectorResources(ctx, k8sClient, operatorNamespace, EndpointDash0Test, AuthorizationDefaultEnvVar, AuthorizationTokenTest)
 		})
 
 		It("should delete the Dash0 collectors if operator configuration has telemetryCollection.enabled=false ", func() {
@@ -589,27 +366,23 @@ var _ = Describe("The collector manager", Ordered, func() {
 			)
 			hasBeenReconciled, err := collectorManager.ReconcileOpenTelemetryCollector(
 				ctx,
-				nil,
-				TriggeredByDash0ResourceReconcile,
 			)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(hasBeenReconciled).To(BeTrue())
-			VerifyCollectorResources(ctx, k8sClient, operatorNamespace, EndpointDash0Test, AuthorizationTokenTest)
+			VerifyCollectorResources(ctx, k8sClient, operatorNamespace, EndpointDash0Test, AuthorizationDefaultEnvVar, AuthorizationTokenTest)
 
 			operatorConfiguration.Spec.TelemetryCollection.Enabled = ptr.To(false)
 			Expect(k8sClient.Update(ctx, operatorConfiguration)).To(Succeed())
 
 			hasBeenReconciled, err = collectorManager.ReconcileOpenTelemetryCollector(
 				ctx,
-				nil,
-				TriggeredByDash0ResourceReconcile,
 			)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(hasBeenReconciled).To(BeTrue())
 			VerifyCollectorResourcesDoNotExist(ctx, k8sClient, operatorNamespace)
 		})
 
-		It("should delete the collector if the operator configuration is deleted and there are no monitoring resources", func() {
+		It("should delete the collector if the operator configuration is deleted", func() {
 			operatorConfigurationResource := CreateDefaultOperatorConfigurationResource(
 				ctx,
 				k8sClient,
@@ -617,73 +390,26 @@ var _ = Describe("The collector manager", Ordered, func() {
 
 			_, err := collectorManager.ReconcileOpenTelemetryCollector(
 				ctx,
-				nil,
-				TriggeredByDash0ResourceReconcile,
 			)
 			Expect(err).ToNot(HaveOccurred())
-			VerifyCollectorResources(ctx, k8sClient, operatorNamespace, EndpointDash0Test, AuthorizationTokenTest)
+			VerifyCollectorResources(ctx, k8sClient, operatorNamespace, EndpointDash0Test, AuthorizationDefaultEnvVar, AuthorizationTokenTest)
 
 			Expect(k8sClient.Delete(ctx, operatorConfigurationResource)).To(Succeed())
 
 			hasBeenReconciled, err := collectorManager.ReconcileOpenTelemetryCollector(
 				ctx,
-				nil,
-				TriggeredByDash0ResourceReconcile,
 			)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(hasBeenReconciled).To(BeTrue())
 			VerifyCollectorResourcesDoNotExist(ctx, k8sClient, operatorNamespace)
 		})
 
-		It("should delete the collector if the operator configuration is deleted and there are only monitoring resources without an export", func() {
+		It("should delete the collector if the operator configuration is deleted even if monitoring resources with export exist", func() {
 			operatorConfigurationResource := CreateDefaultOperatorConfigurationResource(
 				ctx,
 				k8sClient,
 			)
 
-			// create multiple monitoring resources, all without export
-			firstName := types.NamespacedName{Namespace: TestNamespaceName, Name: "dash0-monitoring-test-resource-1"}
-			firstDash0MonitoringResource :=
-				EnsureMonitoringResourceWithSpecExistsInNamespaceAndIsAvailable(ctx, k8sClient,
-					dash0v1beta1.Dash0MonitoringSpec{}, firstName)
-			createdObjectsCollectorManagerTest = append(createdObjectsCollectorManagerTest, firstDash0MonitoringResource)
-
-			secondName := types.NamespacedName{Namespace: TestNamespaceName, Name: "dash0-monitoring-test-resource-2"}
-			secondDash0MonitoringResource :=
-				EnsureMonitoringResourceWithSpecExistsInNamespaceAndIsAvailable(ctx, k8sClient,
-					dash0v1beta1.Dash0MonitoringSpec{}, secondName)
-			createdObjectsCollectorManagerTest = append(createdObjectsCollectorManagerTest, secondDash0MonitoringResource)
-
-			thirdName := types.NamespacedName{Namespace: TestNamespaceName, Name: "dash0-monitoring-test-resource-3"}
-			thirdDash0MonitoringResource :=
-				EnsureMonitoringResourceWithSpecExistsInNamespaceAndIsAvailable(ctx, k8sClient,
-					dash0v1beta1.Dash0MonitoringSpec{}, thirdName)
-			createdObjectsCollectorManagerTest = append(createdObjectsCollectorManagerTest, thirdDash0MonitoringResource)
-
-			hasBeenReconciled, err := collectorManager.ReconcileOpenTelemetryCollector(
-				ctx,
-				nil,
-				TriggeredByDash0ResourceReconcile,
-			)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(hasBeenReconciled).To(BeTrue())
-			VerifyCollectorResources(ctx, k8sClient, operatorNamespace, EndpointDash0Test, AuthorizationTokenTest)
-
-			Expect(k8sClient.Delete(ctx, operatorConfigurationResource)).To(Succeed())
-
-			hasBeenReconciled, err = collectorManager.ReconcileOpenTelemetryCollector(
-				ctx,
-				nil,
-				TriggeredByDash0ResourceReconcile,
-			)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(hasBeenReconciled).To(BeTrue())
-			// verify the collector is not deleted even if the last monitoring resource has been deleted, but there is
-			// still an operator configuration left,
-			VerifyCollectorResourcesDoNotExist(ctx, k8sClient, operatorNamespace)
-		})
-
-		It("should delete the collector if there is no operator configuration, and if the monitoring resource that is being deleted is the only one left", func() {
 			resourceName := types.NamespacedName{Namespace: TestNamespaceName, Name: "dash0-monitoring-test-resource-1"}
 			monitoringResource := EnsureMonitoringResourceExistsInNamespaceAndIsAvailable(ctx, k8sClient, resourceName)
 			createdObjectsCollectorManagerTest = append(createdObjectsCollectorManagerTest, monitoringResource)
@@ -691,64 +417,29 @@ var _ = Describe("The collector manager", Ordered, func() {
 			// Let the manager create the collector so there is something to delete.
 			hasBeenReconciled, err := collectorManager.ReconcileOpenTelemetryCollector(
 				ctx,
-				monitoringResource,
-				TriggeredByDash0ResourceReconcile,
 			)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(hasBeenReconciled).To(BeTrue())
-			VerifyCollectorResources(ctx, k8sClient, operatorNamespace, EndpointDash0Test, AuthorizationTokenTest)
+			VerifyCollectorResources(ctx, k8sClient, operatorNamespace, EndpointDash0Test, AuthorizationDefaultEnvVar, AuthorizationTokenTest)
 
-			// When deleting the resource, it will be marked as about to be deleted=degraded in the finalizer handling
-			// before calling manager.ReconcileOpenTelemetryCollector (this happens in
-			// monitoring_controller.go#runCleanup). This is important for ReconcileOpenTelemetryCollector, so it does
-			// not accidentally find an available monitoring resource.
-			monitoringResource.EnsureResourceIsMarkedAsAboutToBeDeleted()
-			Expect(k8sClient.Status().Update(ctx, monitoringResource)).To(Succeed())
+			// Delete the operator configuration
+			Expect(k8sClient.Delete(ctx, operatorConfigurationResource)).To(Succeed())
 
 			hasBeenReconciled, err = collectorManager.ReconcileOpenTelemetryCollector(
 				ctx,
-				monitoringResource,
-				TriggeredByDash0ResourceReconcile,
 			)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(hasBeenReconciled).To(BeTrue())
-			// verify the collector is deleted when the monitoring resource provided as a parameter is the only
-			// one left
-			VerifyCollectorResourcesDoNotExist(ctx, k8sClient, operatorNamespace)
-		})
-
-		It("should delete the collector if no operator configuration and no monitoring resource exists", func() {
-			// Let the manager create the collector so there is something to delete.
-			monitoringResource := EnsureMonitoringResourceExistsAndIsAvailable(
-				ctx,
-				k8sClient,
-			)
-			createdObjectsCollectorManagerTest = append(createdObjectsCollectorManagerTest, monitoringResource)
-			hasBeenReconciled, err := collectorManager.ReconcileOpenTelemetryCollector(
-				ctx,
-				monitoringResource,
-				TriggeredByDash0ResourceReconcile,
-			)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(hasBeenReconciled).To(BeTrue())
-			VerifyCollectorResources(ctx, k8sClient, operatorNamespace, EndpointDash0Test, AuthorizationTokenTest)
-
-			Expect(k8sClient.Delete(ctx, monitoringResource)).To(Succeed())
-			createdObjectsCollectorManagerTest = createdObjectsCollectorManagerTest[0 : len(createdObjectsCollectorManagerTest)-1]
-
-			hasBeenReconciled, err = collectorManager.ReconcileOpenTelemetryCollector(
-				ctx,
-				nil,
-				TriggeredByDash0ResourceReconcile,
-			)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(hasBeenReconciled).To(BeTrue())
+			// verify the collector is deleted when operator config is removed,
+			// even if monitoring resources with export still exist
 			VerifyCollectorResourcesDoNotExist(ctx, k8sClient, operatorNamespace)
 		})
 	})
 
 	Describe("when updating the extra config map", func() {
 		BeforeEach(func() {
+			// Create operator configuration resource - required for collector creation
+			CreateDefaultOperatorConfigurationResource(ctx, k8sClient)
 			// creating a valid monitoring resource beforehand, just so we get past the
 			// m.findAllMonitoringResources step.
 			resource := EnsureMonitoringResourceExistsAndIsAvailable(
@@ -770,36 +461,24 @@ var _ = Describe("The collector manager", Ordered, func() {
 		})
 
 		It("should ignore updates if extra config map content has not changed", func() {
-			CreateDefaultOperatorConfigurationResource(
-				ctx,
-				k8sClient,
-			)
 			hasBeenReconciled, err := collectorManager.ReconcileOpenTelemetryCollector(
 				ctx,
-				nil,
-				TriggeredByDash0ResourceReconcile,
 			)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(hasBeenReconciled).To(BeTrue())
-			VerifyCollectorResources(ctx, k8sClient, operatorNamespace, EndpointDash0Test, AuthorizationTokenTest)
+			VerifyCollectorResources(ctx, k8sClient, operatorNamespace, EndpointDash0Test, AuthorizationDefaultEnvVar, AuthorizationTokenTest)
 
 			collectorManager.UpdateExtraConfig(ctx, util.ExtraConfigDefaults, &logger)
-			VerifyCollectorResources(ctx, k8sClient, operatorNamespace, EndpointDash0Test, AuthorizationTokenTest)
+			VerifyCollectorResources(ctx, k8sClient, operatorNamespace, EndpointDash0Test, AuthorizationDefaultEnvVar, AuthorizationTokenTest)
 		})
 
 		It("should apply updates if extra config map content has changed", func() {
-			CreateDefaultOperatorConfigurationResource(
-				ctx,
-				k8sClient,
-			)
 			hasBeenReconciled, err := collectorManager.ReconcileOpenTelemetryCollector(
 				ctx,
-				nil,
-				TriggeredByDash0ResourceReconcile,
 			)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(hasBeenReconciled).To(BeTrue())
-			VerifyCollectorResources(ctx, k8sClient, operatorNamespace, EndpointDash0Test, AuthorizationTokenTest)
+			VerifyCollectorResources(ctx, k8sClient, operatorNamespace, EndpointDash0Test, AuthorizationDefaultEnvVar, AuthorizationTokenTest)
 
 			changedConfig := util.ExtraConfigDefaults
 			changedConfig.CollectorDaemonSetCollectorContainerResources = util.ResourceRequirementsWithGoMemLimit{
@@ -873,24 +552,3 @@ var _ = Describe("The collector manager", Ordered, func() {
 		})
 	})
 })
-
-func assembleMonitoringResource(endpoint string, authorizationToken string) *dash0v1beta1.Dash0Monitoring {
-	monitoringResource := &dash0v1beta1.Dash0Monitoring{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "dash0-monitoring-test-resource",
-			Namespace: TestNamespaceName,
-		},
-		Spec: dash0v1beta1.Dash0MonitoringSpec{
-			Export: &dash0common.Export{
-				Dash0: &dash0common.Dash0Configuration{
-					Endpoint: endpoint,
-					Authorization: dash0common.Authorization{
-						Token: &authorizationToken,
-					},
-				},
-			},
-		},
-	}
-	monitoringResource.EnsureResourceIsMarkedAsAvailable()
-	return monitoringResource
-}

--- a/internal/collectors/otelcolresources/authorization.go
+++ b/internal/collectors/otelcolresources/authorization.go
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: Copyright 2026 Dash0 Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package otelcolresources
+
+import (
+	"fmt"
+	"strings"
+
+	dash0common "github.com/dash0hq/dash0-operator/api/operator/common"
+	dash0v1alpha1 "github.com/dash0hq/dash0-operator/api/operator/v1alpha1"
+	dash0v1beta1 "github.com/dash0hq/dash0-operator/api/operator/v1beta1"
+)
+
+const authEnvVarPrefix = "OTELCOL_AUTH_TOKEN"
+
+var authEnvVarNameDefault = fmt.Sprintf("%s_DEFAULT", authEnvVarPrefix)
+
+type dash0ExporterAuthorization struct {
+	EnvVarName    string
+	Authorization dash0common.Authorization
+}
+
+type dash0ExporterAuthorizationByNamespace = map[string]dash0ExporterAuthorization
+
+type dash0ExporterAuthorizations struct {
+	DefaultDash0ExporterAuthorization     *dash0ExporterAuthorization
+	NamespacedDash0ExporterAuthorizations dash0ExporterAuthorizationByNamespace
+}
+
+func (auths dash0ExporterAuthorizations) all() []dash0ExporterAuthorization {
+	allAuths := make([]dash0ExporterAuthorization, 0)
+	if auths.DefaultDash0ExporterAuthorization != nil {
+		allAuths = append(allAuths, *auths.DefaultDash0ExporterAuthorization)
+	}
+	for _, auth := range auths.NamespacedDash0ExporterAuthorizations {
+		allAuths = append(allAuths, auth)
+	}
+	return allAuths
+}
+
+func authEnvVarNameForNs(namespace string) string {
+	envVarSuffix := strings.ReplaceAll(namespace, "-", "_")
+	envVarSuffix = strings.ToUpper(envVarSuffix)
+
+	return fmt.Sprintf("%s_NS_%s", authEnvVarPrefix, envVarSuffix)
+}
+
+func collectDash0ExporterAuthorizations(operatorConfigurationResource *dash0v1alpha1.Dash0OperatorConfiguration,
+	allMonitoringResources []dash0v1beta1.Dash0Monitoring) dash0ExporterAuthorizations {
+	var defaultAuth *dash0ExporterAuthorization = nil
+	if operatorConfigurationResource != nil && operatorConfigurationResource.Spec.Export != nil && operatorConfigurationResource.Spec.Export.Dash0 != nil {
+		defaultAuth = &dash0ExporterAuthorization{
+			EnvVarName:    authEnvVarNameDefault,
+			Authorization: operatorConfigurationResource.Spec.Export.Dash0.Authorization,
+		}
+	}
+	nsAuths := make(dash0ExporterAuthorizationByNamespace)
+	for _, m := range allMonitoringResources {
+		if m.Spec.Export != nil && m.Spec.Export.Dash0 != nil {
+			nsAuths[m.Namespace] = dash0ExporterAuthorization{
+				EnvVarName:    authEnvVarNameForNs(m.Namespace),
+				Authorization: m.Spec.Export.Dash0.Authorization,
+			}
+		}
+	}
+	return dash0ExporterAuthorizations{
+		DefaultDash0ExporterAuthorization:     defaultAuth,
+		NamespacedDash0ExporterAuthorizations: nsAuths,
+	}
+}

--- a/internal/collectors/otelcolresources/authorization_test.go
+++ b/internal/collectors/otelcolresources/authorization_test.go
@@ -1,0 +1,403 @@
+// SPDX-FileCopyrightText: Copyright 2026 Dash0 Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package otelcolresources
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	dash0common "github.com/dash0hq/dash0-operator/api/operator/common"
+	dash0v1alpha1 "github.com/dash0hq/dash0-operator/api/operator/v1alpha1"
+	dash0v1beta1 "github.com/dash0hq/dash0-operator/api/operator/v1beta1"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	. "github.com/dash0hq/dash0-operator/test/util"
+)
+
+var _ = Describe("Authorization", func() {
+
+	Describe("authEnvVarNameForNs", func() {
+		It("should convert a simple namespace to env var name", func() {
+			result := authEnvVarNameForNs("default")
+			Expect(result).To(Equal("OTELCOL_AUTH_TOKEN_NS_DEFAULT"))
+		})
+
+		It("should convert a namespace with hyphens to env var name with underscores", func() {
+			result := authEnvVarNameForNs("my-namespace")
+			Expect(result).To(Equal("OTELCOL_AUTH_TOKEN_NS_MY_NAMESPACE"))
+		})
+
+		It("should convert a namespace with multiple hyphens to env var name", func() {
+			result := authEnvVarNameForNs("my-long-namespace-name")
+			Expect(result).To(Equal("OTELCOL_AUTH_TOKEN_NS_MY_LONG_NAMESPACE_NAME"))
+		})
+
+		It("should convert lowercase letters to uppercase", func() {
+			result := authEnvVarNameForNs("myNamespace")
+			Expect(result).To(Equal("OTELCOL_AUTH_TOKEN_NS_MYNAMESPACE"))
+		})
+
+		It("should handle a namespace that is already uppercase", func() {
+			result := authEnvVarNameForNs("UPPERCASE")
+			Expect(result).To(Equal("OTELCOL_AUTH_TOKEN_NS_UPPERCASE"))
+		})
+
+		It("should handle a namespace with numbers", func() {
+			result := authEnvVarNameForNs("namespace-123")
+			Expect(result).To(Equal("OTELCOL_AUTH_TOKEN_NS_NAMESPACE_123"))
+		})
+	})
+
+	Describe("dash0ExporterAuthorizations.all", func() {
+		It("should return an empty slice when there are no authorizations", func() {
+			auths := dash0ExporterAuthorizations{
+				DefaultDash0ExporterAuthorization:     nil,
+				NamespacedDash0ExporterAuthorizations: nil,
+			}
+			result := auths.all()
+			Expect(result).To(HaveLen(0))
+		})
+
+		It("should return only the default authorization when no namespaced authorizations exist", func() {
+			defaultAuth := dash0ExporterAuthorization{
+				EnvVarName: authEnvVarNameDefault,
+				Authorization: dash0common.Authorization{
+					Token: &AuthorizationTokenTest,
+				},
+			}
+			auths := dash0ExporterAuthorizations{
+				DefaultDash0ExporterAuthorization:     &defaultAuth,
+				NamespacedDash0ExporterAuthorizations: nil,
+			}
+			result := auths.all()
+			Expect(result).To(HaveLen(1))
+			Expect(result).To(ContainElement(defaultAuth))
+		})
+
+		It("should return only namespaced authorizations when no default authorization exists", func() {
+			nsAuth := dash0ExporterAuthorization{
+				EnvVarName: authEnvVarNameForNs("test-namespace"),
+				Authorization: dash0common.Authorization{
+					Token: &AuthorizationTokenTest,
+				},
+			}
+			auths := dash0ExporterAuthorizations{
+				DefaultDash0ExporterAuthorization: nil,
+				NamespacedDash0ExporterAuthorizations: dash0ExporterAuthorizationByNamespace{
+					"test-namespace": nsAuth,
+				},
+			}
+			result := auths.all()
+			Expect(result).To(HaveLen(1))
+			Expect(result).To(ContainElement(nsAuth))
+		})
+
+		It("should return both default and namespaced authorizations", func() {
+			defaultAuth := dash0ExporterAuthorization{
+				EnvVarName: authEnvVarNameDefault,
+				Authorization: dash0common.Authorization{
+					Token: &AuthorizationTokenTest,
+				},
+			}
+			nsAuth1 := dash0ExporterAuthorization{
+				EnvVarName: authEnvVarNameForNs("namespace-1"),
+				Authorization: dash0common.Authorization{
+					Token: &AuthorizationTokenTest,
+				},
+			}
+			nsAuth2 := dash0ExporterAuthorization{
+				EnvVarName: authEnvVarNameForNs("namespace-2"),
+				Authorization: dash0common.Authorization{
+					SecretRef: &SecretRefTest,
+				},
+			}
+			auths := dash0ExporterAuthorizations{
+				DefaultDash0ExporterAuthorization: &defaultAuth,
+				NamespacedDash0ExporterAuthorizations: dash0ExporterAuthorizationByNamespace{
+					"namespace-1": nsAuth1,
+					"namespace-2": nsAuth2,
+				},
+			}
+			result := auths.all()
+			Expect(result).To(HaveLen(3))
+			Expect(result).To(ContainElement(defaultAuth))
+			Expect(result).To(ContainElement(nsAuth1))
+			Expect(result).To(ContainElement(nsAuth2))
+		})
+	})
+
+	Describe("collectDash0ExporterAuthorizations", func() {
+		var (
+			operatorConfig *dash0v1alpha1.Dash0OperatorConfiguration
+		)
+
+		BeforeEach(func() {
+			operatorConfig = &dash0v1alpha1.Dash0OperatorConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-operator-config",
+				},
+				Spec: dash0v1alpha1.Dash0OperatorConfigurationSpec{
+					Export: &dash0common.Export{},
+				},
+			}
+		})
+
+		Context("when operator configuration has Dash0 export with token", func() {
+			BeforeEach(func() {
+				operatorConfig.Spec.Export = &dash0common.Export{
+					Dash0: &dash0common.Dash0Configuration{
+						Endpoint: EndpointDash0Test,
+						Authorization: dash0common.Authorization{
+							Token: &AuthorizationTokenTest,
+						},
+					},
+				}
+			})
+
+			It("should set the default authorization from operator config", func() {
+				result := collectDash0ExporterAuthorizations(operatorConfig, nil)
+
+				Expect(result.DefaultDash0ExporterAuthorization).NotTo(BeNil())
+				Expect(result.DefaultDash0ExporterAuthorization.EnvVarName).To(Equal(authEnvVarNameDefault))
+				Expect(result.DefaultDash0ExporterAuthorization.Authorization.Token).To(Equal(&AuthorizationTokenTest))
+			})
+
+			It("should have empty namespaced authorizations when no monitoring resources exist", func() {
+				result := collectDash0ExporterAuthorizations(operatorConfig, nil)
+
+				Expect(result.NamespacedDash0ExporterAuthorizations).To(BeEmpty())
+			})
+		})
+
+		Context("when operator configuration has Dash0 export with secret ref", func() {
+			BeforeEach(func() {
+				operatorConfig.Spec.Export = &dash0common.Export{
+					Dash0: &dash0common.Dash0Configuration{
+						Endpoint: EndpointDash0Test,
+						Authorization: dash0common.Authorization{
+							SecretRef: &SecretRefTest,
+						},
+					},
+				}
+			})
+
+			It("should set the default authorization with secret ref", func() {
+				result := collectDash0ExporterAuthorizations(operatorConfig, nil)
+
+				Expect(result.DefaultDash0ExporterAuthorization).NotTo(BeNil())
+				Expect(result.DefaultDash0ExporterAuthorization.EnvVarName).To(Equal(authEnvVarNameDefault))
+				Expect(result.DefaultDash0ExporterAuthorization.Authorization.SecretRef).To(Equal(&SecretRefTest))
+			})
+		})
+
+		Context("when operator configuration does not have Dash0 export", func() {
+			BeforeEach(func() {
+				operatorConfig.Spec.Export = &dash0common.Export{
+					Grpc: &dash0common.GrpcConfiguration{
+						Endpoint: EndpointGrpcTest,
+					},
+				}
+			})
+
+			It("should have nil default authorization", func() {
+				result := collectDash0ExporterAuthorizations(operatorConfig, nil)
+
+				Expect(result.DefaultDash0ExporterAuthorization).To(BeNil())
+			})
+		})
+
+		Context("when monitoring resources have Dash0 export", func() {
+			var monitoringResources []dash0v1beta1.Dash0Monitoring
+
+			BeforeEach(func() {
+				operatorConfig.Spec.Export = &dash0common.Export{
+					Dash0: &dash0common.Dash0Configuration{
+						Endpoint: EndpointDash0Test,
+						Authorization: dash0common.Authorization{
+							Token: &AuthorizationTokenTest,
+						},
+					},
+				}
+				monitoringResources = []dash0v1beta1.Dash0Monitoring{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      MonitoringResourceName,
+							Namespace: "namespace-1",
+						},
+						Spec: dash0v1beta1.Dash0MonitoringSpec{
+							Export: &dash0common.Export{
+								Dash0: &dash0common.Dash0Configuration{
+									Endpoint: EndpointDash0TestAlternative,
+									Authorization: dash0common.Authorization{
+										Token: &AuthorizationTokenTestAlternative,
+									},
+								},
+							},
+						},
+					},
+				}
+			})
+
+			It("should include namespaced authorization from monitoring resource", func() {
+				result := collectDash0ExporterAuthorizations(operatorConfig, monitoringResources)
+
+				Expect(result.NamespacedDash0ExporterAuthorizations).NotTo(BeNil())
+				Expect(result.NamespacedDash0ExporterAuthorizations).To(HaveKey("namespace-1"))
+				nsAuth := result.NamespacedDash0ExporterAuthorizations["namespace-1"]
+				Expect(nsAuth.EnvVarName).To(Equal("OTELCOL_AUTH_TOKEN_NS_NAMESPACE_1"))
+			})
+		})
+
+		Context("when monitoring resources do not have Dash0 export", func() {
+			var monitoringResources []dash0v1beta1.Dash0Monitoring
+
+			BeforeEach(func() {
+				operatorConfig.Spec.Export = &dash0common.Export{
+					Dash0: &dash0common.Dash0Configuration{
+						Endpoint: EndpointDash0Test,
+						Authorization: dash0common.Authorization{
+							Token: &AuthorizationTokenTest,
+						},
+					},
+				}
+				monitoringResources = []dash0v1beta1.Dash0Monitoring{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      MonitoringResourceName,
+							Namespace: "namespace-without-dash0-export",
+						},
+						Spec: dash0v1beta1.Dash0MonitoringSpec{
+							Export: &dash0common.Export{
+								Grpc: &dash0common.GrpcConfiguration{
+									Endpoint: EndpointGrpcTest,
+								},
+							},
+						},
+					},
+				}
+			})
+
+			It("should not include namespaced authorization for monitoring resource without Dash0 export", func() {
+				result := collectDash0ExporterAuthorizations(operatorConfig, monitoringResources)
+
+				Expect(result.NamespacedDash0ExporterAuthorizations).To(BeEmpty())
+			})
+		})
+
+		Context("with multiple monitoring resources", func() {
+			var monitoringResources []dash0v1beta1.Dash0Monitoring
+
+			BeforeEach(func() {
+				operatorConfig.Spec.Export = &dash0common.Export{
+					Dash0: &dash0common.Dash0Configuration{
+						Endpoint: EndpointDash0Test,
+						Authorization: dash0common.Authorization{
+							Token: &AuthorizationTokenTest,
+						},
+					},
+				}
+				monitoringResources = []dash0v1beta1.Dash0Monitoring{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      MonitoringResourceName,
+							Namespace: "namespace-with-dash0",
+						},
+						Spec: dash0v1beta1.Dash0MonitoringSpec{
+							Export: &dash0common.Export{
+								Dash0: &dash0common.Dash0Configuration{
+									Endpoint: EndpointDash0TestAlternative,
+									Authorization: dash0common.Authorization{
+										Token: &AuthorizationTokenTestAlternative,
+									},
+								},
+							},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      MonitoringResourceName,
+							Namespace: "namespace-without-dash0",
+						},
+						Spec: dash0v1beta1.Dash0MonitoringSpec{
+							Export: &dash0common.Export{
+								Http: &dash0common.HttpConfiguration{
+									Endpoint: EndpointHttpTest,
+								},
+							},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      MonitoringResourceName,
+							Namespace: "another-namespace-with-dash0",
+						},
+						Spec: dash0v1beta1.Dash0MonitoringSpec{
+							Export: &dash0common.Export{
+								Dash0: &dash0common.Dash0Configuration{
+									Endpoint: EndpointDash0Test,
+									Authorization: dash0common.Authorization{
+										SecretRef: &SecretRefTest,
+									},
+								},
+							},
+						},
+					},
+				}
+			})
+
+			It("should include authorizations only for monitoring resources with Dash0 export", func() {
+				result := collectDash0ExporterAuthorizations(operatorConfig, monitoringResources)
+
+				Expect(result.NamespacedDash0ExporterAuthorizations).NotTo(BeNil())
+				Expect(result.NamespacedDash0ExporterAuthorizations).To(HaveLen(2))
+				Expect(result.NamespacedDash0ExporterAuthorizations).To(HaveKey("namespace-with-dash0"))
+				Expect(result.NamespacedDash0ExporterAuthorizations).To(HaveKey("another-namespace-with-dash0"))
+				Expect(result.NamespacedDash0ExporterAuthorizations).NotTo(HaveKey("namespace-without-dash0"))
+			})
+
+			It("should generate correct env var names for each namespace", func() {
+				result := collectDash0ExporterAuthorizations(operatorConfig, monitoringResources)
+
+				ns1Auth := result.NamespacedDash0ExporterAuthorizations["namespace-with-dash0"]
+				Expect(ns1Auth.EnvVarName).To(Equal("OTELCOL_AUTH_TOKEN_NS_NAMESPACE_WITH_DASH0"))
+
+				ns2Auth := result.NamespacedDash0ExporterAuthorizations["another-namespace-with-dash0"]
+				Expect(ns2Auth.EnvVarName).To(Equal("OTELCOL_AUTH_TOKEN_NS_ANOTHER_NAMESPACE_WITH_DASH0"))
+			})
+		})
+
+		Context("when monitoring resource has nil export", func() {
+			var monitoringResources []dash0v1beta1.Dash0Monitoring
+
+			BeforeEach(func() {
+				operatorConfig.Spec.Export = &dash0common.Export{
+					Dash0: &dash0common.Dash0Configuration{
+						Endpoint: EndpointDash0Test,
+						Authorization: dash0common.Authorization{
+							Token: &AuthorizationTokenTest,
+						},
+					},
+				}
+				monitoringResources = []dash0v1beta1.Dash0Monitoring{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      MonitoringResourceName,
+							Namespace: "namespace-with-nil-export",
+						},
+						Spec: dash0v1beta1.Dash0MonitoringSpec{
+							Export: nil,
+						},
+					},
+				}
+			})
+
+			It("should not include namespaced authorization for monitoring resource with nil export", func() {
+				result := collectDash0ExporterAuthorizations(operatorConfig, monitoringResources)
+
+				Expect(result.NamespacedDash0ExporterAuthorizations).To(BeEmpty())
+			})
+		})
+	})
+})

--- a/internal/collectors/otelcolresources/daemonset.config.yaml.template
+++ b/internal/collectors/otelcolresources/daemonset.config.yaml.template
@@ -19,6 +19,9 @@ them also have to be avoided.
 Note that the first option will also consume _all_ preceding line breaks, so if a line break is desired in the output,
 use option 2.
 */}}
+
+{{- $root := . -}}
+
 extensions:
   health_check:
     endpoint: "{{ .SelfIpReference }}:13133"
@@ -29,11 +32,55 @@ extensions:
   pprof: {}
   {{- end }}
 
-
 connectors:
-  forward/metrics: {}
-  forward/logs: {}
+  forward/traces-processors: {}
+  forward/metrics-processors: {}
+  forward/logs-processors: {}
+  forward/traces-default-exporter: {}
+  forward/metrics-default-exporter: {}
+  forward/logs-default-exporter: {}
 
+  {{- $hasNamespacedExporters := gt (len .NamespacedExporters) 0 }}
+
+  {{- if $hasNamespacedExporters }}
+  routing/traces:
+    default_pipelines: [traces/export/default]
+    error_mode: ignore
+    table:
+    {{- range $ns, $exporters := .NamespacedExporters }}
+      - context: resource
+        condition: attributes["k8s.namespace.name"] == "{{ $ns }}"
+        pipelines:
+        {{- range $i, $exporter := $exporters }}
+          - traces/export/ns/{{ $ns }}
+        {{- end }}
+    {{- end }}
+  routing/metrics:
+    default_pipelines: [metrics/export/default]
+    error_mode: ignore
+    table:
+    {{- range $ns, $exporters := .NamespacedExporters }}
+      - context: resource
+        condition: attributes["k8s.namespace.name"] == "{{ $ns }}"
+        pipelines:
+        {{- range $i, $exporter := $exporters }}
+          - metrics/export/ns/{{ $ns }}
+        {{- end }}
+    {{- end }}
+  routing/logs:
+    default_pipelines: [logs/export/default]
+    error_mode: ignore
+    table:
+    {{- range $ns, $exporters := .NamespacedExporters }}
+      - context: resource
+        condition: attributes["k8s.namespace.name"] == "{{ $ns }}"
+
+        pipelines:
+        {{- range $i, $exporter := $exporters }}
+          - logs/export/ns/{{ $ns }}
+        {{- end }}
+    {{- end }}
+  {{- end }}
 
 receivers:
   otlp:
@@ -44,32 +91,34 @@ receivers:
       http:
         endpoint: "{{ .SelfIpReference }}:4318"
 
-{{- if .KubeletStatsReceiverConfig.Enabled }}
+  {{- if .KubeletStatsReceiverConfig.Enabled }}
   kubeletstats:
     endpoint: '{{ .KubeletStatsReceiverConfig.Endpoint }}'
     auth_type: "{{ .KubeletStatsReceiverConfig.AuthType }}"
     collection_interval: 20s
-{{- if .KubeletStatsReceiverConfig.InsecureSkipVerify }}
+    {{- if .KubeletStatsReceiverConfig.InsecureSkipVerify }}
     insecure_skip_verify: true
-{{ end }}
-{{- /* Note: Even if we use K8s_NODE_IP for the endpoint, it is still correct to use K8S_NODE_NAME for 'node'. The node
-      value will only be used as a resource attribute. */}}
+    {{- end }}
+    {{- /*
+    Note: Even if we use K8s_NODE_IP for the endpoint, it is still correct to use K8S_NODE_NAME for 'node'. The node
+    value will only be used as a resource attribute.
+    */}}
     node: '${env:K8S_NODE_NAME}'
     metric_groups:
     - container
     - pod
     - node
     - volume
-    {{- /*
-    Collecting any metadata label requires the nodes/proxy permission, which will not be granted in GKE Autopilot
-    clusters, see:
-    - https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/kubeletstatsreceiver/scraper.go#L112
-    - https://cloud.google.com/kubernetes-engine/docs/how-to/disable-kubelet-readonly-port#:~:text=In%20Kubernetes%20clusters%2C%20including%20GKE,more%20secure%2C%20authenticated%20port%2010250%20.
-      > If your workload uses the /pods endpoint on the insecure kubelet read-only port, you need to grant the
-      > nodes/proxy RBAC permission to access the endpoint on the secure kubelet port. nodes/proxy is a powerful
-      > permission that you can't grant in GKE Autopilot clusters [...].
-    Hence, these labels are disabled on GKE autopilot.
-    */}}
+  {{- /*
+  Collecting any metadata label requires the nodes/proxy permission, which will not be granted in GKE Autopilot
+  clusters, see:
+  - https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/kubeletstatsreceiver/scraper.go#L112
+  - https://cloud.google.com/kubernetes-engine/docs/how-to/disable-kubelet-readonly-port#:~:text=In%20Kubernetes%20clusters%2C%20including%20GKE,more%20secure%2C%20authenticated%20port%2010250%20.
+    > If your workload uses the /pods endpoint on the insecure kubelet read-only port, you need to grant the
+    > nodes/proxy RBAC permission to access the endpoint on the secure kubelet port. nodes/proxy is a powerful
+    > permission that you can't grant in GKE Autopilot clusters [...].
+  Hence, these labels are disabled on GKE autopilot.
+  */}}
     {{- if not .IsGkeAutopilot }}
     extra_metadata_labels:
       - container.id
@@ -106,9 +155,9 @@ receivers:
         enabled: true
     {{- end }}
 
-{{- end }}{{/* if .KubeletStatsReceiverConfig.Enabled */}}
+  {{- end }}{{/* if .KubeletStatsReceiverConfig.Enabled */}}
 
-{{- if .UseHostMetricsReceiver }}
+  {{- if .UseHostMetricsReceiver }}
   hostmetrics:
     collection_interval: 60s
     root_path: /hostfs
@@ -176,13 +225,13 @@ receivers:
             enabled: false
           system.memory.utilization:
             enabled: true
-{{- end }}{{/* if .UseHostMetricsReceiver */}}
+  {{- end }}{{/* if .UseHostMetricsReceiver */}}
 
-{{- $hasPrometheusScrapingEnabledForAtLeastOneNamespace := gt (len .NamespacesWithPrometheusScraping) 0 }}
+  {{- $hasPrometheusScrapingEnabledForAtLeastOneNamespace := gt (len .NamespacesWithPrometheusScraping) 0 }}
 
-{{- if $hasPrometheusScrapingEnabledForAtLeastOneNamespace }}
+  {{- if $hasPrometheusScrapingEnabledForAtLeastOneNamespace }}
   prometheus:
-{{- if .PrometheusCrdSupportEnabled }}
+    {{- if .PrometheusCrdSupportEnabled }}
     target_allocator:
       {{- if .TargetAllocatorMtlsEnabled }}
       endpoint: https://{{ .TargetAllocatorServiceName }}:443
@@ -197,14 +246,14 @@ receivers:
         cert_file: {{ .TargetAllocatorMtlsClientCertsDir }}/tls.crt
         key_file: {{ .TargetAllocatorMtlsClientCertsDir }}/tls.key
       {{- end }}
-{{- end }}
+    {{- end }}
     config:
-{{- /*
-This particular set of scrape config jobs (dash0-kubernetes-pods-scrape-config and
-dash0-kubernetes-pods-scrape-config-slow) is mostly a copy of
-https://github.com/prometheus-community/helm-charts/blob/5adf0ee898e8e5430471cb43a5f9532745c22f81/charts/prometheus/values.yaml
-to be compatible with the well-known configuration via annotations.
-*/}}
+      {{- /*
+      This particular set of scrape config jobs (dash0-kubernetes-pods-scrape-config and
+      dash0-kubernetes-pods-scrape-config-slow) is mostly a copy of
+      https://github.com/prometheus-community/helm-charts/blob/5adf0ee898e8e5430471cb43a5f9532745c22f81/charts/prometheus/values.yaml
+      to be compatible with the well-known configuration via annotations.
+      */}}
       scrape_configs:
 
       # The relabeling allows the actual pod scrape endpoint to be configured via the
@@ -344,14 +393,14 @@ to be compatible with the well-known configuration via annotations.
           - source_labels: [__meta_kubernetes_pod_node_name]
             action: replace
             target_label: node
-{{- end }}
+  {{- end }}
 
-{{- if .NamespacesWithLogCollection }}
+  {{- if .NamespacesWithLogCollection }}
   filelog:
     include:
-{{- range $i, $namespace := .NamespacesWithLogCollection }}
-    - /var/log/pods/{{ $namespace }}_*/*/*.log
-{{- end}}
+    {{- range $i, $namespace := .NamespacesWithLogCollection }}
+      - /var/log/pods/{{ $namespace }}_*/*/*.log
+    {{- end}}
     storage: file_storage/filelogreceiver_offsets
     include_file_path: true
     include_file_name: false
@@ -360,15 +409,15 @@ to be compatible with the well-known configuration via annotations.
     - id: container-parser
       max_log_size: 102400
       type: container
-{{- end}}
+  {{- end}}
 
 processors:
-{{- if .SendBatchMaxSize }}
+  {{- if .SendBatchMaxSize }}
   batch:
     send_batch_max_size: {{ .SendBatchMaxSize }}
-{{- else }}
+  {{- else }}
   batch: {}
-{{- end }}
+  {{- end }}
 
   resourcedetection:
     detectors:
@@ -424,7 +473,7 @@ processors:
       # The following two work only if k8s.pod.uid and k8s.container.name are set
       - container.image.name
       - container.image.tag
-{{- if .CollectPodLabelsAndAnnotationsEnabled }}
+      {{- if .CollectPodLabelsAndAnnotationsEnabled }}
       labels:
         - tag_name: k8s.pod.label.$$1
           key_regex: (.*)
@@ -433,7 +482,7 @@ processors:
         - tag_name: k8s.pod.annotation.$$1
           key_regex: (.*)
           from: pod
-{{- end }}
+      {{- end }}
     filter:
       node_from_env_var: K8S_NODE_NAME
     passthrough: false
@@ -453,15 +502,15 @@ processors:
     error_mode: ignore
     trace_statements:
       - context: resource
-      - statements:
+        statements:
         - truncate_all(resource.attributes, 2048)
     metric_statements:
       - context: resource
-      - statements:
+        statements:
         - truncate_all(resource.attributes, 2048)
     log_statements:
       - context: resource
-      - statements:
+        statements:
         - truncate_all(resource.attributes, 2048)
 
   {{- if $hasPrometheusScrapingEnabledForAtLeastOneNamespace }}
@@ -520,7 +569,7 @@ processors:
         action: insert
   {{- end }}
 
-{{ if .NamespaceOttlFilter }}
+  {{- if .NamespaceOttlFilter }}
   # This is a standard filter which is always on; metrics collection receivers generate metrics for all namespaces in
   # the cluster, however, we only want to collect metrics from monitored namespaces, hence this filter.
   # See filter/metrics/$namespaceName filters for user-configurable filters per namespace.
@@ -528,9 +577,9 @@ processors:
     metrics:
       metric:
         - {{ .NamespaceOttlFilter }}
-{{- end }}
+  {{- end }}
 
-{{ if .CustomFilters.HasTraceFilters }}
+  {{- if .CustomFilters.HasTraceFilters }}
   filter/traces/custom_telemetry_filter:
     error_mode: {{ .CustomFilters.ErrorMode }}
     traces:
@@ -546,8 +595,8 @@ processors:
         - '{{ $condition }}'
         {{- end }}
       {{- end }}
-{{- end }}
-{{ if .CustomFilters.HasMetricFilters }}
+  {{- end }}
+  {{- if .CustomFilters.HasMetricFilters }}
   filter/metrics/custom_telemetry_filter:
     error_mode: {{ .CustomFilters.ErrorMode }}
     metrics:
@@ -563,8 +612,8 @@ processors:
         - '{{ $condition }}'
         {{- end }}
       {{- end }}
-{{ end }}
-{{ if .CustomFilters.HasLogFilters }}
+  {{- end }}
+  {{- if .CustomFilters.HasLogFilters }}
   filter/logs/custom_telemetry_filter:
     error_mode: {{ .CustomFilters.ErrorMode }}
     logs:
@@ -574,9 +623,9 @@ processors:
         - '{{ $condition }}'
         {{- end }}
       {{- end }}
-{{- end }}
+  {{- end }}
 
-{{ if .CustomTransforms.HasTraceTransforms }}
+  {{- if .CustomTransforms.HasTraceTransforms }}
   transform/traces/custom_telemetry_transform:
     error_mode: {{ .CustomTransforms.GlobalErrorMode }}
     trace_statements:
@@ -598,8 +647,8 @@ processors:
         context: {{ $group.Context }}
       {{- end }}
       {{- end }}
-{{- end }}
-{{ if .CustomTransforms.HasMetricTransforms }}
+  {{- end }}
+  {{- if .CustomTransforms.HasMetricTransforms }}
   transform/metrics/custom_telemetry_transform:
     error_mode: {{ .CustomTransforms.GlobalErrorMode }}
     metric_statements:
@@ -621,8 +670,8 @@ processors:
         context: {{ $group.Context }}
       {{- end }}
       {{- end }}
-{{- end }}
-{{ if .CustomTransforms.HasLogTransforms }}
+  {{- end }}
+  {{- if .CustomTransforms.HasLogTransforms }}
   transform/logs/custom_telemetry_transform:
     error_mode: {{ .CustomTransforms.GlobalErrorMode }}
     log_statements:
@@ -644,42 +693,64 @@ processors:
         context: {{ $group.Context }}
       {{- end }}
       {{- end }}
-{{- end }}
+  {{- end }}
 
   memory_limiter:
     check_interval: 1s
     limit_percentage: 80
     spike_limit_percentage: 25
 
-
 exporters:
-{{- if .DebugVerbosityDetailed }}
+  {{- if .DebugVerbosityDetailed }}
   debug:
     verbosity: detailed
-{{ else if .DevelopmentMode }}
+  {{- else if .DevelopmentMode }}
   debug: {}
-{{- end }}
-{{- range $i, $exporter := .Exporters }}
+  {{- end }}
+
+  {{- range $i, $exporter := .DefaultExporters }}
   {{ $exporter.Name }}:
     endpoint: "{{ $exporter.Endpoint }}"
-{{- if $exporter.Insecure }}
+    {{- if $exporter.Insecure }}
     tls:
       insecure: true
-{{- else if $exporter.InsecureSkipVerify }}
+    {{- else if $exporter.InsecureSkipVerify }}
     tls:
       insecure_skip_verify: true
-{{- end }}
-{{- if $exporter.Headers }}
+    {{- end }}
+    {{- if $exporter.Headers }}
     headers:
-{{- range $i, $header := $exporter.Headers }}
+      {{- range $i, $header := $exporter.Headers }}
       "{{ $header.Name }}": "{{ $header.Value }}"
-{{- end }}
-{{- end }}
-{{- if $exporter.Encoding }}
+      {{- end }}
+    {{- end }}
+    {{- if $exporter.Encoding }}
     encoding: "{{ $exporter.Encoding }}"
-{{- end }}
-{{- end }}
+    {{- end }}
+  {{- end }}
 
+  {{- range $ns, $exporters := .NamespacedExporters }}
+  {{- range $i, $exporter := $exporters }}
+  {{ $exporter.Name }}:
+    endpoint: "{{ $exporter.Endpoint }}"
+    {{- if $exporter.Insecure }}
+    tls:
+      insecure: true
+    {{- else if $exporter.InsecureSkipVerify }}
+    tls:
+      insecure_skip_verify: true
+    {{- end }}
+    {{- if $exporter.Headers }}
+    headers:
+      {{- range $i, $header := $exporter.Headers }}
+      "{{ $header.Name }}": "{{ $header.Value }}"
+      {{- end }}
+    {{- end }}
+    {{- if $exporter.Encoding }}
+    encoding: "{{ $exporter.Encoding }}"
+    {{- end }}
+  {{- end }}
+  {{- end }}
 
 service:
   extensions:
@@ -688,133 +759,221 @@ service:
   {{- if .EnableProfExtension }}
   - pprof
   {{- end }}
+
   pipelines:
-    traces/downstream:
+    traces/otlp-to-forwarder:
       receivers:
-      - otlp
+        - otlp
+      exporters:
+        - forward/traces-processors
+
+    traces/common-processors:
+      receivers:
+        - forward/traces-processors
       processors:
-      - memory_limiter
-      - resourcedetection
-      - k8sattributes
-      {{- if .ClusterName }}
-      - resource/clustername
-      {{- end }}
-      {{- if .CustomFilters.HasTraceFilters }}
-      - filter/traces/custom_telemetry_filter
-      {{- end }}
-      - batch
-      {{- if .CustomTransforms.HasTraceTransforms }}
-      - transform/traces/custom_telemetry_transform
-      {{- end }}
-      - transform/resources
+        - memory_limiter
+        - resourcedetection
+        - k8sattributes
+        {{- if .ClusterName }}
+        - resource/clustername
+        {{- end }}
+        {{- if .CustomFilters.HasTraceFilters }}
+        - filter/traces/custom_telemetry_filter
+        {{- end }}
+        - batch
+        {{- if .CustomTransforms.HasTraceTransforms }}
+        - transform/traces/custom_telemetry_transform
+        {{- end }}
+        - transform/resources
+      exporters:
+        {{- if $hasNamespacedExporters }}
+        - routing/traces
+        {{- else }}
+        - forward/traces-default-exporter
+        {{- end }}
+
+    traces/export/default:
+      receivers:
+        {{- if $hasNamespacedExporters }}
+        - routing/traces
+        {{- else }}
+        - forward/traces-default-exporter
+        {{- end}}
       exporters:
       {{- if (or .DevelopmentMode .DebugVerbosityDetailed) }}
-      - debug
+        - debug
       {{- end }}
-      {{- range $i, $exporter := .Exporters }}
-      - {{ $exporter.Name }}
+      {{- range $i, $exporter := .DefaultExporters }}
+        - {{ $exporter.Name }}
       {{- end }}
 
-    metrics/default:
+    {{- range $ns, $exporters := .NamespacedExporters }}
+    traces/export/ns/{{- $ns -}}:
       receivers:
-      - otlp
-      {{- if .KubeletStatsReceiverConfig.Enabled }}
-      - kubeletstats
-      {{- end }}
-      {{- if .UseHostMetricsReceiver }}
-      - hostmetrics
-      {{- end }}
-      processors:
-      - memory_limiter
+        - routing/traces
       exporters:
-      - forward/metrics
+      {{- if (or $root.DevelopmentMode $root.DebugVerbosityDetailed) }}
+        - debug
+      {{- end }}
+      {{- range $i, $exporter := $exporters }}
+        - {{ $exporter.Name }}
+      {{- end }}
+    {{- end }}
 
-{{- if $hasPrometheusScrapingEnabledForAtLeastOneNamespace }}
-    metrics/prometheus:
+    metrics/otlp-to-forwarder:
       receivers:
-      - prometheus
+        - otlp
+        {{- if .KubeletStatsReceiverConfig.Enabled }}
+        - kubeletstats
+        {{- end }}
+        {{- if .UseHostMetricsReceiver }}
+        - hostmetrics
+        {{- end }}
       processors:
-      - memory_limiter
-      - transform/metrics/prometheus_service_attributes
+        - memory_limiter
       exporters:
-      - forward/metrics
-{{- end }}
+        - forward/metrics-processors
 
-    metrics/downstream:
+    {{- if $hasPrometheusScrapingEnabledForAtLeastOneNamespace }}
+    metrics/prometheus-to-forwarder:
       receivers:
-      - forward/metrics
+        - prometheus
       processors:
-      - resourcedetection
-      - k8sattributes
-      {{- if .ClusterName }}
-      - resource/clustername
-      {{- end }}
-      {{- if .NamespaceOttlFilter }}
-      - filter/metrics/only_monitored_namespaces
-      {{- end }}
-      {{- if .CustomFilters.HasMetricFilters }}
-      - filter/metrics/custom_telemetry_filter
-      {{- end }}
-      - batch
-      {{- if .CustomTransforms.HasMetricTransforms }}
-      - transform/metrics/custom_telemetry_transform
-      {{- end }}
-      - transform/resources
+        - memory_limiter
+        - transform/metrics/prometheus_service_attributes
       exporters:
-      {{- if (or .DevelopmentMode .DebugVerbosityDetailed) }}
-      - debug
-      {{- end }}
-      {{- range $i, $exporter := .Exporters }}
-      - {{ $exporter.Name }}
-      {{- end }}
+        - forward/metrics-processors
+    {{- end }}
 
-    logs/otlp:
+    metrics/common-processors:
       receivers:
-      - otlp
+        - forward/metrics-processors
       processors:
-      - memory_limiter
+        - resourcedetection
+        - k8sattributes
+        {{- if .ClusterName }}
+        - resource/clustername
+        {{- end }}
+        {{- if .NamespaceOttlFilter }}
+        - filter/metrics/only_monitored_namespaces
+        {{- end }}
+        {{- if .CustomFilters.HasMetricFilters }}
+        - filter/metrics/custom_telemetry_filter
+        {{- end }}
+        - batch
+        {{- if .CustomTransforms.HasMetricTransforms }}
+        - transform/metrics/custom_telemetry_transform
+        {{- end }}
+        - transform/resources
       exporters:
-      - forward/logs
+        {{- if $hasNamespacedExporters }}
+        - routing/metrics
+        {{- else }}
+        - forward/metrics-default-exporter
+        {{- end }}
 
-{{- if .NamespacesWithLogCollection }}
-    logs/filelog:
+    metrics/export/default:
       receivers:
-      - filelog
-      processors:
-      - memory_limiter
+        {{- if $hasNamespacedExporters }}
+        - routing/metrics
+        {{- else }}
+        - forward/metrics-default-exporter
+        {{- end}}
       exporters:
-      - forward/logs
-{{- end }}
+        {{- if (or .DevelopmentMode .DebugVerbosityDetailed) }}
+        - debug
+        {{- end }}
+        {{- range $i, $exporter := .DefaultExporters }}
+        - {{ $exporter.Name }}
+        {{- end }}
 
-    logs/downstream:
+    {{- range $ns, $exporters := .NamespacedExporters }}
+    metrics/export/ns/{{- $ns -}}:
       receivers:
-      - forward/logs
-      processors:
-      - resourcedetection
-      - k8sattributes
-      {{- if .NamespacesWithLogCollection }}
-      - transform/logs/filelog_service_attributes
-      {{- end }}
-      {{- if .ClusterName }}
-      - resource/clustername
-      {{- end }}
-      {{- if .CustomFilters.HasLogFilters }}
-      - filter/logs/custom_telemetry_filter
-      {{- end }}
-      - batch
-      {{- if .CustomTransforms.HasLogTransforms }}
-      - transform/logs/custom_telemetry_transform
-      {{- end }}
-      - transform/resources
+        - routing/metrics
       exporters:
-      {{- if (or .DevelopmentMode .DebugVerbosityDetailed) }}
-      - debug
+        {{- if (or $root.DevelopmentMode $root.DebugVerbosityDetailed) }}
+        - debug
+        {{- end }}
+        {{- range $i, $exporter := $exporters }}
+        - {{ $exporter.Name }}
       {{- end }}
-      {{- range $i, $exporter := .Exporters }}
-      - {{ $exporter.Name }}
-      {{- end }}
+    {{- end }}
 
-{{- if .InternalTelemetryEnabled }}
+    logs/otlp-to-forwarder:
+      receivers:
+        - otlp
+      processors:
+        - memory_limiter
+      exporters:
+        - forward/logs-processors
+
+    {{- if .NamespacesWithLogCollection }}
+    logs/filelog-to-forwarder:
+      receivers:
+        - filelog
+      processors:
+        - memory_limiter
+      exporters:
+        - forward/logs-processors
+    {{- end }}
+
+    logs/common-processors:
+      receivers:
+        - forward/logs-processors
+      processors:
+        - resourcedetection
+        - k8sattributes
+        {{- if .NamespacesWithLogCollection }}
+        - transform/logs/filelog_service_attributes
+        {{- end }}
+        {{- if .ClusterName }}
+        - resource/clustername
+        {{- end }}
+        {{- if .CustomFilters.HasLogFilters }}
+        - filter/logs/custom_telemetry_filter
+        {{- end }}
+        - batch
+        {{- if .CustomTransforms.HasLogTransforms }}
+        - transform/logs/custom_telemetry_transform
+        {{- end }}
+        - transform/resources
+      exporters:
+        {{- if $hasNamespacedExporters }}
+        - routing/logs
+        {{- else }}
+        - forward/logs-default-exporter
+        {{- end }}
+
+    logs/export/default:
+      receivers:
+        {{- if $hasNamespacedExporters }}
+        - routing/logs
+        {{- else }}
+        - forward/logs-default-exporter
+        {{- end}}
+      exporters:
+        {{- if (or .DevelopmentMode .DebugVerbosityDetailed) }}
+        - debug
+        {{- end }}
+        {{- range $i, $exporter := .DefaultExporters }}
+        - {{ $exporter.Name }}
+        {{- end }}
+
+    {{- range $ns, $exporters := .NamespacedExporters }}
+    logs/export/ns/{{- $ns -}}:
+      receivers:
+        - routing/logs
+      exporters:
+        {{- if (or $root.DevelopmentMode $root.DebugVerbosityDetailed) }}
+        - debug
+        {{- end }}
+        {{- range $i, $exporter := $exporters }}
+        - {{ $exporter.Name }}
+        {{- end }}
+    {{- end }}
+
+  {{- if .InternalTelemetryEnabled }}
   telemetry:
     resource:
       "k8s.cluster.uid": "{{- .PseudoClusterUid }}"
@@ -829,10 +988,10 @@ service:
       "k8s.pod.name": "${env:K8S_POD_NAME}"
       "k8s.container.name": "opentelemetry-collector"
 
-{{- if .SelfMonitoringMetricsConfig }}
-{{- .SelfMonitoringMetricsConfig }}
-{{- end }}
-{{- if .SelfMonitoringLogsConfig }}
-{{- .SelfMonitoringLogsConfig }}
-{{- end }}
-{{- end }}
+  {{- if .SelfMonitoringMetricsConfig }}
+  {{- .SelfMonitoringMetricsConfig }}
+  {{- end }}
+  {{- if .SelfMonitoringLogsConfig }}
+  {{- .SelfMonitoringLogsConfig }}
+  {{- end }}
+  {{- end }}

--- a/internal/collectors/otelcolresources/deployment.config.yaml.template
+++ b/internal/collectors/otelcolresources/deployment.config.yaml.template
@@ -24,7 +24,7 @@ receivers:
     namespaces:
     {{- range $i, $namespace := .NamespacesWithEventCollection }}
     - '{{ $namespace }}'
-     {{- end }}
+    {{- end }}
   {{- end }}
 
 processors:
@@ -313,7 +313,7 @@ exporters:
 {{ else if .DevelopmentMode }}
   debug: {}
 {{- end }}
-{{- range $i, $exporter := .Exporters }}
+{{- range $i, $exporter := .DefaultExporters }}
   {{ $exporter.Name }}:
     endpoint: "{{ $exporter.Endpoint }}"
     {{- if $exporter.Insecure }}
@@ -345,7 +345,7 @@ service:
   pipelines:
 
     {{- if .KubernetesInfrastructureMetricsCollectionEnabled }}
-    metrics/downstream:
+    metrics/common-processors:
       receivers:
       - k8s_cluster
       processors:
@@ -370,7 +370,7 @@ service:
       {{- if (or .DevelopmentMode .DebugVerbosityDetailed) }}
       - debug
       {{- end }}
-      {{- range $i, $exporter := .Exporters }}
+      {{- range $i, $exporter := .DefaultExporters }}
       - {{ $exporter.Name }}
       {{- end }}
     {{- end }}
@@ -392,7 +392,7 @@ service:
       {{- if (or .DevelopmentMode .DebugVerbosityDetailed) }}
       - debug
       {{- end }}
-      {{- range $i, $exporter := .Exporters }}
+      {{- range $i, $exporter := .DefaultExporters }}
       - {{ $exporter.Name }}
       {{- end }}
     {{- end }}

--- a/internal/collectors/otelcolresources/desired_state.go
+++ b/internal/collectors/otelcolresources/desired_state.go
@@ -33,7 +33,9 @@ type oTelColConfig struct {
 	// the environment variable OTEL_COLLECTOR_NAME_PREFIX, which is set to the Helm release name by the operator Helm
 	// chart.
 	NamePrefix                                       string
-	Export                                           dash0common.Export
+	Exporters                                        otlpExporters
+	Authorizations                                   dash0ExporterAuthorizations
+	AllMonitoringResources                           []dash0v1beta1.Dash0Monitoring
 	SendBatchMaxSize                                 *uint32
 	SelfMonitoringConfiguration                      selfmonitoringapiaccess.SelfMonitoringConfiguration
 	KubernetesInfrastructureMetricsCollectionEnabled bool
@@ -114,8 +116,6 @@ const (
 	appKubernetesIoNameValue      = openTelemetryCollector
 	appKubernetesIoInstanceValue  = "dash0-operator"
 	appKubernetesIoManagedByValue = "dash0-operator"
-
-	authTokenEnvVarName = "AUTH_TOKEN"
 
 	configMapVolumeName            = "opentelemetry-collector-configmap"
 	collectorConfigurationYaml     = "config.yaml"
@@ -963,10 +963,10 @@ func assembleCollectorEnvVars(
 		},
 	}
 
-	if config.Export.Dash0 != nil {
+	for _, auth := range config.Authorizations.all() {
 		authTokenEnvVar, err := util.CreateEnvVarForAuthorization(
-			(*(config.Export.Dash0)).Authorization,
-			authTokenEnvVarName,
+			auth.Authorization,
+			auth.EnvVarName,
 		)
 		if err != nil {
 			return nil, err

--- a/internal/collectors/otelcolresources/exporter.go
+++ b/internal/collectors/otelcolresources/exporter.go
@@ -1,0 +1,194 @@
+// SPDX-FileCopyrightText: Copyright 2026 Dash0 Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package otelcolresources
+
+import (
+	"fmt"
+
+	dash0common "github.com/dash0hq/dash0-operator/api/operator/common"
+	dash0v1alpha1 "github.com/dash0hq/dash0-operator/api/operator/v1alpha1"
+	dash0v1beta1 "github.com/dash0hq/dash0-operator/api/operator/v1beta1"
+	"github.com/dash0hq/dash0-operator/internal/util"
+	"github.com/go-logr/logr"
+)
+
+type otlpExporter struct {
+	Name               string
+	Endpoint           string
+	Headers            []dash0common.Header
+	Encoding           string
+	Insecure           bool
+	InsecureSkipVerify bool
+}
+
+type defaultOtlpExporters = []otlpExporter
+
+type namespacedOtlpExporters = map[string][]otlpExporter
+
+type otlpExporters struct {
+	Default    defaultOtlpExporters
+	Namespaced namespacedOtlpExporters
+}
+
+const (
+	dash0ExporterNamePrefix = "otlp/dash0"
+	grpcExporterNamePrefix  = "otlp/grpc"
+	httpExporterNamePrefix  = "otlphttp"
+)
+
+func getDefaultOtlpExporters(dash0Config *dash0v1alpha1.Dash0OperatorConfiguration) ([]otlpExporter, error) {
+	return convertExportSettingsToExporterList(dash0Config.Spec.Export, true, nil)
+}
+
+// getNamespacedOtlpExporters will log and continue on errors. If a namespace has invalid exporter settings, the
+// remaining namespaces will still be handled correctly. For the invalid namespace, the default exporters will be used.
+func getNamespacedOtlpExporters(allMonitoringResources []dash0v1beta1.Dash0Monitoring, logger *logr.Logger) namespacedOtlpExporters {
+	nsExporters := make(map[string][]otlpExporter, len(allMonitoringResources))
+	for _, monitoringResource := range allMonitoringResources {
+		if monitoringResource.Spec.Export == nil {
+			continue
+		}
+		ns := monitoringResource.Namespace
+		otlpExporters, err := convertExportSettingsToExporterList(monitoringResource.Spec.Export, false, &ns)
+		if err != nil {
+			logger.Error(err, fmt.Sprintf("Custom exporters for namespace %s could not be applied. "+
+				"Default exporters will be used for this namespace.", ns))
+		} else {
+			nsExporters[ns] = otlpExporters
+		}
+	}
+	return nsExporters
+}
+
+func convertExportSettingsToExporterList(export *dash0common.Export, isDefault bool, namespace *string) ([]otlpExporter, error) {
+	if export == nil {
+		return nil, nil
+	}
+	if !isDefault && namespace == nil {
+		return nil, fmt.Errorf("no valid nameSuffix provided for namespaced exporter, unable to create OpenTelemetry collector")
+	}
+
+	var nameSuffix string
+	if isDefault {
+		nameSuffix = "default"
+	} else {
+		nameSuffix = namespaceToNameSuffix(*namespace)
+	}
+
+	var exporters []otlpExporter
+
+	if export.Dash0 == nil && export.Grpc == nil && export.Http == nil {
+		return nil, fmt.Errorf("%s no exporter configuration found", commonExportErrorPrefix)
+	}
+
+	if export.Dash0 != nil {
+		var envVarName string
+		if isDefault {
+			envVarName = authEnvVarNameDefault
+		} else {
+			envVarName = authEnvVarNameForNs(*namespace)
+		}
+		dash0Exporter, err := convertDash0ExporterToOtlpExporter(export.Dash0, nameSuffix, envVarName)
+		if err != nil {
+			return nil, err
+		}
+		exporters = append(exporters, *dash0Exporter)
+	}
+
+	if export.Grpc != nil {
+		grpcExporter, err := convertGrpcExporterToOtlpExporter(export.Grpc, nameSuffix)
+		if err != nil {
+			return nil, err
+		}
+		exporters = append(exporters, *grpcExporter)
+	}
+
+	if export.Http != nil {
+		httpExporter, err := convertHttpExporterToOtlpExporter(export.Http, nameSuffix)
+		if err != nil {
+			return nil, err
+		}
+		exporters = append(exporters, *httpExporter)
+	}
+
+	return exporters, nil
+}
+
+func convertDash0ExporterToOtlpExporter(d0 *dash0common.Dash0Configuration, nameSuffix string, authEnvVarName string) (*otlpExporter, error) {
+	if d0.Endpoint == "" {
+		return nil, fmt.Errorf("no endpoint provided for the Dash0 exporter, unable to create the OpenTelemetry collector")
+	}
+	headers := []dash0common.Header{{
+		Name:  util.AuthorizationHeaderName,
+		Value: authHeaderValue(authEnvVarName),
+	}}
+	if d0.Dataset != "" && d0.Dataset != util.DatasetDefault {
+		headers = append(headers, dash0common.Header{
+			Name:  util.Dash0DatasetHeaderName,
+			Value: d0.Dataset,
+		})
+	}
+	dash0Exporter := otlpExporter{
+		Name:     fmt.Sprintf("%s/%s", dash0ExporterNamePrefix, nameSuffix),
+		Endpoint: d0.Endpoint,
+		Headers:  headers,
+	}
+	setGrpcTlsFromPrefix(d0.Endpoint, &dash0Exporter)
+	return &dash0Exporter, nil
+}
+
+func convertGrpcExporterToOtlpExporter(grpc *dash0common.GrpcConfiguration, nameSuffix string) (*otlpExporter, error) {
+	if grpc.Endpoint == "" {
+		return nil, fmt.Errorf("no endpoint provided for the gRPC exporter, unable to create the OpenTelemetry collector")
+	}
+	grpcExporter := otlpExporter{
+		Name:     fmt.Sprintf("%s/%s", grpcExporterNamePrefix, nameSuffix),
+		Endpoint: grpc.Endpoint,
+		Headers:  grpc.Headers,
+	}
+	if grpc.Insecure != nil {
+		grpcExporter.Insecure = *grpc.Insecure
+	} else {
+		setGrpcTlsFromPrefix(grpc.Endpoint, &grpcExporter)
+	}
+	setInsecureSkipVerify(grpc.Endpoint, grpc.InsecureSkipVerify, &grpcExporter)
+	if len(grpc.Headers) > 0 {
+		grpcExporter.Headers = grpc.Headers
+	}
+	return &grpcExporter, nil
+}
+
+func convertHttpExporterToOtlpExporter(http *dash0common.HttpConfiguration, nameSuffix string) (*otlpExporter, error) {
+	if http.Endpoint == "" {
+		return nil, fmt.Errorf("no endpoint provided for the HTTP exporter, unable to create the OpenTelemetry collector")
+	}
+	if http.Encoding == "" {
+		return nil, fmt.Errorf("no encoding provided for the HTTP exporter, unable to create the OpenTelemetry collector")
+	}
+	encoding := string(http.Encoding)
+	httpExporter := otlpExporter{
+		Name:     fmt.Sprintf("%s/%s/%s", httpExporterNamePrefix, nameSuffix, encoding),
+		Endpoint: http.Endpoint,
+		Encoding: encoding,
+	}
+	setInsecureSkipVerify(http.Endpoint, http.InsecureSkipVerify, &httpExporter)
+	if len(http.Headers) > 0 {
+		httpExporter.Headers = http.Headers
+	}
+	return &httpExporter, nil
+}
+
+func setInsecureSkipVerify(endpoint string, insecureSkipVerify *bool, exporter *otlpExporter) {
+	if !hasNonTlsPrefix(endpoint) && util.ReadBoolPointerWithDefault(insecureSkipVerify, false) {
+		exporter.InsecureSkipVerify = true
+	}
+}
+
+func namespaceToNameSuffix(namespace string) string {
+	return fmt.Sprintf("ns/%s", namespace)
+}
+
+func authHeaderValue(envVarName string) string {
+	return fmt.Sprintf("Bearer ${env:%s}", envVarName)
+}

--- a/internal/collectors/otelcolresources/exporter_test.go
+++ b/internal/collectors/otelcolresources/exporter_test.go
@@ -1,0 +1,626 @@
+// SPDX-FileCopyrightText: Copyright 2026 Dash0 Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package otelcolresources
+
+import (
+	"github.com/go-logr/logr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	dash0common "github.com/dash0hq/dash0-operator/api/operator/common"
+	dash0v1alpha1 "github.com/dash0hq/dash0-operator/api/operator/v1alpha1"
+	dash0v1beta1 "github.com/dash0hq/dash0-operator/api/operator/v1beta1"
+	"github.com/dash0hq/dash0-operator/internal/util"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	. "github.com/dash0hq/dash0-operator/test/util"
+)
+
+// Test helper functions (existing)
+func DefaultOtlpExportersTest() []otlpExporter {
+	return []otlpExporter{{
+		Name:     "otlp/dash0/default",
+		Endpoint: EndpointDash0Test,
+		Headers: []dash0common.Header{
+			{
+				Name:  util.AuthorizationHeaderName,
+				Value: AuthorizationTokenTest,
+			},
+		},
+	},
+	}
+}
+
+func DefaultOtlpExportersWithCustomDatasetTest() []otlpExporter {
+	return []otlpExporter{{
+		Name:     "otlp/dash0/default",
+		Endpoint: EndpointDash0Test,
+		Headers: []dash0common.Header{
+			{
+				Name:  util.AuthorizationHeaderName,
+				Value: AuthorizationTokenTest,
+			},
+			{
+				Name:  util.Dash0DatasetHeaderName,
+				Value: DatasetCustomTest,
+			},
+		},
+	},
+	}
+}
+
+func DefaultOtlpExportersWithGrpc() []otlpExporter {
+	return []otlpExporter{{
+		Name:     "otlp/grpc/default",
+		Endpoint: EndpointDash0Test,
+		Headers: []dash0common.Header{
+			{
+				Name:  "Key",
+				Value: "Value",
+			},
+		},
+	},
+	}
+}
+
+func DefaultOtlpExportersWithHttp() []otlpExporter {
+	return []otlpExporter{{
+		Name:     "otlp/grpc/default",
+		Endpoint: EndpointDash0Test,
+		Headers: []dash0common.Header{
+			{
+				Name:  "Key",
+				Value: "Value",
+			},
+		},
+	},
+	}
+}
+
+var _ = Describe("Exporter", func() {
+
+	Describe("namespaceToNameSuffix", func() {
+		It("should convert namespace to name suffix", func() {
+			Expect(namespaceToNameSuffix("default")).To(Equal("ns/default"))
+		})
+
+		It("should handle namespace with hyphens", func() {
+			Expect(namespaceToNameSuffix("my-namespace")).To(Equal("ns/my-namespace"))
+		})
+	})
+
+	Describe("authHeaderValue", func() {
+		It("should generate correct auth header value for default env var", func() {
+			result := authHeaderValue(authEnvVarNameDefault)
+			Expect(result).To(Equal("Bearer ${env:OTELCOL_AUTH_TOKEN_DEFAULT}"))
+		})
+
+		It("should generate correct auth header value for namespaced env var", func() {
+			envVarName := authEnvVarNameForNs("test-namespace")
+			result := authHeaderValue(envVarName)
+			Expect(result).To(Equal("Bearer ${env:OTELCOL_AUTH_TOKEN_NS_TEST_NAMESPACE}"))
+		})
+	})
+
+	Describe("ConvertDash0ExporterToOtlpExporter", func() {
+		It("should convert Dash0 config to OTLP exporter with default suffix", func() {
+			d0Config := &dash0common.Dash0Configuration{
+				Endpoint: EndpointDash0Test,
+				Authorization: dash0common.Authorization{
+					Token: &AuthorizationTokenTest,
+				},
+			}
+
+			exporter, err := convertDash0ExporterToOtlpExporter(d0Config, "default", authEnvVarNameDefault)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(exporter).NotTo(BeNil())
+			Expect(exporter.Name).To(Equal("otlp/dash0/default"))
+			Expect(exporter.Endpoint).To(Equal(EndpointDash0Test))
+			Expect(exporter.Headers).To(HaveLen(1))
+			Expect(exporter.Headers[0].Name).To(Equal(util.AuthorizationHeaderName))
+			Expect(exporter.Headers[0].Value).To(Equal("Bearer ${env:OTELCOL_AUTH_TOKEN_DEFAULT}"))
+		})
+
+		It("should convert Dash0 config with custom dataset", func() {
+			d0Config := &dash0common.Dash0Configuration{
+				Endpoint: EndpointDash0Test,
+				Dataset:  DatasetCustomTest,
+				Authorization: dash0common.Authorization{
+					Token: &AuthorizationTokenTest,
+				},
+			}
+
+			exporter, err := convertDash0ExporterToOtlpExporter(d0Config, "default", authEnvVarNameDefault)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(exporter.Headers).To(HaveLen(2))
+			Expect(exporter.Headers[1].Name).To(Equal(util.Dash0DatasetHeaderName))
+			Expect(exporter.Headers[1].Value).To(Equal(DatasetCustomTest))
+		})
+
+		It("should not add dataset header for default dataset", func() {
+			d0Config := &dash0common.Dash0Configuration{
+				Endpoint: EndpointDash0Test,
+				Dataset:  util.DatasetDefault,
+				Authorization: dash0common.Authorization{
+					Token: &AuthorizationTokenTest,
+				},
+			}
+
+			exporter, err := convertDash0ExporterToOtlpExporter(d0Config, "default", authEnvVarNameDefault)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(exporter.Headers).To(HaveLen(1))
+		})
+
+		It("should return error when endpoint is empty", func() {
+			d0Config := &dash0common.Dash0Configuration{
+				Endpoint: "",
+				Authorization: dash0common.Authorization{
+					Token: &AuthorizationTokenTest,
+				},
+			}
+
+			exporter, err := convertDash0ExporterToOtlpExporter(d0Config, "default", authEnvVarNameDefault)
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("no endpoint provided"))
+			Expect(exporter).To(BeNil())
+		})
+
+		It("should use namespace suffix for namespaced exporter", func() {
+			d0Config := &dash0common.Dash0Configuration{
+				Endpoint: EndpointDash0Test,
+				Authorization: dash0common.Authorization{
+					Token: &AuthorizationTokenTest,
+				},
+			}
+			nsEnvVar := authEnvVarNameForNs("my-namespace")
+
+			exporter, err := convertDash0ExporterToOtlpExporter(d0Config, "ns/my-namespace", nsEnvVar)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(exporter.Name).To(Equal("otlp/dash0/ns/my-namespace"))
+			Expect(exporter.Headers[0].Value).To(Equal("Bearer ${env:OTELCOL_AUTH_TOKEN_NS_MY_NAMESPACE}"))
+		})
+
+		It("should set insecure for http:// endpoint", func() {
+			d0Config := &dash0common.Dash0Configuration{
+				Endpoint: "http://insecure-endpoint:4317",
+				Authorization: dash0common.Authorization{
+					Token: &AuthorizationTokenTest,
+				},
+			}
+
+			exporter, err := convertDash0ExporterToOtlpExporter(d0Config, "default", authEnvVarNameDefault)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(exporter.Insecure).To(BeTrue())
+		})
+	})
+
+	Describe("ConvertGrpcExporterToOtlpExporter", func() {
+		It("should convert gRPC config to OTLP exporter", func() {
+			grpcConfig := &dash0common.GrpcConfiguration{
+				Endpoint: EndpointGrpcTest,
+				Headers: []dash0common.Header{
+					{Name: "Key", Value: "Value"},
+				},
+			}
+
+			exporter, err := convertGrpcExporterToOtlpExporter(grpcConfig, "default")
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(exporter).NotTo(BeNil())
+			Expect(exporter.Name).To(Equal("otlp/grpc/default"))
+			Expect(exporter.Endpoint).To(Equal(EndpointGrpcTest))
+			Expect(exporter.Headers).To(HaveLen(1))
+			Expect(exporter.Headers[0].Name).To(Equal("Key"))
+		})
+
+		It("should return error when endpoint is empty", func() {
+			grpcConfig := &dash0common.GrpcConfiguration{
+				Endpoint: "",
+			}
+
+			exporter, err := convertGrpcExporterToOtlpExporter(grpcConfig, "default")
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("no endpoint provided for the gRPC exporter"))
+			Expect(exporter).To(BeNil())
+		})
+
+		It("should respect explicit insecure setting", func() {
+			insecure := true
+			grpcConfig := &dash0common.GrpcConfiguration{
+				Endpoint: "https://secure-endpoint:4317",
+				Insecure: &insecure,
+			}
+
+			exporter, err := convertGrpcExporterToOtlpExporter(grpcConfig, "default")
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(exporter.Insecure).To(BeTrue())
+		})
+
+		It("should set insecure for http:// endpoint when not explicitly set", func() {
+			grpcConfig := &dash0common.GrpcConfiguration{
+				Endpoint: "http://insecure-endpoint:4317",
+			}
+
+			exporter, err := convertGrpcExporterToOtlpExporter(grpcConfig, "default")
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(exporter.Insecure).To(BeTrue())
+		})
+
+		It("should set insecureSkipVerify when specified for https endpoint", func() {
+			skipVerify := true
+			grpcConfig := &dash0common.GrpcConfiguration{
+				Endpoint:           "https://endpoint:4317",
+				InsecureSkipVerify: &skipVerify,
+			}
+
+			exporter, err := convertGrpcExporterToOtlpExporter(grpcConfig, "default")
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(exporter.InsecureSkipVerify).To(BeTrue())
+		})
+
+		It("should not set insecureSkipVerify for http endpoint even if specified", func() {
+			skipVerify := true
+			grpcConfig := &dash0common.GrpcConfiguration{
+				Endpoint:           "http://endpoint:4317",
+				InsecureSkipVerify: &skipVerify,
+			}
+
+			exporter, err := convertGrpcExporterToOtlpExporter(grpcConfig, "default")
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(exporter.InsecureSkipVerify).To(BeFalse())
+		})
+
+		It("should use namespace suffix for namespaced exporter", func() {
+			grpcConfig := &dash0common.GrpcConfiguration{
+				Endpoint: EndpointGrpcTest,
+			}
+
+			exporter, err := convertGrpcExporterToOtlpExporter(grpcConfig, "ns/test-namespace")
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(exporter.Name).To(Equal("otlp/grpc/ns/test-namespace"))
+		})
+	})
+
+	Describe("ConvertHttpExporterToOtlpExporter", func() {
+		It("should convert HTTP config with proto encoding to OTLP exporter", func() {
+			httpConfig := &dash0common.HttpConfiguration{
+				Endpoint: EndpointHttpTest,
+				Encoding: dash0common.Proto,
+				Headers: []dash0common.Header{
+					{Name: "Key", Value: "Value"},
+				},
+			}
+
+			exporter, err := convertHttpExporterToOtlpExporter(httpConfig, "default")
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(exporter).NotTo(BeNil())
+			Expect(exporter.Name).To(Equal("otlphttp/default/proto"))
+			Expect(exporter.Endpoint).To(Equal(EndpointHttpTest))
+			Expect(exporter.Encoding).To(Equal("proto"))
+			Expect(exporter.Headers).To(HaveLen(1))
+		})
+
+		It("should convert HTTP config with json encoding to OTLP exporter", func() {
+			httpConfig := &dash0common.HttpConfiguration{
+				Endpoint: EndpointHttpTest,
+				Encoding: dash0common.Json,
+			}
+
+			exporter, err := convertHttpExporterToOtlpExporter(httpConfig, "default")
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(exporter.Name).To(Equal("otlphttp/default/json"))
+			Expect(exporter.Encoding).To(Equal("json"))
+		})
+
+		It("should return error when endpoint is empty", func() {
+			httpConfig := &dash0common.HttpConfiguration{
+				Endpoint: "",
+				Encoding: dash0common.Proto,
+			}
+
+			exporter, err := convertHttpExporterToOtlpExporter(httpConfig, "default")
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("no endpoint provided for the HTTP exporter"))
+			Expect(exporter).To(BeNil())
+		})
+
+		It("should return error when encoding is empty", func() {
+			httpConfig := &dash0common.HttpConfiguration{
+				Endpoint: EndpointHttpTest,
+				Encoding: "",
+			}
+
+			exporter, err := convertHttpExporterToOtlpExporter(httpConfig, "default")
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("no encoding provided for the HTTP exporter"))
+			Expect(exporter).To(BeNil())
+		})
+
+		It("should set insecureSkipVerify when specified for https endpoint", func() {
+			skipVerify := true
+			httpConfig := &dash0common.HttpConfiguration{
+				Endpoint:           "https://endpoint:4318",
+				Encoding:           dash0common.Proto,
+				InsecureSkipVerify: &skipVerify,
+			}
+
+			exporter, err := convertHttpExporterToOtlpExporter(httpConfig, "default")
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(exporter.InsecureSkipVerify).To(BeTrue())
+		})
+
+		It("should use namespace suffix for namespaced exporter", func() {
+			httpConfig := &dash0common.HttpConfiguration{
+				Endpoint: EndpointHttpTest,
+				Encoding: dash0common.Proto,
+			}
+
+			exporter, err := convertHttpExporterToOtlpExporter(httpConfig, "ns/test-namespace")
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(exporter.Name).To(Equal("otlphttp/ns/test-namespace/proto"))
+		})
+	})
+
+	Describe("ConvertExportSettingsToExporterList", func() {
+		Context("with nil export", func() {
+			It("should return nil when export is nil", func() {
+				exporters, err := convertExportSettingsToExporterList(nil, true, nil)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(exporters).To(BeNil())
+			})
+		})
+
+		Context("with default exporter", func() {
+			It("should convert Dash0 export settings", func() {
+				export := Dash0ExportWithEndpointAndToken()
+
+				exporters, err := convertExportSettingsToExporterList(export, true, nil)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(exporters).To(HaveLen(1))
+				Expect(exporters[0].Name).To(Equal("otlp/dash0/default"))
+			})
+
+			It("should convert gRPC export settings", func() {
+				export := GrpcExportTest()
+
+				exporters, err := convertExportSettingsToExporterList(export, true, nil)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(exporters).To(HaveLen(1))
+				Expect(exporters[0].Name).To(Equal("otlp/grpc/default"))
+			})
+
+			It("should convert HTTP export settings", func() {
+				export := HttpExportTest()
+
+				exporters, err := convertExportSettingsToExporterList(export, true, nil)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(exporters).To(HaveLen(1))
+				Expect(exporters[0].Name).To(Equal("otlphttp/default/proto"))
+			})
+
+			It("should convert combined export settings", func() {
+				export := &dash0common.Export{
+					Dash0: &dash0common.Dash0Configuration{
+						Endpoint: EndpointDash0Test,
+						Authorization: dash0common.Authorization{
+							Token: &AuthorizationTokenTest,
+						},
+					},
+					Grpc: &dash0common.GrpcConfiguration{
+						Endpoint: EndpointGrpcTest,
+					},
+					Http: &dash0common.HttpConfiguration{
+						Endpoint: EndpointHttpTest,
+						Encoding: dash0common.Proto,
+					},
+				}
+
+				exporters, err := convertExportSettingsToExporterList(export, true, nil)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(exporters).To(HaveLen(3))
+			})
+
+			It("should return error when no exporter is configured", func() {
+				export := &dash0common.Export{}
+
+				exporters, err := convertExportSettingsToExporterList(export, true, nil)
+
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("no exporter configuration found"))
+				Expect(exporters).To(BeNil())
+			})
+		})
+
+		Context("with namespaced exporter", func() {
+			It("should return error when namespace is nil for non-default", func() {
+				export := Dash0ExportWithEndpointAndToken()
+
+				exporters, err := convertExportSettingsToExporterList(export, false, nil)
+
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("no valid nameSuffix provided"))
+				Expect(exporters).To(BeNil())
+			})
+
+			It("should use namespace suffix for namespaced exporter", func() {
+				export := Dash0ExportWithEndpointAndToken()
+				ns := "test-namespace"
+
+				exporters, err := convertExportSettingsToExporterList(export, false, &ns)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(exporters).To(HaveLen(1))
+				Expect(exporters[0].Name).To(Equal("otlp/dash0/ns/test-namespace"))
+			})
+		})
+	})
+
+	Describe("GetDefaultOtlpExporters", func() {
+		It("should get default exporters from operator config", func() {
+			operatorConfig := &dash0v1alpha1.Dash0OperatorConfiguration{
+				Spec: dash0v1alpha1.Dash0OperatorConfigurationSpec{
+					Export: Dash0ExportWithEndpointAndToken(),
+				},
+			}
+
+			exporters, err := getDefaultOtlpExporters(operatorConfig)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(exporters).To(HaveLen(1))
+			Expect(exporters[0].Name).To(Equal("otlp/dash0/default"))
+		})
+
+		It("should return error when no export configured", func() {
+			operatorConfig := &dash0v1alpha1.Dash0OperatorConfiguration{
+				Spec: dash0v1alpha1.Dash0OperatorConfigurationSpec{
+					Export: &dash0common.Export{},
+				},
+			}
+
+			exporters, err := getDefaultOtlpExporters(operatorConfig)
+
+			Expect(err).To(HaveOccurred())
+			Expect(exporters).To(BeNil())
+		})
+	})
+
+	Describe("GetNamespacedOtlpExporters", func() {
+		var logger logr.Logger
+
+		BeforeEach(func() {
+			logger = logr.Discard()
+		})
+
+		It("should return empty map when no monitoring resources have export", func() {
+			monitoringResources := []dash0v1beta1.Dash0Monitoring{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      MonitoringResourceName,
+						Namespace: "test-namespace",
+					},
+					Spec: dash0v1beta1.Dash0MonitoringSpec{
+						Export: nil,
+					},
+				},
+			}
+
+			exporters := getNamespacedOtlpExporters(monitoringResources, &logger)
+
+			Expect(exporters).To(BeEmpty())
+		})
+
+		It("should return exporters for monitoring resources with export", func() {
+			monitoringResources := []dash0v1beta1.Dash0Monitoring{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      MonitoringResourceName,
+						Namespace: "namespace-1",
+					},
+					Spec: dash0v1beta1.Dash0MonitoringSpec{
+						Export: Dash0ExportWithEndpointAndToken(),
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      MonitoringResourceName,
+						Namespace: "namespace-2",
+					},
+					Spec: dash0v1beta1.Dash0MonitoringSpec{
+						Export: GrpcExportTest(),
+					},
+				},
+			}
+
+			exporters := getNamespacedOtlpExporters(monitoringResources, &logger)
+
+			Expect(exporters).To(HaveLen(2))
+			Expect(exporters).To(HaveKey("namespace-1"))
+			Expect(exporters).To(HaveKey("namespace-2"))
+			Expect(exporters["namespace-1"][0].Name).To(Equal("otlp/dash0/ns/namespace-1"))
+			Expect(exporters["namespace-2"][0].Name).To(Equal("otlp/grpc/ns/namespace-2"))
+		})
+
+		It("should skip monitoring resources with nil export", func() {
+			monitoringResources := []dash0v1beta1.Dash0Monitoring{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      MonitoringResourceName,
+						Namespace: "namespace-with-export",
+					},
+					Spec: dash0v1beta1.Dash0MonitoringSpec{
+						Export: Dash0ExportWithEndpointAndToken(),
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      MonitoringResourceName,
+						Namespace: "namespace-without-export",
+					},
+					Spec: dash0v1beta1.Dash0MonitoringSpec{
+						Export: nil,
+					},
+				},
+			}
+
+			exporters := getNamespacedOtlpExporters(monitoringResources, &logger)
+
+			Expect(exporters).To(HaveLen(1))
+			Expect(exporters).To(HaveKey("namespace-with-export"))
+			Expect(exporters).NotTo(HaveKey("namespace-without-export"))
+		})
+
+		It("should continue on error and skip invalid export", func() {
+			monitoringResources := []dash0v1beta1.Dash0Monitoring{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      MonitoringResourceName,
+						Namespace: "valid-namespace",
+					},
+					Spec: dash0v1beta1.Dash0MonitoringSpec{
+						Export: Dash0ExportWithEndpointAndToken(),
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      MonitoringResourceName,
+						Namespace: "invalid-namespace",
+					},
+					Spec: dash0v1beta1.Dash0MonitoringSpec{
+						Export: &dash0common.Export{}, // empty export causes error
+					},
+				},
+			}
+
+			exporters := getNamespacedOtlpExporters(monitoringResources, &logger)
+
+			Expect(exporters).To(HaveLen(1))
+			Expect(exporters).To(HaveKey("valid-namespace"))
+			Expect(exporters).NotTo(HaveKey("invalid-namespace"))
+		})
+	})
+})

--- a/internal/controller/operator_configuration_controller.go
+++ b/internal/controller/operator_configuration_controller.go
@@ -359,8 +359,6 @@ func (r *OperatorConfigurationReconciler) reconcileOpenTelemetryCollector(
 ) error {
 	if _, err := r.collectorManager.ReconcileOpenTelemetryCollector(
 		ctx,
-		nil,
-		collectors.TriggeredByDash0ResourceReconcile,
 	); err != nil {
 		logger.Error(err, "Failed to reconcile the OpenTelemetry collector, requeuing reconcile request.")
 		return err

--- a/internal/controller/operator_configuration_controller_test.go
+++ b/internal/controller/operator_configuration_controller_test.go
@@ -244,7 +244,7 @@ var _ = Describe("The operation configuration resource controller", Ordered, fun
 
 				triggerOperatorConfigurationReconcileRequest(ctx, reconciler, OperatorConfigurationResourceName)
 
-				VerifyCollectorResources(ctx, k8sClient, operatorNamespace, EndpointDash0Test, AuthorizationTokenTest)
+				VerifyCollectorResources(ctx, k8sClient, operatorNamespace, EndpointDash0Test, AuthorizationDefaultEnvVar, AuthorizationTokenTest)
 			})
 
 			DescribeTable("it starts the OTel SDK for self-monitoring in the operator manager deployment",
@@ -555,7 +555,7 @@ var _ = Describe("The operation configuration resource controller", Ordered, fun
 		})
 
 		It("should remove the collector resources when the operator configuration resource is deleted", func() {
-			VerifyCollectorResources(ctx, k8sClient, operatorNamespace, EndpointDash0Test, AuthorizationTokenTest)
+			VerifyCollectorResources(ctx, k8sClient, operatorNamespace, EndpointDash0Test, AuthorizationDefaultEnvVar, AuthorizationTokenTest)
 
 			resource := LoadOperatorConfigurationResourceOrFail(ctx, k8sClient, Default)
 			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())

--- a/internal/predelete/operator_pre_delete_handler_test.go
+++ b/internal/predelete/operator_pre_delete_handler_test.go
@@ -53,6 +53,7 @@ var _ = Describe("Uninstalling the Dash0 operator", Ordered, func() {
 	})
 
 	BeforeEach(func() {
+		CreateDefaultOperatorConfigurationResource(ctx, k8sClient)
 		createdObjectsPreDeleteHandlerTest, deployment1 = setupNamespaceWithDash0MonitoringResourceAndWorkload(
 			ctx,
 			k8sClient,
@@ -71,6 +72,7 @@ var _ = Describe("Uninstalling the Dash0 operator", Ordered, func() {
 		createdObjectsPreDeleteHandlerTest = DeleteAllCreatedObjects(ctx, k8sClient, createdObjectsPreDeleteHandlerTest)
 		DeleteMonitoringResourceByName(ctx, k8sClient, dash0MonitoringResourceName1, false)
 		DeleteMonitoringResourceByName(ctx, k8sClient, dash0MonitoringResourceName2, false)
+		DeleteAllOperatorConfigurationResources(ctx, k8sClient)
 	})
 
 	It("should time out if the deletion of all Dash0 monitoring resources does not happen in a timely manner", func() {

--- a/internal/selfmonitoringapiaccess/self_monitoring_and_api_access.go
+++ b/internal/selfmonitoringapiaccess/self_monitoring_and_api_access.go
@@ -67,16 +67,6 @@ var (
               otlp:`
 )
 
-func (c *SelfMonitoringConfiguration) HasDash0ApiAccessConfigured() bool {
-	return c.Export.Dash0 != nil &&
-		c.Export.Dash0.ApiEndpoint != "" &&
-		(c.Export.Dash0.Authorization.Token != nil || c.Export.Dash0.Authorization.SecretRef != nil)
-}
-
-func (c *SelfMonitoringConfiguration) GetDash0Authorization() dash0common.Authorization {
-	return c.Export.Dash0.Authorization
-}
-
 func ConvertOperatorConfigurationResourceToSelfMonitoringConfiguration(
 	resource *dash0v1alpha1.Dash0OperatorConfiguration,
 	logger *logr.Logger,

--- a/test-resources/bin/lib/util
+++ b/test-resources/bin/lib/util
@@ -681,6 +681,13 @@ install_monitoring_resource() {
   fi
 }
 
+install_monitoring_resource_with_namespaced_exporter() {
+  kubectl apply -n ${target_namespace} -f test-resources/customresources/dash0monitoring/dash0monitoring-with-namespaced-exporter.yaml
+
+  echo "waiting for the monitoring resource to become available"
+  kubectl wait --namespace ${target_namespace} dash0monitorings.operator.dash0.com/dash0-monitoring-resource --for condition=Available
+}
+
 deploy_application_under_monitoring() {
   if [[ "${DEPLOY_APPLICATION_UNDER_MONITORING:-}" = "false" ]]; then
     return

--- a/test-resources/bin/render-templates.sh
+++ b/test-resources/bin/render-templates.sh
@@ -104,6 +104,19 @@ cat \
   SYNCHRONIZE_PROMETHEUS_RULES="${SYNCHRONIZE_PROMETHEUS_RULES:-true}" \
   envsubst > \
   test-resources/customresources/dash0monitoring/dash0monitoring-3.yaml
+# shellcheck disable=SC2002
+cat \
+  test-resources/customresources/dash0monitoring/dash0monitoring-with-namespaced-exporter.yaml.template | \
+  DASH0_INGRESS_ENDPOINT="$DASH0_INGRESS_ENDPOINT" \
+  DASH0_AUTHORIZATION_TOKEN="$DASH0_AUTHORIZATION_TOKEN" \
+  DASH0_API_ENDPOINT="$DASH0_API_ENDPOINT" \
+  INSTRUMENT_WORKLOADS_MODE="$INSTRUMENT_WORKLOADS_MODE" \
+  LOG_COLLECTION="$LOG_COLLECTION" \
+  PROMETHEUS_SCRAPING_ENABLED="$PROMETHEUS_SCRAPING_ENABLED" \
+  SYNCHRONIZE_PERSES_DASHBOARDS="${SYNCHRONIZE_PERSES_DASHBOARDS:-true}" \
+  SYNCHRONIZE_PROMETHEUS_RULES="${SYNCHRONIZE_PROMETHEUS_RULES:-true}" \
+  envsubst > \
+  test-resources/customresources/dash0monitoring/dash0monitoring-with-namespaced-exporter.yaml
 
 # shellcheck disable=SC2002
 cat \

--- a/test-resources/bin/test-scenario-07-namespaced-exporter.sh
+++ b/test-resources/bin/test-scenario-07-namespaced-exporter.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright 2025 Dash0 Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+# Note: to run this script, you need to set DASH0_NAMESPACED_AUTHORIZATION_TOKEN and DASH0_NAMESPACED_DATASET.
+# The dataset and token will be used in the monitoring resource of the test namespace, effectively overriding
+# the defaults from the operator configuration resource.
+
+project_root="$(dirname "${BASH_SOURCE[0]}")"/../..
+scripts_lib="test-resources/bin/lib"
+
+cd "$project_root"
+
+# shellcheck source=./lib/constants
+source "$scripts_lib/constants"
+# shellcheck source=./lib/kind
+source "$scripts_lib/kind"
+# shellcheck source=./lib/registry
+source "$scripts_lib/registry"
+
+operator_namespace="${OPERATOR_NAMESPACE:-$default_operator_ns}"
+target_namespace="${1:-$default_target_ns}"
+kind="${2:-$default_workload_kind}"
+runtime_under_test="${3:-$default_runtime}"
+additional_namespaces="false"
+
+# shellcheck source=./lib/util
+source "$scripts_lib/util"
+
+load_env_file
+verify_kubectx
+setup_test_environment
+
+step_counter=1
+
+echo "STEP $step_counter: remove old test resources"
+test-resources/bin/test-cleanup.sh "${target_namespace}" false
+finish_step
+
+echo "STEP $step_counter: creating target namespace (if necessary)"
+ensure_namespace_exists "${target_namespace}"
+finish_step
+
+echo "STEP $step_counter: creating operator namespace and authorization token secret"
+ensure_namespace_exists "$operator_namespace"
+kubectl create secret \
+  generic \
+  dash0-authorization-secret \
+  --namespace "$operator_namespace" \
+  --from-literal=token="${DASH0_AUTHORIZATION_TOKEN}"
+finish_step
+
+echo "STEP $step_counter: install third-party custom resource definitions"
+install_third_party_crds
+finish_step
+
+deploy_additional_resources
+
+deploy_dash0_api_sync_resources
+
+echo "STEP $step_counter: rebuild images"
+build_all_images
+finish_step
+
+echo "STEP $step_counter: push images"
+push_all_images
+finish_step
+
+echo "STEP $step_counter: deploy the Dash0 operator using helm"
+deploy_via_helm
+finish_step
+
+echo "STEP $step_counter: deploy the Dash0 monitoring resource to namespace ${target_namespace}"
+install_monitoring_resource_with_namespaced_exporter
+finish_step
+
+deploy_application_under_monitoring "$runtime_under_test"
+
+finish_scenario

--- a/test-resources/customresources/dash0monitoring/.gitignore
+++ b/test-resources/customresources/dash0monitoring/.gitignore
@@ -1,3 +1,4 @@
 dash0monitoring.yaml
 dash0monitoring-2.yaml
 dash0monitoring-3.yaml
+dash0monitoring-with-namespaced-exporter.yaml

--- a/test-resources/customresources/dash0monitoring/dash0monitoring-with-namespaced-exporter.yaml.template
+++ b/test-resources/customresources/dash0monitoring/dash0monitoring-with-namespaced-exporter.yaml.template
@@ -1,0 +1,14 @@
+# This resource will be deployed to the namespace test-namespace unless DEPLOY_MONITORING_RESOURCE=false has been
+# provided.
+apiVersion: operator.dash0.com/v1beta1
+kind: Dash0Monitoring
+metadata:
+  name: dash0-monitoring-resource
+spec:
+  export:
+    dash0:
+      apiEndpoint: "$DASH0_API_ENDPOINT"
+      authorization:
+        token: "$DASH0_NAMESPACED_AUTHORIZATION_TOKEN"
+      dataset: "$DASH0_NAMESPACED_DATASET"
+      endpoint: "$DASH0_INGRESS_ENDPOINT"

--- a/test/e2e/collector.go
+++ b/test/e2e/collector.go
@@ -124,6 +124,12 @@ func verifyThatCollectorIsRemovedEventually() {
 	Eventually(verifyCollectorDeploymentIsNotPresent, 60*time.Second, time.Second).Should(Succeed())
 }
 
+func verifyThatCollectorIsNotPresentConsistently() {
+	By("validating that the OpenTelemetry collector is not present consistently")
+	Consistently(verifyCollectorDaemonSetIsNotPresent, 30*time.Second, time.Second).Should(Succeed())
+	Consistently(verifyCollectorDeploymentIsNotPresent, 30*time.Second, time.Second).Should(Succeed())
+}
+
 func verifyCollectorDaemonSetIsNotPresent(g Gomega) {
 	g.Expect(runAndIgnoreOutput(
 		exec.Command(

--- a/test/e2e/dash0_monitoring_resource.go
+++ b/test/e2e/dash0_monitoring_resource.go
@@ -142,12 +142,6 @@ func deployRenderedMonitoringResourceWithRetry(
 	Expect(err).ToNot(HaveOccurred())
 
 	waitForMonitoringResourceToBecomeAvailable(namespace)
-
-	if dash0MonitoringValues.Endpoint != "" {
-		// Deploying the Dash0 monitoring with an export will trigger creating the OpenTelemetry collector resources,
-		// assuming there is no operator configuration resource with an export.
-		waitForCollectorToStart(operatorNamespace, operatorHelmChart)
-	}
 }
 
 func waitForMonitoringResourceToBecomeAvailable(namespace string) {

--- a/test/e2e/metrics.go
+++ b/test/e2e/metrics.go
@@ -30,25 +30,16 @@ var (
 	deploymentMetricsMatchConfig = metricsResourceMatchConfig{
 		expectedDeploymentName: "dash0-operator-nodejs-20-express-test-deployment",
 		expectPodUid:           true,
-		namespaceChecks: namespaceChecks{
-			failOnNamespaceOtherThan: applicationUnderTestNamespace,
-		},
 	}
 
 	workloadMetricsMatchConfig = metricsResourceMatchConfig{
 		expectedDeploymentName: "",
 		expectPodUid:           true,
-		namespaceChecks: namespaceChecks{
-			failOnNamespaceOtherThan: applicationUnderTestNamespace,
-		},
 	}
 
 	nodeMetricsMatchConfig = metricsResourceMatchConfig{
 		expectedDeploymentName: "",
 		expectPodUid:           false,
-		namespaceChecks: namespaceChecks{
-			failOnNamespaceScopedMetric: true,
-		},
 	}
 
 	matchAllConfig = metricsResourceMatchConfig{

--- a/test/e2e/spans.go
+++ b/test/e2e/spans.go
@@ -27,7 +27,7 @@ func verifySpans(
 	g Gomega,
 	runtime runtimeType,
 	workloadType workloadType,
-	route string,
+	route string, //nolint:unparam
 	query string,
 	timestampLowerBound time.Time,
 	expectClusterName bool,

--- a/test/e2e/verify_instrumentation.go
+++ b/test/e2e/verify_instrumentation.go
@@ -27,7 +27,6 @@ func verifyThatWorkloadHasBeenInstrumented(
 	testId string,
 	images Images,
 	instrumentationBy string,
-	expectClusterName bool,
 ) {
 	By(fmt.Sprintf("%s %s: waiting for the workload to get instrumented (polling its labels and events to check)",
 		runtime.runtimeTypeLabel,
@@ -70,7 +69,7 @@ func verifyThatWorkloadHasBeenInstrumented(
 			testEndpoint,
 			query,
 			timestampLowerBound,
-			expectClusterName,
+			true,
 		)
 	}, spanTimeout, pollingInterval).Should(Succeed())
 	By(fmt.Sprintf("%s %s: matching spans have been received", runtime.runtimeTypeLabel, workloadType.workloadTypeString))

--- a/test/util/constants.go
+++ b/test/util/constants.go
@@ -62,6 +62,7 @@ const (
 )
 
 var (
+	AuthorizationDefaultEnvVar         = "OTELCOL_AUTH_TOKEN_DEFAULT"
 	AuthorizationTokenTest             = "authorization-token-test"
 	AuthorizationHeaderTest            = fmt.Sprintf("Bearer %s", AuthorizationTokenTest)
 	AuthorizationTokenTestAlternative  = "authorization-token-test-alternative"


### PR DESCRIPTION
## Overview

Adds support for per-namespace export settings via the `Dash0Monitoring` resource.

The export settings from the `Dash0OperatorConfiguration` serve as defaults that can be overridden by providing an `export` in a namespace's `Dash0Monitoring`.

## How to test

Besides running the unit and e2e tests, the quickest way to test it is to create a dataset and a token with ingestion permissions for that dataset and set the env vars `DASH0_NAMESPACED_DATASET` and `DASH0_NAMESPACED_AUTHORIZATION_TOKEN` in addition to the common env vars used by the test scripts.

After that, running

```sh
test-resources/bin/test-scenario-07-namespaced-exporter.sh
```

will install the operator with a config resource using the default export config and a monitoring resource in a test namespace that uses the custom settings.

In Dash0, you should see data in both the default dataset (coming from the operator itself and cluster telemetry) and in the namespaced dataset coming from the monitored workload in that namespace.