### PR TITLE
chore(deps): revert sigs.k8s.io/controller-runtime update 0.23.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	k8s.io/apimachinery v0.35.0
 	k8s.io/client-go v0.35.0
 	k8s.io/utils v0.0.0-20251002143259-bc988d571ff4
-	sigs.k8s.io/controller-runtime v0.23.1
+	sigs.k8s.io/controller-runtime v0.22.4
 	sigs.k8s.io/yaml v1.6.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -438,8 +438,8 @@ k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912 h1:Y3gxNAuB0OBLImH611+UDZ
 k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912/go.mod h1:kdmbQkyfwUagLfXIad1y2TdrjPFWp2Q89B3qkRwf/pQ=
 k8s.io/utils v0.0.0-20251002143259-bc988d571ff4 h1:SjGebBtkBqHFOli+05xYbK8YF1Dzkbzn+gDM4X9T4Ck=
 k8s.io/utils v0.0.0-20251002143259-bc988d571ff4/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
-sigs.k8s.io/controller-runtime v0.23.1 h1:TjJSM80Nf43Mg21+RCy3J70aj/W6KyvDtOlpKf+PupE=
-sigs.k8s.io/controller-runtime v0.23.1/go.mod h1:B6COOxKptp+YaUT5q4l6LqUJTRpizbgf9KSRNdQGns0=
+sigs.k8s.io/controller-runtime v0.22.4 h1:GEjV7KV3TY8e+tJ2LCTxUTanW4z/FmNB7l327UfMq9A=
+sigs.k8s.io/controller-runtime v0.22.4/go.mod h1:+QX1XUpTXN4mLoblf4tqr5CQcyHPAki2HLXqQMY6vh8=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5EXP7sU1kvOlxwZh5txg=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=

--- a/helm-chart/dash0-operator/templates/operator/cluster-roles.yaml
+++ b/helm-chart/dash0-operator/templates/operator/cluster-roles.yaml
@@ -59,7 +59,7 @@ rules:
 # Permissions required to queue events to report about the operator's actions, and to attach dangling events to their
 # respective involved objects:
 - apiGroups:
-  - events.k8s.io
+  - ""
   resources:
   - events
   verbs:

--- a/helm-chart/dash0-operator/tests/operator/__snapshot__/cluster-roles_test.yaml.snap
+++ b/helm-chart/dash0-operator/tests/operator/__snapshot__/cluster-roles_test.yaml.snap
@@ -52,7 +52,7 @@ cluster roles should match snapshot:
         verbs:
           - list
       - apiGroups:
-          - events.k8s.io
+          - ""
         resources:
           - events
         verbs:

--- a/internal/controller/controller_suite_test.go
+++ b/internal/controller/controller_suite_test.go
@@ -14,7 +14,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/events"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -41,7 +41,7 @@ var (
 	cfg       *rest.Config
 	k8sClient client.Client
 	clientset *kubernetes.Clientset
-	recorder  events.EventRecorder
+	recorder  record.EventRecorder
 	testEnv   *envtest.Environment
 )
 
@@ -85,7 +85,7 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(mgr).NotTo(BeNil())
-	recorder = mgr.GetEventRecorder("dash0-controller")
+	recorder = mgr.GetEventRecorderFor("dash0-controller")
 })
 
 var _ = AfterSuite(func() {

--- a/internal/controller/monitoring_controller.go
+++ b/internal/controller/monitoring_controller.go
@@ -5,12 +5,14 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
 	otelmetric "go.opentelemetry.io/otel/metric"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -251,6 +253,8 @@ func (r *MonitoringReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		}
 	}
 
+	r.scheduleAttachDanglingEvents(ctx, monitoringResource, &logger)
+
 	if err = r.updateStatusAfterReconcile(ctx, monitoringResource, statusUpdate, &logger); err != nil {
 		// The error has already been logged in updateStatusAfterReconcile
 		return ctrl.Result{}, err
@@ -437,6 +441,89 @@ func (r *MonitoringReconciler) runCleanupActions(
 		}
 	}
 	return nil
+}
+
+func (r *MonitoringReconciler) scheduleAttachDanglingEvents(
+	ctx context.Context,
+	monitoringResource *dash0v1beta1.Dash0Monitoring,
+	logger *logr.Logger,
+) {
+	// execute the event attaching in a separate go routine to not block the main reconcile loop
+	go func() {
+		if r.danglingEventsTimeouts.InitialTimeout > 0 {
+			// wait a bit before attempting to attach dangling events, since the K8s resources do not exist yet when
+			// the webhook queues the events
+			time.Sleep(r.danglingEventsTimeouts.InitialTimeout)
+		}
+		r.attachDanglingEvents(ctx, monitoringResource, logger)
+	}()
+}
+
+/*
+ * attachDanglingEvents attaches events that have been created by the webhook to the involved object of the event.
+ * When the webhook creates the respective events, the workload might not exist yet, so the UID of the workload is not
+ * set in the event. The list of events for that workload will not contain this event. We go the extra mile here and
+ * retroactively fix the reference of all those events.
+ */
+func (r *MonitoringReconciler) attachDanglingEvents(
+	ctx context.Context,
+	monitoringResource *dash0v1beta1.Dash0Monitoring,
+	logger *logr.Logger,
+) {
+	namespace := monitoringResource.Namespace
+	eventApi := r.clientset.CoreV1().Events(namespace)
+	backoff := r.danglingEventsTimeouts.Backoff
+	for _, eventType := range util.AllEvents {
+		retryErr := util.RetryWithCustomBackoff(
+			"attaching dangling event to involved object",
+			func() error {
+				danglingEvents, listErr := eventApi.List(ctx, metav1.ListOptions{
+					FieldSelector: fmt.Sprintf("involvedObject.uid=,reason=%s", eventType),
+				})
+				if listErr != nil {
+					return listErr
+				}
+
+				if len(danglingEvents.Items) > 0 {
+					logger.Info(fmt.Sprintf("Attempting to attach %d dangling event(s).", len(danglingEvents.Items)))
+				}
+
+				var allAttachErrors []error
+				for _, event := range danglingEvents.Items {
+					attachErr := util.AttachEventToInvolvedObject(ctx, r.Client, eventApi, &event)
+					if attachErr != nil {
+						allAttachErrors = append(allAttachErrors, attachErr)
+					} else {
+						involvedObject := event.InvolvedObject
+						logger.Info(fmt.Sprintf("Attached '%s' event (uid: %s) to its associated object (%s %s/%s).",
+							eventType, event.UID, involvedObject.Kind, involvedObject.Namespace, involvedObject.Name))
+					}
+				}
+				if len(allAttachErrors) > 0 {
+					return errors.Join(allAttachErrors...)
+				}
+
+				if len(danglingEvents.Items) > 0 {
+					logger.Info(
+						fmt.Sprintf(
+							"%d dangling event(s) have been successfully attached to its/their associated object(s).",
+							len(danglingEvents.Items)),
+					)
+				}
+
+				return nil
+			},
+			backoff,
+			false,
+			false,
+			logger,
+		)
+
+		if retryErr != nil {
+			logger.Error(retryErr, fmt.Sprintf(
+				"Could not attach all dangling events after %d retries.", backoff.Steps))
+		}
+	}
 }
 
 func (r *MonitoringReconciler) reconcileOpenTelemetryCollector(

--- a/internal/instrumentation/instrumentation_suite_test.go
+++ b/internal/instrumentation/instrumentation_suite_test.go
@@ -12,7 +12,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/events"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
@@ -33,7 +33,7 @@ var (
 	cfg       *rest.Config
 	k8sClient client.Client
 	clientset *kubernetes.Clientset
-	recorder  events.EventRecorder
+	recorder  record.EventRecorder
 	testEnv   *envtest.Environment
 )
 
@@ -78,7 +78,7 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(mgr).NotTo(BeNil())
-	recorder = mgr.GetEventRecorder("dash0-controller")
+	recorder = mgr.GetEventRecorderFor("dash0-controller")
 })
 
 var _ = AfterSuite(func() {

--- a/internal/instrumentation/instrumenter.go
+++ b/internal/instrumentation/instrumenter.go
@@ -17,8 +17,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/events"
 	"k8s.io/client-go/tools/pager"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -32,7 +32,7 @@ import (
 type Instrumenter struct {
 	client.Client
 	Clientset                    *kubernetes.Clientset
-	Recorder                     events.EventRecorder
+	Recorder                     record.EventRecorder
 	ClusterInstrumentationConfig *util.ClusterInstrumentationConfig
 }
 
@@ -79,7 +79,7 @@ func (e ImmutableWorkloadError) Error() string {
 func NewInstrumenter(
 	client client.Client,
 	clientset *kubernetes.Clientset,
-	recorder events.EventRecorder,
+	recorder record.EventRecorder,
 	clusterInstrumentationConfig *util.ClusterInstrumentationConfig,
 ) *Instrumenter {
 	if clusterInstrumentationConfig == nil {

--- a/internal/predelete/pre_delete_suite_test.go
+++ b/internal/predelete/pre_delete_suite_test.go
@@ -97,7 +97,7 @@ var _ = BeforeSuite(func() {
 	instrumenter := instrumentation.NewInstrumenter(
 		k8sClient,
 		clientset,
-		mgr.GetEventRecorder("dash0-monitoring-controller"),
+		mgr.GetEventRecorderFor("dash0-monitoring-controller"),
 		util.NewClusterInstrumentationConfig(
 			TestImages,
 			OTelCollectorNodeLocalBaseUrlTest,

--- a/internal/startup/operator_manager_startup.go
+++ b/internal/startup/operator_manager_startup.go
@@ -891,7 +891,7 @@ func startDash0Controllers(
 		// The k8s client will be added later, in internal/startup/instrument_at_startup.go#Start.
 		nil,
 		clientset,
-		mgr.GetEventRecorder("dash0-startup-tasks"),
+		mgr.GetEventRecorderFor("dash0-startup-tasks"),
 		clusterInstrumentationConfig,
 	)
 	// For consistency, we update the extra config map in the startupInstrumenter handler as well if it changes. Since
@@ -916,7 +916,7 @@ func startDash0Controllers(
 	instrumenter := instrumentation.NewInstrumenter(
 		k8sClient,
 		clientset,
-		mgr.GetEventRecorder("dash0-monitoring-controller"),
+		mgr.GetEventRecorderFor("dash0-monitoring-controller"),
 		clusterInstrumentationConfig,
 	)
 	// For consistency, we update the extra config map in the instrumenter handler as well. However, even if
@@ -1106,7 +1106,7 @@ func startDash0Controllers(
 
 	instrumentationWebhookHandler := webhooks.NewInstrumentationWebhookHandler(
 		k8sClient,
-		mgr.GetEventRecorder("dash0-instrumentation-webhook"),
+		mgr.GetEventRecorderFor("dash0-instrumentation-webhook"),
 		clusterInstrumentationConfig,
 	)
 	if err := instrumentationWebhookHandler.SetupWebhookWithManager(mgr); err != nil {

--- a/internal/util/types.go
+++ b/internal/util/types.go
@@ -13,13 +13,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
-type Action string
-
-const (
-	ActionInstrumentation   Action = "Instrumentation"
-	ActionUninstrumentation Action = "Uninstrumentation"
-)
-
 type Reason string
 
 const (

--- a/internal/webhooks/attach_dangling_events_test.go
+++ b/internal/webhooks/attach_dangling_events_test.go
@@ -1,0 +1,203 @@
+// SPDX-FileCopyrightText: Copyright 2024 Dash0 Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package webhooks
+
+import (
+	"context"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	dash0v1beta1 "github.com/dash0hq/dash0-operator/api/operator/v1beta1"
+	"github.com/dash0hq/dash0-operator/internal/collectors"
+	"github.com/dash0hq/dash0-operator/internal/collectors/otelcolresources"
+	"github.com/dash0hq/dash0-operator/internal/controller"
+	"github.com/dash0hq/dash0-operator/internal/instrumentation"
+	"github.com/dash0hq/dash0-operator/internal/targetallocator"
+	"github.com/dash0hq/dash0-operator/internal/targetallocator/taresources"
+	"github.com/dash0hq/dash0-operator/internal/util"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	. "github.com/dash0hq/dash0-operator/test/util"
+)
+
+var _ = Describe("The Dash0 webhook and the Dash0 controller", Ordered, func() {
+	var reconciler *controller.MonitoringReconciler
+	var dash0MonitoringResource *dash0v1beta1.Dash0Monitoring
+	var createdObjectsAttachEventsTest []client.Object
+
+	BeforeAll(func() {
+		EnsureOperatorNamespaceExists(ctx, k8sClient)
+
+		recorder := manager.GetEventRecorderFor("dash0-monitoring-controller")
+		instrumenter := instrumentation.NewInstrumenter(
+			k8sClient,
+			clientset,
+			recorder,
+			util.NewClusterInstrumentationConfig(
+				TestImages,
+				OTelCollectorNodeLocalBaseUrlTest,
+				util.ExtraConfigDefaults,
+				nil,
+				false,
+			),
+		)
+		oTelColResourceManager := otelcolresources.NewOTelColResourceManager(
+			k8sClient,
+			k8sClient.Scheme(),
+			OperatorManagerDeployment,
+			util.CollectorConfig{
+				Images:                    TestImages,
+				OperatorNamespace:         OperatorNamespace,
+				OTelCollectorNamePrefix:   OTelCollectorNamePrefixTest,
+				TargetAllocatorNamePrefix: TargetAllocatorPrefixTest,
+			},
+		)
+		collectorManager := collectors.NewCollectorManager(
+			k8sClient,
+			clientset,
+			util.ExtraConfigDefaults,
+			false,
+			oTelColResourceManager,
+		)
+
+		targetAllocatorResourceManager := taresources.NewTargetAllocatorResourceManager(
+			k8sClient,
+			k8sClient.Scheme(),
+			OperatorManagerDeployment,
+			util.TargetAllocatorConfig{
+				Images:                    TestImages,
+				OperatorNamespace:         OperatorNamespace,
+				TargetAllocatorNamePrefix: TargetAllocatorPrefixTest,
+				CollectorComponent:        otelcolresources.CollectorDaemonSetServiceComponent(),
+			},
+		)
+		targetAllocatorManager := targetallocator.NewTargetAllocatorManager(
+			k8sClient,
+			clientset,
+			util.ExtraConfigDefaults,
+			false,
+			targetAllocatorResourceManager,
+		)
+		reconciler = controller.NewMonitoringReconciler(
+			k8sClient,
+			clientset,
+			nil,
+			instrumenter,
+			collectorManager,
+			targetAllocatorManager,
+			&DanglingEventsTimeoutsTest,
+		)
+
+		dash0MonitoringResource = EnsureMonitoringResourceExistsAndIsAvailable(ctx, k8sClient)
+	})
+
+	AfterAll(func() {
+		DeleteMonitoringResource(ctx, k8sClient)
+	})
+
+	BeforeEach(func() {
+		createdObjectsAttachEventsTest = make([]client.Object, 0)
+	})
+
+	AfterEach(func() {
+		createdObjectsAttachEventsTest = DeleteAllCreatedObjects(ctx, k8sClient, createdObjectsAttachEventsTest)
+		DeleteAllEvents(ctx, clientset, TestNamespaceName)
+	})
+
+	DescribeTable("when attaching events to their involved objects", func(config WorkloadTestConfig) {
+		name := UniqueName(config.WorkloadNamePrefix)
+		workload := config.CreateFn(ctx, k8sClient, TestNamespaceName, name)
+		createdObjectsAttachEventsTest = append(createdObjectsAttachEventsTest, workload.Get())
+		workload = config.GetFn(ctx, k8sClient, TestNamespaceName, name)
+		event := VerifySuccessfulInstrumentationEvent(ctx, clientset, TestNamespaceName, name, "webhook")
+
+		Expect(event.InvolvedObject.UID).To(BeEmpty())
+		Expect(event.InvolvedObject.ResourceVersion).To(BeEmpty())
+
+		triggerReconcileRequest(ctx, reconciler, dash0MonitoringResource)
+
+		Eventually(func(g Gomega) {
+			// refetch event and check that the UID and ResourceVersion are set correctly now
+			var err error
+			event, err = clientset.CoreV1().Events(TestNamespaceName).Get(ctx, event.Name, metav1.GetOptions{})
+			g.Expect(err).NotTo(HaveOccurred())
+
+			g.Expect(event.InvolvedObject.UID).To(Equal(workload.Get().GetUID()))
+			g.Expect(event.InvolvedObject.ResourceVersion).To(Equal(workload.Get().GetResourceVersion()))
+		}, 5*time.Second, 100*time.Millisecond).Should(Succeed())
+	}, Entry("should attach event to a cron job", WorkloadTestConfig{
+		WorkloadNamePrefix: CronJobNamePrefix,
+		CreateFn:           WrapCronJobFnAsTestableWorkload(CreateBasicCronJob),
+		GetFn:              WrapCronJobFnAsTestableWorkload(GetCronJob),
+		VerifyFn: func(workload TestableWorkload) {
+			VerifyModifiedCronJob(workload.Get().(*batchv1.CronJob), BasicInstrumentedPodSpecExpectations())
+		},
+	}), Entry("should attach event to a daemon set", WorkloadTestConfig{
+		WorkloadNamePrefix: DaemonSetNamePrefix,
+		CreateFn:           WrapDaemonSetFnAsTestableWorkload(CreateBasicDaemonSet),
+		GetFn:              WrapDaemonSetFnAsTestableWorkload(GetDaemonSet),
+		VerifyFn: func(workload TestableWorkload) {
+			VerifyModifiedDaemonSet(workload.Get().(*appsv1.DaemonSet), BasicInstrumentedPodSpecExpectations())
+		},
+	}), Entry("should attach event to a deployment", WorkloadTestConfig{
+		WorkloadNamePrefix: DeploymentNamePrefix,
+		CreateFn:           WrapDeploymentFnAsTestableWorkload(CreateBasicDeployment),
+		GetFn:              WrapDeploymentFnAsTestableWorkload(GetDeployment),
+		VerifyFn: func(workload TestableWorkload) {
+			VerifyModifiedDeployment(workload.Get().(*appsv1.Deployment), BasicInstrumentedPodSpecExpectations())
+		},
+	}), Entry("should attach event to a job", WorkloadTestConfig{
+		WorkloadNamePrefix: JobNamePrefix,
+		CreateFn:           WrapJobFnAsTestableWorkload(CreateBasicJob),
+		GetFn:              WrapJobFnAsTestableWorkload(GetJob),
+		VerifyFn: func(workload TestableWorkload) {
+			VerifyModifiedJob(workload.Get().(*batchv1.Job), BasicInstrumentedPodSpecExpectations())
+		},
+	}), Entry("should attach event to a ownerless pod", WorkloadTestConfig{
+		WorkloadNamePrefix: PodNamePrefix,
+		CreateFn:           WrapPodFnAsTestableWorkload(CreateBasicPod),
+		GetFn:              WrapPodFnAsTestableWorkload(GetPod),
+		VerifyFn: func(workload TestableWorkload) {
+			VerifyModifiedPod(workload.Get().(*corev1.Pod), BasicInstrumentedPodSpecExpectations())
+		},
+	}), Entry("should attach event to a ownerless replica set", WorkloadTestConfig{
+		WorkloadNamePrefix: ReplicaSetNamePrefix,
+		CreateFn:           WrapReplicaSetFnAsTestableWorkload(CreateBasicReplicaSet),
+		GetFn:              WrapReplicaSetFnAsTestableWorkload(GetReplicaSet),
+		VerifyFn: func(workload TestableWorkload) {
+			VerifyModifiedReplicaSet(workload.Get().(*appsv1.ReplicaSet), BasicInstrumentedPodSpecExpectations())
+		},
+	}), Entry("should attach event to a stateful set", WorkloadTestConfig{
+		WorkloadNamePrefix: StatefulSetNamePrefix,
+		CreateFn:           WrapStatefulSetFnAsTestableWorkload(CreateBasicStatefulSet),
+		GetFn:              WrapStatefulSetFnAsTestableWorkload(GetStatefulSet),
+		VerifyFn: func(workload TestableWorkload) {
+			VerifyModifiedStatefulSet(workload.Get().(*appsv1.StatefulSet), BasicInstrumentedPodSpecExpectations())
+		},
+	}))
+})
+
+func triggerReconcileRequest(
+	ctx context.Context,
+	reconciler *controller.MonitoringReconciler,
+	dash0MonitoringResource *dash0v1beta1.Dash0Monitoring,
+) {
+	By("Trigger reconcile request")
+	_, err := reconciler.Reconcile(ctx, reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: dash0MonitoringResource.Namespace,
+			Name:      dash0MonitoringResource.Name,
+		},
+	})
+	Expect(err).NotTo(HaveOccurred())
+}

--- a/internal/webhooks/instrumentation_webhook.go
+++ b/internal/webhooks/instrumentation_webhook.go
@@ -17,7 +17,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/tools/events"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -31,7 +31,7 @@ import (
 
 type InstrumentationWebhookHandler struct {
 	Client                       client.Client
-	Recorder                     events.EventRecorder
+	Recorder                     record.EventRecorder
 	ClusterInstrumentationConfig *util.ClusterInstrumentationConfig
 }
 
@@ -98,7 +98,7 @@ var (
 
 func NewInstrumentationWebhookHandler(
 	client client.Client,
-	recorder events.EventRecorder,
+	recorder record.EventRecorder,
 	clusterInstrumentationConfig *util.ClusterInstrumentationConfig,
 ) *InstrumentationWebhookHandler {
 	if clusterInstrumentationConfig == nil {

--- a/internal/webhooks/instrumentation_webhook_test.go
+++ b/internal/webhooks/instrumentation_webhook_test.go
@@ -482,9 +482,7 @@ var _ = Describe("The Dash0 instrumentation webhook", func() {
 					clientset,
 					TestNamespaceName,
 					name,
-					corev1.EventTypeWarning,
 					util.ReasonPartiallyUnsuccessfulInstrumentation,
-					util.ActionInstrumentation,
 					"Dash0 instrumentation of this workload by the webhook has been partially unsuccessful, 1 out of "+
 						"2 containers have instrumentation issues. test-container-0: Dash0 cannot prepend anything to "+
 						"the environment variable LD_PRELOAD as it is specified via ValueFrom, this container will "+

--- a/internal/webhooks/monitoring_conversion_webhook.go
+++ b/internal/webhooks/monitoring_conversion_webhook.go
@@ -15,7 +15,7 @@ import (
 func SetupDash0MonitoringConversionWebhookWithManager(mgr ctrl.Manager) error {
 	return errors.Join(
 		//
-		ctrl.NewWebhookManagedBy(mgr, &dash0v1alpha1.Dash0Monitoring{}).Complete(),
-		ctrl.NewWebhookManagedBy(mgr, &dash0v1beta1.Dash0Monitoring{}).Complete(),
+		ctrl.NewWebhookManagedBy(mgr).For(&dash0v1alpha1.Dash0Monitoring{}).Complete(),
+		ctrl.NewWebhookManagedBy(mgr).For(&dash0v1beta1.Dash0Monitoring{}).Complete(),
 	)
 }

--- a/internal/webhooks/webhook_suite_test.go
+++ b/internal/webhooks/webhook_suite_test.go
@@ -123,7 +123,7 @@ var _ = BeforeSuite(func() {
 
 	Expect(NewInstrumentationWebhookHandler(
 		k8sClient,
-		manager.GetEventRecorder("dash0-webhook"),
+		manager.GetEventRecorderFor("dash0-webhook"),
 		util.NewClusterInstrumentationConfig(
 			TestImages,
 			OTelCollectorNodeLocalBaseUrlTest,

--- a/test/e2e/applications_under_test.go
+++ b/test/e2e/applications_under_test.go
@@ -19,39 +19,32 @@ const (
 
 var (
 	workloadTypeCronjob = workloadType{
-		workloadTypeString:          "cronjob",
-		workloadTypeStringCamelCase: "CronJob",
-		isBatch:                     true,
+		workloadTypeString: "cronjob",
+		isBatch:            true,
 	}
 	workloadTypeDaemonSet = workloadType{
-		workloadTypeString:          "daemonset",
-		workloadTypeStringCamelCase: "DaemonSet",
-		isBatch:                     false,
+		workloadTypeString: "daemonset",
+		isBatch:            false,
 	}
 	workloadTypeDeployment = workloadType{
-		workloadTypeString:          "deployment",
-		workloadTypeStringCamelCase: "Deployment",
-		isBatch:                     false,
+		workloadTypeString: "deployment",
+		isBatch:            false,
 	}
 	workloadTypeJob = workloadType{
-		workloadTypeString:          "job",
-		workloadTypeStringCamelCase: "Job",
-		isBatch:                     true,
+		workloadTypeString: "job",
+		isBatch:            true,
 	}
 	workloadTypePod = workloadType{
-		workloadTypeString:          "pod",
-		workloadTypeStringCamelCase: "Pod",
-		isBatch:                     false,
+		workloadTypeString: "pod",
+		isBatch:            false,
 	}
 	workloadTypeReplicaSet = workloadType{
-		workloadTypeString:          "replicaset",
-		workloadTypeStringCamelCase: "ReplicaSet",
-		isBatch:                     false,
+		workloadTypeString: "replicaset",
+		isBatch:            false,
 	}
 	workloadTypeStatefulSet = workloadType{
-		workloadTypeString:          "statefulset",
-		workloadTypeStringCamelCase: "StatefulSet",
-		isBatch:                     false,
+		workloadTypeString: "statefulset",
+		isBatch:            false,
 	}
 
 	runtimeTypeNodeJs = runtimeType{

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -13,7 +13,7 @@ require (
 	k8s.io/api v0.35.0
 	k8s.io/apimachinery v0.35.0
 	k8s.io/utils v0.0.0-20251002143259-bc988d571ff4
-	sigs.k8s.io/controller-runtime v0.23.1
+	sigs.k8s.io/controller-runtime v0.22.4
 )
 
 require (

--- a/test/e2e/go.sum
+++ b/test/e2e/go.sum
@@ -454,8 +454,8 @@ k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912 h1:Y3gxNAuB0OBLImH611+UDZ
 k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912/go.mod h1:kdmbQkyfwUagLfXIad1y2TdrjPFWp2Q89B3qkRwf/pQ=
 k8s.io/utils v0.0.0-20251002143259-bc988d571ff4 h1:SjGebBtkBqHFOli+05xYbK8YF1Dzkbzn+gDM4X9T4Ck=
 k8s.io/utils v0.0.0-20251002143259-bc988d571ff4/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
-sigs.k8s.io/controller-runtime v0.23.1 h1:TjJSM80Nf43Mg21+RCy3J70aj/W6KyvDtOlpKf+PupE=
-sigs.k8s.io/controller-runtime v0.23.1/go.mod h1:B6COOxKptp+YaUT5q4l6LqUJTRpizbgf9KSRNdQGns0=
+sigs.k8s.io/controller-runtime v0.22.4 h1:GEjV7KV3TY8e+tJ2LCTxUTanW4z/FmNB7l327UfMq9A=
+sigs.k8s.io/controller-runtime v0.22.4/go.mod h1:+QX1XUpTXN4mLoblf4tqr5CQcyHPAki2HLXqQMY6vh8=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5EXP7sU1kvOlxwZh5txg=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -62,9 +62,8 @@ type neccessaryCleanupSteps struct {
 }
 
 type workloadType struct {
-	workloadTypeString          string
-	workloadTypeStringCamelCase string
-	isBatch                     bool
+	workloadTypeString string
+	isBatch            bool
 }
 
 type runtimeType struct {

--- a/test/util/matchers.go
+++ b/test/util/matchers.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
-	eventsv1 "k8s.io/api/events/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/dash0hq/dash0-operator/internal/util"
@@ -165,19 +164,15 @@ func (matcher *MatchVolumeMountMatcher) NegatedFailureMessage(actual interface{}
 func MatchEvent(
 	namespace string,
 	resourceName string,
-	eventType string,
 	reason util.Reason,
-	action util.Action,
-	note string,
+	message string,
 	args ...interface{},
 ) gomega.OmegaMatcher {
 	return &MatchEventMatcher{
 		Namespace:    namespace,
 		ResourceName: resourceName,
-		EventType:    eventType,
-		Reason:       reason,
-		Action:       action,
-		Note:         note,
+		Reason:       string(reason),
+		Message:      message,
 		Args:         args,
 	}
 }
@@ -185,26 +180,22 @@ func MatchEvent(
 type MatchEventMatcher struct {
 	Namespace    string
 	ResourceName string
-	EventType    string
-	Reason       util.Reason
-	Action       util.Action
-	Note         string
+	Reason       string
+	Message      string
 	Args         []interface{}
 }
 
 func (matcher *MatchEventMatcher) Match(actual interface{}) (success bool, err error) {
-	event, ok := actual.(eventsv1.Event)
+	event, ok := actual.(corev1.Event)
 	if !ok {
 		return false, fmt.Errorf(
-			"MatchEvent matcher requires a eventsv1.Event. Got:\n%s",
+			"MatchEvent matcher requires a corev1.Event. Got:\n%s",
 			format.Object(actual, 1))
 	}
 	return matcher.Namespace == event.ObjectMeta.Namespace &&
 			strings.Contains(event.ObjectMeta.Name, matcher.ResourceName) &&
-			matcher.EventType == event.Type &&
-			string(matcher.Reason) == event.Reason &&
-			string(matcher.Action) == event.Action &&
-			matcher.Note == event.Note,
+			matcher.Reason == event.Reason &&
+			matcher.Message == event.Message,
 		nil
 }
 
@@ -213,13 +204,11 @@ func (matcher *MatchEventMatcher) FailureMessage(actual interface{}) (message st
 }
 
 func (matcher *MatchEventMatcher) message() string {
-	return fmt.Sprintf("to contain event with for resource %s/%s, type %s, reason %s, action %s and note %s",
+	return fmt.Sprintf("to contain event with for resource %s/%sreason %s and message %s",
 		matcher.Namespace,
 		matcher.ResourceName,
-		matcher.EventType,
 		matcher.Reason,
-		matcher.Action,
-		matcher.Note,
+		matcher.Message,
 	)
 }
 

--- a/test/util/resources.go
+++ b/test/util/resources.go
@@ -1254,12 +1254,12 @@ func DeleteAllEvents(
 	clientset *kubernetes.Clientset,
 	namespace string,
 ) {
-	err := clientset.EventsV1().Events(namespace).DeleteCollection(ctx, metav1.DeleteOptions{
+	err := clientset.CoreV1().Events(namespace).DeleteCollection(ctx, metav1.DeleteOptions{
 		GracePeriodSeconds: new(int64), // delete immediately
 	}, metav1.ListOptions{})
 	Expect(err).NotTo(HaveOccurred())
 
-	allEvents, err := clientset.EventsV1().Events(namespace).List(ctx, metav1.ListOptions{})
+	allEvents, err := clientset.CoreV1().Events(namespace).List(ctx, metav1.ListOptions{})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(allEvents.Items).To(BeEmpty())
 }

--- a/test/util/verification.go
+++ b/test/util/verification.go
@@ -14,7 +14,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	eventsv1 "k8s.io/api/events/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
@@ -500,7 +499,7 @@ func VerifyNoEvents(
 	clientset *kubernetes.Clientset,
 	namespace string,
 ) {
-	allEvents, err := clientset.EventsV1().Events(namespace).List(ctx, metav1.ListOptions{})
+	allEvents, err := clientset.CoreV1().Events(namespace).List(ctx, metav1.ListOptions{})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(allEvents.Items).To(BeEmpty())
 }
@@ -511,15 +510,13 @@ func VerifySuccessfulInstrumentationEvent(
 	namespace string,
 	resourceName string,
 	eventSource string,
-) *eventsv1.Event {
+) *corev1.Event {
 	return VerifyEvent(
 		ctx,
 		clientset,
 		namespace,
 		resourceName,
-		corev1.EventTypeNormal,
 		util.ReasonSuccessfulInstrumentation,
-		util.ActionInstrumentation,
 		fmt.Sprintf("Dash0 instrumentation of this workload by the %s has been successful.", eventSource),
 	)
 }
@@ -530,15 +527,13 @@ func VerifyInstrumentationViaHigherOrderWorkloadEvent(
 	namespace string,
 	resourceName string,
 	eventSource string,
-) *eventsv1.Event {
+) *corev1.Event {
 	return VerifyEvent(
 		ctx,
 		clientset,
 		namespace,
 		resourceName,
-		corev1.EventTypeNormal,
 		util.ReasonNoInstrumentationNecessary,
-		util.ActionInstrumentation,
 		fmt.Sprintf(
 			"The workload is part of a higher order workload that will be instrumented by the %s, "+
 				"no modification by the %s is necessary.",
@@ -552,15 +547,13 @@ func VerifyFailedInstrumentationEvent(
 	namespace string,
 	resourceName string,
 	message string,
-) *eventsv1.Event {
+) *corev1.Event {
 	return VerifyEvent(
 		ctx,
 		clientset,
 		namespace,
 		resourceName,
-		corev1.EventTypeWarning,
 		util.ReasonFailedInstrumentation,
-		util.ActionInstrumentation,
 		message,
 	)
 }
@@ -571,15 +564,13 @@ func VerifySuccessfulUninstrumentationEvent(
 	namespace string,
 	resourceName string,
 	eventSource string,
-) *eventsv1.Event {
+) *corev1.Event {
 	return VerifyEvent(
 		ctx,
 		clientset,
 		namespace,
 		resourceName,
-		corev1.EventTypeNormal,
 		util.ReasonSuccessfulUninstrumentation,
-		util.ActionUninstrumentation,
 		fmt.Sprintf("The %s successfully removed the Dash0 instrumentation from this workload.", eventSource),
 	)
 }
@@ -591,16 +582,14 @@ func VerifySuccessfulUninstrumentationEventEventually(
 	namespace string,
 	resourceName string,
 	eventSource string,
-) *eventsv1.Event {
+) *corev1.Event {
 	return verifyEventEventually(
 		ctx,
 		clientset,
 		g,
 		namespace,
 		resourceName,
-		corev1.EventTypeNormal,
 		util.ReasonSuccessfulUninstrumentation,
-		util.ActionUninstrumentation,
 		fmt.Sprintf("The %s successfully removed the Dash0 instrumentation from this workload.", eventSource),
 	)
 }
@@ -611,15 +600,13 @@ func VerifyFailedUninstrumentationEvent(
 	namespace string,
 	resourceName string,
 	message string,
-) *eventsv1.Event {
+) *corev1.Event {
 	return VerifyEvent(
 		ctx,
 		clientset,
 		namespace,
 		resourceName,
-		corev1.EventTypeWarning,
 		util.ReasonFailedUninstrumentation,
-		util.ActionUninstrumentation,
 		message,
 	)
 }
@@ -629,14 +616,12 @@ func VerifyEvent(
 	clientset *kubernetes.Clientset,
 	namespace string,
 	resourceName string,
-	eventType string,
 	reason util.Reason,
-	action util.Action,
-	note string,
-) *eventsv1.Event {
-	var event *eventsv1.Event
+	message string,
+) *corev1.Event {
+	var event *corev1.Event
 	Eventually(func(g Gomega) {
-		event = verifyEventEventually(ctx, clientset, g, namespace, resourceName, eventType, reason, action, note)
+		event = verifyEventEventually(ctx, clientset, g, namespace, resourceName, reason, message)
 	}, eventTimeout).Should(Succeed())
 	return event
 }
@@ -647,22 +632,19 @@ func verifyEventEventually(
 	g Gomega,
 	namespace string,
 	resourceName string,
-	eventType string,
 	reason util.Reason,
-	action util.Action,
-	note string,
-) *eventsv1.Event {
+	message string,
+) *corev1.Event {
 	matcher := MatchEvent(
 		namespace,
 		resourceName,
-		eventType,
 		reason,
-		action,
-		note,
+		message,
 	)
 
-	allEvents, err := clientset.EventsV1().Events(namespace).List(ctx, metav1.ListOptions{})
+	allEvents, err := clientset.CoreV1().Events(namespace).List(ctx, metav1.ListOptions{})
 	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(allEvents.Items).To(HaveLen(1))
 	g.Expect(allEvents.Items).To(ContainElement(matcher))
 
 	for _, event := range allEvents.Items {


### PR DESCRIPTION
Revert "chore(deps): bump sigs.k8s.io/controller-runtime from 0.22.4 to 0.23.0 in the production-dependencies group across 1 directory (#727)"

This reverts commit fc455d37cfa341fe45821ed92220eb8a073c7885.

The commit was merged prematurely. Since the update requires extensive changes, it will be postponed to a later release.