### PR TITLE
chore: enable dependabot upgrade to go1.26

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -60,9 +60,10 @@ updates:
     groups:
       production-dependencies:
         dependency-type: "production"
-    ignore:
-      - dependency-name: "golang"
-        update-types: ["version-update:semver-minor"]
+    # enable the following `ignore` to prevent upgrades to RCs
+    # ignore:
+    #   - dependency-name: "golang"
+    #     update-types: ["version-update:semver-minor"]
 
   # -----------------------
   # -- Test applications --
@@ -99,9 +100,10 @@ updates:
           - "*"
     commit-message:
       prefix: "test"
-    ignore:
-      - dependency-name: "golang"
-        update-types: ["version-update:semver-minor"]
+    # enable the following `ignore` to prevent upgrades to RCs
+    # ignore:
+    #   - dependency-name: "golang"
+    #     update-types: ["version-update:semver-minor"]
 
   - package-ecosystem: "maven"
     directory: "test-resources/jvm/spring-boot"


### PR DESCRIPTION
this PR removes the temporary comments that have been added to prevent dependabot upgrades to go1.26rc...

ideally this will be fixed in dependabot before the next RC is released, but I'm leaving the comments in place for now in case undesired versions show up again

we can remove them if the updates to 1.27 work as expected