### PR TITLE
chore: update deprecated otlp exporter names

### DIFF
--- a/internal/collectors/otelcolresources/collector_config_maps_test.go
+++ b/internal/collectors/otelcolresources/collector_config_maps_test.go
@@ -261,7 +261,7 @@ var _ = Describe("The OpenTelemetry Collector ConfigMaps", func() {
 			exporters := exportersRaw.(map[string]interface{})
 			Expect(exporters).To(HaveLen(1))
 
-			exporter := exporters["otlp/dash0/default"]
+			exporter := exporters["otlp_grpc/dash0/default"]
 			Expect(exporter).ToNot(BeNil())
 			dash0OtlpExporter := exporter.(map[string]interface{})
 			Expect(dash0OtlpExporter).ToNot(BeNil())
@@ -291,7 +291,7 @@ var _ = Describe("The OpenTelemetry Collector ConfigMaps", func() {
 			exporters := exportersRaw.(map[string]interface{})
 			Expect(exporters).To(HaveLen(1))
 
-			exporter := exporters["otlp/dash0/default"]
+			exporter := exporters["otlp_grpc/dash0/default"]
 			Expect(exporter).ToNot(BeNil())
 			dash0OtlpExporter := exporter.(map[string]interface{})
 			Expect(dash0OtlpExporter).ToNot(BeNil())
@@ -326,7 +326,7 @@ var _ = Describe("The OpenTelemetry Collector ConfigMaps", func() {
 			debugExporter := debugExporterRaw.(map[string]interface{})
 			Expect(debugExporter).To(HaveLen(0))
 
-			exporter := exporters["otlp/dash0/default"]
+			exporter := exporters["otlp_grpc/dash0/default"]
 			Expect(exporter).ToNot(BeNil())
 			dash0OtlpExporter := exporter.(map[string]interface{})
 			Expect(dash0OtlpExporter).ToNot(BeNil())
@@ -422,7 +422,7 @@ var _ = Describe("The OpenTelemetry Collector ConfigMaps", func() {
 			Expect(exporters).To(HaveLen(2))
 
 			// Verify Dash0 exporter
-			dash0Exporter := exporters["otlp/dash0/default"]
+			dash0Exporter := exporters["otlp_grpc/dash0/default"]
 			Expect(dash0Exporter).ToNot(BeNil())
 			dash0OtlpExporter := dash0Exporter.(map[string]interface{})
 			Expect(dash0OtlpExporter["endpoint"]).To(Equal(EndpointDash0Test))
@@ -432,7 +432,7 @@ var _ = Describe("The OpenTelemetry Collector ConfigMaps", func() {
 			Expect(headers[util.AuthorizationHeaderName]).To(Equal(bearerWithAuthToken))
 
 			// Verify gRPC exporter
-			grpcExporter := exporters["otlp/grpc/default"]
+			grpcExporter := exporters["otlp_grpc/default"]
 			Expect(grpcExporter).ToNot(BeNil())
 			grpcOtlpExporter := grpcExporter.(map[string]interface{})
 			Expect(grpcOtlpExporter["endpoint"]).To(Equal(EndpointGrpcTest))
@@ -458,13 +458,13 @@ var _ = Describe("The OpenTelemetry Collector ConfigMaps", func() {
 			Expect(exporters).To(HaveLen(2))
 
 			// Verify Dash0 exporter
-			dash0Exporter := exporters["otlp/dash0/default"]
+			dash0Exporter := exporters["otlp_grpc/dash0/default"]
 			Expect(dash0Exporter).ToNot(BeNil())
 			dash0OtlpExporter := dash0Exporter.(map[string]interface{})
 			Expect(dash0OtlpExporter["endpoint"]).To(Equal(EndpointDash0Test))
 
 			// Verify HTTP exporter
-			httpExporter := exporters["otlphttp/default/proto"]
+			httpExporter := exporters["otlp_http/default/proto"]
 			Expect(httpExporter).ToNot(BeNil())
 			httpOtlpExporter := httpExporter.(map[string]interface{})
 			Expect(httpOtlpExporter["endpoint"]).To(Equal(EndpointHttpTest))
@@ -491,19 +491,19 @@ var _ = Describe("The OpenTelemetry Collector ConfigMaps", func() {
 			Expect(exporters).To(HaveLen(3))
 
 			// Verify Dash0 exporter
-			dash0Exporter := exporters["otlp/dash0/default"]
+			dash0Exporter := exporters["otlp_grpc/dash0/default"]
 			Expect(dash0Exporter).ToNot(BeNil())
 			dash0OtlpExporter := dash0Exporter.(map[string]interface{})
 			Expect(dash0OtlpExporter["endpoint"]).To(Equal(EndpointDash0Test))
 
 			// Verify gRPC exporter
-			grpcExporter := exporters["otlp/grpc/default"]
+			grpcExporter := exporters["otlp_grpc/default"]
 			Expect(grpcExporter).ToNot(BeNil())
 			grpcOtlpExporter := grpcExporter.(map[string]interface{})
 			Expect(grpcOtlpExporter["endpoint"]).To(Equal(EndpointGrpcTest))
 
 			// Verify HTTP exporter
-			httpExporter := exporters["otlphttp/default/proto"]
+			httpExporter := exporters["otlp_http/default/proto"]
 			Expect(httpExporter).ToNot(BeNil())
 			httpOtlpExporter := httpExporter.(map[string]interface{})
 			Expect(httpOtlpExporter["endpoint"]).To(Equal(EndpointHttpTest))
@@ -526,7 +526,7 @@ var _ = Describe("The OpenTelemetry Collector ConfigMaps", func() {
 			Expect(exporters).To(HaveLen(1))
 
 			// Verify gRPC exporter with insecure flag
-			grpcExporter := exporters["otlp/grpc/default"]
+			grpcExporter := exporters["otlp_grpc/default"]
 			Expect(grpcExporter).ToNot(BeNil())
 			grpcOtlpExporter := grpcExporter.(map[string]interface{})
 			Expect(grpcOtlpExporter["endpoint"]).To(Equal(grpcEndpointTest))
@@ -554,7 +554,7 @@ var _ = Describe("The OpenTelemetry Collector ConfigMaps", func() {
 			Expect(exporters).To(HaveLen(1))
 
 			// Verify HTTP exporter with insecure endpoint
-			httpExporter := exporters["otlphttp/default/proto"]
+			httpExporter := exporters["otlp_http/default/proto"]
 			Expect(httpExporter).ToNot(BeNil())
 			httpOtlpExporter := httpExporter.(map[string]interface{})
 			Expect(httpOtlpExporter["endpoint"]).To(Equal(httpInsecureEndpointTest))
@@ -577,17 +577,17 @@ var _ = Describe("The OpenTelemetry Collector ConfigMaps", func() {
 			Expect(exporters).To(HaveLen(3))
 
 			// Verify default Dash0 exporter
-			dash0Exporter := exporters["otlp/dash0/default"]
+			dash0Exporter := exporters["otlp_grpc/dash0/default"]
 			Expect(dash0Exporter).ToNot(BeNil())
 
 			// Verify namespaced gRPC exporter for namespace1
-			grpcExporterNs1 := exporters["otlp/grpc/ns/"+namespace1]
+			grpcExporterNs1 := exporters["otlp_grpc/ns/"+namespace1]
 			Expect(grpcExporterNs1).ToNot(BeNil())
 			grpcOtlpExporter := grpcExporterNs1.(map[string]interface{})
 			Expect(grpcOtlpExporter["endpoint"]).To(Equal(EndpointGrpcTest))
 
 			// Verify namespaced HTTP exporter for namespace2
-			httpExporterNs2 := exporters["otlphttp/ns/"+namespace2+"/proto"]
+			httpExporterNs2 := exporters["otlp_http/ns/"+namespace2+"/proto"]
 			Expect(httpExporterNs2).ToNot(BeNil())
 			httpOtlpExporter := httpExporterNs2.(map[string]interface{})
 			Expect(httpOtlpExporter["endpoint"]).To(Equal(EndpointHttpTest))
@@ -610,18 +610,18 @@ var _ = Describe("The OpenTelemetry Collector ConfigMaps", func() {
 			Expect(exporters).To(HaveLen(4))
 
 			// Verify default Dash0 exporter
-			dash0Exporter := exporters["otlp/dash0/default"]
+			dash0Exporter := exporters["otlp_grpc/dash0/default"]
 			Expect(dash0Exporter).ToNot(BeNil())
 
 			// Verify namespace1 has both gRPC and HTTP exporters
-			grpcExporterNs1 := exporters["otlp/grpc/ns/"+namespace1]
+			grpcExporterNs1 := exporters["otlp_grpc/ns/"+namespace1]
 			Expect(grpcExporterNs1).ToNot(BeNil())
 
-			httpExporterNs1 := exporters["otlphttp/ns/"+namespace1+"/proto"]
+			httpExporterNs1 := exporters["otlp_http/ns/"+namespace1+"/proto"]
 			Expect(httpExporterNs1).ToNot(BeNil())
 
 			// Verify namespace2 has a Dash0 exporter
-			dash0ExporterNs2 := exporters["otlp/dash0/ns/"+namespace2]
+			dash0ExporterNs2 := exporters["otlp_grpc/dash0/ns/"+namespace2]
 			Expect(dash0ExporterNs2).ToNot(BeNil())
 			dash0OtlpExporter := dash0ExporterNs2.(map[string]interface{})
 			Expect(dash0OtlpExporter["endpoint"]).To(Equal(EndpointDash0TestAlternative))
@@ -784,34 +784,34 @@ var _ = Describe("The OpenTelemetry Collector ConfigMaps", func() {
 			tracesExportNs1Receivers := readPipelineReceivers(pipelines, "traces/export/ns/"+namespace1)
 			Expect(tracesExportNs1Receivers).To(ContainElement("routing/traces"))
 			tracesExportNs1Exporters := readPipelineExporters(pipelines, "traces/export/ns/"+namespace1)
-			Expect(tracesExportNs1Exporters).To(ContainElement("otlp/grpc/ns/" + namespace1))
+			Expect(tracesExportNs1Exporters).To(ContainElement("otlp_grpc/ns/" + namespace1))
 
 			tracesExportNs2Receivers := readPipelineReceivers(pipelines, "traces/export/ns/"+namespace2)
 			Expect(tracesExportNs2Receivers).To(ContainElement("routing/traces"))
 			tracesExportNs2Exporters := readPipelineExporters(pipelines, "traces/export/ns/"+namespace2)
-			Expect(tracesExportNs2Exporters).To(ContainElement("otlphttp/ns/" + namespace2 + "/proto"))
+			Expect(tracesExportNs2Exporters).To(ContainElement("otlp_http/ns/" + namespace2 + "/proto"))
 
 			// Verify namespace-specific metrics export pipelines
 			metricsExportNs1Receivers := readPipelineReceivers(pipelines, "metrics/export/ns/"+namespace1)
 			Expect(metricsExportNs1Receivers).To(ContainElement("routing/metrics"))
 			metricsExportNs1Exporters := readPipelineExporters(pipelines, "metrics/export/ns/"+namespace1)
-			Expect(metricsExportNs1Exporters).To(ContainElement("otlp/grpc/ns/" + namespace1))
+			Expect(metricsExportNs1Exporters).To(ContainElement("otlp_grpc/ns/" + namespace1))
 
 			metricsExportNs2Receivers := readPipelineReceivers(pipelines, "metrics/export/ns/"+namespace2)
 			Expect(metricsExportNs2Receivers).To(ContainElement("routing/metrics"))
 			metricsExportNs2Exporters := readPipelineExporters(pipelines, "metrics/export/ns/"+namespace2)
-			Expect(metricsExportNs2Exporters).To(ContainElement("otlphttp/ns/" + namespace2 + "/proto"))
+			Expect(metricsExportNs2Exporters).To(ContainElement("otlp_http/ns/" + namespace2 + "/proto"))
 
 			// Verify namespace-specific logs export pipelines
 			logsExportNs1Receivers := readPipelineReceivers(pipelines, "logs/export/ns/"+namespace1)
 			Expect(logsExportNs1Receivers).To(ContainElement("routing/logs"))
 			logsExportNs1Exporters := readPipelineExporters(pipelines, "logs/export/ns/"+namespace1)
-			Expect(logsExportNs1Exporters).To(ContainElement("otlp/grpc/ns/" + namespace1))
+			Expect(logsExportNs1Exporters).To(ContainElement("otlp_grpc/ns/" + namespace1))
 
 			logsExportNs2Receivers := readPipelineReceivers(pipelines, "logs/export/ns/"+namespace2)
 			Expect(logsExportNs2Receivers).To(ContainElement("routing/logs"))
 			logsExportNs2Exporters := readPipelineExporters(pipelines, "logs/export/ns/"+namespace2)
-			Expect(logsExportNs2Exporters).To(ContainElement("otlphttp/ns/" + namespace2 + "/proto"))
+			Expect(logsExportNs2Exporters).To(ContainElement("otlp_http/ns/" + namespace2 + "/proto"))
 		})
 
 		It("should render namespace-specific export pipelines [Deployment])", func() {
@@ -830,23 +830,23 @@ var _ = Describe("The OpenTelemetry Collector ConfigMaps", func() {
 			metricsExportNs1Receivers := readPipelineReceivers(pipelines, "metrics/export/ns/"+namespace1)
 			Expect(metricsExportNs1Receivers).To(ContainElement("routing/metrics"))
 			metricsExportNs1Exporters := readPipelineExporters(pipelines, "metrics/export/ns/"+namespace1)
-			Expect(metricsExportNs1Exporters).To(ContainElement("otlp/grpc/ns/" + namespace1))
+			Expect(metricsExportNs1Exporters).To(ContainElement("otlp_grpc/ns/" + namespace1))
 
 			metricsExportNs2Receivers := readPipelineReceivers(pipelines, "metrics/export/ns/"+namespace2)
 			Expect(metricsExportNs2Receivers).To(ContainElement("routing/metrics"))
 			metricsExportNs2Exporters := readPipelineExporters(pipelines, "metrics/export/ns/"+namespace2)
-			Expect(metricsExportNs2Exporters).To(ContainElement("otlphttp/ns/" + namespace2 + "/proto"))
+			Expect(metricsExportNs2Exporters).To(ContainElement("otlp_http/ns/" + namespace2 + "/proto"))
 
 			// Verify namespace-specific logs export pipelines
 			logsExportNs1Receivers := readPipelineReceivers(pipelines, "logs/export/ns/"+namespace1)
 			Expect(logsExportNs1Receivers).To(ContainElement("routing/logs"))
 			logsExportNs1Exporters := readPipelineExporters(pipelines, "logs/export/ns/"+namespace1)
-			Expect(logsExportNs1Exporters).To(ContainElement("otlp/grpc/ns/" + namespace1))
+			Expect(logsExportNs1Exporters).To(ContainElement("otlp_grpc/ns/" + namespace1))
 
 			logsExportNs2Receivers := readPipelineReceivers(pipelines, "logs/export/ns/"+namespace2)
 			Expect(logsExportNs2Receivers).To(ContainElement("routing/logs"))
 			logsExportNs2Exporters := readPipelineExporters(pipelines, "logs/export/ns/"+namespace2)
-			Expect(logsExportNs2Exporters).To(ContainElement("otlphttp/ns/" + namespace2 + "/proto"))
+			Expect(logsExportNs2Exporters).To(ContainElement("otlp_http/ns/" + namespace2 + "/proto"))
 		})
 
 		It("should wire common-processors pipelines to routing connectors when namespaced exporters exist [DaemonSet]", func() {

--- a/internal/collectors/otelcolresources/desired_state_test.go
+++ b/internal/collectors/otelcolresources/desired_state_test.go
@@ -50,7 +50,7 @@ const (
 func defaultDash0Exporters() otlpExporters {
 	return otlpExporters{
 		Default: []otlpExporter{{
-			Name:     "otlp/dash0/default",
+			Name:     "otlp_grpc/dash0/default",
 			Endpoint: EndpointDash0Test,
 			Headers: []dash0common.Header{
 				{
@@ -65,7 +65,7 @@ func defaultDash0Exporters() otlpExporters {
 func defaultDash0ExportersWithCustomDataset() otlpExporters {
 	return otlpExporters{
 		Default: []otlpExporter{{
-			Name:     "otlp/dash0/default",
+			Name:     "otlp_grpc/dash0/default",
 			Endpoint: EndpointDash0Test,
 			Headers: []dash0common.Header{
 				{
@@ -84,7 +84,7 @@ func defaultDash0ExportersWithCustomDataset() otlpExporters {
 func defaultGrpcExporters() otlpExporters {
 	return otlpExporters{
 		Default: []otlpExporter{{
-			Name:     "otlp/grpc/default",
+			Name:     "otlp_grpc/default",
 			Endpoint: EndpointGrpcTest,
 			Headers: []dash0common.Header{
 				{Name: "Key", Value: "Value"},
@@ -96,7 +96,7 @@ func defaultGrpcExporters() otlpExporters {
 func defaultHttpExporters() otlpExporters {
 	return otlpExporters{
 		Default: []otlpExporter{{
-			Name:     "otlphttp/default/proto",
+			Name:     "otlp_http/default/proto",
 			Endpoint: EndpointHttpTest,
 			Encoding: "proto",
 			Headers: []dash0common.Header{
@@ -397,7 +397,7 @@ var _ = Describe("The desired state of the OpenTelemetry Collector resources", f
 
 		exporters := otlpExporters{
 			Default: []otlpExporter{{
-				Name:     "otlp/dash0/default",
+				Name:     "otlp_grpc/dash0/default",
 				Endpoint: EndpointDash0Test,
 				Headers: []dash0common.Header{
 					{
@@ -408,7 +408,7 @@ var _ = Describe("The desired state of the OpenTelemetry Collector resources", f
 			}},
 			Namespaced: namespacedOtlpExporters{
 				namespace1: []otlpExporter{{
-					Name:     fmt.Sprintf("otlp/dash0/ns/%s", namespace1),
+					Name:     fmt.Sprintf("otlp_grpc/dash0/ns/%s", namespace1),
 					Endpoint: EndpointDash0Test,
 					Headers: []dash0common.Header{
 						{
@@ -418,7 +418,7 @@ var _ = Describe("The desired state of the OpenTelemetry Collector resources", f
 					},
 				}},
 				namespace2: []otlpExporter{{
-					Name:     fmt.Sprintf("otlp/dash0/ns/%s", namespace2),
+					Name:     fmt.Sprintf("otlp_grpc/dash0/ns/%s", namespace2),
 					Endpoint: EndpointDash0Test,
 					Headers: []dash0common.Header{
 						{
@@ -495,7 +495,7 @@ var _ = Describe("The desired state of the OpenTelemetry Collector resources", f
 
 		exporters := otlpExporters{
 			Default: []otlpExporter{{
-				Name:     "otlp/dash0/default",
+				Name:     "otlp_grpc/dash0/default",
 				Endpoint: EndpointDash0Test,
 				Headers: []dash0common.Header{
 					{
@@ -506,7 +506,7 @@ var _ = Describe("The desired state of the OpenTelemetry Collector resources", f
 			}},
 			Namespaced: namespacedOtlpExporters{
 				namespace1: []otlpExporter{{
-					Name:     fmt.Sprintf("otlp/dash0/ns/%s", namespace1),
+					Name:     fmt.Sprintf("otlp_grpc/dash0/ns/%s", namespace1),
 					Endpoint: EndpointDash0Test,
 					Headers: []dash0common.Header{
 						{
@@ -516,7 +516,7 @@ var _ = Describe("The desired state of the OpenTelemetry Collector resources", f
 					},
 				}},
 				namespace2: []otlpExporter{{
-					Name:     fmt.Sprintf("otlp/dash0/ns/%s", namespace2),
+					Name:     fmt.Sprintf("otlp_grpc/dash0/ns/%s", namespace2),
 					Endpoint: EndpointDash0Test,
 					Headers: []dash0common.Header{
 						{
@@ -593,7 +593,7 @@ var _ = Describe("The desired state of the OpenTelemetry Collector resources", f
 
 		exporters := otlpExporters{
 			Default: []otlpExporter{{
-				Name:     "otlp/dash0/default",
+				Name:     "otlp_grpc/dash0/default",
 				Endpoint: EndpointDash0Test,
 				Headers: []dash0common.Header{
 					{
@@ -604,7 +604,7 @@ var _ = Describe("The desired state of the OpenTelemetry Collector resources", f
 			}},
 			Namespaced: namespacedOtlpExporters{
 				namespace1: []otlpExporter{{
-					Name:     fmt.Sprintf("otlp/dash0/ns/%s", namespace1),
+					Name:     fmt.Sprintf("otlp_grpc/dash0/ns/%s", namespace1),
 					Endpoint: EndpointDash0Test,
 					Headers: []dash0common.Header{
 						{
@@ -614,7 +614,7 @@ var _ = Describe("The desired state of the OpenTelemetry Collector resources", f
 					},
 				}},
 				namespace2: []otlpExporter{{
-					Name:     fmt.Sprintf("otlp/dash0/ns/%s", namespace2),
+					Name:     fmt.Sprintf("otlp_grpc/dash0/ns/%s", namespace2),
 					Endpoint: EndpointDash0Test,
 					Headers: []dash0common.Header{
 						{
@@ -687,7 +687,7 @@ var _ = Describe("The desired state of the OpenTelemetry Collector resources", f
 		exporters := otlpExporters{
 			Namespaced: namespacedOtlpExporters{
 				namespace1: []otlpExporter{{
-					Name:     fmt.Sprintf("otlp/dash0/ns/%s", namespace1),
+					Name:     fmt.Sprintf("otlp_grpc/dash0/ns/%s", namespace1),
 					Endpoint: EndpointDash0Test,
 					Headers: []dash0common.Header{
 						{
@@ -697,7 +697,7 @@ var _ = Describe("The desired state of the OpenTelemetry Collector resources", f
 					},
 				}},
 				namespace2: []otlpExporter{{
-					Name:     fmt.Sprintf("otlp/dash0/ns/%s", namespace2),
+					Name:     fmt.Sprintf("otlp_grpc/dash0/ns/%s", namespace2),
 					Endpoint: EndpointDash0Test,
 					Headers: []dash0common.Header{
 						{
@@ -707,7 +707,7 @@ var _ = Describe("The desired state of the OpenTelemetry Collector resources", f
 					},
 				}},
 				namespace3: []otlpExporter{{
-					Name:     fmt.Sprintf("otlp/dash0/ns/%s", namespace3),
+					Name:     fmt.Sprintf("otlp_grpc/dash0/ns/%s", namespace3),
 					Endpoint: EndpointDash0Test,
 					Headers: []dash0common.Header{
 						{

--- a/internal/collectors/otelcolresources/exporter.go
+++ b/internal/collectors/otelcolresources/exporter.go
@@ -32,9 +32,9 @@ type otlpExporters struct {
 }
 
 const (
-	dash0ExporterNamePrefix = "otlp/dash0"
-	grpcExporterNamePrefix  = "otlp/grpc"
-	httpExporterNamePrefix  = "otlphttp"
+	dash0ExporterNamePrefix = "otlp_grpc/dash0"
+	grpcExporterNamePrefix  = "otlp_grpc"
+	httpExporterNamePrefix  = "otlp_http"
 )
 
 func getDefaultOtlpExporters(dash0Config *dash0v1alpha1.Dash0OperatorConfiguration) ([]otlpExporter, error) {

--- a/internal/collectors/otelcolresources/exporter_test.go
+++ b/internal/collectors/otelcolresources/exporter_test.go
@@ -21,7 +21,7 @@ import (
 // Test helper functions (existing)
 func DefaultOtlpExportersTest() []otlpExporter {
 	return []otlpExporter{{
-		Name:     "otlp/dash0/default",
+		Name:     "otlp_grpc/dash0/default",
 		Endpoint: EndpointDash0Test,
 		Headers: []dash0common.Header{
 			{
@@ -35,7 +35,7 @@ func DefaultOtlpExportersTest() []otlpExporter {
 
 func DefaultOtlpExportersWithCustomDatasetTest() []otlpExporter {
 	return []otlpExporter{{
-		Name:     "otlp/dash0/default",
+		Name:     "otlp_grpc/dash0/default",
 		Endpoint: EndpointDash0Test,
 		Headers: []dash0common.Header{
 			{
@@ -53,7 +53,7 @@ func DefaultOtlpExportersWithCustomDatasetTest() []otlpExporter {
 
 func DefaultOtlpExportersWithGrpc() []otlpExporter {
 	return []otlpExporter{{
-		Name:     "otlp/grpc/default",
+		Name:     "otlp_grpc/default",
 		Endpoint: EndpointDash0Test,
 		Headers: []dash0common.Header{
 			{
@@ -67,7 +67,7 @@ func DefaultOtlpExportersWithGrpc() []otlpExporter {
 
 func DefaultOtlpExportersWithHttp() []otlpExporter {
 	return []otlpExporter{{
-		Name:     "otlp/grpc/default",
+		Name:     "otlp_grpc/default",
 		Endpoint: EndpointDash0Test,
 		Headers: []dash0common.Header{
 			{
@@ -117,7 +117,7 @@ var _ = Describe("Exporter", func() {
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(exporter).NotTo(BeNil())
-			Expect(exporter.Name).To(Equal("otlp/dash0/default"))
+			Expect(exporter.Name).To(Equal("otlp_grpc/dash0/default"))
 			Expect(exporter.Endpoint).To(Equal(EndpointDash0Test))
 			Expect(exporter.Headers).To(HaveLen(1))
 			Expect(exporter.Headers[0].Name).To(Equal(util.AuthorizationHeaderName))
@@ -183,7 +183,7 @@ var _ = Describe("Exporter", func() {
 			exporter, err := convertDash0ExporterToOtlpExporter(d0Config, "ns/my-namespace", nsEnvVar)
 
 			Expect(err).NotTo(HaveOccurred())
-			Expect(exporter.Name).To(Equal("otlp/dash0/ns/my-namespace"))
+			Expect(exporter.Name).To(Equal("otlp_grpc/dash0/ns/my-namespace"))
 			Expect(exporter.Headers[0].Value).To(Equal("Bearer ${env:OTELCOL_AUTH_TOKEN_NS_MY_NAMESPACE}"))
 		})
 
@@ -215,7 +215,7 @@ var _ = Describe("Exporter", func() {
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(exporter).NotTo(BeNil())
-			Expect(exporter.Name).To(Equal("otlp/grpc/default"))
+			Expect(exporter.Name).To(Equal("otlp_grpc/default"))
 			Expect(exporter.Endpoint).To(Equal(EndpointGrpcTest))
 			Expect(exporter.Headers).To(HaveLen(1))
 			Expect(exporter.Headers[0].Name).To(Equal("Key"))
@@ -291,7 +291,7 @@ var _ = Describe("Exporter", func() {
 			exporter, err := convertGrpcExporterToOtlpExporter(grpcConfig, "ns/test-namespace")
 
 			Expect(err).NotTo(HaveOccurred())
-			Expect(exporter.Name).To(Equal("otlp/grpc/ns/test-namespace"))
+			Expect(exporter.Name).To(Equal("otlp_grpc/ns/test-namespace"))
 		})
 	})
 
@@ -309,7 +309,7 @@ var _ = Describe("Exporter", func() {
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(exporter).NotTo(BeNil())
-			Expect(exporter.Name).To(Equal("otlphttp/default/proto"))
+			Expect(exporter.Name).To(Equal("otlp_http/default/proto"))
 			Expect(exporter.Endpoint).To(Equal(EndpointHttpTest))
 			Expect(exporter.Encoding).To(Equal("proto"))
 			Expect(exporter.Headers).To(HaveLen(1))
@@ -324,7 +324,7 @@ var _ = Describe("Exporter", func() {
 			exporter, err := convertHttpExporterToOtlpExporter(httpConfig, "default")
 
 			Expect(err).NotTo(HaveOccurred())
-			Expect(exporter.Name).To(Equal("otlphttp/default/json"))
+			Expect(exporter.Name).To(Equal("otlp_http/default/json"))
 			Expect(exporter.Encoding).To(Equal("json"))
 		})
 
@@ -377,7 +377,7 @@ var _ = Describe("Exporter", func() {
 			exporter, err := convertHttpExporterToOtlpExporter(httpConfig, "ns/test-namespace")
 
 			Expect(err).NotTo(HaveOccurred())
-			Expect(exporter.Name).To(Equal("otlphttp/ns/test-namespace/proto"))
+			Expect(exporter.Name).To(Equal("otlp_http/ns/test-namespace/proto"))
 		})
 	})
 
@@ -399,7 +399,7 @@ var _ = Describe("Exporter", func() {
 
 				Expect(err).NotTo(HaveOccurred())
 				Expect(exporters).To(HaveLen(1))
-				Expect(exporters[0].Name).To(Equal("otlp/dash0/default"))
+				Expect(exporters[0].Name).To(Equal("otlp_grpc/dash0/default"))
 			})
 
 			It("should convert gRPC export settings", func() {
@@ -409,7 +409,7 @@ var _ = Describe("Exporter", func() {
 
 				Expect(err).NotTo(HaveOccurred())
 				Expect(exporters).To(HaveLen(1))
-				Expect(exporters[0].Name).To(Equal("otlp/grpc/default"))
+				Expect(exporters[0].Name).To(Equal("otlp_grpc/default"))
 			})
 
 			It("should convert HTTP export settings", func() {
@@ -419,7 +419,7 @@ var _ = Describe("Exporter", func() {
 
 				Expect(err).NotTo(HaveOccurred())
 				Expect(exporters).To(HaveLen(1))
-				Expect(exporters[0].Name).To(Equal("otlphttp/default/proto"))
+				Expect(exporters[0].Name).To(Equal("otlp_http/default/proto"))
 			})
 
 			It("should convert combined export settings", func() {
@@ -475,7 +475,7 @@ var _ = Describe("Exporter", func() {
 
 				Expect(err).NotTo(HaveOccurred())
 				Expect(exporters).To(HaveLen(1))
-				Expect(exporters[0].Name).To(Equal("otlp/dash0/ns/test-namespace"))
+				Expect(exporters[0].Name).To(Equal("otlp_grpc/dash0/ns/test-namespace"))
 			})
 		})
 	})
@@ -492,7 +492,7 @@ var _ = Describe("Exporter", func() {
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(exporters).To(HaveLen(1))
-			Expect(exporters[0].Name).To(Equal("otlp/dash0/default"))
+			Expect(exporters[0].Name).To(Equal("otlp_grpc/dash0/default"))
 		})
 
 		It("should return error when no export configured", func() {
@@ -561,8 +561,8 @@ var _ = Describe("Exporter", func() {
 			Expect(exporters).To(HaveLen(2))
 			Expect(exporters).To(HaveKey("namespace-1"))
 			Expect(exporters).To(HaveKey("namespace-2"))
-			Expect(exporters["namespace-1"][0].Name).To(Equal("otlp/dash0/ns/namespace-1"))
-			Expect(exporters["namespace-2"][0].Name).To(Equal("otlp/grpc/ns/namespace-2"))
+			Expect(exporters["namespace-1"][0].Name).To(Equal("otlp_grpc/dash0/ns/namespace-1"))
+			Expect(exporters["namespace-2"][0].Name).To(Equal("otlp_grpc/ns/namespace-2"))
 		})
 
 		It("should skip monitoring resources with nil export", func() {


### PR DESCRIPTION
The names for the otlp exporters have now been standardized to `otlp_grpc` and `otlp_http`: https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.144.0

The old/deprecated names still work but cause frequent warnings being logged.