### PR TITLE
test(test-resources): add in-process Prometheus metrics in JVM test app

### DIFF
--- a/test-resources/bin/lib/util
+++ b/test-resources/bin/lib/util
@@ -328,6 +328,9 @@ determine_test_app_images() {
   test_app_python_image_repository="${image_repository_prefix}dash0-operator-python-flask-test-app"
   test_app_python_image_tag="$image_tag"
   test_app_python_image_pull_policy="$pull_policy"
+  telemetry_matcher_image_repository="${image_repository_prefix}telemetry-matcher"
+  telemetry_matcher_image_tag="$image_tag"
+  telemetry_matcher_image_pull_policy="$pull_policy"
 
   if [[ -n "${TEST_APP_DOTNET_IMAGE_REPOSITORY:-}" ]]; then
     test_app_dotnet_image_repository="$TEST_APP_DOTNET_IMAGE_REPOSITORY"
@@ -367,6 +370,16 @@ determine_test_app_images() {
   fi
   if [[ -n "${TEST_APP_PYTHON_IMAGE_PULL_POLICY:-}" ]]; then
     test_app_python_image_pull_policy="$TEST_APP_PYTHON_IMAGE_PULL_POLICY"
+  fi
+
+  if [[ -n "${TELEMETRY_MATCHER_IMAGE_REPOSITORY:-}" ]]; then
+    telemetry_matcher_image_repository="$TELEMETRY_MATCHER_IMAGE_REPOSITORY"
+  fi
+  if [[ -n "${TELEMETRY_MATCHER_IMAGE_TAG:-}" ]]; then
+    telemetry_matcher_image_tag="$TELEMETRY_MATCHER_IMAGE_TAG"
+  fi
+  if [[ -n "${TELEMETRY_MATCHER_IMAGE_PULL_POLICY:-}" ]]; then
+    telemetry_matcher_image_pull_policy="$TELEMETRY_MATCHER_IMAGE_PULL_POLICY"
   fi
 }
 
@@ -647,7 +660,18 @@ deploy_otlp_sink_if_requested() {
     return
   fi
 
-  local helm_install_command="helm install --namespace otlp-sink --create-namespace --wait --timeout 60s otlp-sink test/e2e/otlp-sink/helm-chart"
+  local helm_install_command="helm install --namespace otlp-sink --create-namespace --wait --timeout 60s"
+  if [[ -n "$telemetry_matcher_image_repository" ]]; then
+    helm_install_command+=" --set telemetryMatcher.image.repository=$telemetry_matcher_image_repository"
+  fi
+  if [[ -n "$telemetry_matcher_image_tag" ]]; then
+    helm_install_command+=" --set telemetryMatcher.image.tag=$telemetry_matcher_image_tag"
+  fi
+  if [[ -n "$telemetry_matcher_image_pull_policy" ]]; then
+    helm_install_command+=" --set telemetryMatcher.image.pullPolicy=$telemetry_matcher_image_pull_policy"
+  fi
+
+  helm_install_command+=" otlp-sink test/e2e/otlp-sink/helm-chart"
   echo "deploying otlp-sink"
   echo "$helm_install_command"
   $helm_install_command

--- a/test-resources/jvm/spring-boot/helm-chart/templates/daemonset.yaml
+++ b/test-resources/jvm/spring-boot/helm-chart/templates/daemonset.yaml
@@ -31,6 +31,8 @@ spec:
           env:
             - name: PORT
               value: "{{ .Values.daemonset.targetPort }}"
+            - name: SIMULATE_LATENCY
+              value: "{{ .Values.simulateLatency }}"
           ports:
             - containerPort: {{ .Values.daemonset.targetPort }}
           resources:

--- a/test-resources/jvm/spring-boot/helm-chart/templates/deployment.yaml
+++ b/test-resources/jvm/spring-boot/helm-chart/templates/deployment.yaml
@@ -32,6 +32,8 @@ spec:
           env:
             - name: PORT
               value: "{{ .Values.deployment.targetPort }}"
+            - name: SIMULATE_LATENCY
+              value: "{{ .Values.simulateLatency }}"
           ports:
             - containerPort: {{ .Values.deployment.targetPort }}
           resources:

--- a/test-resources/jvm/spring-boot/helm-chart/templates/pod.yaml
+++ b/test-resources/jvm/spring-boot/helm-chart/templates/pod.yaml
@@ -23,6 +23,8 @@ spec:
       env:
         - name: PORT
           value: "{{ .Values.pod.targetPort }}"
+        - name: SIMULATE_LATENCY
+          value: "{{ .Values.simulateLatency }}"
       ports:
         - containerPort: {{ .Values.pod.targetPort }}
       resources:

--- a/test-resources/jvm/spring-boot/helm-chart/templates/replicaset.yaml
+++ b/test-resources/jvm/spring-boot/helm-chart/templates/replicaset.yaml
@@ -32,6 +32,8 @@ spec:
           env:
             - name: PORT
               value: "{{ .Values.replicaset.targetPort }}"
+            - name: SIMULATE_LATENCY
+              value: "{{ .Values.simulateLatency }}"
           ports:
             - containerPort: {{ .Values.replicaset.targetPort }}
           resources:

--- a/test-resources/jvm/spring-boot/helm-chart/templates/statefulset.yaml
+++ b/test-resources/jvm/spring-boot/helm-chart/templates/statefulset.yaml
@@ -33,6 +33,8 @@ spec:
           env:
             - name: PORT
               value: "{{ .Values.statefulset.targetPort }}"
+            - name: SIMULATE_LATENCY
+              value: "{{ .Values.simulateLatency }}"
           ports:
             - containerPort: {{ .Values.statefulset.targetPort }}
           resources:

--- a/test-resources/jvm/spring-boot/helm-chart/values.yaml
+++ b/test-resources/jvm/spring-boot/helm-chart/values.yaml
@@ -50,3 +50,5 @@ statefulset:
   targetPort: 1310
   selector: dash0-operator-jvm-spring-boot-test-statefulset-app
   ingressPath: /statefulset/jvm(/|$)(.*)
+
+simulateLatency: false

--- a/test-resources/jvm/spring-boot/pom.xml
+++ b/test-resources/jvm/spring-boot/pom.xml
@@ -26,6 +26,16 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>io.prometheus</groupId>
+			<artifactId>prometheus-metrics-core</artifactId>
+			<version>1.3.1</version>
+		</dependency>
+		<dependency>
+			<groupId>io.prometheus</groupId>
+			<artifactId>prometheus-metrics-exporter-servlet-jakarta</artifactId>
+			<version>1.3.1</version>
+		</dependency>
 	</dependencies>
 	<build>
 		<finalName>app</finalName>

--- a/test-resources/jvm/spring-boot/src/main/java/com/dash0/app_under_test/Controller.java
+++ b/test-resources/jvm/spring-boot/src/main/java/com/dash0/app_under_test/Controller.java
@@ -1,5 +1,6 @@
 package com.dash0.app_under_test;
 
+import io.prometheus.metrics.core.metrics.Histogram;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.node.ObjectNode;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,18 +13,52 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class Controller {
 
+    private static final String[] CONNECTOR_LATENCY_MILLISECONDS_LABELS = new String[]{"endpoint", "status"};
+    private static final boolean SIMULATE_LATENCY =
+        "true".equalsIgnoreCase(System.getenv("SIMULATE_LATENCY"));
+
+    private final Histogram connectorLatencyMillisecondsHistogram =
+        Histogram.builder()
+            .name("pipeline_connector_request_duration_milliseconds")
+            .help("Histogram of request durations with native histograms")
+            .nativeOnly()
+            .labelNames(CONNECTOR_LATENCY_MILLISECONDS_LABELS)
+            .register();
+
     @Autowired
     private ObjectMapper mapper;
 
     @GetMapping("/ready")
     @ResponseStatus(code = HttpStatus.NO_CONTENT)
     public void ready() {
+        long startTime = System.currentTimeMillis();
+        if (SIMULATE_LATENCY) {
+            try {
+                // Simulate some work
+                Thread.sleep((long) (Math.random() * 200));
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+        long duration = System.currentTimeMillis() - startTime;
+        connectorLatencyMillisecondsHistogram.labelValues("/ready", "success").observe(duration);
     }
 
     @GetMapping(path="/dash0-k8s-operator-test", produces= MediaType.APPLICATION_JSON_VALUE)
     public ObjectNode test() {
+        long startTime = System.currentTimeMillis();
+        if (SIMULATE_LATENCY) {
+            try {
+                // Simulate some work
+                Thread.sleep((long) (Math.random() * 10_000));
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
         ObjectNode response = mapper.createObjectNode();
         response.put("message", "We make Observability easy for every developer.");
+        long duration = System.currentTimeMillis() - startTime;
+        connectorLatencyMillisecondsHistogram.labelValues("/dash0-k8s-operator-test", "success").observe(duration);
         return response;
     }
 }

--- a/test-resources/jvm/spring-boot/src/main/java/com/dash0/app_under_test/MetricsConfiguration.java
+++ b/test-resources/jvm/spring-boot/src/main/java/com/dash0/app_under_test/MetricsConfiguration.java
@@ -1,0 +1,15 @@
+package com.dash0.app_under_test;
+
+import io.prometheus.metrics.exporter.servlet.jakarta.PrometheusMetricsServlet;
+import org.springframework.boot.web.servlet.ServletRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class MetricsConfiguration {
+
+    @Bean
+    public ServletRegistrationBean<PrometheusMetricsServlet> prometheusServlet() {
+        return new ServletRegistrationBean<>(new PrometheusMetricsServlet(), "/metrics");
+    }
+}

--- a/test/e2e/otlp-sink/helm-chart/values.yaml
+++ b/test/e2e/otlp-sink/helm-chart/values.yaml
@@ -14,7 +14,7 @@ telemetryFilesVolume:
 collector:
   image:
     repository: otel/opentelemetry-collector-contrib
-    tag: 0.139.0
+    tag: 0.143.1
 
   grpcPort: 4317
   httpPort: 4318


### PR DESCRIPTION
Set "simulateLatency: true" in
test-resources/jvm/spring-boot/helm-chart/values.yaml to get some variety for the metric values.

Also: Fix image pull policy for telemetry-matcher image when deploying via test-resources/bin/*.sh scripts.