### PR TITLE
chore(deps): update sigs.k8s.io/controller-runtime from 0.22.4 to 0.23.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	k8s.io/apimachinery v0.35.0
 	k8s.io/client-go v0.35.0
 	k8s.io/utils v0.0.0-20251002143259-bc988d571ff4
-	sigs.k8s.io/controller-runtime v0.22.4
+	sigs.k8s.io/controller-runtime v0.23.1
 	sigs.k8s.io/yaml v1.6.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -438,8 +438,8 @@ k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912 h1:Y3gxNAuB0OBLImH611+UDZ
 k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912/go.mod h1:kdmbQkyfwUagLfXIad1y2TdrjPFWp2Q89B3qkRwf/pQ=
 k8s.io/utils v0.0.0-20251002143259-bc988d571ff4 h1:SjGebBtkBqHFOli+05xYbK8YF1Dzkbzn+gDM4X9T4Ck=
 k8s.io/utils v0.0.0-20251002143259-bc988d571ff4/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
-sigs.k8s.io/controller-runtime v0.22.4 h1:GEjV7KV3TY8e+tJ2LCTxUTanW4z/FmNB7l327UfMq9A=
-sigs.k8s.io/controller-runtime v0.22.4/go.mod h1:+QX1XUpTXN4mLoblf4tqr5CQcyHPAki2HLXqQMY6vh8=
+sigs.k8s.io/controller-runtime v0.23.1 h1:TjJSM80Nf43Mg21+RCy3J70aj/W6KyvDtOlpKf+PupE=
+sigs.k8s.io/controller-runtime v0.23.1/go.mod h1:B6COOxKptp+YaUT5q4l6LqUJTRpizbgf9KSRNdQGns0=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5EXP7sU1kvOlxwZh5txg=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=

--- a/helm-chart/dash0-operator/templates/operator/cluster-roles.yaml
+++ b/helm-chart/dash0-operator/templates/operator/cluster-roles.yaml
@@ -56,10 +56,9 @@ rules:
   verbs:
   - list
 
-# Permissions required to queue events to report about the operator's actions, and to attach dangling events to their
-# respective involved objects:
+# Permissions required to queue events to report about the operator's actions:
 - apiGroups:
-  - ""
+  - events.k8s.io
   resources:
   - events
   verbs:
@@ -73,6 +72,16 @@ rules:
   - namespaces
   verbs:
   - get
+
+# Permissions for the legacy event API, required to attach dangling events to their respective involved objects:
+- apiGroups:
+    - ""
+  resources:
+    - events
+  verbs:
+    - list
+    - patch
+    - update
 
 # Permissions required to automatically restart (i.e. delete) pods when instrumenting replicasets that are not part of a
 # higher order workload (e.g. a deployment, daemonset):

--- a/helm-chart/dash0-operator/tests/operator/__snapshot__/cluster-roles_test.yaml.snap
+++ b/helm-chart/dash0-operator/tests/operator/__snapshot__/cluster-roles_test.yaml.snap
@@ -52,7 +52,7 @@ cluster roles should match snapshot:
         verbs:
           - list
       - apiGroups:
-          - ""
+          - events.k8s.io
         resources:
           - events
         verbs:
@@ -66,6 +66,14 @@ cluster roles should match snapshot:
           - namespaces
         verbs:
           - get
+      - apiGroups:
+          - ""
+        resources:
+          - events
+        verbs:
+          - list
+          - patch
+          - update
       - apiGroups:
           - ""
         resources:

--- a/internal/controller/controller_suite_test.go
+++ b/internal/controller/controller_suite_test.go
@@ -14,7 +14,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -41,7 +41,7 @@ var (
 	cfg       *rest.Config
 	k8sClient client.Client
 	clientset *kubernetes.Clientset
-	recorder  record.EventRecorder
+	recorder  events.EventRecorder
 	testEnv   *envtest.Environment
 )
 
@@ -85,7 +85,7 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(mgr).NotTo(BeNil())
-	recorder = mgr.GetEventRecorderFor("dash0-controller")
+	recorder = mgr.GetEventRecorder("dash0-controller")
 })
 
 var _ = AfterSuite(func() {

--- a/internal/instrumentation/instrumentation_suite_test.go
+++ b/internal/instrumentation/instrumentation_suite_test.go
@@ -12,7 +12,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
@@ -33,7 +33,7 @@ var (
 	cfg       *rest.Config
 	k8sClient client.Client
 	clientset *kubernetes.Clientset
-	recorder  record.EventRecorder
+	recorder  events.EventRecorder
 	testEnv   *envtest.Environment
 )
 
@@ -78,7 +78,7 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(mgr).NotTo(BeNil())
-	recorder = mgr.GetEventRecorderFor("dash0-controller")
+	recorder = mgr.GetEventRecorder("dash0-controller")
 })
 
 var _ = AfterSuite(func() {

--- a/internal/instrumentation/instrumenter.go
+++ b/internal/instrumentation/instrumenter.go
@@ -17,8 +17,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/events"
 	"k8s.io/client-go/tools/pager"
-	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -32,7 +32,7 @@ import (
 type Instrumenter struct {
 	client.Client
 	Clientset                    *kubernetes.Clientset
-	Recorder                     record.EventRecorder
+	Recorder                     events.EventRecorder
 	ClusterInstrumentationConfig *util.ClusterInstrumentationConfig
 }
 
@@ -79,7 +79,7 @@ func (e ImmutableWorkloadError) Error() string {
 func NewInstrumenter(
 	client client.Client,
 	clientset *kubernetes.Clientset,
-	recorder record.EventRecorder,
+	recorder events.EventRecorder,
 	clusterInstrumentationConfig *util.ClusterInstrumentationConfig,
 ) *Instrumenter {
 	if clusterInstrumentationConfig == nil {

--- a/internal/predelete/pre_delete_suite_test.go
+++ b/internal/predelete/pre_delete_suite_test.go
@@ -97,7 +97,7 @@ var _ = BeforeSuite(func() {
 	instrumenter := instrumentation.NewInstrumenter(
 		k8sClient,
 		clientset,
-		mgr.GetEventRecorderFor("dash0-monitoring-controller"),
+		mgr.GetEventRecorder("dash0-monitoring-controller"),
 		util.NewClusterInstrumentationConfig(
 			TestImages,
 			OTelCollectorNodeLocalBaseUrlTest,

--- a/internal/startup/operator_manager_startup.go
+++ b/internal/startup/operator_manager_startup.go
@@ -891,7 +891,7 @@ func startDash0Controllers(
 		// The k8s client will be added later, in internal/startup/instrument_at_startup.go#Start.
 		nil,
 		clientset,
-		mgr.GetEventRecorderFor("dash0-startup-tasks"),
+		mgr.GetEventRecorder("dash0-startup-tasks"),
 		clusterInstrumentationConfig,
 	)
 	// For consistency, we update the extra config map in the startupInstrumenter handler as well if it changes. Since
@@ -916,7 +916,7 @@ func startDash0Controllers(
 	instrumenter := instrumentation.NewInstrumenter(
 		k8sClient,
 		clientset,
-		mgr.GetEventRecorderFor("dash0-monitoring-controller"),
+		mgr.GetEventRecorder("dash0-monitoring-controller"),
 		clusterInstrumentationConfig,
 	)
 	// For consistency, we update the extra config map in the instrumenter handler as well. However, even if
@@ -1107,7 +1107,7 @@ func startDash0Controllers(
 
 	instrumentationWebhookHandler := webhooks.NewInstrumentationWebhookHandler(
 		k8sClient,
-		mgr.GetEventRecorderFor("dash0-instrumentation-webhook"),
+		mgr.GetEventRecorder("dash0-instrumentation-webhook"),
 		clusterInstrumentationConfig,
 	)
 	if err := instrumentationWebhookHandler.SetupWebhookWithManager(mgr); err != nil {

--- a/internal/util/types.go
+++ b/internal/util/types.go
@@ -13,6 +13,13 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
+type Action string
+
+const (
+	ActionInstrumentation   Action = "Instrumentation"
+	ActionUninstrumentation Action = "Uninstrumentation"
+)
+
 type Reason string
 
 const (

--- a/internal/webhooks/attach_dangling_events_test.go
+++ b/internal/webhooks/attach_dangling_events_test.go
@@ -38,7 +38,7 @@ var _ = Describe("The Dash0 webhook and the Dash0 controller", Ordered, func() {
 	BeforeAll(func() {
 		EnsureOperatorNamespaceExists(ctx, k8sClient)
 
-		recorder := manager.GetEventRecorderFor("dash0-monitoring-controller")
+		recorder := manager.GetEventRecorder("dash0-monitoring-controller")
 		instrumenter := instrumentation.NewInstrumenter(
 			k8sClient,
 			clientset,
@@ -122,19 +122,19 @@ var _ = Describe("The Dash0 webhook and the Dash0 controller", Ordered, func() {
 		workload = config.GetFn(ctx, k8sClient, TestNamespaceName, name)
 		event := VerifySuccessfulInstrumentationEvent(ctx, clientset, TestNamespaceName, name, "webhook")
 
-		Expect(event.InvolvedObject.UID).To(BeEmpty())
-		Expect(event.InvolvedObject.ResourceVersion).To(BeEmpty())
+		Expect(event.Regarding.UID).To(BeEmpty())
+		Expect(event.Regarding.ResourceVersion).To(BeEmpty())
 
 		triggerReconcileRequest(ctx, reconciler, dash0MonitoringResource)
 
 		Eventually(func(g Gomega) {
 			// refetch event and check that the UID and ResourceVersion are set correctly now
 			var err error
-			event, err = clientset.CoreV1().Events(TestNamespaceName).Get(ctx, event.Name, metav1.GetOptions{})
+			event, err = clientset.EventsV1().Events(TestNamespaceName).Get(ctx, event.Name, metav1.GetOptions{})
 			g.Expect(err).NotTo(HaveOccurred())
 
-			g.Expect(event.InvolvedObject.UID).To(Equal(workload.Get().GetUID()))
-			g.Expect(event.InvolvedObject.ResourceVersion).To(Equal(workload.Get().GetResourceVersion()))
+			g.Expect(event.Regarding.UID).To(Equal(workload.Get().GetUID()))
+			g.Expect(event.Regarding.ResourceVersion).To(Equal(workload.Get().GetResourceVersion()))
 		}, 5*time.Second, 100*time.Millisecond).Should(Succeed())
 	}, Entry("should attach event to a cron job", WorkloadTestConfig{
 		WorkloadNamePrefix: CronJobNamePrefix,

--- a/internal/webhooks/instrumentation_webhook.go
+++ b/internal/webhooks/instrumentation_webhook.go
@@ -17,7 +17,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -31,7 +31,7 @@ import (
 
 type InstrumentationWebhookHandler struct {
 	Client                       client.Client
-	Recorder                     record.EventRecorder
+	Recorder                     events.EventRecorder
 	ClusterInstrumentationConfig *util.ClusterInstrumentationConfig
 }
 
@@ -98,7 +98,7 @@ var (
 
 func NewInstrumentationWebhookHandler(
 	client client.Client,
-	recorder record.EventRecorder,
+	recorder events.EventRecorder,
 	clusterInstrumentationConfig *util.ClusterInstrumentationConfig,
 ) *InstrumentationWebhookHandler {
 	if clusterInstrumentationConfig == nil {

--- a/internal/webhooks/instrumentation_webhook_test.go
+++ b/internal/webhooks/instrumentation_webhook_test.go
@@ -482,7 +482,9 @@ var _ = Describe("The Dash0 instrumentation webhook", func() {
 					clientset,
 					TestNamespaceName,
 					name,
+					corev1.EventTypeWarning,
 					util.ReasonPartiallyUnsuccessfulInstrumentation,
+					util.ActionInstrumentation,
 					"Dash0 instrumentation of this workload by the webhook has been partially unsuccessful, 1 out of "+
 						"2 containers have instrumentation issues. test-container-0: Dash0 cannot prepend anything to "+
 						"the environment variable LD_PRELOAD as it is specified via ValueFrom, this container will "+

--- a/internal/webhooks/monitoring_conversion_webhook.go
+++ b/internal/webhooks/monitoring_conversion_webhook.go
@@ -15,7 +15,7 @@ import (
 func SetupDash0MonitoringConversionWebhookWithManager(mgr ctrl.Manager) error {
 	return errors.Join(
 		//
-		ctrl.NewWebhookManagedBy(mgr).For(&dash0v1alpha1.Dash0Monitoring{}).Complete(),
-		ctrl.NewWebhookManagedBy(mgr).For(&dash0v1beta1.Dash0Monitoring{}).Complete(),
+		ctrl.NewWebhookManagedBy(mgr, &dash0v1alpha1.Dash0Monitoring{}).Complete(),
+		ctrl.NewWebhookManagedBy(mgr, &dash0v1beta1.Dash0Monitoring{}).Complete(),
 	)
 }

--- a/internal/webhooks/webhook_suite_test.go
+++ b/internal/webhooks/webhook_suite_test.go
@@ -123,7 +123,7 @@ var _ = BeforeSuite(func() {
 
 	Expect(NewInstrumentationWebhookHandler(
 		k8sClient,
-		manager.GetEventRecorderFor("dash0-webhook"),
+		manager.GetEventRecorder("dash0-webhook"),
 		util.NewClusterInstrumentationConfig(
 			TestImages,
 			OTelCollectorNodeLocalBaseUrlTest,

--- a/test/e2e/applications_under_test.go
+++ b/test/e2e/applications_under_test.go
@@ -19,32 +19,39 @@ const (
 
 var (
 	workloadTypeCronjob = workloadType{
-		workloadTypeString: "cronjob",
-		isBatch:            true,
+		workloadTypeString:          "cronjob",
+		workloadTypeStringCamelCase: "CronJob",
+		isBatch:                     true,
 	}
 	workloadTypeDaemonSet = workloadType{
-		workloadTypeString: "daemonset",
-		isBatch:            false,
+		workloadTypeString:          "daemonset",
+		workloadTypeStringCamelCase: "DaemonSet",
+		isBatch:                     false,
 	}
 	workloadTypeDeployment = workloadType{
-		workloadTypeString: "deployment",
-		isBatch:            false,
+		workloadTypeString:          "deployment",
+		workloadTypeStringCamelCase: "Deployment",
+		isBatch:                     false,
 	}
 	workloadTypeJob = workloadType{
-		workloadTypeString: "job",
-		isBatch:            true,
+		workloadTypeString:          "job",
+		workloadTypeStringCamelCase: "Job",
+		isBatch:                     true,
 	}
 	workloadTypePod = workloadType{
-		workloadTypeString: "pod",
-		isBatch:            false,
+		workloadTypeString:          "pod",
+		workloadTypeStringCamelCase: "Pod",
+		isBatch:                     false,
 	}
 	workloadTypeReplicaSet = workloadType{
-		workloadTypeString: "replicaset",
-		isBatch:            false,
+		workloadTypeString:          "replicaset",
+		workloadTypeStringCamelCase: "ReplicaSet",
+		isBatch:                     false,
 	}
 	workloadTypeStatefulSet = workloadType{
-		workloadTypeString: "statefulset",
-		isBatch:            false,
+		workloadTypeString:          "statefulset",
+		workloadTypeStringCamelCase: "StatefulSet",
+		isBatch:                     false,
 	}
 
 	runtimeTypeNodeJs = runtimeType{

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -13,7 +13,7 @@ require (
 	k8s.io/api v0.35.0
 	k8s.io/apimachinery v0.35.0
 	k8s.io/utils v0.0.0-20251002143259-bc988d571ff4
-	sigs.k8s.io/controller-runtime v0.22.4
+	sigs.k8s.io/controller-runtime v0.23.1
 )
 
 require (

--- a/test/e2e/go.sum
+++ b/test/e2e/go.sum
@@ -454,8 +454,8 @@ k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912 h1:Y3gxNAuB0OBLImH611+UDZ
 k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912/go.mod h1:kdmbQkyfwUagLfXIad1y2TdrjPFWp2Q89B3qkRwf/pQ=
 k8s.io/utils v0.0.0-20251002143259-bc988d571ff4 h1:SjGebBtkBqHFOli+05xYbK8YF1Dzkbzn+gDM4X9T4Ck=
 k8s.io/utils v0.0.0-20251002143259-bc988d571ff4/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
-sigs.k8s.io/controller-runtime v0.22.4 h1:GEjV7KV3TY8e+tJ2LCTxUTanW4z/FmNB7l327UfMq9A=
-sigs.k8s.io/controller-runtime v0.22.4/go.mod h1:+QX1XUpTXN4mLoblf4tqr5CQcyHPAki2HLXqQMY6vh8=
+sigs.k8s.io/controller-runtime v0.23.1 h1:TjJSM80Nf43Mg21+RCy3J70aj/W6KyvDtOlpKf+PupE=
+sigs.k8s.io/controller-runtime v0.23.1/go.mod h1:B6COOxKptp+YaUT5q4l6LqUJTRpizbgf9KSRNdQGns0=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5EXP7sU1kvOlxwZh5txg=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -62,8 +62,9 @@ type neccessaryCleanupSteps struct {
 }
 
 type workloadType struct {
-	workloadTypeString string
-	isBatch            bool
+	workloadTypeString          string
+	workloadTypeStringCamelCase string
+	isBatch                     bool
 }
 
 type runtimeType struct {

--- a/test/util/resources.go
+++ b/test/util/resources.go
@@ -1254,12 +1254,12 @@ func DeleteAllEvents(
 	clientset *kubernetes.Clientset,
 	namespace string,
 ) {
-	err := clientset.CoreV1().Events(namespace).DeleteCollection(ctx, metav1.DeleteOptions{
+	err := clientset.EventsV1().Events(namespace).DeleteCollection(ctx, metav1.DeleteOptions{
 		GracePeriodSeconds: new(int64), // delete immediately
 	}, metav1.ListOptions{})
 	Expect(err).NotTo(HaveOccurred())
 
-	allEvents, err := clientset.CoreV1().Events(namespace).List(ctx, metav1.ListOptions{})
+	allEvents, err := clientset.EventsV1().Events(namespace).List(ctx, metav1.ListOptions{})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(allEvents.Items).To(BeEmpty())
 }


### PR DESCRIPTION
This re-applies the commit reverted in https://github.com/dash0hq/dash0-operator/commit/2695ed20353e8fb80e7a0940974d71384119d792, plus restoring the capability to attach dangling webhook events.

Necessary changes after updating sigs.k8s.io/controller-runtime to
version 0.23.0:
- migrate from k8s.io/api/core/v1 events to k8s.io/api/events/v1
- update from GetEventRecorderFor to GetEventRecorder
- change rbac from core events to events.k8s.io
- update from NewWebhookManagedBy(mgr).For(&...) to
  NewWebhookManagedBy(mgr, &...)
- update sigs.k8s.io/controller-runtime in test/e2e/go.mod
- the functionality to attach dangling events still needs to use
  the legacy event API, as regarding.uid is immutable in the new API