### PR TITLE
chore: update kind setup to be compatible with kind >= 0.31.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -293,6 +293,8 @@ Moving beyond the quickstart instructions, here are more details on the test scr
       The default is to use the secret ref.
       This setting is used in both modes, that is, independent of whether `DEPLOY_OPERATOR_CONFIGURATION_VIA_HELM=false`
       has been provided.
+    * `ALLOW_MORE_TIME_FOR_COLLECTOR_STARTUP` set to `true` increases the `failureThreshold` for the startup probes of
+      collectors to support slower environments (e.g. running kind with limited resources).
     * Additional configuration for the Helm deployment can be put into `test-resources/bin/extra-values.yaml` (create
       the file if necessary).
 * Last but not least, there are a couple of environment variables that control which images are built and used, and whether

--- a/test-resources/bin/create_cluster_and_registry.sh
+++ b/test-resources/bin/create_cluster_and_registry.sh
@@ -24,8 +24,10 @@ load_env_file
 create_cluster_and_registry() {
   local kind_cluster="${DASH0_KIND_CLUSTER:-$default_kind_cluster}"
   local kind_config="${DASH0_KIND_CONFIG:-$default_kind_config}"
+
   start_kind "$kind_cluster" "$kind_config"
   create_registry "$local_reg_name" "$local_reg_port" "$LOCAL_REGISTRY_VOLUME_PATH"
+  add_registry_config_to_nodes "$kind_cluster" "$local_reg_name" "$local_reg_port"
   connect_kind_network "$local_reg_name"
 }
 

--- a/test-resources/bin/lib/kind
+++ b/test-resources/bin/lib/kind
@@ -15,12 +15,32 @@ start_kind() {
   local kind_config="${2}"
   echo "Creating kind cluster with [name=$name] and [config=$kind_config]..."
   kind create cluster --name "$name" --config "$kind_config"
-  echo "Done."
+  echo "Done creating cluster."
 }
 
 delete_cluster() {
   local name="${1}"
   echo "Deleting kind cluster with [name=$name]..."
   kind delete cluster -n "$name"
-  echo "Done."
+  echo "Done deleting cluster."
+}
+
+add_registry_config_to_nodes() {
+  local cluster_name="${1}"
+  local reg_name="${2}"
+  local reg_port="${3}"
+  local reg_dir="/etc/containerd/certs.d/localhost:${reg_port}"
+  echo "Adding registry config to nodes of cluster [name=$cluster_name], using [reg_dir=$reg_dir]..."
+  for node in $(kind get nodes --name "$cluster_name"); do
+    # when running with podman/nerdctl kind prints some extra info that breaks the script, so we make sure
+    # to only look at actual node names, which are prefixed with the cluster name
+    if [[ $node == "$cluster_name"* ]]; then
+      echo "Patching node [name=$node]"
+      docker exec "${node}" mkdir -p "${reg_dir}"
+      cat <<EOF | docker exec -i "${node}" cp /dev/stdin "${reg_dir}/hosts.toml"
+[host."http://${reg_name}:5000"]
+EOF
+    fi
+  done
+  echo "Done adding registry config to nodes."
 }

--- a/test-resources/bin/lib/util
+++ b/test-resources/bin/lib/util
@@ -645,6 +645,12 @@ run_helm() {
     helm_install_command+=" --set operator.replicaCount=${OPERATOR_REPLICAS:-1}"
   fi
 
+  # on kind, the collectors sometimes need more time to start
+  if [[ "${ALLOW_MORE_TIME_FOR_COLLECTOR_STARTUP:-}" == "true" ]]; then
+    helm_install_command+=" --set operator.collectors.daemonSetProbes.startup.failureThreshold=60"
+    helm_install_command+=" --set operator.collectors.deploymentProbes.startup.failureThreshold=60"
+  fi
+
   helm_install_command+=" dash0-operator"
   helm_install_command+=" ${OPERATOR_HELM_CHART:-helm-chart/dash0-operator}"
   echo Helm install command:

--- a/test-resources/kind-config.yaml
+++ b/test-resources/kind-config.yaml
@@ -20,10 +20,6 @@
 ---
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
-containerdConfigPatches:
-  - |-
-    [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:5001"]
-      endpoint = ["http://kind-registry:5000"]
 nodes:
   - role: control-plane
     extraMounts:


### PR DESCRIPTION
With kind versions >= 0.31.0, the existing setup, more specifically the `containerdConfigPatches` for the local registry, did no longer work.

This PR updates the setup to work with the latest version of kind.