### PR TITLE
chore(target-allocator): remove overly verbose logs

### DIFF
--- a/internal/targetallocator/taresources/ta_resources.go
+++ b/internal/targetallocator/taresources/ta_resources.go
@@ -63,7 +63,6 @@ func (m *TargetAllocatorResourceManager) CreateOrUpdateTargetAllocatorResources(
 	resourcesHaveBeenUpdated := false
 	for _, wrapper := range desiredState {
 		desiredResource := wrapper.object
-		logger.Info("creating or updating", "ta_resource", desiredResource)
 		isNew, isChanged, err := m.createOrUpdateResource(
 			ctx,
 			desiredResource,


### PR DESCRIPTION
this line created overly verbose logs for every resource that we create as part of the target-allocator component (deployment, configmap, role,...)