### PR TITLE
test(target-allocator): add cadvisor example

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -269,6 +269,9 @@ Moving beyond the quickstart instructions, here are more details on the test scr
     * `PROMETHEUS_SCRAPING_ENABLED`: Set this to "false" to disable Prometheus scraping in the test namespace via the
       monitoring resource.
       This defaults to `$TELEMETRY_COLLECTION_ENABLED`, which in turn defaults to "true".
+    * `PROMETHEUS_CRD_SUPPORT_ENABLED`: Set this to `true` to enable support for Prometheus CRDs (e.g. ServiceMonitor).
+      If at least one namespace has a monitoring resource with Prometheus scraping enabled, the OpenTelemetry
+      target-allocator will be deployed.
     * `SELF_MONITORING_ENABLED`: Set this to "false" to disable the operator's self monitoring.
       This defaults to "true".
     * `SYNCHRONIZE_PERSES_DASHBOARDS`: Set this to "false" to disable synchronizing Perses dashboard resources via the

--- a/test-resources/bin/lib/util
+++ b/test-resources/bin/lib/util
@@ -61,12 +61,13 @@ verify_kubectx() {
 }
 
 setup_test_environment () {
+  local target_namespace="${1:-$default_target_ns}"
   if ! docker info > /dev/null 2>&1; then
     echo "This script uses docker, but it looks like Docker is not running. Please start docker and try again."
     exit 1
   fi
 
-  test-resources/bin/render-templates.sh
+  test-resources/bin/render-templates.sh "$target_namespace"
   determine_container_images
   determine_test_app_images
 
@@ -942,6 +943,15 @@ install_prometheus_crds() {
     --set crds.prometheusrules.enabled=false \
     prometheus-crds \
     prometheus-community/prometheus-operator-crds
+}
+
+deploy_cadvisor_scrapeconfig() {
+  if [[ "${DEPLOY_CADVISOR_SCRAPECONFIG:-}" != "true" ]]; then
+    return
+  fi
+  echo "STEP $step_counter: deploy a ScrapeConfig for scraping cadvisor metrics to ${target_namespace}"
+  kubectl apply -n "$target_namespace" -f test-resources/customresources/prometheus/cadvisor-scrapeconfig.yaml
+  finish_step
 }
 
 deploy_dash0_api_sync_resources() {

--- a/test-resources/bin/render-templates.sh
+++ b/test-resources/bin/render-templates.sh
@@ -10,8 +10,12 @@ scripts_lib="test-resources/bin/lib"
 
 cd "$project_root"
 
+# shellcheck source=./lib/constants
+source "$scripts_lib/constants"
 # shellcheck source=./lib/util
 source "$scripts_lib/util"
+
+target_namespace="${1:-$default_target_ns}"
 
 load_env_file
 
@@ -153,3 +157,10 @@ cat \
   OPERATOR_NAMESPACE="$operator_namespace" \
   envsubst > \
   test-resources/cert-manager/helm-values.yaml
+
+# shellcheck disable=SC2002
+cat \
+  test-resources/customresources/prometheus/cadvisor-scrapeconfig.yaml.template | \
+  TARGET_NAMESPACE="$target_namespace" \
+  envsubst > \
+  test-resources/customresources/prometheus/cadvisor-scrapeconfig.yaml

--- a/test-resources/bin/test-scenario-01-aum-operator-cr.sh
+++ b/test-resources/bin/test-scenario-01-aum-operator-cr.sh
@@ -25,7 +25,7 @@ source "$scripts_lib/util"
 
 load_env_file
 verify_kubectx
-setup_test_environment
+setup_test_environment "$target_namespace"
 
 step_counter=1
 

--- a/test-resources/bin/test-scenario-02-operator-cr-aum.sh
+++ b/test-resources/bin/test-scenario-02-operator-cr-aum.sh
@@ -25,7 +25,7 @@ source "$scripts_lib/util"
 
 load_env_file
 verify_kubectx
-setup_test_environment
+setup_test_environment "$target_namespace"
 
 step_counter=1
 

--- a/test-resources/bin/test-scenario-03-rebuild-update-operator-no-cleanup.sh
+++ b/test-resources/bin/test-scenario-03-rebuild-update-operator-no-cleanup.sh
@@ -21,7 +21,7 @@ source "$scripts_lib/util"
 
 load_env_file
 verify_kubectx
-setup_test_environment
+setup_test_environment "$target_namespace"
 
 step_counter=1
 

--- a/test-resources/bin/test-scenario-04-minimal-operator.sh
+++ b/test-resources/bin/test-scenario-04-minimal-operator.sh
@@ -27,7 +27,7 @@ source "$scripts_lib/util"
 
 load_env_file
 verify_kubectx
-setup_test_environment
+setup_test_environment "$target_namespace"
 
 step_counter=1
 

--- a/test-resources/bin/test-scenario-05-operator-prom-crd.sh
+++ b/test-resources/bin/test-scenario-05-operator-prom-crd.sh
@@ -28,7 +28,7 @@ source "$scripts_lib/util"
 
 load_env_file
 verify_kubectx
-setup_test_environment
+setup_test_environment "$target_namespace"
 
 step_counter=1
 

--- a/test-resources/bin/test-scenario-06-ta-mtls.sh
+++ b/test-resources/bin/test-scenario-06-ta-mtls.sh
@@ -23,14 +23,16 @@ kind="deployment"
 runtime_under_test="nodejs" # nodejs is currently the only runtime with a /metrics endpoint
 additional_namespaces="false"
 USE_CERT_MANAGER="true"
+PROMETHEUS_CRD_SUPPORT_ENABLED="true"
 TA_MTLS_ENABLED="true"
+DEPLOY_CADVISOR_SCRAPECONFIG="true"
 
 # shellcheck source=./lib/util
 source "$scripts_lib/util"
 
 load_env_file
 verify_kubectx
-setup_test_environment
+setup_test_environment "$target_namespace"
 
 step_counter=1
 
@@ -74,6 +76,10 @@ finish_step
 
 echo "STEP $step_counter: deploy nodejs app with servicemonitor (or podmonitor)"
 deploy_application_under_monitoring "$runtime_under_test" "$nodejs_values_with_service_monitor"
+finish_step
+
+echo "STEP $step_counter: deploy scrapeconfig for scraping cadvisor metrics"
+deploy_cadvisor_scrapeconfig
 finish_step
 
 if [[ "${DEPLOY_MONITORING_RESOURCE:-}" != "false" ]]; then

--- a/test-resources/bin/test-scenario-07-namespaced-exporter.sh
+++ b/test-resources/bin/test-scenario-07-namespaced-exporter.sh
@@ -32,7 +32,7 @@ source "$scripts_lib/util"
 
 load_env_file
 verify_kubectx
-setup_test_environment
+setup_test_environment "$target_namespace"
 
 step_counter=1
 

--- a/test-resources/customresources/prometheus/.gitignore
+++ b/test-resources/customresources/prometheus/.gitignore
@@ -1,0 +1,1 @@
+cadvisor-scrapeconfig.yaml

--- a/test-resources/customresources/prometheus/cadvisor-scrapeconfig.yaml.template
+++ b/test-resources/customresources/prometheus/cadvisor-scrapeconfig.yaml.template
@@ -1,0 +1,76 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus-cadvisor
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prometheus-cadvisor
+rules:
+  - apiGroups: [""]
+    resources: [nodes]
+    verbs: [list, watch, get]
+  - apiGroups: [""]
+    resources: [nodes/proxy]
+    verbs: [get]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-cadvisor
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus-cadvisor
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-cadvisor
+    namespace: $TARGET_NAMESPACE
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: prometheus-sa-token
+  annotations:
+    kubernetes.io/service-account.name: prometheus-cadvisor
+type: kubernetes.io/service-account-token
+---
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: ScrapeConfig
+metadata:
+  name: cadvisor
+spec:
+  scheme: https
+  scrapeInterval: 30s
+
+  authorization:
+    type: Bearer
+    credentials:
+      name: prometheus-sa-token
+      key: token
+
+  tlsConfig:
+    ca:
+      secret:
+        name: prometheus-sa-token
+        key: ca.crt
+    insecureSkipVerify: true
+
+  kubernetesSDConfigs:
+    - role: Node
+
+  relabelings:
+    - action: labelmap
+      regex: __meta_kubernetes_node_label_(.+)
+
+    - targetLabel: __address__
+      replacement: kubernetes.default.svc:443
+
+    - sourceLabels: [__meta_kubernetes_node_name]
+      regex: (.+)
+      targetLabel: __metrics_path__
+      replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
+
+    - sourceLabels: [__meta_kubernetes_node_name]
+      targetLabel: instance


### PR DESCRIPTION
Adds an example/test to `test-resources/bin/test-scenario-06-ta-mtls.sh` for deploying a `ScrapeConfig` (and related resources) to demo scraping cadvisor metrics with discovery via the target-allocator.

Tested on EKS and locally with kind.