### PR TITLE
chore(collectors): optimize processor order for k8s_events pipeline

### DIFF
--- a/internal/collectors/otelcolresources/deployment.config.yaml.template
+++ b/internal/collectors/otelcolresources/deployment.config.yaml.template
@@ -467,14 +467,14 @@ service:
       receivers:
         - k8s_events
       processors:
+        - memory_limiter
         - transform/k8s_events
         - k8sattributes
         {{- if .ClusterName }}
         - resource/clustername
         {{- end }}
-        - transform/resources
-        - memory_limiter
         - batch
+        - transform/resources
       exporters:
         {{- if $hasNamespacedExporters }}
         - routing/logs


### PR DESCRIPTION
This is a follow up to 8bda420d11185e0c94bbd5231b59b49160bba292 and aligns the order of processors in the deployment collector's log pipeline (i.e. the pipeline for the k8s_events receiver's data) with all other pipelines:
* move memory_limiter to the start of the pipelines
* move batch processor between filters and transforms