### PR TITLE
feat(collector): enable prometheus api server when development mode is enabled

### DIFF
--- a/internal/collectors/otelcolresources/daemonset.config.yaml.template
+++ b/internal/collectors/otelcolresources/daemonset.config.yaml.template
@@ -251,6 +251,12 @@ receivers:
 
   {{- if or $hasPrometheusScrapingEnabledForAtLeastOneNamespace (and .SelfMonitoringEnabled .PrometheusCrdSupportEnabled) }}
   prometheus:
+    {{- if .DevelopmentMode }}
+    api_server:
+      enabled: true
+      server_config:
+        endpoint: "localhost:9191"
+    {{- end }}
     {{- if and .PrometheusCrdSupportEnabled $hasPrometheusScrapingEnabledForAtLeastOneNamespace }}
     target_allocator:
       {{- if .TargetAllocatorMtlsEnabled }}


### PR DESCRIPTION
enables the [Prometheus API server](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/prometheusreceiver/README.md#prometheus-api-server) in the collector's `prometheusreceiver` if `developmentMode` is enabled