### PR TITLE
feat(checkrules): merge top level metadata annotations

### DIFF
--- a/helm-chart/dash0-operator/README.md
+++ b/helm-chart/dash0-operator/README.md
@@ -1906,7 +1906,12 @@ Prometheus rules will be mapped to Dash0 check rules as follows:
 * The `interval` attribute of the group will be used for the setting "Evaluate every" for each Dash0 check rule in that
   group.
 * Other attributes in the Prometheus rule are converted to Dash0 check rule attributes as described in the table below.
-* Some annotations and labels are interpreted by Dash0, these are described in the conversion table below.
+* Top level Kubernetes annotations from the PrometheusRule metadata are added to each check rule's annotation map.
+  If the same annotation appears in both the PrometheusRule metadata and an individual rule, the annotation value in
+  the individual check rule takes priority and overrides the metadata annotation.
+  This allows defining common annotations at the PrometheusRule level and selectively override them for specific rules
+  as needed.
+* Some rule annotations and labels are interpreted by Dash0, these are described in the conversion table below.
   For example, to set the summary of the Dash0 check rule, add an annotation `summary` to the `rules` item in the
   Prometheus rule resource.
 * If `expr` contains the token `$__threshold`, and neither annotation `dash0-threshold-degraded` nor

--- a/internal/startup/operator_manager_startup.go
+++ b/internal/startup/operator_manager_startup.go
@@ -502,9 +502,9 @@ func setUpLogging(crZapOpts crzap.Opts) *zaputil.DelegatingZapCoreWrapper {
 
 	delegatingZapCoreWrapper := zaputil.NewDelegatingZapCoreWrapper()
 
-	// Multiplex log records to stdout (defaultZapCore) and also to the OTel log SDK (delegatingZapCore). Additional
-	// plot twist: The OTel logger will only be initialized later, potentially after the operator configuration has been
-	// reconciled. The delegatingZapCore will buffer all messages logged at startup up to th point when the OTel logger
+	// Send log records to stdout (defaultZapCore) and also to the OTel log SDK (delegatingZapCore). Additional plot
+	// twist: The OTel logger will only be initialized later, potentially after the operator configuration has been
+	// reconciled. The delegatingZapCore will buffer all messages logged at startup up to the point when the OTel logger
 	// is actually initialized, then re-spool them to the OTel SDK logger.
 	teeCore := zapcore.NewTee(
 		defaultZapCore,
@@ -513,7 +513,7 @@ func setUpLogging(crZapOpts crzap.Opts) *zaputil.DelegatingZapCoreWrapper {
 	crZapRawLogger := zaputil.NewRawFromCore(o, teeCore)
 	zapLogger := zapr.NewLogger(crZapRawLogger)
 
-	// Set the created multiplexing logger as the logger for the controller-runtime package.
+	// Set the created tee logger as the logger for the controller-runtime package.
 	ctrl.SetLogger(zapLogger)
 
 	setupLog = ctrl.Log.WithName("setup")


### PR DESCRIPTION
Merge top level metadata annotations with the rule annotations in individual check rules. This allows to put common annotations into the PrometheusRule's metadata annotations instead of repeating them in every rule.