### PR TITLE
chore(collectors): downgrade resourcedetectionprocessor

### DIFF
--- a/images/collector/src/builder/config.yaml
+++ b/images/collector/src/builder/config.yaml
@@ -28,7 +28,7 @@ processors:
   - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.146.0"
   - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor v0.146.0"
   - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.146.0"
-  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.146.0"
+  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.145.0"
   - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.146.0"
 connectors:
   - gomod: "go.opentelemetry.io/collector/connector/forwardconnector v0.146.1"

--- a/internal/collectors/otelcolresources/desired_state.go
+++ b/internal/collectors/otelcolresources/desired_state.go
@@ -1013,6 +1013,7 @@ func assembleDaemonSetCollectorContainer(
 		Name: openTelemetryCollector,
 		Args: []string{
 			"--config=file:" + collectorConfigurationFilePath,
+			"--feature-gates=-processor.resourcedetection.propagateerrors",
 		},
 		SecurityContext: &corev1.SecurityContext{
 			AllowPrivilegeEscalation: new(false),

--- a/internal/collectors/otelcolresources/desired_state_test.go
+++ b/internal/collectors/otelcolresources/desired_state_test.go
@@ -444,8 +444,9 @@ var _ = Describe("The desired state of the OpenTelemetry Collector resources", f
 		Expect(daemonSetCollectorContainer.ImagePullPolicy).To(Equal(corev1.PullAlways))
 		Expect(daemonSetCollectorContainer.Resources.Limits.Memory().String()).To(Equal("500Mi"))
 		Expect(daemonSetCollectorContainer.Resources.Requests.Memory().String()).To(Equal("500Mi"))
-		Expect(daemonSetCollectorContainerArgs).To(HaveLen(1))
+		Expect(daemonSetCollectorContainerArgs).To(HaveLen(2))
 		Expect(daemonSetCollectorContainerArgs[0]).To(Equal("--config=file:/etc/otelcol/conf/config.yaml"))
+		Expect(daemonSetCollectorContainerArgs[1]).To(Equal("--feature-gates=-processor.resourcedetection.propagateerrors"))
 		Expect(daemonSetCollectorContainer.VolumeMounts).To(HaveLen(6))
 		Expect(daemonSetCollectorContainer.VolumeMounts).To(
 			ContainElement(MatchVolumeMount("opentelemetry-collector-configmap", "/etc/otelcol/conf")))


### PR DESCRIPTION
* downgrades the resourcedetectionprocessor to 0.145.0 again
* add back the --feature-gates=-processor.resourcedetection.propagateerrors setting