### PR TITLE
fix: unset export in existing operator config when updating config via helm

### DIFF
--- a/internal/startup/auto_operator_configuration_handler.go
+++ b/internal/startup/auto_operator_configuration_handler.go
@@ -215,6 +215,13 @@ func (r *AutoOperatorConfigurationResourceHandler) createOrUpdateOperatorConfigu
 			)
 		}
 
+		// Since version 0.102.0 we are setting the `exports` field when auto-creating the operator config resource and
+		// if the existing resource (from before the upgrade) still has an `export` field, we would end up with an
+		// operator config that has both `export` and `exports` set and gets rejected by the validating webhook.
+		// For this reason we remove the `export from the existing resource.
+		//nolint:staticcheck
+		existingOperatorConfigurationResource.Spec.Export = nil
+
 		existingOperatorConfigurationResource.Spec = operatorConfigurationResource.Spec
 		if err := r.Update(ctx, &existingOperatorConfigurationResource); err != nil {
 			return fmt.Errorf("failed to update the Dash0 operator configuration resource: %w", err)


### PR DESCRIPTION
Version 0.102.0 improves support for exporting to multiple endpoints simultaneously and for this reason, `export` is now an array called `exports`. The new version handles the migration automatically (i.e. existing configs with `export` will simply be transformed into `exports`). However during the upgrade there is still an "old" existing config with the `export` field that hasn't been migrated yet and during the upgrade we set the `exports` field and end up with both `export` and `exports` being set and the validating webhook rejects it.