### PR TITLE
chore(test-resources): add utility script to list resources in namespace

### DIFF
--- a/test-resources/bin/list-all-resources-in-namespace.sh
+++ b/test-resources/bin/list-all-resources-in-namespace.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright 2026 Dash0 Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+namespace="${1:-}"
+
+if [[ -z $namespace ]]; then
+  echo Missing mandatory parameter: namespace
+  exit 1
+fi
+
+resource_types=$(kubectl api-resources --verbs=list --namespaced -o name)
+
+while IFS= read -r resource_type; do
+  resources=$(kubectl get -n "$namespace" "$resource_type" 2>&1)
+  if [[ ! "$resources" =~ ^"No resources found in " ]]; then
+    echo "Resource type $resource_type:"
+    echo "$resources"
+    echo
+  fi
+done <<< "$resource_types"


### PR DESCRIPTION
Working on the operator, one might occasionally end up with a namespace being permanently stuck in the terminating state in the local test cluster, because some resource in it cannot be deleted. The script will iterate over all resource types and list the existing resources per type, which is convenient to track down what exactly blocks namespace deletion.