### PR TITLE
fix(workloads): sort key-value pairs for DASH0_RESOURCE_ATTRIBUTES

### DIFF
--- a/internal/workloads/workload_modifier.go
+++ b/internal/workloads/workload_modifier.go
@@ -5,6 +5,7 @@ package workloads
 
 import (
 	"fmt"
+	"maps"
 	"reflect"
 	"slices"
 	"strings"
@@ -692,7 +693,8 @@ func (m *ResourceModifier) addEnvironmentVariables(
 	}
 	if len(resourceAttributes) > 0 {
 		var resourceAttributeList []string
-		for resourceAttributeKey, resourceAttributeValue := range resourceAttributes {
+		for _, resourceAttributeKey := range slices.Sorted(maps.Keys(resourceAttributes)) {
+			resourceAttributeValue := resourceAttributes[resourceAttributeKey]
 			resourceAttributeList = append(
 				resourceAttributeList,
 				fmt.Sprintf("%s=%s", resourceAttributeKey, resourceAttributeValue))


### PR DESCRIPTION
We need to guarantee a stable value for DASH0_RESOURCE_ATTRIBUTES, independent of the order in which resource.opentelemetry.io/* annotations are provided by Kubernetes, to make sure we are not changing the pod spec template back and forth.