### PR TITLE
test(e2e): wait for kubectl rollout status before checking spans

### DIFF
--- a/test-resources/jvm/spring-boot/src/main/java/com/dash0/app_under_test/Controller.java
+++ b/test-resources/jvm/spring-boot/src/main/java/com/dash0/app_under_test/Controller.java
@@ -1,17 +1,21 @@
 package com.dash0.app_under_test;
 
 import io.prometheus.metrics.core.metrics.Histogram;
-import tools.jackson.databind.ObjectMapper;
-import tools.jackson.databind.node.ObjectNode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ObjectNode;
 
 @RestController
 public class Controller {
+
+    private static final Logger logger = LoggerFactory.getLogger(RequestLoggingFilter.class);
 
     private static final String[] CONNECTOR_LATENCY_MILLISECONDS_LABELS = new String[]{"endpoint", "status"};
     private static final boolean SIMULATE_LATENCY =
@@ -32,14 +36,7 @@ public class Controller {
     @ResponseStatus(code = HttpStatus.NO_CONTENT)
     public void ready() {
         long startTime = System.currentTimeMillis();
-        if (SIMULATE_LATENCY) {
-            try {
-                // Simulate some work
-                Thread.sleep((long) (Math.random() * 200));
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-            }
-        }
+        simulateArtificialLatency("/ready", 200);
         long duration = System.currentTimeMillis() - startTime;
         connectorLatencyMillisecondsHistogram.labelValues("/ready", "success").observe(duration);
     }
@@ -47,18 +44,23 @@ public class Controller {
     @GetMapping(path="/dash0-k8s-operator-test", produces= MediaType.APPLICATION_JSON_VALUE)
     public ObjectNode test() {
         long startTime = System.currentTimeMillis();
-        if (SIMULATE_LATENCY) {
-            try {
-                // Simulate some work
-                Thread.sleep((long) (Math.random() * 10_000));
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-            }
-        }
+        simulateArtificialLatency("/dash0-k8s-operator-test", 10_000);
         ObjectNode response = mapper.createObjectNode();
         response.put("message", "We make Observability easy for every developer.");
         long duration = System.currentTimeMillis() - startTime;
         connectorLatencyMillisecondsHistogram.labelValues("/dash0-k8s-operator-test", "success").observe(duration);
         return response;
+    }
+
+    private static void simulateArtificialLatency(String endpoint, int maxLatencyMillis) {
+        if (SIMULATE_LATENCY) {
+            try {
+                long randomLatencyMillis = Math.round(Math.random() * maxLatencyMillis);
+                logger.info("simulating latency in endpoint %s: %d ms".formatted(endpoint, maxLatencyMillis));
+                Thread.sleep(randomLatencyMillis);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
     }
 }

--- a/test-resources/jvm/spring-boot/src/main/java/com/dash0/app_under_test/RequestLoggingFilter.java
+++ b/test-resources/jvm/spring-boot/src/main/java/com/dash0/app_under_test/RequestLoggingFilter.java
@@ -1,0 +1,38 @@
+package com.dash0.app_under_test;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class RequestLoggingFilter implements Filter {
+
+    private static final Logger logger = LoggerFactory.getLogger(RequestLoggingFilter.class);
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+
+        HttpServletRequest httpRequest = (HttpServletRequest) request;
+        HttpServletResponse httpResponse = (HttpServletResponse) response;
+
+        String path = httpRequest.getRequestURI();
+        String method = httpRequest.getMethod();
+
+        try {
+            chain.doFilter(request, response);
+        } finally {
+            int status = httpResponse.getStatus();
+            logger.info("{} {} - {}", method, path, status);
+        }
+    }
+}

--- a/test/e2e/applications_under_test.go
+++ b/test/e2e/applications_under_test.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os/exec"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -19,67 +18,6 @@ const (
 )
 
 var (
-	workloadTypeCronjob = workloadType{
-		workloadTypeString:          "cronjob",
-		workloadTypeStringCamelCase: "CronJob",
-		isBatch:                     true,
-	}
-	workloadTypeDaemonSet = workloadType{
-		workloadTypeString:          "daemonset",
-		workloadTypeStringCamelCase: "DaemonSet",
-		isBatch:                     false,
-	}
-	workloadTypeDeployment = workloadType{
-		workloadTypeString:          "deployment",
-		workloadTypeStringCamelCase: "Deployment",
-		isBatch:                     false,
-	}
-	workloadTypeJob = workloadType{
-		workloadTypeString:          "job",
-		workloadTypeStringCamelCase: "Job",
-		isBatch:                     true,
-	}
-	workloadTypePod = workloadType{
-		workloadTypeString:          "pod",
-		workloadTypeStringCamelCase: "Pod",
-		isBatch:                     false,
-	}
-	workloadTypeReplicaSet = workloadType{
-		workloadTypeString:          "replicaset",
-		workloadTypeStringCamelCase: "ReplicaSet",
-		isBatch:                     false,
-	}
-	workloadTypeStatefulSet = workloadType{
-		workloadTypeString:          "statefulset",
-		workloadTypeStringCamelCase: "StatefulSet",
-		isBatch:                     false,
-	}
-
-	runtimeTypeDotnet = runtimeType{
-		runtimeTypeLabel: runtimeTypeLabelDotnet,
-		workloadName:     workloadNameDotnet,
-		helmChartPath:    chartPathDotnet,
-		helmReleaseName:  releaseNameDotnet,
-	}
-	runtimeTypeJvm = runtimeType{
-		runtimeTypeLabel: runtimeTypeLabelJvm,
-		workloadName:     workloadNameJvm,
-		helmChartPath:    chartPathJvm,
-		helmReleaseName:  releaseNameJvm,
-	}
-	runtimeTypeNodeJs = runtimeType{
-		runtimeTypeLabel: runtimeTypeLabelNodeJs,
-		workloadName:     workloadNameNodeJs,
-		helmChartPath:    chartPathNodeJs,
-		helmReleaseName:  releaseNameNodeJs,
-	}
-	runtimeTypePython = runtimeType{
-		runtimeTypeLabel: runtimeTypeLabelPython,
-		workloadName:     workloadNamePython,
-		helmChartPath:    chartPathPython,
-		helmReleaseName:  releaseNamePython,
-	}
-
 	testAppImages = make(map[runtimeType]ImageSpec)
 )
 
@@ -326,17 +264,6 @@ func runTestAppHelmInstall(
 	args = append(args, setValues...)
 
 	return runAndIgnoreOutput(exec.Command("helm", args...))
-}
-
-func waitForApplicationToBecomeResponsive(
-	runtime runtimeType,
-	workloadType workloadType,
-	route string,
-	query string,
-) {
-	Eventually(func(g Gomega) {
-		sendRequest(g, runtime, workloadType, route, query)
-	}, 30*time.Second, pollingInterval).Should(Succeed())
 }
 
 func runTestAppHelmUninstall(namespace string, releaseName string) error {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -784,19 +784,6 @@ var _ = Describe("Dash0 Operator", Ordered, ContinueOnFailure, func() {
 						operatorNamespace,
 					)
 
-					// Note: On kind, this fails sometimes due to missing workload resource attribute
-					//  - k8s.deployment.name: ! FAILED - expected dash0-operator-nodejs-20-express-test-deployment but the
-					//    span has no such attribute
-					//  - k8s.pod.name: passed
-					//  - timestamp: skipped - no lower bound provided
-					//  - span.kind: passed
-					//  - http.target: passed
-					//  Expected
-					//      <bool>: false
-					//  to be true
-					//  In [It] at: /Users/bastian/dco/test/e2e/verify_instrumentation.go:64 @ 11/26/24 10:28:53.645
-					// No amount of retrying helps. Once the collector is in this state, all spans lack that resource
-					// attribute. See comment in spans.go#workloadSpansResourceMatcher.
 					runInParallel(workloadTestConfigs, func(c runtimeWorkloadTestConfig) {
 						By(fmt.Sprintf("verifying that the %s %s has been instrumented by the controller",
 							c.runtime.runtimeTypeLabel,

--- a/test/e2e/runtime_types.go
+++ b/test/e2e/runtime_types.go
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: Copyright 2026 Dash0 Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+type runtimeType struct {
+	runtimeTypeLabel string
+	workloadName     string
+	helmChartPath    string
+	helmReleaseName  string
+}
+
+var (
+	runtimeTypeDotnet = runtimeType{
+		runtimeTypeLabel: runtimeTypeLabelDotnet,
+		workloadName:     workloadNameDotnet,
+		helmChartPath:    chartPathDotnet,
+		helmReleaseName:  releaseNameDotnet,
+	}
+	runtimeTypeJvm = runtimeType{
+		runtimeTypeLabel: runtimeTypeLabelJvm,
+		workloadName:     workloadNameJvm,
+		helmChartPath:    chartPathJvm,
+		helmReleaseName:  releaseNameJvm,
+	}
+	runtimeTypeNodeJs = runtimeType{
+		runtimeTypeLabel: runtimeTypeLabelNodeJs,
+		workloadName:     workloadNameNodeJs,
+		helmChartPath:    chartPathNodeJs,
+		helmReleaseName:  releaseNameNodeJs,
+	}
+	runtimeTypePython = runtimeType{
+		runtimeTypeLabel: runtimeTypeLabelPython,
+		workloadName:     workloadNamePython,
+		helmChartPath:    chartPathPython,
+		helmReleaseName:  releaseNamePython,
+	}
+)

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -61,19 +61,6 @@ type neccessaryCleanupSteps struct {
 	removeTestApplications         bool
 }
 
-type workloadType struct {
-	workloadTypeString          string
-	workloadTypeStringCamelCase string
-	isBatch                     bool
-}
-
-type runtimeType struct {
-	runtimeTypeLabel string
-	workloadName     string
-	helmChartPath    string
-	helmReleaseName  string
-}
-
 // getProjectDir returns the repository's root directory
 func getProjectDir() (string, error) {
 	wd, err := os.Getwd()
@@ -110,7 +97,11 @@ func workloadName(runtime runtimeType, workloadType workloadType) string {
 }
 
 func sendRequest(g Gomega, runtime runtimeType, workloadType workloadType, route string, query string) {
-	httpPathWithQuery := fmt.Sprintf("%s?%s", route, query)
+	httpPathWithQuery := route
+	if query != "" {
+		httpPathWithQuery = fmt.Sprintf("%s?%s", route, query)
+	}
+
 	executeTestAppHttpRequest(
 		g,
 		runtime.runtimeTypeLabel,
@@ -148,7 +139,7 @@ func executeTestAppHttpRequest(
 		httpPathWithQuery,
 	)
 	httpClient := http.Client{
-		Timeout: 500 * time.Millisecond,
+		Timeout: 5000 * time.Millisecond,
 	}
 	if verboseHttp {
 		e2ePrint("%s: sending HTTP GET request\n", url)

--- a/test/e2e/wait_for_apps.go
+++ b/test/e2e/wait_for_apps.go
@@ -1,0 +1,152 @@
+// SPDX-FileCopyrightText: Copyright 2026 Dash0 Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"slices"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// waitForRollout waits until the new pods of a recently modified workload (e.g. after instrumenting or uninstrumenting)
+// are ready, and all old pods have terminated.
+func waitForRollout(namespace string, runtime runtimeType, workloadTp workloadType) {
+	if slices.Contains([]workloadType{
+		workloadTypeDaemonSet,
+		workloadTypeDeployment,
+		workloadTypeStatefulSet,
+	}, workloadTp) {
+		By(fmt.Sprintf(
+			"%s %s: waiting for all new pods to become ready and old pods to get removed",
+			runtime.runtimeTypeLabel,
+			workloadTp.workloadTypeString))
+		Eventually(func(g Gomega) {
+			g.Expect(runAndIgnoreOutput(
+				exec.Command("kubectl",
+					"rollout",
+					"status",
+					workloadTp.workloadTypeString,
+					workloadName(runtime, workloadTp),
+					"--namespace",
+					namespace,
+					"--timeout",
+					"60s",
+				))).To(Succeed())
+		}, 60*time.Second, 1*time.Second).Should(Succeed())
+		By(fmt.Sprintf(
+			"%s %s: rollout complete, new pods are ready, old pods have been removed",
+			runtime.runtimeTypeLabel,
+			workloadTp.workloadTypeString))
+		return
+	} else if workloadTp == workloadTypePod {
+		waitUntilStandalonePodIsReady(namespace, runtime, workloadTp)
+	} else if workloadTp == workloadTypeReplicaSet {
+		waitUntilReplicaSetPodsAreReady(namespace, runtime, workloadTp)
+	}
+}
+
+func waitUntilStandalonePodIsReady(namespace string, runtime runtimeType, workloadType workloadType) {
+	By(fmt.Sprintf(
+		"%s %s: waiting for pod to become ready",
+		runtime.runtimeTypeLabel,
+		workloadType.workloadTypeString))
+	Eventually(func(g Gomega) {
+		wlName := workloadName(runtime, workloadType)
+		podJson, err := run(exec.Command(
+			"kubectl",
+			"get",
+			"pod",
+			wlName,
+			"--namespace",
+			namespace,
+			"-o",
+			"json",
+		), false)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		var pod corev1.Pod
+		g.Expect(json.Unmarshal([]byte(podJson), &pod)).To(Succeed())
+		g.Expect(pod.Status.Phase).To(
+			Equal(corev1.PodRunning),
+			"Pod \"%s\" is not running: phase=%s",
+			wlName,
+			pod.Status.Phase,
+		)
+		for _, condition := range pod.Status.Conditions {
+			if condition.Type == corev1.PodReady {
+				g.Expect(condition.Status).To(
+					Equal(corev1.ConditionTrue),
+					"Pod \"%s\" is not ready: Ready condition status=%s",
+					wlName,
+					condition.Status,
+				)
+				break
+			}
+		}
+	}, 60*time.Second, 1*time.Second).Should(Succeed())
+	By(fmt.Sprintf(
+		"%s %s: pod is ready",
+		runtime.runtimeTypeLabel,
+		workloadType.workloadTypeString))
+}
+
+func waitUntilReplicaSetPodsAreReady(namespace string, runtime runtimeType, workloadType workloadType) {
+	By(fmt.Sprintf(
+		"%s %s: waiting for replicaset to become ready",
+		runtime.runtimeTypeLabel,
+		workloadType.workloadTypeString))
+	Eventually(func(g Gomega) {
+		wlName := workloadName(runtime, workloadType)
+		replicaSetJson, err := run(exec.Command(
+			"kubectl",
+			"get",
+			"replicaset",
+			wlName,
+			"--namespace",
+			namespace,
+			"-o",
+			"json",
+		), false)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		var rs appsv1.ReplicaSet
+		g.Expect(json.Unmarshal([]byte(replicaSetJson), &rs)).To(Succeed())
+		g.Expect(rs.Spec.Replicas).ToNot(BeNil())
+		g.Expect(*rs.Spec.Replicas).To(BeNumerically(">=", 1))
+		g.Expect(rs.Status.ReadyReplicas).To(
+			Equal(*rs.Spec.Replicas),
+			"Not all pods of replicaset \"%s\" are ready: desired=%d, readyReplicas=%d",
+			wlName,
+			*rs.Spec.Replicas,
+			rs.Status.ReadyReplicas,
+		)
+	}, 60*time.Second, 1*time.Second).Should(Succeed())
+	By(fmt.Sprintf(
+		"%s %s: all pods are ready",
+		runtime.runtimeTypeLabel,
+		workloadType.workloadTypeString))
+}
+
+func waitForApplicationToBecomeResponsive(
+	runtime runtimeType,
+	workloadType workloadType,
+	route string,
+	query string,
+) {
+	if workloadType.isBatch {
+		return
+	}
+	Eventually(func(g Gomega) {
+		sendRequest(g, runtime, workloadType, route, query)
+	}, 30*time.Second, pollingInterval).Should(Succeed())
+}

--- a/test/e2e/workload_types.go
+++ b/test/e2e/workload_types.go
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: Copyright 2026 Dash0 Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+type workloadType struct {
+	workloadTypeString          string
+	workloadTypeStringCamelCase string
+	isBatch                     bool
+}
+
+var (
+	workloadTypeCronjob = workloadType{
+		workloadTypeString:          "cronjob",
+		workloadTypeStringCamelCase: "CronJob",
+		isBatch:                     true,
+	}
+	workloadTypeDaemonSet = workloadType{
+		workloadTypeString:          "daemonset",
+		workloadTypeStringCamelCase: "DaemonSet",
+		isBatch:                     false,
+	}
+	workloadTypeDeployment = workloadType{
+		workloadTypeString:          "deployment",
+		workloadTypeStringCamelCase: "Deployment",
+		isBatch:                     false,
+	}
+	workloadTypeJob = workloadType{
+		workloadTypeString:          "job",
+		workloadTypeStringCamelCase: "Job",
+		isBatch:                     true,
+	}
+	workloadTypePod = workloadType{
+		workloadTypeString:          "pod",
+		workloadTypeStringCamelCase: "Pod",
+		isBatch:                     false,
+	}
+	workloadTypeReplicaSet = workloadType{
+		workloadTypeString:          "replicaset",
+		workloadTypeStringCamelCase: "ReplicaSet",
+		isBatch:                     false,
+	}
+	workloadTypeStatefulSet = workloadType{
+		workloadTypeString:          "statefulset",
+		workloadTypeStringCamelCase: "StatefulSet",
+		isBatch:                     false,
+	}
+)


### PR DESCRIPTION
For the workload types daemonset, deployment, replicaset and stateful set, tests would sometimes fail because of timing issues, in particular with JVM workloads. The test would for example uninstrument the workload and then start to check for 20 seconds that spans are no longer produced. Due to the sometimes lengthy startup time of JVM containers (up to 20 seconds or more), the test would start verifying that no spans are produced while the new, uninstrumented pods had not become ready yet, and hence the old instrumented pods were still up.

Fixed by waiting via kubectl rollout status for the instrumentation/uninstrumentation to be completed, that is, for new pods to become ready and old pods to get removed. For replicasets and standalone pods, we simply wait until they are in the ready state.

Also:
* add request logging to the JVM test app
* move workloadType and runtimeType types to separate files
* remove obsolete comment on missing resource attributes