### PR TITLE
chore: add .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+
+# Go files
+[*.go]
+indent_style = tab
+
+# Python files
+[*.py]
+indent_size = 4
+
+# Makefiles
+[{Makefile,*.mk}]
+indent_style = tab


### PR DESCRIPTION
This is mostly to avoid issues like
fc37911edcd0708c4c2dd321a624ef98ca419c16, which introduced extraneous whitespace in deployment.config.yaml.template, which in turn broke "kubectl edit configmap". (Fixed in
27ed05076949a19900b8765829fe24ad8cf0eeef.)

We have linters in place for most of this, but having an .editorconfig in place should improves the experience for first-time contributors.