### PR TITLE
feat(controller): send a snapshot of the full resources as an event

### DIFF
--- a/api/operator/v1alpha1/operator_configuration_types_test.go
+++ b/api/operator/v1alpha1/operator_configuration_types_test.go
@@ -1,0 +1,136 @@
+// SPDX-FileCopyrightText: Copyright 2026 Dash0 Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha1
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	dash0common "github.com/dash0hq/dash0-operator/api/operator/common"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+const (
+	EndpointHttpTest = "https://endpoint.backend.com:4318"
+)
+
+var (
+	SecretRefTest = dash0common.SecretRef{
+		Name: "secret-ref",
+		Key:  "key",
+	}
+)
+
+var _ = Describe("v1alpha1 Dash0 operator configuration CRD", func() {
+
+	Describe("cloneAndRedact", func() {
+
+		It("should clear ManagedFields", func() {
+			original := Dash0OperatorConfiguration{}
+			original.ManagedFields = []metav1.ManagedFieldsEntry{{Manager: "some-manager"}}
+
+			redacted := original.cloneAndRedact()
+
+			Expect(redacted.ManagedFields).To(BeNil())
+			Expect(original.ManagedFields).To(HaveLen(1))
+		})
+
+		It("should handle a resource with no exports", func() {
+			original := Dash0OperatorConfiguration{}
+
+			redacted := original.cloneAndRedact()
+
+			Expect(redacted.Spec.Exports).To(BeEmpty())
+		})
+
+		It("should redact the Dash0 token", func() {
+			token := "my-secret-token"
+			original := Dash0OperatorConfiguration{
+				Spec: Dash0OperatorConfigurationSpec{
+					Exports: []dash0common.Export{{
+						Dash0: &dash0common.Dash0Configuration{
+							Endpoint: EndpointDash0Test,
+							Authorization: dash0common.Authorization{
+								Token: &token,
+							},
+						},
+					}},
+				},
+			}
+
+			redacted := original.cloneAndRedact()
+
+			Expect(*redacted.Spec.Exports[0].Dash0.Authorization.Token).To(Equal("<redacted>"))
+			Expect(*original.Spec.Exports[0].Dash0.Authorization.Token).To(Equal("my-secret-token"))
+		})
+
+		It("should not redact a Dash0 export that uses a SecretRef instead of a token", func() {
+			original := Dash0OperatorConfiguration{
+				Spec: Dash0OperatorConfigurationSpec{
+					Exports: []dash0common.Export{{
+						Dash0: &dash0common.Dash0Configuration{
+							Endpoint: EndpointDash0Test,
+							Authorization: dash0common.Authorization{
+								SecretRef: new(SecretRefTest),
+							},
+						},
+					}},
+				},
+			}
+
+			redacted := original.cloneAndRedact()
+
+			Expect(redacted.Spec.Exports[0].Dash0.Authorization.Token).To(BeNil())
+			Expect(redacted.Spec.Exports[0].Dash0.Authorization.SecretRef).ToNot(BeNil())
+			Expect(redacted.Spec.Exports[0].Dash0.Authorization.SecretRef.Name).To(Equal(SecretRefTest.Name))
+		})
+
+		It("should redact HTTP header values", func() {
+			original := Dash0OperatorConfiguration{
+				Spec: Dash0OperatorConfigurationSpec{
+					Exports: []dash0common.Export{{
+						Http: &dash0common.HttpConfiguration{
+							Endpoint: EndpointHttpTest,
+							Headers: []dash0common.Header{
+								{Name: "Authorization", Value: "Bearer secret-token"},
+								{Name: "X-Custom-Header", Value: "another-secret"},
+							},
+						},
+					}},
+				},
+			}
+
+			redacted := original.cloneAndRedact()
+
+			Expect(redacted.Spec.Exports[0].Http.Headers[0].Name).To(Equal("Authorization"))
+			Expect(redacted.Spec.Exports[0].Http.Headers[0].Value).To(Equal("<redacted>"))
+			Expect(redacted.Spec.Exports[0].Http.Headers[1].Name).To(Equal("X-Custom-Header"))
+			Expect(redacted.Spec.Exports[0].Http.Headers[1].Value).To(Equal("<redacted>"))
+			Expect(original.Spec.Exports[0].Http.Headers[0].Value).To(Equal("Bearer secret-token"))
+			Expect(original.Spec.Exports[0].Http.Headers[1].Value).To(Equal("another-secret"))
+		})
+
+		It("should redact gRPC header values", func() {
+			original := Dash0OperatorConfiguration{
+				Spec: Dash0OperatorConfigurationSpec{
+					Exports: []dash0common.Export{{
+						Grpc: &dash0common.GrpcConfiguration{
+							Endpoint: EndpointHttpTest,
+							Headers: []dash0common.Header{
+								{Name: "Authorization", Value: "Bearer secret-token"},
+							},
+						},
+					}},
+				},
+			}
+
+			redacted := original.cloneAndRedact()
+
+			Expect(redacted.Spec.Exports[0].Grpc.Headers[0].Name).To(Equal("Authorization"))
+			Expect(redacted.Spec.Exports[0].Grpc.Headers[0].Value).To(Equal("<redacted>"))
+			Expect(original.Spec.Exports[0].Grpc.Headers[0].Value).To(Equal("Bearer secret-token"))
+		})
+	})
+})

--- a/api/operator/v1beta1/dash0monitoring_types_test.go
+++ b/api/operator/v1beta1/dash0monitoring_types_test.go
@@ -1,0 +1,134 @@
+// SPDX-FileCopyrightText: Copyright 2026 Dash0 Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1beta1
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	dash0common "github.com/dash0hq/dash0-operator/api/operator/common"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+const (
+	EndpointDash0Test = "endpoint.dash0.com:4317"
+	EndpointHttpTest  = "https://endpoint.backend.com:4318"
+)
+
+var (
+	SecretRefTest = dash0common.SecretRef{
+		Name: "secret-ref",
+		Key:  "key",
+	}
+)
+
+var _ = Describe("v1beta1 Dash0 monitoring CRD", func() {
+	Describe("cloneAndRedact", func() {
+
+		It("should clear ManagedFields", func() {
+			original := Dash0Monitoring{}
+			original.ManagedFields = []metav1.ManagedFieldsEntry{{Manager: "some-manager"}}
+
+			redacted := original.cloneAndRedact()
+
+			Expect(redacted.ManagedFields).To(BeNil())
+			Expect(original.ManagedFields).To(HaveLen(1))
+		})
+
+		It("should handle a resource with no exports", func() {
+			original := Dash0Monitoring{}
+			redacted := original.cloneAndRedact()
+			Expect(redacted.Spec.Exports).To(BeEmpty())
+		})
+
+		It("should redact the Dash0 token", func() {
+			token := "my-secret-token"
+			original := Dash0Monitoring{
+				Spec: Dash0MonitoringSpec{
+					Exports: []dash0common.Export{{
+						Dash0: &dash0common.Dash0Configuration{
+							Endpoint: EndpointDash0Test,
+							Authorization: dash0common.Authorization{
+								Token: &token,
+							},
+						},
+					}},
+				},
+			}
+
+			redacted := original.cloneAndRedact()
+
+			Expect(*redacted.Spec.Exports[0].Dash0.Authorization.Token).To(Equal("<redacted>"))
+			Expect(*original.Spec.Exports[0].Dash0.Authorization.Token).To(Equal("my-secret-token"))
+		})
+
+		It("should not redact a Dash0 export that uses a SecretRef instead of a token", func() {
+			original := Dash0Monitoring{
+				Spec: Dash0MonitoringSpec{
+					Exports: []dash0common.Export{{
+						Dash0: &dash0common.Dash0Configuration{
+							Endpoint: EndpointDash0Test,
+							Authorization: dash0common.Authorization{
+								SecretRef: new(SecretRefTest),
+							},
+						},
+					}},
+				},
+			}
+
+			redacted := original.cloneAndRedact()
+
+			Expect(redacted.Spec.Exports[0].Dash0.Authorization.Token).To(BeNil())
+			Expect(redacted.Spec.Exports[0].Dash0.Authorization.SecretRef).ToNot(BeNil())
+			Expect(redacted.Spec.Exports[0].Dash0.Authorization.SecretRef.Name).To(Equal(SecretRefTest.Name))
+		})
+
+		It("should redact HTTP header values", func() {
+			original := Dash0Monitoring{
+				Spec: Dash0MonitoringSpec{
+					Exports: []dash0common.Export{{
+						Http: &dash0common.HttpConfiguration{
+							Endpoint: EndpointHttpTest,
+							Headers: []dash0common.Header{
+								{Name: "Authorization", Value: "Bearer secret-token"},
+								{Name: "X-Custom-Header", Value: "another-secret"},
+							},
+						},
+					}},
+				},
+			}
+
+			redacted := original.cloneAndRedact()
+
+			Expect(redacted.Spec.Exports[0].Http.Headers[0].Name).To(Equal("Authorization"))
+			Expect(redacted.Spec.Exports[0].Http.Headers[0].Value).To(Equal("<redacted>"))
+			Expect(redacted.Spec.Exports[0].Http.Headers[1].Name).To(Equal("X-Custom-Header"))
+			Expect(redacted.Spec.Exports[0].Http.Headers[1].Value).To(Equal("<redacted>"))
+			Expect(original.Spec.Exports[0].Http.Headers[0].Value).To(Equal("Bearer secret-token"))
+			Expect(original.Spec.Exports[0].Http.Headers[1].Value).To(Equal("another-secret"))
+		})
+
+		It("should redact gRPC header values", func() {
+			original := Dash0Monitoring{
+				Spec: Dash0MonitoringSpec{
+					Exports: []dash0common.Export{{
+						Grpc: &dash0common.GrpcConfiguration{
+							Endpoint: EndpointHttpTest,
+							Headers: []dash0common.Header{
+								{Name: "Authorization", Value: "Bearer secret-token"},
+							},
+						},
+					}},
+				},
+			}
+
+			redacted := original.cloneAndRedact()
+
+			Expect(redacted.Spec.Exports[0].Grpc.Headers[0].Name).To(Equal("Authorization"))
+			Expect(redacted.Spec.Exports[0].Grpc.Headers[0].Value).To(Equal("<redacted>"))
+			Expect(original.Spec.Exports[0].Grpc.Headers[0].Value).To(Equal("Bearer secret-token"))
+		})
+	})
+})

--- a/internal/controller/monitoring_controller.go
+++ b/internal/controller/monitoring_controller.go
@@ -115,17 +115,8 @@ func (r *MonitoringReconciler) InitializeSelfMonitoringMetrics(
 	}
 }
 
-// Reconcile is part of the main kubernetes reconciliation loop which aims to
-// move the current state of the cluster closer to the desired state.
-// It is essential for the controller's reconciliation loop to be idempotent. By following the Operator
-// pattern you will create Controllers which provide a reconcile function
-// responsible for synchronizing resources until the desired state is reached on the cluster.
-// Breaking this recommendation goes against the design principles of controller-runtime.
-// and may lead to unforeseen consequences such as resources becoming stuck and requiring manual intervention.
-// For further info:
-// - About Operator Pattern: https://kubernetes.io/docs/concepts/extend-kubernetes/operator/
-// - About Controllers: https://kubernetes.io/docs/concepts/architecture/controller/
-// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.16.3/pkg/reconcile
+// Reconcile is part of the main kubernetes reconciliation loop which aims to move the current state of the cluster
+// closer to the desired state. Needs to be idempotent.
 func (r *MonitoringReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	if monitoringReconcileRequestMetric != nil {
 		monitoringReconcileRequestMetric.Add(ctx, 1)
@@ -176,6 +167,9 @@ func (r *MonitoringReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	}
 
 	monitoringResource := checkResourceResult.Resource.(*dash0v1beta1.Dash0Monitoring)
+	defer func() {
+		monitoringResource.LogResourceAsEvent(logger)
+	}()
 
 	isFirstReconcile, err := resources.InitStatusConditions(
 		ctx,

--- a/internal/controller/operator_configuration_controller.go
+++ b/internal/controller/operator_configuration_controller.go
@@ -108,17 +108,8 @@ func (r *OperatorConfigurationReconciler) InitializeSelfMonitoringMetrics(
 	}
 }
 
-// Reconcile is part of the main kubernetes reconciliation loop which aims to
-// move the current state of the cluster closer to the desired state.
-// It is essential for the controller's reconciliation loop to be idempotent. By following the Operator
-// pattern you will create Controllers which provide a reconcile function
-// responsible for synchronizing resources until the desired state is reached on the cluster.
-// Breaking this recommendation goes against the design principles of controller-runtime.
-// and may lead to unforeseen consequences such as resources becoming stuck and requiring manual intervention.
-// For further info:
-// - About Operator Pattern: https://kubernetes.io/docs/concepts/extend-kubernetes/operator/
-// - About Controllers: https://kubernetes.io/docs/concepts/architecture/controller/
-// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.16.3/pkg/reconcile
+// Reconcile is part of the main kubernetes reconciliation loop which aims to move the current state of the cluster
+// closer to the desired state. Needs to be idempotent.
 func (r *OperatorConfigurationReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	if operatorReconcileRequestMetric != nil {
 		operatorReconcileRequestMetric.Add(ctx, 1)
@@ -158,6 +149,9 @@ func (r *OperatorConfigurationReconciler) Reconcile(ctx context.Context, req ctr
 	}
 
 	operatorConfigurationResource := checkResourceResult.Resource.(*dash0v1alpha1.Dash0OperatorConfiguration)
+	defer func() {
+		operatorConfigurationResource.LogResourceAsEvent(logger)
+	}()
 
 	stopReconcile, err :=
 		resources.VerifyThatResourceIsUniqueInScope(

--- a/internal/startup/log_config_resources_runnable.go
+++ b/internal/startup/log_config_resources_runnable.go
@@ -1,0 +1,100 @@
+// SPDX-FileCopyrightText: Copyright 2026 Dash0 Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package startup
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-logr/logr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/pager"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	dash0v1alpha1 "github.com/dash0hq/dash0-operator/api/operator/v1alpha1"
+	dash0v1beta1 "github.com/dash0hq/dash0-operator/api/operator/v1beta1"
+)
+
+const (
+	logInterval                     = 24 * time.Hour
+	monitoringResourcesListPageSize = 50
+)
+
+// LogConfigurationResourcesRunnable is a repeating task that lists all Dash0OperatorConfiguration and Dash0Monitoring
+// resources in the cluster and logs each one as an event via LogResourceAsEvent. It runs every 24 hours, with the first
+// run 24 hours after startup. We also log them at the end of each reconcile request. This additional logging makes sure
+// we have the resource content available in the self-monitoring telemetry, even if some resources have not changed
+// and have not reconciled for a long time.
+type LogConfigurationResourcesRunnable struct {
+	client client.Client
+}
+
+func NewLogConfigurationResourcesRunnable(client client.Client) *LogConfigurationResourcesRunnable {
+	return &LogConfigurationResourcesRunnable{
+		client: client,
+	}
+}
+
+// NeedLeaderElection implements the LeaderElectionRunnable interface, which indicates that the
+// LogConfigurationResourcesRunnable requires leader election.
+func (r *LogConfigurationResourcesRunnable) NeedLeaderElection() bool {
+	return true
+}
+
+func (r *LogConfigurationResourcesRunnable) Start(ctx context.Context) error {
+	ticker := time.NewTicker(logInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			r.logAllResources(ctx)
+		case <-ctx.Done():
+			log.FromContext(ctx).Info("Stopping LogConfigurationResourcesRunnable")
+			return nil
+		}
+	}
+}
+
+func (r *LogConfigurationResourcesRunnable) logAllResources(ctx context.Context) {
+	logger := log.FromContext(ctx)
+	r.logOperatorConfigurationResources(ctx, logger)
+	r.logMonitoringResources(ctx, logger)
+}
+
+func (r *LogConfigurationResourcesRunnable) logOperatorConfigurationResources(ctx context.Context, logger logr.Logger) {
+	allOperatorConfigurationResources := &dash0v1alpha1.Dash0OperatorConfigurationList{}
+	if err := r.client.List(ctx, allOperatorConfigurationResources); err != nil {
+		logger.Error(err, "failed to list Dash0OperatorConfiguration resources for logging")
+		return
+	}
+	for i := range allOperatorConfigurationResources.Items {
+		allOperatorConfigurationResources.Items[i].LogResourceAsEvent(logger)
+	}
+}
+
+func (r *LogConfigurationResourcesRunnable) logMonitoringResources(ctx context.Context, logger logr.Logger) {
+	pgr := pager.New(pager.SimplePageFunc(
+		func(opts metav1.ListOptions) (runtime.Object, error) {
+			list := &dash0v1beta1.Dash0MonitoringList{}
+			if err := r.client.List(ctx, list, &client.ListOptions{
+				Limit:    opts.Limit,
+				Continue: opts.Continue,
+			}); err != nil {
+				return nil, err
+			}
+			return list, nil
+		},
+	))
+	pgr.PageSize = monitoringResourcesListPageSize
+	if err := pgr.EachListItem(ctx, metav1.ListOptions{},
+		func(resource runtime.Object) error {
+			resource.(*dash0v1beta1.Dash0Monitoring).LogResourceAsEvent(logger)
+			return nil
+		},
+	); err != nil {
+		logger.Error(err, "failed to list Dash0Monitoring resources for logging")
+	}
+}

--- a/internal/startup/operator_manager_startup.go
+++ b/internal/startup/operator_manager_startup.go
@@ -962,6 +962,10 @@ func startDash0Controllers(
 
 	k8sClient := mgr.GetClient()
 
+	if err = mgr.Add(NewLogConfigurationResourcesRunnable(k8sClient)); err != nil {
+		return fmt.Errorf("unable to add log-operator-configuration task: %w", err)
+	}
+
 	instrumenter := instrumentation.NewInstrumenter(
 		k8sClient,
 		clientset,


### PR DESCRIPTION
Send the Dash0OperatorConfiguration and Dash0Monitoring resources as events at the end of each reconcile request. Also send them once every 24 hours, to always have the up-to-date resource content, independent of reconcile requests and log retention.