### PR TITLE
chore: use workflow_call instead of workflow_run

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -217,6 +217,13 @@ jobs:
           scan: 'true'
           scanSeverity: 'CRITICAL'
 
+  e2e_tests:
+    name: End-to-end Tests
+    needs:
+      - build_and_push_images
+    if: ${{ github.ref == 'refs/heads/main' && needs.build_and_push_images.result == 'success' }}
+    uses: ./.github/workflows/e2e.yaml
+
   publish_helm_chart_dry_run:
     name: Publish Helm Chart (Dry Run)
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -4,10 +4,7 @@
 name: Run e2e tests on kind
 
 on:
-  workflow_run:
-    workflows: ["CI"]
-    types: [completed]
-    branches: [main]
+  workflow_call:
   workflow_dispatch:
 
 env:
@@ -23,7 +20,6 @@ env:
 jobs:
   run-e2e-tests-on-kind:
     name: Set up cluster and run e2e tests
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: 8core_32gb
     timeout-minutes: 60
 


### PR DESCRIPTION
While `workflow_run` does trigger the workflow, it does not show up among the checks (no nice :x: in case things don't work), so it's not very visible and can be easily missed unless one navigates to the `Actions` tab.

Using `workflow_call` should improve that while still ensuring the remaining CI jobs work even when the (sometimes flaky) e2e tests fail.