### PR TITLE
fix(chart): fix default values for collector probes

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -11,6 +11,10 @@ on:
       SLACK_CHANNEL_ID:
         required: true
   workflow_dispatch:
+    inputs:
+      focus:
+        required: false
+        description: Execute a subset of tests by providing the focus parameter.
 
 env:
   DASH0_KIND_CLUSTER: dash0-operator-ci
@@ -103,6 +107,8 @@ jobs:
           curl -s http://localhost:5001/v2/_catalog || echo "Registry catalog endpoint responded"
 
       - name: Run e2e tests
+        env:
+          GINKGO_FOCUS: ${{ inputs.focus }}
         run: |
           make build-all-push-all-test-e2e
 
@@ -130,6 +136,8 @@ jobs:
                     text: ':seedling: <${{ github.server_url }}/${{ github.repository }}/tree/${{ github.head_ref || github.ref_name }}|${{ github.head_ref || github.ref_name }}>'
                   - type: mrkdwn
                     text: ':diff: <${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}|Commit>'
+                  - type: mrkdwn
+                    text: ":mag: ${{ inputs.focus != '' && inputs.focus || 'full test suite' }}"
 
       - name: Upload Kubernetes cluster information and pod logs for failed tests
         id: upload-k8s-logs
@@ -166,3 +174,5 @@ jobs:
                     text: ':diff: <${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}|Commit>'
                   - type: mrkdwn
                     text: ':scroll: <${{ steps.upload-k8s-logs.outputs.artifact-url }}|K8s cluster info/pod logs>'
+                  - type: mrkdwn
+                    text: ":mag: ${{ inputs.focus != '' && inputs.focus || 'full test suite' }}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -494,7 +494,7 @@ architecture of the machine running `make build-all-push-all-test-e2e` and the c
 
 Assuming worloads in the cluster can be reached, running the end-to-end tests can be done as follows:
 
-**With locally build images and the local Helm chart:**
+**With locally built images and the local Helm chart:**
 
 These require a remote registry that you can push to, which is network-reachable from the test cluster.
 If the registry requires authentication, additional steps are necessary.

--- a/helm-chart/dash0-operator/tests/operator/__snapshot__/extra-config-map_test.yaml.snap
+++ b/helm-chart/dash0-operator/tests/operator/__snapshot__/extra-config-map_test.yaml.snap
@@ -39,7 +39,7 @@ extra config map should match snapshot:
                 - linux
         daemonSetProbes:
           liveness:
-            failureThreshold: 3
+            failureThreshold: 20
             initialDelaySeconds: 0
             periodSeconds: 2
             timeoutSeconds: 1
@@ -81,7 +81,7 @@ extra config map should match snapshot:
                 - linux
         deploymentProbes:
           liveness:
-            failureThreshold: 3
+            failureThreshold: 20
             initialDelaySeconds: 0
             periodSeconds: 2
             timeoutSeconds: 1

--- a/helm-chart/dash0-operator/tests/operator/extra-config-map_test.yaml
+++ b/helm-chart/dash0-operator/tests/operator/extra-config-map_test.yaml
@@ -472,7 +472,7 @@ tests:
                     - linux
             daemonSetProbes:
               liveness:
-                failureThreshold: 3
+                failureThreshold: 20
                 initialDelaySeconds: 0
                 periodSeconds: 2
                 timeoutSeconds: 1
@@ -518,7 +518,7 @@ tests:
                     - linux
             deploymentProbes:
               liveness:
-                failureThreshold: 3
+                failureThreshold: 20
                 initialDelaySeconds: 0
                 periodSeconds: 2
                 timeoutSeconds: 1

--- a/helm-chart/dash0-operator/values.yaml
+++ b/helm-chart/dash0-operator/values.yaml
@@ -583,11 +583,17 @@ operator:
     # Parameters for the liveness, readiness and startup probes of the DaemonSet collectors.
     # See https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
     daemonSetProbes:
+      # Note: The liveness probe is also relevant for when new namespaces start to be monitored, or monitored namespaces
+      # are deleted. Both events will change the colletor config map and result in the collector reloading its
+      # configuration internally. This will make the collector fail the liveness probe temporarily. If the probe is
+      # configured too tightly, Kubernetes will restart the opentelemetry-collector container via SIGTERM. If you notice
+      # frequent collector restarts after adding or removing Dash0Monitoring resources, try to provide a higher
+      # failureThreshold value.
       liveness:
         initialDelaySeconds: 0
         periodSeconds: 2
         timeoutSeconds: 1
-        failureThreshold: 3
+        failureThreshold: 20
       readiness:
         initialDelaySeconds: 0
         periodSeconds: 2
@@ -667,11 +673,17 @@ operator:
     # Parameters for the liveness, readiness and startup probes of the collector Deployment (cluster-metrics-collector).
     # See https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
     deploymentProbes:
+      # Note: The liveness probe is also relevant for when new namespaces start to be monitored, or monitored namespaces
+      # are deleted. Both events will change the colletor config map and result in the collector reloading its
+      # configuration internally. This will make the collector fail the liveness probe temporarily. If the probe is
+      # configured too tightly, Kubernetes will restart the opentelemetry-collector container via SIGTERM. If you notice
+      # frequent collector restarts after adding or removing Dash0Monitoring resources, try to provide a higher
+      # failureThreshold value.
       liveness:
         initialDelaySeconds: 0
         periodSeconds: 2
         timeoutSeconds: 1
-        failureThreshold: 3
+        failureThreshold: 20
       readiness:
         initialDelaySeconds: 0
         periodSeconds: 2

--- a/images/configreloader/src/configreloader.go
+++ b/images/configreloader/src/configreloader.go
@@ -72,9 +72,18 @@ func main() {
 		"",
 		"path to the collector's pid file, which contains the PID of the collector's process",
 	)
+
+	// Note: The checkFrequency of the configreloader is not the determining factor in how fast a changed config map will
+	// be noticed and a config update in the collector process will be triggered. Instead, this is mostly determined by
+	// the kubelet sync loop - the kubelet periodically polls the API server to detect changes to ConfigMaps/Secrets.
+	// This interval is controlled by the kubelet's syncFrequency setting, see
+	//nolint:lll
+	// https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/#kubelet-config-k8s-io-v1beta1-KubeletConfiguration
+	// This defaults to 1 minute. So it might take up to a minute from changing the config map content until the
+	// configreloader can see the config change.
 	checkFrequency := flag.Duration(
 		"frequency",
-		1*time.Second,
+		5*time.Second,
 		"how often to check for changes in the configuration files",
 	)
 

--- a/test/e2e/collector.go
+++ b/test/e2e/collector.go
@@ -4,6 +4,7 @@
 package e2e
 
 import (
+	"encoding/json"
 	"fmt"
 	"os/exec"
 	"strings"
@@ -202,10 +203,11 @@ func verifyConfigMapDoesNotContainStrings(operatorNamespace string, configMapNam
 	)
 }
 
-func findMostRecentCollectorReadyLogLine(g Gomega) time.Time {
+func findMostRecentCollectorReadyLogLine(g Gomega, collectorName string) time.Time {
 	allCollectorReadyLogLines := getMatchingLogLinesFomCollectorContainerLog(
 		g,
 		operatorNamespace,
+		collectorName,
 		"opentelemetry-collector",
 		collectorReadyLogMessage,
 	)
@@ -223,12 +225,13 @@ func findMostRecentCollectorReadyLogLine(g Gomega) time.Time {
 func getMatchingLogLinesFomCollectorContainerLog(
 	g Gomega,
 	operatorNamespace string,
+	collectorName string,
 	containerName string,
 	needle string,
 ) []string {
 	matchingLines := []string{}
-	command := getLogsViaKubectl(operatorNamespace, collectorDaemonSetNameQualified, containerName)
-	logs, err := run(command, true)
+	command := getLogsViaKubectl(operatorNamespace, collectorName, containerName)
+	logs, err := run(command, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	lines := strings.Split(logs, "\n")
 	for _, line := range lines {
@@ -249,4 +252,66 @@ func getLogsViaKubectl(namespace string, workloadName string, containerName stri
 		"-c",
 		containerName,
 	)
+}
+
+// getDaemonSetCollectorPodRestartCounts returns the restart counts of the opentelemetry-collector container
+// for all pods belonging to the collector daemonset, with the pod name as the key.
+func getDaemonSetCollectorPodRestartCounts(operatorNamespace string) map[string]int {
+	return getCollectorPodRestartCounts(
+		operatorNamespace,
+		"app.kubernetes.io/name=opentelemetry-collector,app.kubernetes.io/component=agent-collector",
+	)
+}
+
+// getDeploymentCollectorPodRestartCounts returns the restart counts of the opentelemetry-collector container
+// for all pods belonging to the collector deployment, with the pod name as the key.
+func getDeploymentCollectorPodRestartCounts(operatorNamespace string) map[string]int {
+	return getCollectorPodRestartCounts(
+		operatorNamespace,
+		"app.kubernetes.io/name=opentelemetry-collector,app.kubernetes.io/component=cluster-metrics-collector",
+	)
+}
+
+func getCollectorPodRestartCounts(operatorNamespace string, labelSelector string) map[string]int {
+	output, err := run(
+		exec.Command(
+			"kubectl",
+			"get",
+			"pods",
+			"--namespace",
+			operatorNamespace,
+			"-l",
+			labelSelector,
+			"-o",
+			"json",
+		),
+		false,
+	)
+	Expect(err).ToNot(HaveOccurred())
+
+	var podList struct {
+		Items []struct {
+			Metadata struct {
+				Name string `json:"name"`
+			} `json:"metadata"`
+			Status struct {
+				ContainerStatuses []struct {
+					Name         string `json:"name"`
+					RestartCount int    `json:"restartCount"`
+				} `json:"containerStatuses"`
+			} `json:"status"`
+		} `json:"items"`
+	}
+	Expect(json.Unmarshal([]byte(output), &podList)).To(Succeed())
+
+	restartCounts := map[string]int{}
+	for _, pod := range podList.Items {
+		for _, containerStatus := range pod.Status.ContainerStatuses {
+			if containerStatus.Name == "opentelemetry-collector" {
+				restartCounts[pod.Metadata.Name] = containerStatus.RestartCount
+				break
+			}
+		}
+	}
+	return restartCounts
 }

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1182,9 +1182,9 @@ traces:
 						// nolint:lll
 						`- 'resource.attributes["k8s.namespace.name"] == "e2e-application-under-test-namespace" and (attributes["http.route"] == "/ready")'`,
 					)
-					By("verify that the collector has restarted after the config change")
+					By("verify that the collector has reloaded its configuration")
 					Eventually(func(g Gomega) {
-						mostRecentCollectorReadyTimeStamp := findMostRecentCollectorReadyLogLine(g)
+						mostRecentCollectorReadyTimeStamp := findMostRecentCollectorReadyLogLine(g, collectorDaemonSetNameQualified)
 						g.Expect(mostRecentCollectorReadyTimeStamp).To(BeTemporally(">", minTimestampCollectorRestart))
 					}, 90*time.Second, time.Second).Should(Succeed())
 
@@ -1254,9 +1254,9 @@ trace_statements:
 						operatorNamespace,
 						`- 'resource.attributes["k8s.namespace.name"] == "e2e-application-under-test-namespace"'`,
 					)
-					By("verify that the collector has restarted after the config change")
+					By("verify that the collector has reloaded its configuration")
 					Eventually(func(g Gomega) {
-						mostRecentCollectorReadyTimeStamp := findMostRecentCollectorReadyLogLine(g)
+						mostRecentCollectorReadyTimeStamp := findMostRecentCollectorReadyLogLine(g, collectorDaemonSetNameQualified)
 						g.Expect(mostRecentCollectorReadyTimeStamp).To(BeTemporally(">", minTimestampCollectorRestart))
 					}, 90*time.Second, time.Second).Should(Succeed())
 
@@ -1631,7 +1631,7 @@ trace_statements:
 			})
 
 			//nolint:lll
-			It("should update the daemon set collector configuration when updating the Dash0 endpoint in the operator configuration resource", func() {
+			It("should update and reload the collector configuration when updating the Dash0 endpoint in the operator configuration resource", func() {
 				deployDash0OperatorConfigurationResourceWithRetry(dash0OperatorConfigurationValues{
 					SelfMonitoringEnabled:      false,
 					Endpoint:                   defaultEndpoint,
@@ -1650,25 +1650,76 @@ trace_statements:
 					operatorNamespace,
 				)
 
-				By("waiting for the collector to be ready")
-				var firstCollectorReadyTimeStamp time.Time
+				By("waiting for the collectors to be ready")
+				var firstDaemonSetCollectorReadyTimeStamp time.Time
+				var firstDeploymentCollectorReadyTimeStamp time.Time
 				Eventually(func(g Gomega) {
-					firstCollectorReadyTimeStamp = findMostRecentCollectorReadyLogLine(g)
+					firstDaemonSetCollectorReadyTimeStamp = findMostRecentCollectorReadyLogLine(g, collectorDaemonSetNameQualified)
 				}, 30*time.Second, time.Second).Should(Succeed())
+				Eventually(func(g Gomega) {
+					firstDeploymentCollectorReadyTimeStamp = findMostRecentCollectorReadyLogLine(g, collectorDeploymentNameQualified)
+				}, 30*time.Second, time.Second).Should(Succeed())
+
+				daemonSetRestartCountsBeforeConfigChange := getDaemonSetCollectorPodRestartCounts(operatorNamespace)
+				deploymentRestartCountsBeforeConfigChange := getDeploymentCollectorPodRestartCounts(operatorNamespace)
 
 				By("updating the Dash0 operator configuration endpoint setting")
 				newEndpoint := "ingress.eu-east-1.aws.dash0-dev.com:4317"
 				updateEndpointOfDash0OperatorConfigurationResource(newEndpoint)
 
-				By("verify that the config map has been updated by the controller")
+				By("verify that the config maps have been updated by the controller")
 				verifyDaemonSetCollectorConfigMapContainsString(operatorNamespace, newEndpoint)
+				verifyDeploymentCollectorConfigMapContainsString(operatorNamespace, newEndpoint)
 
-				By("verify that the collector has restarted and has become ready once more")
+				By("verify that the collectors have reloaded their configuration")
+				// Note: It can take up to a minute until the config change can be detected by the configreloader, due to the
+				// default of 1 minute for kubelet's syncFrequency setting, see
+				// https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/#kubelet-config-k8s-io-v1beta1-KubeletConfiguration.
+				// And then it also takes a couple of seconds until the collector has actually reloaded its configuration after
+				// receiving SIGHUB. Hence, we use a 2 minute timeout here.
 				Eventually(func(g Gomega) {
-					secondCollectorReadyTimeStamp := findMostRecentCollectorReadyLogLine(g)
-					g.Expect(secondCollectorReadyTimeStamp).To(BeTemporally(">", firstCollectorReadyTimeStamp))
+					secondDaemonSetCollectorReadyTimeStamp := findMostRecentCollectorReadyLogLine(g, collectorDaemonSetNameQualified)
+					g.Expect(secondDaemonSetCollectorReadyTimeStamp).To(BeTemporally(">", firstDaemonSetCollectorReadyTimeStamp))
+				}, 2*time.Minute, time.Second).Should(Succeed())
+				Eventually(func(g Gomega) {
+					secondDeploymentCollectorReadyTimeStamp := findMostRecentCollectorReadyLogLine(g, collectorDaemonSetNameQualified)
+					g.Expect(secondDeploymentCollectorReadyTimeStamp).To(BeTemporally(">", firstDeploymentCollectorReadyTimeStamp))
 				}, 2*time.Minute, time.Second).Should(Succeed())
 
+				// Verify that the collector has reloaded the configuration in-process, instead of restarting the process.
+				By("verify that the collectors have not restarted")
+				daemonSetRestartCountsAfterConfigChange := getDaemonSetCollectorPodRestartCounts(operatorNamespace)
+				Expect(daemonSetRestartCountsAfterConfigChange).To(HaveLen(len(daemonSetRestartCountsBeforeConfigChange)))
+				for podName, restartCountBefore := range daemonSetRestartCountsBeforeConfigChange {
+					restartCountAfter, ok := daemonSetRestartCountsAfterConfigChange[podName]
+					Expect(ok).To(BeTrue(), "daemonset collector pod is missing after config change")
+					Expect(restartCountAfter).To(
+						Equal(restartCountBefore),
+						fmt.Sprintf(
+							"Pod %s had a restart count of %d before the config change, and now has a restart count of %d,",
+							podName,
+							restartCountBefore,
+							restartCountAfter,
+						)+". This means it has been restarted due to the config change. This is unexpected, it should have "+
+							"reloaded the configuration in-process.",
+					)
+				}
+				deploymentRestartCountsAfterConfigChange := getDeploymentCollectorPodRestartCounts(operatorNamespace)
+				Expect(deploymentRestartCountsAfterConfigChange).To(HaveLen(len(deploymentRestartCountsBeforeConfigChange)))
+				for podName, restartCountBefore := range deploymentRestartCountsBeforeConfigChange {
+					restartCountAfter, ok := deploymentRestartCountsAfterConfigChange[podName]
+					Expect(ok).To(BeTrue(), "deployment collector pod is missing after config change")
+					Expect(restartCountAfter).To(
+						Equal(restartCountBefore),
+						fmt.Sprintf(
+							"Pod %s had a restart count of %d before the config change, and now has a restart count of %d,",
+							podName,
+							restartCountBefore,
+							restartCountAfter,
+						)+". This means it has been restarted due to the config change. This is unexpected, it should have "+
+							"reloaded the configuration in-process.",
+					)
+				}
 			})
 		})
 

--- a/test/e2e/operator.go
+++ b/test/e2e/operator.go
@@ -20,9 +20,8 @@ import (
 )
 
 const (
-	localHelmChart            = "helm-chart/dash0-operator"
-	operatorHelmReleaseName   = "e2e-tests-operator-hr"
-	defaultWebhookServiceName = "dash0-operator-webhook-service"
+	localHelmChart          = "helm-chart/dash0-operator"
+	operatorHelmReleaseName = "e2e-tests-operator-hr"
 )
 
 var (


### PR DESCRIPTION
The previous probes were too tight. This was especially problematic when the configreloader container instructed the collector container to reload its configuration via SIGHUB. When doing that, the collector temporarily goes into a state where the liveness probe fails.

Due to the small failureThreshold for the liveness probe, this would usually result in Kubernetes sending SIGTERM and restart the container entirely. With the increased default for the failureThreshold value, the collector container will reload the configuration in-process correctly, without a container restart.