### PR TITLE
feat: add logd logger with debug level

### DIFF
--- a/api/operator/v1alpha1/operator_configuration_types.go
+++ b/api/operator/v1alpha1/operator_configuration_types.go
@@ -6,7 +6,6 @@ package v1alpha1
 import (
 	"encoding/json"
 
-	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -15,6 +14,7 @@ import (
 
 	dash0operator "github.com/dash0hq/dash0-operator/api/operator"
 	dash0common "github.com/dash0hq/dash0-operator/api/operator/common"
+	"github.com/dash0hq/dash0-operator/internal/util/logd"
 )
 
 // Dash0OperatorConfiguration is the schema for the Dash0OperatorConfiguration API
@@ -430,7 +430,7 @@ func (d *Dash0OperatorConfiguration) At(list client.ObjectList, index int) dash0
 	return &list.(*Dash0OperatorConfigurationList).Items[index]
 }
 
-func (d *Dash0OperatorConfiguration) LogResourceAsEvent(logger logr.Logger) {
+func (d *Dash0OperatorConfiguration) LogResourceAsEvent(logger logd.Logger) {
 	redactedOperatorConfiguration := d.cloneAndRedact()
 	if operatorConfigurationResourceMarshalled, err := json.Marshal(redactedOperatorConfiguration); err != nil {
 		logger.Error(err, "cannot marshal Dash0OperatorConfiguration resource for dash0.operator_configuration event")

--- a/api/operator/v1beta1/dash0monitoring_types.go
+++ b/api/operator/v1beta1/dash0monitoring_types.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"slices"
 
-	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -18,6 +17,7 @@ import (
 	dash0operator "github.com/dash0hq/dash0-operator/api/operator"
 	dash0common "github.com/dash0hq/dash0-operator/api/operator/common"
 	"github.com/dash0hq/dash0-operator/internal/util"
+	"github.com/dash0hq/dash0-operator/internal/util/logd"
 )
 
 // Dash0Monitoring is the schema for the Dash0Monitoring API
@@ -501,7 +501,7 @@ func (d *Dash0Monitoring) GetDash0Exports() []dash0common.Dash0Configuration {
 	return res
 }
 
-func (d *Dash0Monitoring) LogResourceAsEvent(logger logr.Logger) {
+func (d *Dash0Monitoring) LogResourceAsEvent(logger logd.Logger) {
 	redactedMonitoringResource := d.cloneAndRedact()
 	if redactedMonitoringResourceMarshalled, err := json.Marshal(redactedMonitoringResource); err != nil {
 		logger.Error(err, "cannot marshal Dash0Monitoring resource for dash0.monitoring_resource event")

--- a/internal/collectors/collector_controller.go
+++ b/internal/collectors/collector_controller.go
@@ -15,11 +15,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/dash0hq/dash0-operator/internal/collectors/otelcolresources"
+	"github.com/dash0hq/dash0-operator/internal/util/logd"
 )
 
 type CollectorReconciler struct {
@@ -131,7 +131,7 @@ func (r *CollectorReconciler) Reconcile(
 	ctx context.Context,
 	request reconcile.Request,
 ) (reconcile.Result, error) {
-	logger := log.FromContext(ctx)
+	logger := logd.FromContext(ctx)
 	logger.Info("reconciling collector resources", "request", request)
 
 	hasBeenReconciled, err := r.collectorManager.ReconcileOpenTelemetryCollector(

--- a/internal/collectors/collector_manager.go
+++ b/internal/collectors/collector_manager.go
@@ -11,12 +11,10 @@ import (
 	"strings"
 	"sync/atomic"
 
-	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	dash0common "github.com/dash0hq/dash0-operator/api/operator/common"
 	dash0v1alpha1 "github.com/dash0hq/dash0-operator/api/operator/v1alpha1"
@@ -24,6 +22,7 @@ import (
 	"github.com/dash0hq/dash0-operator/internal/collectors/otelcolresources"
 	"github.com/dash0hq/dash0-operator/internal/resources"
 	"github.com/dash0hq/dash0-operator/internal/util"
+	"github.com/dash0hq/dash0-operator/internal/util/logd"
 )
 
 type CollectorManager struct {
@@ -65,7 +64,7 @@ func NewCollectorManager(
 	return m
 }
 
-func (m *CollectorManager) UpdateExtraConfig(ctx context.Context, newConfig util.ExtraConfig, logger logr.Logger) {
+func (m *CollectorManager) UpdateExtraConfig(ctx context.Context, newConfig util.ExtraConfig, logger logd.Logger) {
 	previousConfig := m.extraConfig.Swap(&newConfig)
 	if previousConfig == nil || !reflect.DeepEqual(*previousConfig, newConfig) {
 		hasBeenReconciled, err := m.ReconcileOpenTelemetryCollector(ctx)
@@ -94,12 +93,10 @@ func (m *CollectorManager) UpdateExtraConfig(ctx context.Context, newConfig util
 func (m *CollectorManager) ReconcileOpenTelemetryCollector(
 	ctx context.Context,
 ) (bool, error) {
-	logger := log.FromContext(ctx)
+	logger := logd.FromContext(ctx)
 	if m.updateInProgress.Load() {
-		if m.developmentMode {
-			logger.Info("creation/update of the OpenTelemetry collector resources is already in progress, skipping " +
-				"additional reconciliation request.")
-		}
+		logger.Debug("creation/update of the OpenTelemetry collector resources is already in progress, skipping " +
+			"additional reconciliation request.")
 		return false, nil
 	}
 
@@ -151,7 +148,7 @@ func (m *CollectorManager) createOrUpdateOpenTelemetryCollector(
 	operatorConfigurationResource *dash0v1alpha1.Dash0OperatorConfiguration,
 	allMonitoringResources []dash0v1beta1.Dash0Monitoring,
 	extraConfig util.ExtraConfig,
-	logger logr.Logger,
+	logger logd.Logger,
 ) error {
 	slices.SortFunc(
 		allMonitoringResources,
@@ -188,7 +185,7 @@ func (m *CollectorManager) createOrUpdateOpenTelemetryCollector(
 func (m *CollectorManager) removeOpenTelemetryCollector(
 	ctx context.Context,
 	extraConfig util.ExtraConfig,
-	logger logr.Logger,
+	logger logd.Logger,
 ) error {
 	resourcesHaveBeenDeleted, err := m.oTelColResourceManager.DeleteResources(
 		ctx,
@@ -210,7 +207,7 @@ func (m *CollectorManager) removeOpenTelemetryCollector(
 
 func (m *CollectorManager) findOperatorConfigurationResource(
 	ctx context.Context,
-	logger logr.Logger,
+	logger logd.Logger,
 ) (*dash0v1alpha1.Dash0OperatorConfiguration, error) {
 	operatorConfigurationResource, err := resources.FindUniqueOrMostRecentResourceInScope(
 		ctx,
@@ -230,7 +227,7 @@ func (m *CollectorManager) findOperatorConfigurationResource(
 
 func (m *CollectorManager) findAllMonitoringResources(
 	ctx context.Context,
-	logger logr.Logger,
+	logger logd.Logger,
 ) ([]dash0v1beta1.Dash0Monitoring, error) {
 	monitoringResourceList := dash0v1beta1.Dash0MonitoringList{}
 	if err := m.List(

--- a/internal/collectors/collector_manager_test.go
+++ b/internal/collectors/collector_manager_test.go
@@ -14,13 +14,13 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	dash0common "github.com/dash0hq/dash0-operator/api/operator/common"
 	dash0v1alpha1 "github.com/dash0hq/dash0-operator/api/operator/v1alpha1"
 	dash0v1beta1 "github.com/dash0hq/dash0-operator/api/operator/v1beta1"
 	"github.com/dash0hq/dash0-operator/internal/collectors/otelcolresources"
 	"github.com/dash0hq/dash0-operator/internal/util"
+	"github.com/dash0hq/dash0-operator/internal/util/logd"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -34,7 +34,7 @@ var (
 
 var _ = Describe("The collector manager", Ordered, func() {
 	ctx := context.Background()
-	logger := log.FromContext(ctx)
+	logger := logd.FromContext(ctx)
 
 	var createdObjectsCollectorManagerTest []client.Object
 

--- a/internal/collectors/otelcolresources/exporter.go
+++ b/internal/collectors/otelcolresources/exporter.go
@@ -11,7 +11,7 @@ import (
 	dash0v1alpha1 "github.com/dash0hq/dash0-operator/api/operator/v1alpha1"
 	dash0v1beta1 "github.com/dash0hq/dash0-operator/api/operator/v1beta1"
 	"github.com/dash0hq/dash0-operator/internal/util"
-	"github.com/go-logr/logr"
+	"github.com/dash0hq/dash0-operator/internal/util/logd"
 )
 
 type otlpExporter struct {
@@ -85,7 +85,7 @@ func getDefaultOtlpExporters(dash0Config *dash0v1alpha1.Dash0OperatorConfigurati
 // remaining namespaces will still be handled correctly. For the invalid namespace, the default exporters will be used.
 func getNamespacedOtlpExporters(
 	allMonitoringResources []dash0v1beta1.Dash0Monitoring,
-	logger logr.Logger,
+	logger logd.Logger,
 ) namespacedOtlpExporters {
 	nsExporters := make(map[string][]otlpExporter, len(allMonitoringResources))
 	for _, monitoringResource := range allMonitoringResources {

--- a/internal/collectors/otelcolresources/exporter_test.go
+++ b/internal/collectors/otelcolresources/exporter_test.go
@@ -4,13 +4,13 @@
 package otelcolresources
 
 import (
-	"github.com/go-logr/logr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	dash0common "github.com/dash0hq/dash0-operator/api/operator/common"
 	dash0v1alpha1 "github.com/dash0hq/dash0-operator/api/operator/v1alpha1"
 	dash0v1beta1 "github.com/dash0hq/dash0-operator/api/operator/v1beta1"
 	"github.com/dash0hq/dash0-operator/internal/util"
+	"github.com/dash0hq/dash0-operator/internal/util/logd"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -567,10 +567,10 @@ var _ = Describe("Exporter Conversion", func() {
 	})
 
 	Describe("GetNamespacedOtlpExporters", func() {
-		var logger logr.Logger
+		var logger logd.Logger
 
 		BeforeEach(func() {
-			logger = logr.Discard()
+			logger = logd.Discard()
 		})
 
 		It("should return empty map when no monitoring resources have export", func() {

--- a/internal/collectors/otelcolresources/otelcol_resources.go
+++ b/internal/collectors/otelcolresources/otelcol_resources.go
@@ -16,7 +16,6 @@ import (
 	"sync/atomic"
 
 	"github.com/cisco-open/k8s-objectmatcher/patch"
-	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -28,6 +27,7 @@ import (
 	dash0v1beta1 "github.com/dash0hq/dash0-operator/api/operator/v1beta1"
 	"github.com/dash0hq/dash0-operator/internal/selfmonitoringapiaccess"
 	"github.com/dash0hq/dash0-operator/internal/util"
+	"github.com/dash0hq/dash0-operator/internal/util/logd"
 	"github.com/dash0hq/dash0-operator/internal/util/resources"
 )
 
@@ -91,7 +91,7 @@ func (m *OTelColResourceManager) CreateOrUpdateOpenTelemetryCollectorResources(
 	extraConfig util.ExtraConfig,
 	operatorConfigurationResource *dash0v1alpha1.Dash0OperatorConfiguration,
 	allMonitoringResources []dash0v1beta1.Dash0Monitoring,
-	logger logr.Logger,
+	logger logd.Logger,
 ) (bool, bool, error) {
 	selfMonitoringConfiguration, err :=
 		selfmonitoringapiaccess.ConvertOperatorConfigurationResourceToSelfMonitoringConfiguration(
@@ -222,7 +222,7 @@ func (m *OTelColResourceManager) CreateOrUpdateOpenTelemetryCollectorResources(
 func (m *OTelColResourceManager) createOrUpdateResource(
 	ctx context.Context,
 	desiredResource client.Object,
-	logger logr.Logger,
+	logger logd.Logger,
 ) (bool, bool, error) {
 	existingResource, err := resources.CreateEmptyReceiverFor(desiredResource)
 	if err != nil {
@@ -251,7 +251,7 @@ func (m *OTelColResourceManager) createOrUpdateResource(
 func (m *OTelColResourceManager) createResource(
 	ctx context.Context,
 	desiredResource client.Object,
-	logger logr.Logger,
+	logger logd.Logger,
 ) error {
 	if err := resources.SetOwnerReference(m.operatorManagerDeployment, m.scheme, desiredResource, logger); err != nil {
 		return err
@@ -275,7 +275,7 @@ func (m *OTelColResourceManager) updateResource(
 	ctx context.Context,
 	existingResource client.Object,
 	desiredResource client.Object,
-	logger logr.Logger,
+	logger logd.Logger,
 ) (bool, error) {
 	if err := resources.SetOwnerReference(m.operatorManagerDeployment, m.scheme, desiredResource, logger); err != nil {
 		return false, err
@@ -365,7 +365,7 @@ func addSelfReferenceUidToAllContainers(containers *[]corev1.Container, envVarNa
 func (m *OTelColResourceManager) DeleteResources(
 	ctx context.Context,
 	extraConfig util.ExtraConfig,
-	logger logr.Logger,
+	logger logd.Logger,
 ) (bool, error) {
 	logger.Info(
 		fmt.Sprintf(
@@ -435,7 +435,7 @@ func (m *OTelColResourceManager) deleteResourcesThatAreNoLongerDesired(
 	config oTelColConfig,
 	extraConfig util.ExtraConfig,
 	desiredState []clientObject,
-	logger logr.Logger,
+	logger logd.Logger,
 ) error {
 	// override actual config settings with settings that will produce all possible resources
 	config.KubernetesInfrastructureMetricsCollectionEnabled = true
@@ -485,7 +485,7 @@ func (m *OTelColResourceManager) deleteResourcesThatAreNoLongerDesired(
 func (m *OTelColResourceManager) deleteObsoleteResourcesFromPreviousOperatorVersions(
 	ctx context.Context,
 	namespace string,
-	logger logr.Logger,
+	logger logd.Logger,
 ) error {
 	if m.obsoleteResourcesHaveBeenDeleted.Load() {
 		return nil
@@ -521,7 +521,7 @@ func (m *OTelColResourceManager) deleteObsoleteResourcesFromPreviousOperatorVers
 
 func (m *OTelColResourceManager) determineKubeletstatsReceiverEndpoint(
 	kubernetesInfrastructureMetricsCollectionEnabled bool,
-	logger logr.Logger,
+	logger logd.Logger,
 ) KubeletStatsReceiverConfig {
 	cachedConfig := m.kubeletStatsReceiverConfig.Load()
 	if cachedConfig != nil {
@@ -705,7 +705,7 @@ func isTlsError(err error) bool {
 	return strings.Contains(err.Error(), "tls: failed to verify certificate:")
 }
 
-func (m *OTelColResourceManager) logErrorAndDisableKubeletStatsReceiver(logger logr.Logger) KubeletStatsReceiverConfig {
+func (m *OTelColResourceManager) logErrorAndDisableKubeletStatsReceiver(logger logd.Logger) KubeletStatsReceiverConfig {
 	logger.Error(
 		fmt.Errorf("cannot determine viable endpoint for kubeletstats receiver endpoint, see above"),
 		"The operator ran out of options when trying to find a viable kubeletstats receiver endpoint. The "+

--- a/internal/collectors/otelcolresources/otelcol_resources_test.go
+++ b/internal/collectors/otelcolresources/otelcol_resources_test.go
@@ -12,10 +12,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	dash0v1alpha1 "github.com/dash0hq/dash0-operator/api/operator/v1alpha1"
 	"github.com/dash0hq/dash0-operator/internal/util"
+	"github.com/dash0hq/dash0-operator/internal/util/logd"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -44,7 +44,7 @@ var (
 
 var _ = Describe("The OpenTelemetry Collector resource manager", Ordered, func() {
 	ctx := context.Background()
-	logger := log.FromContext(ctx)
+	logger := logd.FromContext(ctx)
 
 	var oTelColResourceManager *OTelColResourceManager
 

--- a/internal/controller/api_sync_common.go
+++ b/internal/controller/api_sync_common.go
@@ -18,7 +18,7 @@ import (
 	dash0v1beta1 "github.com/dash0hq/dash0-operator/api/operator/v1beta1"
 	"github.com/dash0hq/dash0-operator/internal/resources"
 	"github.com/dash0hq/dash0-operator/internal/util"
-	"github.com/go-logr/logr"
+	"github.com/dash0hq/dash0-operator/internal/util/logd"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -53,13 +53,13 @@ func NewValidatedApiConfigAndToken(endpoint string, dataset string, token string
 }
 
 type ApiClient interface {
-	SetDefaultApiConfigs(context.Context, []ApiConfig, logr.Logger)
-	RemoveDefaultApiConfigs(context.Context, logr.Logger)
+	SetDefaultApiConfigs(context.Context, []ApiConfig, logd.Logger)
+	RemoveDefaultApiConfigs(context.Context, logd.Logger)
 }
 
 type NamespacedApiClient interface {
-	SetNamespacedApiConfigs(context.Context, string, []ApiConfig, logr.Logger)
-	RemoveNamespacedApiConfigs(context.Context, string, logr.Logger)
+	SetNamespacedApiConfigs(context.Context, string, []ApiConfig, logd.Logger)
+	RemoveNamespacedApiConfigs(context.Context, string, logd.Logger)
 }
 
 type ResourceToRequestsResult struct {
@@ -186,11 +186,11 @@ type ApiSyncReconciler interface {
 	// - the request objects for which the conversion was successful,
 	// - validation issues for items that were invalid and
 	// - synchronization errors that occurred during the conversion.
-	MapResourceToHttpRequests(*preconditionValidationResult, ApiConfig, apiAction, logr.Logger) *ResourceToRequestsResult
+	MapResourceToHttpRequests(*preconditionValidationResult, ApiConfig, apiAction, logd.Logger) *ResourceToRequestsResult
 
 	ExtractIdFromResponseBody(
 		responseBytes []byte,
-		logger logr.Logger,
+		logger logd.Logger,
 	) (string, error)
 }
 
@@ -206,7 +206,7 @@ type OwnedResourceReconciler interface {
 		context.Context,
 		client.Object,
 		synchronizationResults,
-		logr.Logger,
+		logd.Logger,
 	)
 }
 
@@ -338,7 +338,7 @@ func synchronizeViaApiAndUpdateStatus(
 	dash0ApiResource *unstructured.Unstructured,
 	ownedResource client.Object,
 	action apiAction,
-	logger logr.Logger,
+	logger logd.Logger,
 ) {
 	preconditionChecksResult := validatePreconditionsAndPreprocess(
 		ctx,
@@ -519,7 +519,7 @@ func validatePreconditionsAndPreprocess(
 	ctx context.Context,
 	apiSyncReconciler ApiSyncReconciler,
 	dash0ApiResource *unstructured.Unstructured,
-	logger logr.Logger,
+	logger logd.Logger,
 ) *preconditionValidationResult {
 	namespace := dash0ApiResource.GetNamespace()
 	name := dash0ApiResource.GetName()
@@ -764,7 +764,7 @@ func fetchExistingOrigins(
 	apiSyncReconciler ApiSyncReconciler,
 	preconditionChecksResult *preconditionValidationResult,
 	apiConfig ApiConfig,
-	logger logr.Logger,
+	logger logd.Logger,
 ) ([]string, error) {
 	thirdPartyResourceReconciler, ok := apiSyncReconciler.(ThirdPartyResourceReconciler)
 	if !ok {
@@ -824,7 +824,7 @@ func addDeleteRequestsForObjectsThatHaveBeenDeletedInTheKubernetesResource(
 	apiConfig ApiConfig,
 	existingOriginsFromApi []string,
 	resourceToRequestsResult *ResourceToRequestsResult,
-	logger logr.Logger,
+	logger logd.Logger,
 ) {
 	thirdPartyResourceReconciler, ok := apiSyncReconciler.(ThirdPartyResourceReconciler)
 	if !ok {
@@ -868,7 +868,7 @@ func addAuthorizationHeader(req *http.Request, token string) {
 func executeAllHttpRequests(
 	apiSyncReconciler ApiSyncReconciler,
 	allRequests []WrappedApiRequest,
-	logger logr.Logger,
+	logger logd.Logger,
 ) ([]SuccessfulSynchronizationResult, map[string]string) {
 	successfullySynchronized := make([]SuccessfulSynchronizationResult, 0)
 	httpErrors := make(map[string]string)
@@ -924,7 +924,7 @@ func executeSingleHttpRequestWithRetryAndReadBody(
 	req *http.Request,
 	actionLabel string,
 	expectBody bool,
-	logger logr.Logger,
+	logger logd.Logger,
 ) ([]byte, error) {
 	logger.Info(fmt.Sprintf("executing HTTP request to %s", actionLabel))
 	responseBody := &[]byte{}
@@ -963,7 +963,7 @@ func executeSingleHttpRequestAndReadBody(
 	req *http.Request,
 	responseBody *[]byte,
 	actionLabel string,
-	logger logr.Logger,
+	logger logd.Logger,
 ) error {
 	res, err := apiSyncReconciler.HttpClient().Do(req)
 	if err != nil {
@@ -1057,7 +1057,7 @@ func writeSynchronizationResult(
 	ownedResource client.Object,
 	syncResults synchronizationResults,
 	resourceHasBeenDeleted bool,
-	logger logr.Logger,
+	logger logd.Logger,
 
 ) {
 	ownedResourceReconciler, ok := apiSyncReconciler.(OwnedResourceReconciler)

--- a/internal/controller/monitoring_controller.go
+++ b/internal/controller/monitoring_controller.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/dash0hq/dash0-operator/internal/selfmonitoringapiaccess"
-	"github.com/go-logr/logr"
+	"github.com/dash0hq/dash0-operator/internal/util/logd"
 	otelmetric "go.opentelemetry.io/otel/metric"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -19,7 +19,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	dash0common "github.com/dash0hq/dash0-operator/api/operator/common"
 	dash0v1beta1 "github.com/dash0hq/dash0-operator/api/operator/v1beta1"
@@ -102,7 +101,7 @@ func (r *MonitoringReconciler) SetupWithManager(mgr ctrl.Manager) error {
 func (r *MonitoringReconciler) InitializeSelfMonitoringMetrics(
 	meter otelmetric.Meter,
 	metricNamePrefix string,
-	logger logr.Logger,
+	logger logd.Logger,
 ) {
 	reconcileRequestMetricName := fmt.Sprintf("%s%s", metricNamePrefix, "monitoring.reconcile_requests")
 	var err error
@@ -122,7 +121,7 @@ func (r *MonitoringReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		monitoringReconcileRequestMetric.Add(ctx, 1)
 	}
 
-	logger := log.FromContext(ctx)
+	logger := logd.FromContext(ctx)
 	logger.Info("processing reconcile request for a monitoring resource")
 
 	namespaceStillExists, err := resources.CheckIfNamespaceExists(ctx, r.clientset, req.Namespace, logger)
@@ -258,13 +257,15 @@ func (r *MonitoringReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, err
 	}
 
+	logger.Debug("reconciliations triggered by monitoring resource were successful")
+
 	return ctrl.Result{}, nil
 }
 
 func (r *MonitoringReconciler) applyApiAccessSettings(
 	ctx context.Context,
 	monitoringResource *dash0v1beta1.Dash0Monitoring,
-	logger logr.Logger,
+	logger logd.Logger,
 ) {
 	if monitoringResource.HasDash0ApiAccessConfigured() {
 		var apiConfigs []ApiConfig
@@ -333,7 +334,7 @@ func (r *MonitoringReconciler) applyApiAccessSettings(
 func (r *MonitoringReconciler) manageInstrumentWorkloadsChanges(
 	monitoringResource *dash0v1beta1.Dash0Monitoring,
 	isFirstReconcile bool,
-	logger logr.Logger,
+	logger logd.Logger,
 ) (*dash0v1beta1.Dash0Monitoring, util.ModificationMode, statusUpdateInfo) {
 	previousInstrumentWorkloadsMode := monitoringResource.Status.PreviousInstrumentWorkloads.Mode
 	currentInstrumentWorkloadsMode := monitoringResource.ReadInstrumentWorkloadsMode()
@@ -395,7 +396,7 @@ func (r *MonitoringReconciler) manageInstrumentWorkloadsChanges(
 func (r *MonitoringReconciler) runCleanupActions(
 	ctx context.Context,
 	monitoringResource *dash0v1beta1.Dash0Monitoring,
-	logger logr.Logger,
+	logger logd.Logger,
 ) error {
 	if err := r.instrumenter.UninstrumentWorkloadsIfAvailable(
 		ctx,
@@ -444,7 +445,7 @@ func (r *MonitoringReconciler) runCleanupActions(
 func (r *MonitoringReconciler) scheduleAttachDanglingEvents(
 	ctx context.Context,
 	monitoringResource *dash0v1beta1.Dash0Monitoring,
-	logger logr.Logger,
+	logger logd.Logger,
 ) {
 	// execute the event attaching in a separate go routine to not block the main reconcile loop
 	go func() {
@@ -470,7 +471,7 @@ func (r *MonitoringReconciler) scheduleAttachDanglingEvents(
 func (r *MonitoringReconciler) attachDanglingEvents(
 	ctx context.Context,
 	monitoringResource *dash0v1beta1.Dash0Monitoring,
-	logger logr.Logger,
+	logger logd.Logger,
 ) {
 	namespace := monitoringResource.Namespace
 	legacyEventApi := r.clientset.CoreV1().Events(namespace)
@@ -540,7 +541,7 @@ func (r *MonitoringReconciler) attachDanglingEvents(
 
 func (r *MonitoringReconciler) reconcileOpenTelemetryCollector(
 	ctx context.Context,
-	logger logr.Logger,
+	logger logd.Logger,
 ) error {
 	// This will look up the operator configuration resource and all monitoring resources in the cluster (including
 	// the one that has just been reconciled, hence we must only do this _after_ this resource has been updated (e.g.
@@ -556,7 +557,7 @@ func (r *MonitoringReconciler) reconcileOpenTelemetryCollector(
 
 func (r *MonitoringReconciler) reconcileOpenTelemetryTargetAllocator(
 	ctx context.Context,
-	logger logr.Logger,
+	logger logd.Logger,
 ) error {
 	// This will look up the operator configuration resource and all monitoring resources in the cluster (including
 	// the one that has just been reconciled, hence we must only do this _after_ this resource has been updated (e.g.
@@ -575,7 +576,7 @@ func (r *MonitoringReconciler) updateStatusAfterReconcile(
 	ctx context.Context,
 	monitoringResource *dash0v1beta1.Dash0Monitoring,
 	statusUpdate statusUpdateInfo,
-	logger logr.Logger,
+	logger logd.Logger,
 ) error {
 	monitoringResource.EnsureResourceIsMarkedAsAvailable()
 	if statusUpdate.previousInstrumentWorkloadsMode != statusUpdate.currentInstrumentWorkloadsMode {

--- a/internal/controller/operator_configuration_controller.go
+++ b/internal/controller/operator_configuration_controller.go
@@ -7,13 +7,11 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/go-logr/logr"
 	otelmetric "go.opentelemetry.io/otel/metric"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	dash0v1alpha1 "github.com/dash0hq/dash0-operator/api/operator/v1alpha1"
 	"github.com/dash0hq/dash0-operator/internal/collectors"
@@ -21,6 +19,7 @@ import (
 	"github.com/dash0hq/dash0-operator/internal/selfmonitoringapiaccess"
 	"github.com/dash0hq/dash0-operator/internal/targetallocator"
 	"github.com/dash0hq/dash0-operator/internal/util"
+	"github.com/dash0hq/dash0-operator/internal/util/logd"
 )
 
 type OperatorConfigurationReconciler struct {
@@ -95,7 +94,7 @@ func (r *OperatorConfigurationReconciler) SetupWithManager(mgr ctrl.Manager) err
 func (r *OperatorConfigurationReconciler) InitializeSelfMonitoringMetrics(
 	meter otelmetric.Meter,
 	metricNamePrefix string,
-	logger logr.Logger,
+	logger logd.Logger,
 ) {
 	reconcileRequestMetricName := fmt.Sprintf("%s%s", metricNamePrefix, "operatorconfiguration.reconcile_requests")
 	var err error
@@ -115,7 +114,7 @@ func (r *OperatorConfigurationReconciler) Reconcile(ctx context.Context, req ctr
 		operatorReconcileRequestMetric.Add(ctx, 1)
 	}
 
-	logger := log.FromContext(ctx)
+	logger := logd.FromContext(ctx)
 	logger.Info("processing reconcile request for an operator configuration resource")
 
 	resourceDeleted := false
@@ -222,6 +221,8 @@ func (r *OperatorConfigurationReconciler) Reconcile(ctx context.Context, req ctr
 		return ctrl.Result{}, fmt.Errorf("cannot mark the Dash0 operator configuration resource as available: %w", err)
 	}
 
+	logger.Debug("reconciliations triggered by operator configuration were successful")
+
 	return ctrl.Result{}, nil
 }
 
@@ -229,7 +230,7 @@ func (r *OperatorConfigurationReconciler) applyOperatorManagerSelfMonitoringSett
 	ctx context.Context,
 	selfMonitoringAndApiAccessConfiguration selfmonitoringapiaccess.SelfMonitoringConfiguration,
 	clusterName string,
-	logger logr.Logger,
+	logger logd.Logger,
 ) {
 	if selfMonitoringAndApiAccessConfiguration.SelfMonitoringEnabled {
 		r.oTelSdkStarter.SetOTelSdkParameters(
@@ -256,7 +257,7 @@ func (r *OperatorConfigurationReconciler) applyOperatorManagerSelfMonitoringSett
 func (r *OperatorConfigurationReconciler) applyApiAccessSettings(
 	ctx context.Context,
 	operatorConfigurationResource *dash0v1alpha1.Dash0OperatorConfiguration,
-	logger logr.Logger,
+	logger logd.Logger,
 ) {
 	if !operatorConfigurationResource.HasDash0ApiAccessConfigured() {
 		logger.Info(
@@ -320,7 +321,7 @@ func (r *OperatorConfigurationReconciler) applyApiAccessSettings(
 
 func (r *OperatorConfigurationReconciler) removeAllOperatorConfigurationSettings(
 	ctx context.Context,
-	logger logr.Logger,
+	logger logd.Logger,
 ) {
 	for _, apiClient := range r.apiClients {
 		apiClient.RemoveDefaultApiConfigs(ctx, logger)
@@ -333,7 +334,7 @@ func (r *OperatorConfigurationReconciler) removeAllOperatorConfigurationSettings
 
 func (r *OperatorConfigurationReconciler) reconcileOpenTelemetryCollector(
 	ctx context.Context,
-	logger logr.Logger,
+	logger logd.Logger,
 ) error {
 	if _, err := r.collectorManager.ReconcileOpenTelemetryCollector(
 		ctx,
@@ -346,7 +347,7 @@ func (r *OperatorConfigurationReconciler) reconcileOpenTelemetryCollector(
 
 func (r *OperatorConfigurationReconciler) reconcileOpenTelemetryTargetAllocator(
 	ctx context.Context,
-	logger logr.Logger,
+	logger logd.Logger,
 ) error {
 	logger.Info("Reconciling OpenTelemetry target allocator.")
 	if _, err := r.targetAllocatorManager.ReconcileTargetAllocator(

--- a/internal/controller/operator_configuration_controller_test.go
+++ b/internal/controller/operator_configuration_controller_test.go
@@ -23,8 +23,8 @@ import (
 	"github.com/dash0hq/dash0-operator/internal/targetallocator"
 	"github.com/dash0hq/dash0-operator/internal/targetallocator/taresources"
 	"github.com/dash0hq/dash0-operator/internal/util"
+	"github.com/dash0hq/dash0-operator/internal/util/logd"
 	zaputil "github.com/dash0hq/dash0-operator/internal/util/zap"
-	"github.com/go-logr/logr"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -1401,12 +1401,12 @@ type DummyApiClient struct {
 	defaultApiConfigs             []ApiConfig
 }
 
-func (c *DummyApiClient) SetDefaultApiConfigs(_ context.Context, apiConfigs []ApiConfig, _ logr.Logger) {
+func (c *DummyApiClient) SetDefaultApiConfigs(_ context.Context, apiConfigs []ApiConfig, _ logd.Logger) {
 	c.setDefaultApiEndpointCalls++
 	c.defaultApiConfigs = apiConfigs
 }
 
-func (c *DummyApiClient) RemoveDefaultApiConfigs(_ context.Context, _ logr.Logger) {
+func (c *DummyApiClient) RemoveDefaultApiConfigs(_ context.Context, _ logd.Logger) {
 	c.removeDefaultApiEndpointCalls++
 	c.defaultApiConfigs = nil
 }
@@ -1437,13 +1437,13 @@ func (c *DummyNamespacedApiClient) SetNamespacedApiConfigs(
 	_ context.Context,
 	namespace string,
 	apiConfigs []ApiConfig,
-	_ logr.Logger,
+	_ logd.Logger,
 ) {
 	c.setNamespacedApiEndpointCalls++
 	c.namespacedApiconfigs[namespace] = apiConfigs
 }
 
-func (c *DummyNamespacedApiClient) RemoveNamespacedApiConfigs(_ context.Context, namespace string, _ logr.Logger) {
+func (c *DummyNamespacedApiClient) RemoveNamespacedApiConfigs(_ context.Context, namespace string, _ logd.Logger) {
 	c.removeNamespacedApiEndpointCalls++
 	delete(c.namespacedApiconfigs, namespace)
 }

--- a/internal/controller/perses_dashboards_controller.go
+++ b/internal/controller/perses_dashboards_controller.go
@@ -16,7 +16,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/go-logr/logr"
 	otelmetric "go.opentelemetry.io/otel/metric"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -26,13 +25,13 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	dash0common "github.com/dash0hq/dash0-operator/api/operator/common"
 	dash0v1beta1 "github.com/dash0hq/dash0-operator/api/operator/v1beta1"
 	"github.com/dash0hq/dash0-operator/internal/selfmonitoringapiaccess"
 	"github.com/dash0hq/dash0-operator/internal/util"
+	"github.com/dash0hq/dash0-operator/internal/util/logd"
 )
 
 type PersesDashboardCrdReconciler struct {
@@ -141,7 +140,7 @@ func (r *PersesDashboardCrdReconciler) SetupWithManager(
 	ctx context.Context,
 	mgr ctrl.Manager,
 	startupK8sClient client.Client,
-	logger logr.Logger,
+	logger logd.Logger,
 ) error {
 	r.mgr = mgr
 	return SetupThirdPartyCrdReconcilerWithManager(
@@ -160,7 +159,7 @@ func (r *PersesDashboardCrdReconciler) Create(
 	if persesDashboardCrdReconcileRequestMetric != nil {
 		persesDashboardCrdReconcileRequestMetric.Add(ctx, 1)
 	}
-	logger := log.FromContext(ctx)
+	logger := logd.FromContext(ctx)
 	r.persesDashboardCrdExists.Store(true)
 	maybeStartWatchingThirdPartyResources(r, logger)
 }
@@ -182,7 +181,7 @@ func (r *PersesDashboardCrdReconciler) Delete(
 	if persesDashboardCrdReconcileRequestMetric != nil {
 		persesDashboardCrdReconcileRequestMetric.Add(ctx, 1)
 	}
-	logger := log.FromContext(ctx)
+	logger := logd.FromContext(ctx)
 	logger.Info("The PersesDashboard custom resource definition has been deleted.")
 	r.persesDashboardCrdExists.Store(false)
 
@@ -210,7 +209,7 @@ func (r *PersesDashboardCrdReconciler) Reconcile(
 func (r *PersesDashboardCrdReconciler) InitializeSelfMonitoringMetrics(
 	meter otelmetric.Meter,
 	metricNamePrefix string,
-	logger logr.Logger,
+	logger logd.Logger,
 ) {
 	reconcileRequestMetricName := fmt.Sprintf("%s%s", metricNamePrefix, "persesdashboardcrd.reconcile_requests")
 	var err error
@@ -232,7 +231,7 @@ func (r *PersesDashboardCrdReconciler) InitializeSelfMonitoringMetrics(
 func (r *PersesDashboardCrdReconciler) SetDefaultApiConfigs(
 	ctx context.Context,
 	apiConfigs []ApiConfig,
-	logger logr.Logger,
+	logger logd.Logger,
 ) {
 	r.persesDashboardReconciler.defaultApiConfigs.Set(apiConfigs)
 	if len(filterValidApiConfigs(apiConfigs, logger, "default operator configuration")) > 0 {
@@ -242,7 +241,7 @@ func (r *PersesDashboardCrdReconciler) SetDefaultApiConfigs(
 	}
 }
 
-func (r *PersesDashboardCrdReconciler) RemoveDefaultApiConfigs(ctx context.Context, logger logr.Logger) {
+func (r *PersesDashboardCrdReconciler) RemoveDefaultApiConfigs(ctx context.Context, logger logd.Logger) {
 	r.persesDashboardReconciler.defaultApiConfigs.Clear()
 	stopWatchingThirdPartyResources(ctx, r, logger)
 }
@@ -251,7 +250,7 @@ func (r *PersesDashboardCrdReconciler) SetNamespacedApiConfigs(
 	ctx context.Context,
 	namespace string,
 	updatedApiConfigs []ApiConfig,
-	logger logr.Logger,
+	logger logd.Logger,
 ) {
 	if len(updatedApiConfigs) > 0 {
 		previousApiConfigs, _ := r.persesDashboardReconciler.namespacedApiConfigs.Get(namespace)
@@ -267,7 +266,7 @@ func (r *PersesDashboardCrdReconciler) SetNamespacedApiConfigs(
 func (r *PersesDashboardCrdReconciler) RemoveNamespacedApiConfigs(
 	ctx context.Context,
 	namespace string,
-	logger logr.Logger,
+	logger logd.Logger,
 ) {
 	if _, exists := r.persesDashboardReconciler.namespacedApiConfigs.Get(namespace); exists {
 		r.persesDashboardReconciler.namespacedApiConfigs.Delete(namespace)
@@ -278,7 +277,7 @@ func (r *PersesDashboardCrdReconciler) RemoveNamespacedApiConfigs(
 func (r *PersesDashboardReconciler) InitializeSelfMonitoringMetrics(
 	meter otelmetric.Meter,
 	metricNamePrefix string,
-	logger logr.Logger,
+	logger logd.Logger,
 ) {
 	reconcileRequestMetricName := fmt.Sprintf("%s%s", metricNamePrefix, "persesdashboard.reconcile_requests")
 	var err error
@@ -367,7 +366,7 @@ func (r *PersesDashboardReconciler) Create(
 		persesDashboardReconcileRequestMetric.Add(ctx, 1)
 	}
 
-	logger := log.FromContext(ctx)
+	logger := logd.FromContext(ctx)
 	logger.Info(
 		"Detected a new Perses dashboard resource",
 		"namespace",
@@ -388,7 +387,7 @@ func (r *PersesDashboardReconciler) Update(
 		persesDashboardReconcileRequestMetric.Add(ctx, 1)
 	}
 
-	logger := log.FromContext(ctx)
+	logger := logd.FromContext(ctx)
 	logger.Info(
 		"Detected a change for a Perses dashboard resource",
 		"namespace",
@@ -409,7 +408,7 @@ func (r *PersesDashboardReconciler) Delete(
 		persesDashboardReconcileRequestMetric.Add(ctx, 1)
 	}
 
-	logger := log.FromContext(ctx)
+	logger := logd.FromContext(ctx)
 	logger.Info(
 		"Detected the deletion of a Perses dashboard resource",
 		"namespace",
@@ -430,7 +429,7 @@ func (r *PersesDashboardReconciler) Generic(
 		persesDashboardReconcileRequestMetric.Add(ctx, 1)
 	}
 
-	logger := log.FromContext(ctx)
+	logger := logd.FromContext(ctx)
 	logger.Info(
 		"Reconciling dashboard triggered by config event (updated API config or authorization).",
 		"namespace",
@@ -467,7 +466,7 @@ func (r *PersesDashboardReconciler) MapResourceToHttpRequests(
 	preconditionChecksResult *preconditionValidationResult,
 	apiConfig ApiConfig,
 	action apiAction,
-	logger logr.Logger,
+	logger logd.Logger,
 ) *ResourceToRequestsResult {
 	itemName := preconditionChecksResult.k8sName
 
@@ -597,7 +596,7 @@ func (r *PersesDashboardReconciler) CreateDeleteRequests(
 	_ ApiConfig,
 	_ []string,
 	_ []string,
-	_ logr.Logger,
+	_ logd.Logger,
 ) ([]WrappedApiRequest, map[string]string) {
 	// The mechanism to delete individual dashboards when synchronizing one Kubernetes PersesDashboard resource is not
 	// required, since each PersesDashboard only contains one dashboard. It is only needed when the resource type holds
@@ -608,7 +607,7 @@ func (r *PersesDashboardReconciler) CreateDeleteRequests(
 
 func (r *PersesDashboardReconciler) ExtractIdFromResponseBody(
 	responseBytes []byte,
-	logger logr.Logger,
+	logger logd.Logger,
 ) (id string, err error) {
 	objectWithMetadata := Dash0ApiObjectWithMetadata{}
 	if err := json.Unmarshal(responseBytes, &objectWithMetadata); err != nil {
@@ -677,7 +676,7 @@ func (*PersesDashboardReconciler) UpdateSynchronizationResultsInDash0MonitoringS
 func (r *PersesDashboardReconciler) synchronizeNamespacedResources(
 	ctx context.Context,
 	namespace string,
-	logger logr.Logger,
+	logger logd.Logger,
 ) {
 	// do nothing if we are not currently watching the CRDs
 	if !r.IsWatching() {

--- a/internal/controller/perses_dashboards_controller_test.go
+++ b/internal/controller/perses_dashboards_controller_test.go
@@ -20,12 +20,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllertest"
 	"sigs.k8s.io/controller-runtime/pkg/event"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/yaml"
 
 	dash0common "github.com/dash0hq/dash0-operator/api/operator/common"
 	"github.com/dash0hq/dash0-operator/internal/util"
+	"github.com/dash0hq/dash0-operator/internal/util/logd"
 
 	"github.com/h2non/gock"
 	. "github.com/onsi/ginkgo/v2"
@@ -64,7 +64,7 @@ var (
 var _ = Describe(
 	"The Perses dashboard controller", Ordered, func() {
 		ctx := context.Background()
-		logger := log.FromContext(ctx)
+		logger := logd.FromContext(ctx)
 		var clusterId string
 
 		BeforeAll(

--- a/internal/controller/prometheus_rules_controller.go
+++ b/internal/controller/prometheus_rules_controller.go
@@ -18,7 +18,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/go-logr/logr"
 	prometheusv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	otelmetric "go.opentelemetry.io/otel/metric"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -30,7 +29,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/yaml"
 
@@ -38,6 +36,7 @@ import (
 	dash0v1beta1 "github.com/dash0hq/dash0-operator/api/operator/v1beta1"
 	"github.com/dash0hq/dash0-operator/internal/selfmonitoringapiaccess"
 	"github.com/dash0hq/dash0-operator/internal/util"
+	"github.com/dash0hq/dash0-operator/internal/util/logd"
 )
 
 type PrometheusRuleCrdReconciler struct {
@@ -166,7 +165,7 @@ func (r *PrometheusRuleCrdReconciler) SetupWithManager(
 	ctx context.Context,
 	mgr ctrl.Manager,
 	startupK8sClient client.Client,
-	logger logr.Logger,
+	logger logd.Logger,
 ) error {
 	r.mgr = mgr
 	return SetupThirdPartyCrdReconcilerWithManager(
@@ -185,7 +184,7 @@ func (r *PrometheusRuleCrdReconciler) Create(
 	if prometheusRuleCrdReconcileRequestMetric != nil {
 		prometheusRuleCrdReconcileRequestMetric.Add(ctx, 1)
 	}
-	logger := log.FromContext(ctx)
+	logger := logd.FromContext(ctx)
 	r.prometheusRuleCrdExists.Store(true)
 	maybeStartWatchingThirdPartyResources(r, logger)
 }
@@ -207,7 +206,7 @@ func (r *PrometheusRuleCrdReconciler) Delete(
 	if prometheusRuleCrdReconcileRequestMetric != nil {
 		prometheusRuleCrdReconcileRequestMetric.Add(ctx, 1)
 	}
-	logger := log.FromContext(ctx)
+	logger := logd.FromContext(ctx)
 	logger.Info("The PrometheusRule custom resource definition has been deleted.")
 	r.prometheusRuleCrdExists.Store(false)
 
@@ -235,7 +234,7 @@ func (r *PrometheusRuleCrdReconciler) Reconcile(
 func (r *PrometheusRuleCrdReconciler) InitializeSelfMonitoringMetrics(
 	meter otelmetric.Meter,
 	metricNamePrefix string,
-	logger logr.Logger,
+	logger logd.Logger,
 ) {
 	reconcileRequestMetricName := fmt.Sprintf("%s%s", metricNamePrefix, "prometheusrulecrd.reconcile_requests")
 	var err error
@@ -257,7 +256,7 @@ func (r *PrometheusRuleCrdReconciler) InitializeSelfMonitoringMetrics(
 func (r *PrometheusRuleCrdReconciler) SetDefaultApiConfigs(
 	ctx context.Context,
 	apiConfig []ApiConfig,
-	logger logr.Logger,
+	logger logd.Logger,
 ) {
 	r.prometheusRuleReconciler.defaultApiConfigs.Set(apiConfig)
 	if len(filterValidApiConfigs(apiConfig, logger, "default operator configuration")) > 0 {
@@ -267,7 +266,7 @@ func (r *PrometheusRuleCrdReconciler) SetDefaultApiConfigs(
 	}
 }
 
-func (r *PrometheusRuleCrdReconciler) RemoveDefaultApiConfigs(ctx context.Context, logger logr.Logger) {
+func (r *PrometheusRuleCrdReconciler) RemoveDefaultApiConfigs(ctx context.Context, logger logd.Logger) {
 	r.prometheusRuleReconciler.defaultApiConfigs.Set(nil)
 	stopWatchingThirdPartyResources(ctx, r, logger)
 }
@@ -276,7 +275,7 @@ func (r *PrometheusRuleCrdReconciler) SetNamespacedApiConfigs(
 	ctx context.Context,
 	namespace string,
 	updatedApiConfig []ApiConfig,
-	logger logr.Logger,
+	logger logd.Logger,
 ) {
 	if updatedApiConfig != nil {
 		previousApiConfig, _ := r.prometheusRuleReconciler.namespacedApiConfigs.Get(namespace)
@@ -292,7 +291,7 @@ func (r *PrometheusRuleCrdReconciler) SetNamespacedApiConfigs(
 func (r *PrometheusRuleCrdReconciler) RemoveNamespacedApiConfigs(
 	ctx context.Context,
 	namespace string,
-	logger logr.Logger,
+	logger logd.Logger,
 ) {
 	if _, exists := r.prometheusRuleReconciler.namespacedApiConfigs.Get(namespace); exists {
 		r.prometheusRuleReconciler.namespacedApiConfigs.Delete(namespace)
@@ -303,7 +302,7 @@ func (r *PrometheusRuleCrdReconciler) RemoveNamespacedApiConfigs(
 func (r *PrometheusRuleReconciler) InitializeSelfMonitoringMetrics(
 	meter otelmetric.Meter,
 	metricNamePrefix string,
-	logger logr.Logger,
+	logger logd.Logger,
 ) {
 	reconcileRequestMetricName := fmt.Sprintf("%s%s", metricNamePrefix, "prometheusrule.reconcile_requests")
 	var err error
@@ -392,7 +391,7 @@ func (r *PrometheusRuleReconciler) Create(
 		prometheusRuleReconcileRequestMetric.Add(ctx, 1)
 	}
 
-	logger := log.FromContext(ctx)
+	logger := logd.FromContext(ctx)
 	logger.Info(
 		"Detected a new Prometheus rule resource",
 		"namespace",
@@ -413,7 +412,7 @@ func (r *PrometheusRuleReconciler) Update(
 		prometheusRuleReconcileRequestMetric.Add(ctx, 1)
 	}
 
-	logger := log.FromContext(ctx)
+	logger := logd.FromContext(ctx)
 	logger.Info(
 		"Detected a change for a Prometheus rule resource",
 		"namespace",
@@ -434,7 +433,7 @@ func (r *PrometheusRuleReconciler) Delete(
 		prometheusRuleReconcileRequestMetric.Add(ctx, 1)
 	}
 
-	logger := log.FromContext(ctx)
+	logger := logd.FromContext(ctx)
 	logger.Info(
 		"Detected the deletion of a Prometheus rule resource",
 		"namespace",
@@ -455,7 +454,7 @@ func (r *PrometheusRuleReconciler) Generic(
 		prometheusRuleReconcileRequestMetric.Add(ctx, 1)
 	}
 
-	logger := log.FromContext(ctx)
+	logger := logd.FromContext(ctx)
 	logger.Info(
 		"Reconciling check rule triggered by config event (updated API config or authorization).",
 		"namespace",
@@ -495,7 +494,7 @@ func (r *PrometheusRuleReconciler) MapResourceToHttpRequests(
 	preconditionChecksResult *preconditionValidationResult,
 	apiConfig ApiConfig,
 	action apiAction,
-	logger logr.Logger,
+	logger logd.Logger,
 ) *ResourceToRequestsResult {
 	specRaw := preconditionChecksResult.resource["spec"]
 	// convert the untyped spec to a value of type prometheusv1.PrometheusRuleSpec by marshalling and then unmarshalling
@@ -734,7 +733,7 @@ func convertRuleToRequest(
 	groupName string,
 	interval *prometheusv1.Duration,
 	metadataAnnotations map[string]string,
-	logger logr.Logger,
+	logger logd.Logger,
 ) (*http.Request, []string, error, bool) {
 	checkRule, validationIssues, ok := convertRuleToCheckRule(
 		rule,
@@ -810,7 +809,7 @@ func convertRuleToCheckRule(
 	groupName string,
 	interval *prometheusv1.Duration,
 	metadataAnnotations map[string]string,
-	logger logr.Logger,
+	logger logd.Logger,
 ) (*CheckRule, []string, bool) {
 	if rule.Record != "" {
 		logger.Info("Skipping rule with record attribute", "record", rule.Record)
@@ -980,7 +979,7 @@ func (r *PrometheusRuleReconciler) CreateDeleteRequests(
 	apiConfig ApiConfig,
 	existingOriginsFromApi []string,
 	originsInResource []string,
-	logger logr.Logger,
+	logger logd.Logger,
 ) ([]WrappedApiRequest, map[string]string) {
 	var deleteRequests []WrappedApiRequest
 	allSynchronizationErrors := make(map[string]string)
@@ -1017,7 +1016,7 @@ func (r *PrometheusRuleReconciler) CreateDeleteRequests(
 
 func (r *PrometheusRuleReconciler) ExtractIdFromResponseBody(
 	responseBytes []byte,
-	logger logr.Logger,
+	logger logd.Logger,
 ) (id string, err error) {
 	objectWithMetadata := Dash0ApiObjectWithMetadata{}
 	if err := json.Unmarshal(responseBytes, &objectWithMetadata); err != nil {
@@ -1087,7 +1086,7 @@ func (*PrometheusRuleReconciler) UpdateSynchronizationResultsInDash0MonitoringSt
 func (r *PrometheusRuleReconciler) synchronizeNamespacedResources(
 	ctx context.Context,
 	namespace string,
-	logger logr.Logger,
+	logger logd.Logger,
 ) {
 	// do nothing if we are not currently watching the CRDs
 	if !r.IsWatching() {

--- a/internal/controller/prometheus_rules_controller_test.go
+++ b/internal/controller/prometheus_rules_controller_test.go
@@ -24,12 +24,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllertest"
 	"sigs.k8s.io/controller-runtime/pkg/event"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/yaml"
 
 	dash0common "github.com/dash0hq/dash0-operator/api/operator/common"
 	"github.com/dash0hq/dash0-operator/internal/util"
+	"github.com/dash0hq/dash0-operator/internal/util/logd"
 
 	"github.com/h2non/gock"
 	. "github.com/onsi/ginkgo/v2"
@@ -67,7 +67,7 @@ type checkRuleRequestExpectation struct {
 var _ = Describe(
 	"The Prometheus rule controller", Ordered, func() {
 		ctx := context.Background()
-		logger := log.FromContext(ctx)
+		logger := logd.FromContext(ctx)
 		var clusterId string
 
 		BeforeAll(

--- a/internal/controller/synthetic_check_controller.go
+++ b/internal/controller/synthetic_check_controller.go
@@ -17,7 +17,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/go-logr/logr"
 	otelmetric "go.opentelemetry.io/otel/metric"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -25,7 +24,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -34,6 +32,7 @@ import (
 	dash0v1alpha1 "github.com/dash0hq/dash0-operator/api/operator/v1alpha1"
 	"github.com/dash0hq/dash0-operator/internal/selfmonitoringapiaccess"
 	"github.com/dash0hq/dash0-operator/internal/util"
+	"github.com/dash0hq/dash0-operator/internal/util/logd"
 )
 
 type SyntheticCheckReconciler struct {
@@ -82,7 +81,7 @@ func (r *SyntheticCheckReconciler) SetupWithManager(mgr manager.Manager) error {
 func (r *SyntheticCheckReconciler) InitializeSelfMonitoringMetrics(
 	meter otelmetric.Meter,
 	metricNamePrefix string,
-	logger logr.Logger,
+	logger logd.Logger,
 ) {
 	reconcileRequestMetricName := fmt.Sprintf("%s%s", metricNamePrefix, "syntheticcheck.reconcile_requests")
 	var err error
@@ -135,13 +134,13 @@ func (r *SyntheticCheckReconciler) overrideHttpRetryDelay(delay time.Duration) {
 func (r *SyntheticCheckReconciler) SetDefaultApiConfigs(
 	ctx context.Context,
 	apiConfigs []ApiConfig,
-	logger logr.Logger,
+	logger logd.Logger,
 ) {
 	r.defaultApiConfigs.Set(apiConfigs)
 	r.maybeDoInitialSynchronizationOfAllResources(ctx, logger)
 }
 
-func (r *SyntheticCheckReconciler) RemoveDefaultApiConfigs(_ context.Context, _ logr.Logger) {
+func (r *SyntheticCheckReconciler) RemoveDefaultApiConfigs(_ context.Context, _ logd.Logger) {
 	r.defaultApiConfigs.Clear()
 }
 
@@ -149,7 +148,7 @@ func (r *SyntheticCheckReconciler) SetNamespacedApiConfigs(
 	ctx context.Context,
 	namespace string,
 	updatedApiConfigs []ApiConfig,
-	logger logr.Logger,
+	logger logd.Logger,
 ) {
 	if updatedApiConfigs != nil {
 		previousApiConfigs, _ := r.namespacedApiConfigs.Get(namespace)
@@ -165,7 +164,7 @@ func (r *SyntheticCheckReconciler) SetNamespacedApiConfigs(
 func (r *SyntheticCheckReconciler) RemoveNamespacedApiConfigs(
 	ctx context.Context,
 	namespace string,
-	logger logr.Logger,
+	logger logd.Logger,
 ) {
 	if _, exists := r.namespacedApiConfigs.Get(namespace); exists {
 		r.namespacedApiConfigs.Delete(namespace)
@@ -173,13 +172,13 @@ func (r *SyntheticCheckReconciler) RemoveNamespacedApiConfigs(
 	}
 }
 
-func (r *SyntheticCheckReconciler) NotifiyOperatorManagerJustBecameLeader(ctx context.Context, logger logr.Logger) {
+func (r *SyntheticCheckReconciler) NotifiyOperatorManagerJustBecameLeader(ctx context.Context, logger logd.Logger) {
 	r.maybeDoInitialSynchronizationOfAllResources(ctx, logger)
 }
 
 func (r *SyntheticCheckReconciler) maybeDoInitialSynchronizationOfAllResources(
 	ctx context.Context,
-	logger logr.Logger,
+	logger logd.Logger,
 ) {
 	r.initialSyncMutex.Lock()
 	defer r.initialSyncMutex.Unlock()
@@ -240,7 +239,7 @@ func (r *SyntheticCheckReconciler) maybeDoInitialSynchronizationOfAllResources(
 func (r *SyntheticCheckReconciler) synchronizeNamespacedResources(
 	ctx context.Context,
 	namespace string,
-	logger logr.Logger,
+	logger logd.Logger,
 ) {
 	// The namespacedSyncMutex is used so we don't trigger multiple syncs in parallel in a single namespace.
 	// That happens for example when the export from a monitoring resource is removed, since that updates both the API
@@ -295,7 +294,7 @@ func (r *SyntheticCheckReconciler) Reconcile(ctx context.Context, req reconcile.
 	}
 
 	qualifiedName := req.NamespacedName.String() //nolint:staticcheck
-	logger := log.FromContext(ctx)
+	logger := logd.FromContext(ctx)
 	logger.Info("processing reconcile request for a synthetic check resource", "name", qualifiedName)
 
 	action := upsertAction
@@ -353,7 +352,7 @@ func (r *SyntheticCheckReconciler) MapResourceToHttpRequests(
 	preconditionChecksResult *preconditionValidationResult,
 	apiConfig ApiConfig,
 	action apiAction,
-	logger logr.Logger,
+	logger logd.Logger,
 ) *ResourceToRequestsResult {
 	itemName := preconditionChecksResult.k8sName
 	syntheticCheckUrl, syntheticCheckOrigin := r.renderSyntheticCheckUrl(
@@ -439,7 +438,7 @@ func (r *SyntheticCheckReconciler) renderSyntheticCheckUrl(
 
 func (r *SyntheticCheckReconciler) ExtractIdFromResponseBody(
 	responseBytes []byte,
-	logger logr.Logger,
+	logger logd.Logger,
 ) (id string, err error) {
 	objectWithMetadata := Dash0ApiObjectWithMetadata{}
 	if err := json.Unmarshal(responseBytes, &objectWithMetadata); err != nil {
@@ -458,7 +457,7 @@ func (r *SyntheticCheckReconciler) WriteSynchronizationResultToSynchronizedResou
 	ctx context.Context,
 	synchronizedResource client.Object,
 	syncResults synchronizationResults,
-	logger logr.Logger,
+	logger logd.Logger,
 ) {
 	syntheticCheck := synchronizedResource.(*dash0v1alpha1.Dash0SyntheticCheck)
 

--- a/internal/controller/synthetic_check_controller_test.go
+++ b/internal/controller/synthetic_check_controller_test.go
@@ -15,13 +15,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/yaml"
 
 	dash0common "github.com/dash0hq/dash0-operator/api/operator/common"
 	dash0v1alpha1 "github.com/dash0hq/dash0-operator/api/operator/v1alpha1"
 	"github.com/dash0hq/dash0-operator/internal/util"
+	"github.com/dash0hq/dash0-operator/internal/util/logd"
 
 	"github.com/h2non/gock"
 	. "github.com/onsi/ginkgo/v2"
@@ -64,7 +64,7 @@ var (
 var _ = Describe(
 	"The Synthetic Check controller", Ordered, func() {
 		ctx := context.Background()
-		logger := log.FromContext(ctx)
+		logger := logd.FromContext(ctx)
 		var testStartedAt time.Time
 		var clusterId string
 

--- a/internal/controller/third_party_crd_common.go
+++ b/internal/controller/third_party_crd_common.go
@@ -11,7 +11,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/go-logr/logr"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -26,7 +25,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
@@ -34,6 +32,7 @@ import (
 	dash0common "github.com/dash0hq/dash0-operator/api/operator/common"
 	dash0v1beta1 "github.com/dash0hq/dash0-operator/api/operator/v1beta1"
 	"github.com/dash0hq/dash0-operator/internal/util"
+	"github.com/dash0hq/dash0-operator/internal/util/logd"
 )
 
 // ThirdPartyCrdReconciler is an interface for reconcilers that act on CRDs of third-party resource types (i.e. when a
@@ -86,7 +85,7 @@ type ThirdPartyResourceReconciler interface {
 	// resource (say, a PrometheusRule) is potentially associated with multiple Dash0 api objects (multiple checks).
 	// Controllers which manage objects with a one-to-one relation (like Perses dashboards, synthetic checks, view)
 	// should return nil, nil.
-	CreateDeleteRequests(ApiConfig, []string, []string, logr.Logger) ([]WrappedApiRequest, map[string]string)
+	CreateDeleteRequests(ApiConfig, []string, []string, logd.Logger) ([]WrappedApiRequest, map[string]string)
 
 	// UpdateSynchronizationResultsInDash0MonitoringStatus Modifies the status of the provided Dash0Monitoring resource
 	// to reflect the results of the synchronization operation for one third-party Kubernetes resource.
@@ -119,7 +118,7 @@ func SetupThirdPartyCrdReconcilerWithManager(
 	ctx context.Context,
 	k8sClient client.Client,
 	crdReconciler ThirdPartyCrdReconciler,
-	logger logr.Logger,
+	logger logd.Logger,
 ) error {
 	pseudoClusterUid, err := util.ReadPseudoClusterUidOrFail(ctx, k8sClient, logger)
 	if err != nil {
@@ -223,7 +222,7 @@ func isMatchingCrd(group string, kind string, crd client.Object) bool {
 // the third-party resource type.
 func maybeStartWatchingThirdPartyResources(
 	crdReconciler ThirdPartyCrdReconciler,
-	logger logr.Logger,
+	logger logd.Logger,
 ) {
 	resourceReconciler := crdReconciler.ThirdPartyResourceReconciler()
 
@@ -292,7 +291,7 @@ func maybeStartWatchingThirdPartyResources(
 	// Note: We cannot use the controller builder API here since it does not allow passing in a context for starting the
 	// controller. Instead, we create the controller manually and start it in a goroutine.
 	resourceController, err :=
-		controller.NewTypedUnmanaged[reconcile.Request](
+		controller.NewTypedUnmanaged(
 			resourceReconciler.ControllerName(),
 			controller.Options{
 				Reconciler: resourceReconciler,
@@ -352,7 +351,7 @@ func maybeStartWatchingThirdPartyResources(
 func stopWatchingThirdPartyResources(
 	ctx context.Context,
 	crdReconciler ThirdPartyCrdReconciler,
-	logger logr.Logger,
+	logger logd.Logger,
 ) {
 	resourceReconciler := crdReconciler.ThirdPartyResourceReconciler()
 	resourceReconciler.ControllerStopFunctionLock().Lock()
@@ -381,7 +380,7 @@ func stopWatchingThirdPartyResources(
 	resourceReconciler.SetControllerStopFunction(nil)
 }
 
-func filterValidApiConfigs(apiConfigs []ApiConfig, logger logr.Logger, configContext string) []ApiConfig {
+func filterValidApiConfigs(apiConfigs []ApiConfig, logger logd.Logger, configContext string) []ApiConfig {
 	if len(apiConfigs) == 0 {
 		return nil
 	}
@@ -454,13 +453,13 @@ func deleteViaApi(
 
 func StartProcessingThirdPartySynchronizationQueue(
 	thirdPartyResourceSynchronizationQueue *workqueue.Typed[ThirdPartyResourceSyncJob],
-	setupLog logr.Logger,
+	setupLog logd.Logger,
 ) {
 	setupLog.Info("Starting the Dash0 API resource synchronization queue.")
 	go func() {
 		for {
 			ctx := context.Background()
-			logger := log.FromContext(ctx)
+			logger := logd.FromContext(ctx)
 			item, queueShutdown := thirdPartyResourceSynchronizationQueue.Get()
 			if queueShutdown {
 				logger.Info("The Dash0 API resource synchronization queue has been shut down.")
@@ -498,7 +497,7 @@ func StartProcessingThirdPartySynchronizationQueue(
 
 func StopProcessingThirdPartySynchronizationQueue(
 	resourceReconcileQueue *workqueue.Typed[ThirdPartyResourceSyncJob],
-	logger logr.Logger,
+	logger logd.Logger,
 ) {
 	logger.Info("Shutting down the Dash0 API resource synchronization queue.")
 	resourceReconcileQueue.ShutDown()
@@ -510,7 +509,7 @@ func writeSynchronizationResultToDash0MonitoringStatus(
 	monitoringResource *dash0v1beta1.Dash0Monitoring,
 	thirdPartyResource *unstructured.Unstructured,
 	syncResults synchronizationResults,
-	logger logr.Logger,
+	logger logd.Logger,
 ) {
 	qualifiedName := fmt.Sprintf("%s/%s", thirdPartyResource.GetNamespace(), thirdPartyResource.GetName())
 

--- a/internal/controller/view_controller.go
+++ b/internal/controller/view_controller.go
@@ -17,7 +17,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/go-logr/logr"
 	otelmetric "go.opentelemetry.io/otel/metric"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -25,7 +24,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -34,6 +32,7 @@ import (
 	dash0v1alpha1 "github.com/dash0hq/dash0-operator/api/operator/v1alpha1"
 	"github.com/dash0hq/dash0-operator/internal/selfmonitoringapiaccess"
 	"github.com/dash0hq/dash0-operator/internal/util"
+	"github.com/dash0hq/dash0-operator/internal/util/logd"
 )
 
 type ViewReconciler struct {
@@ -82,7 +81,7 @@ func (r *ViewReconciler) SetupWithManager(mgr manager.Manager) error {
 func (r *ViewReconciler) InitializeSelfMonitoringMetrics(
 	meter otelmetric.Meter,
 	metricNamePrefix string,
-	logger logr.Logger,
+	logger logd.Logger,
 ) {
 	reconcileRequestMetricName := fmt.Sprintf("%s%s", metricNamePrefix, "view.reconcile_requests")
 	var err error
@@ -132,12 +131,12 @@ func (r *ViewReconciler) overrideHttpRetryDelay(delay time.Duration) {
 	r.httpRetryDelay = delay
 }
 
-func (r *ViewReconciler) SetDefaultApiConfigs(ctx context.Context, apiConfigs []ApiConfig, logger logr.Logger) {
+func (r *ViewReconciler) SetDefaultApiConfigs(ctx context.Context, apiConfigs []ApiConfig, logger logd.Logger) {
 	r.defaultApiConfigs.Set(apiConfigs)
 	r.maybeDoInitialSynchronizationOfAllResources(ctx, logger)
 }
 
-func (r *ViewReconciler) RemoveDefaultApiConfigs(_ context.Context, _ logr.Logger) {
+func (r *ViewReconciler) RemoveDefaultApiConfigs(_ context.Context, _ logd.Logger) {
 	r.defaultApiConfigs.Clear()
 }
 
@@ -145,7 +144,7 @@ func (r *ViewReconciler) SetNamespacedApiConfigs(
 	ctx context.Context,
 	namespace string,
 	updatedApiConfigs []ApiConfig,
-	logger logr.Logger,
+	logger logd.Logger,
 ) {
 	if updatedApiConfigs != nil {
 		previousApiConfigs, _ := r.namespacedApiConfigs.Get(namespace)
@@ -158,18 +157,18 @@ func (r *ViewReconciler) SetNamespacedApiConfigs(
 	}
 }
 
-func (r *ViewReconciler) RemoveNamespacedApiConfigs(ctx context.Context, namespace string, logger logr.Logger) {
+func (r *ViewReconciler) RemoveNamespacedApiConfigs(ctx context.Context, namespace string, logger logd.Logger) {
 	if _, exists := r.namespacedApiConfigs.Get(namespace); exists {
 		r.namespacedApiConfigs.Delete(namespace)
 		r.synchronizeNamespacedResources(ctx, namespace, logger)
 	}
 }
 
-func (r *ViewReconciler) NotifiyOperatorManagerJustBecameLeader(ctx context.Context, logger logr.Logger) {
+func (r *ViewReconciler) NotifiyOperatorManagerJustBecameLeader(ctx context.Context, logger logd.Logger) {
 	r.maybeDoInitialSynchronizationOfAllResources(ctx, logger)
 }
 
-func (r *ViewReconciler) maybeDoInitialSynchronizationOfAllResources(ctx context.Context, logger logr.Logger) {
+func (r *ViewReconciler) maybeDoInitialSynchronizationOfAllResources(ctx context.Context, logger logd.Logger) {
 	r.initialSyncMutex.Lock()
 	defer r.initialSyncMutex.Unlock()
 
@@ -226,7 +225,7 @@ func (r *ViewReconciler) maybeDoInitialSynchronizationOfAllResources(ctx context
 	}()
 }
 
-func (r *ViewReconciler) synchronizeNamespacedResources(ctx context.Context, namespace string, logger logr.Logger) {
+func (r *ViewReconciler) synchronizeNamespacedResources(ctx context.Context, namespace string, logger logd.Logger) {
 	// namespacedSyncMutex is used so we don't trigger multiple syncs in parallel in a single namespace.
 	// That happens for example when the export from a monitoring resource is removed, since that updates both the API
 	// config and auth token at almost the same time, triggering two resyncs.
@@ -280,7 +279,7 @@ func (r *ViewReconciler) Reconcile(ctx context.Context, req reconcile.Request) (
 	}
 
 	qualifiedName := req.NamespacedName.String() //nolint:staticcheck
-	logger := log.FromContext(ctx)
+	logger := logd.FromContext(ctx)
 	logger.Info("processing reconcile request for a view resource", "name", qualifiedName)
 
 	action := upsertAction
@@ -333,7 +332,7 @@ func (r *ViewReconciler) MapResourceToHttpRequests(
 	preconditionChecksResult *preconditionValidationResult,
 	apiConfig ApiConfig,
 	action apiAction,
-	logger logr.Logger,
+	logger logd.Logger,
 ) *ResourceToRequestsResult {
 	itemName := preconditionChecksResult.k8sName
 
@@ -416,7 +415,7 @@ func (r *ViewReconciler) renderViewUrl(
 
 func (r *ViewReconciler) ExtractIdFromResponseBody(
 	responseBytes []byte,
-	logger logr.Logger,
+	logger logd.Logger,
 ) (id string, err error) {
 	objectWithMetadata := Dash0ApiObjectWithMetadata{}
 	if err := json.Unmarshal(responseBytes, &objectWithMetadata); err != nil {
@@ -435,7 +434,7 @@ func (r *ViewReconciler) WriteSynchronizationResultToSynchronizedResource(
 	ctx context.Context,
 	synchronizedResource client.Object,
 	syncResults synchronizationResults,
-	logger logr.Logger,
+	logger logd.Logger,
 ) {
 	view := synchronizedResource.(*dash0v1alpha1.Dash0View)
 

--- a/internal/controller/view_controller_test.go
+++ b/internal/controller/view_controller_test.go
@@ -15,13 +15,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/yaml"
 
 	dash0common "github.com/dash0hq/dash0-operator/api/operator/common"
 	dash0v1alpha1 "github.com/dash0hq/dash0-operator/api/operator/v1alpha1"
 	"github.com/dash0hq/dash0-operator/internal/util"
+	"github.com/dash0hq/dash0-operator/internal/util/logd"
 
 	"github.com/h2non/gock"
 	. "github.com/onsi/ginkgo/v2"
@@ -64,7 +64,7 @@ var (
 var _ = Describe(
 	"The View controller", Ordered, func() {
 		ctx := context.Background()
-		logger := log.FromContext(ctx)
+		logger := logd.FromContext(ctx)
 		var testStartedAt time.Time
 		var clusterId string
 

--- a/internal/instrumentation/instrumentable_workloads.go
+++ b/internal/instrumentation/instrumentable_workloads.go
@@ -4,7 +4,6 @@
 package instrumentation
 
 import (
-	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -13,6 +12,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/dash0hq/dash0-operator/internal/util"
+	"github.com/dash0hq/dash0-operator/internal/util/logd"
 	"github.com/dash0hq/dash0-operator/internal/workloads"
 )
 
@@ -25,12 +25,12 @@ type instrumentableWorkload interface {
 	instrument(
 		clusterInstrumentationConfig *util.ClusterInstrumentationConfig,
 		namespaceInstrumentationConfig util.NamespaceInstrumentationConfig,
-		logger logr.Logger,
+		logger logd.Logger,
 	) workloads.ModificationResult
 	revert(
 		clusterInstrumentationConfig *util.ClusterInstrumentationConfig,
 		namespaceInstrumentationConfig util.NamespaceInstrumentationConfig,
-		logger logr.Logger,
+		logger logd.Logger,
 	) workloads.ModificationResult
 }
 
@@ -48,14 +48,14 @@ func (w *cronJobWorkload) asClientObject() client.Object   { return w.cronJob }
 func (w *cronJobWorkload) instrument(
 	clusterInstrumentationConfig *util.ClusterInstrumentationConfig,
 	namespaceInstrumentationConfig util.NamespaceInstrumentationConfig,
-	logger logr.Logger,
+	logger logd.Logger,
 ) workloads.ModificationResult {
 	return newWorkloadModifier(clusterInstrumentationConfig, namespaceInstrumentationConfig, logger).ModifyCronJob(w.cronJob)
 }
 func (w *cronJobWorkload) revert(
 	clusterInstrumentationConfig *util.ClusterInstrumentationConfig,
 	namespaceInstrumentationConfig util.NamespaceInstrumentationConfig,
-	logger logr.Logger,
+	logger logd.Logger,
 ) workloads.ModificationResult {
 	return newWorkloadModifier(clusterInstrumentationConfig, namespaceInstrumentationConfig, logger).RevertCronJob(w.cronJob)
 }
@@ -74,14 +74,14 @@ func (w *daemonSetWorkload) asClientObject() client.Object   { return w.daemonSe
 func (w *daemonSetWorkload) instrument(
 	clusterInstrumentationConfig *util.ClusterInstrumentationConfig,
 	namespaceInstrumentationConfig util.NamespaceInstrumentationConfig,
-	logger logr.Logger,
+	logger logd.Logger,
 ) workloads.ModificationResult {
 	return newWorkloadModifier(clusterInstrumentationConfig, namespaceInstrumentationConfig, logger).ModifyDaemonSet(w.daemonSet)
 }
 func (w *daemonSetWorkload) revert(
 	clusterInstrumentationConfig *util.ClusterInstrumentationConfig,
 	namespaceInstrumentationConfig util.NamespaceInstrumentationConfig,
-	logger logr.Logger,
+	logger logd.Logger,
 ) workloads.ModificationResult {
 	return newWorkloadModifier(clusterInstrumentationConfig, namespaceInstrumentationConfig, logger).RevertDaemonSet(w.daemonSet)
 }
@@ -100,14 +100,14 @@ func (w *deploymentWorkload) asClientObject() client.Object   { return w.deploym
 func (w *deploymentWorkload) instrument(
 	clusterInstrumentationConfig *util.ClusterInstrumentationConfig,
 	namespaceInstrumentationConfig util.NamespaceInstrumentationConfig,
-	logger logr.Logger,
+	logger logd.Logger,
 ) workloads.ModificationResult {
 	return newWorkloadModifier(clusterInstrumentationConfig, namespaceInstrumentationConfig, logger).ModifyDeployment(w.deployment)
 }
 func (w *deploymentWorkload) revert(
 	clusterInstrumentationConfig *util.ClusterInstrumentationConfig,
 	namespaceInstrumentationConfig util.NamespaceInstrumentationConfig,
-	logger logr.Logger,
+	logger logd.Logger,
 ) workloads.ModificationResult {
 	return newWorkloadModifier(clusterInstrumentationConfig, namespaceInstrumentationConfig, logger).RevertDeployment(w.deployment)
 }
@@ -126,14 +126,14 @@ func (w *replicaSetWorkload) asClientObject() client.Object   { return w.replica
 func (w *replicaSetWorkload) instrument(
 	clusterInstrumentationConfig *util.ClusterInstrumentationConfig,
 	namespaceInstrumentationConfig util.NamespaceInstrumentationConfig,
-	logger logr.Logger,
+	logger logd.Logger,
 ) workloads.ModificationResult {
 	return newWorkloadModifier(clusterInstrumentationConfig, namespaceInstrumentationConfig, logger).ModifyReplicaSet(w.replicaSet)
 }
 func (w *replicaSetWorkload) revert(
 	clusterInstrumentationConfig *util.ClusterInstrumentationConfig,
 	namespaceInstrumentationConfig util.NamespaceInstrumentationConfig,
-	logger logr.Logger,
+	logger logd.Logger,
 ) workloads.ModificationResult {
 	return newWorkloadModifier(clusterInstrumentationConfig, namespaceInstrumentationConfig, logger).RevertReplicaSet(w.replicaSet)
 }
@@ -152,14 +152,14 @@ func (w *statefulSetWorkload) asClientObject() client.Object   { return w.statef
 func (w *statefulSetWorkload) instrument(
 	clusterInstrumentationConfig *util.ClusterInstrumentationConfig,
 	namespaceInstrumentationConfig util.NamespaceInstrumentationConfig,
-	logger logr.Logger,
+	logger logd.Logger,
 ) workloads.ModificationResult {
 	return newWorkloadModifier(clusterInstrumentationConfig, namespaceInstrumentationConfig, logger).ModifyStatefulSet(w.statefulSet)
 }
 func (w *statefulSetWorkload) revert(
 	clusterInstrumentationConfig *util.ClusterInstrumentationConfig,
 	namespaceInstrumentationConfig util.NamespaceInstrumentationConfig,
-	logger logr.Logger,
+	logger logd.Logger,
 ) workloads.ModificationResult {
 	return newWorkloadModifier(clusterInstrumentationConfig, namespaceInstrumentationConfig, logger).RevertStatefulSet(w.statefulSet)
 }

--- a/internal/instrumentation/instrumenter.go
+++ b/internal/instrumentation/instrumenter.go
@@ -10,7 +10,6 @@ import (
 	"slices"
 	"time"
 
-	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -26,6 +25,7 @@ import (
 	dash0v1beta1 "github.com/dash0hq/dash0-operator/api/operator/v1beta1"
 	"github.com/dash0hq/dash0-operator/internal/resources"
 	"github.com/dash0hq/dash0-operator/internal/util"
+	"github.com/dash0hq/dash0-operator/internal/util/logd"
 	"github.com/dash0hq/dash0-operator/internal/workloads"
 )
 
@@ -93,7 +93,7 @@ func NewInstrumenter(
 	}
 }
 
-func (i *Instrumenter) UpdateExtraConfig(_ context.Context, extraConfig util.ExtraConfig, _ logr.Logger) {
+func (i *Instrumenter) UpdateExtraConfig(_ context.Context, extraConfig util.ExtraConfig, _ logd.Logger) {
 	i.ClusterInstrumentationConfig.ExtraConfig.Store(&extraConfig)
 }
 
@@ -107,7 +107,7 @@ func (i *Instrumenter) UpdateExtraConfig(_ context.Context, extraConfig util.Ext
 // namespaces.
 func (i *Instrumenter) InstrumentAtStartup(
 	ctx context.Context,
-	logger logr.Logger,
+	logger logd.Logger,
 ) {
 	logger.Info("Applying/updating instrumentation at manager startup.")
 	allDash0MonitoringResouresInCluster := &dash0v1beta1.Dash0MonitoringList{}
@@ -187,7 +187,7 @@ func (i *Instrumenter) InstrumentAtStartup(
 func (i *Instrumenter) CheckSettingsAndInstrumentExistingWorkloads(
 	ctx context.Context,
 	dash0MonitoringResource *dash0v1beta1.Dash0Monitoring,
-	logger logr.Logger,
+	logger logd.Logger,
 ) error {
 	instrumentWorkloadsMode := dash0MonitoringResource.ReadInstrumentWorkloadsMode()
 	if instrumentWorkloadsMode == dash0common.InstrumentWorkloadsModeNone {
@@ -217,7 +217,7 @@ func (i *Instrumenter) CheckSettingsAndInstrumentExistingWorkloads(
 func (i *Instrumenter) instrumentAllWorkloads(
 	ctx context.Context,
 	dash0MonitoringResource *dash0v1beta1.Dash0Monitoring,
-	logger logr.Logger,
+	logger logd.Logger,
 ) error {
 	namespace := dash0MonitoringResource.Namespace
 
@@ -245,7 +245,7 @@ func (i *Instrumenter) findAndInstrumentCronJobs(
 	ctx context.Context,
 	namespace string,
 	namespaceInstrumentationConfig util.NamespaceInstrumentationConfig,
-	logger logr.Logger,
+	logger logd.Logger,
 ) error {
 	pgr := pager.New(pager.SimplePageFunc(
 		func(opts metav1.ListOptions) (runtime.Object, error) {
@@ -268,7 +268,7 @@ func (i *Instrumenter) instrumentCronJob(
 	ctx context.Context,
 	cronJob *batchv1.CronJob,
 	namespaceInstrumentationConfig util.NamespaceInstrumentationConfig,
-	reconcileLogger logr.Logger,
+	reconcileLogger logd.Logger,
 ) {
 	i.instrumentWorkload(
 		ctx,
@@ -283,7 +283,7 @@ func (i *Instrumenter) findAndInstrumentyDaemonSets(
 	ctx context.Context,
 	namespace string,
 	namespaceInstrumentationConfig util.NamespaceInstrumentationConfig,
-	logger logr.Logger,
+	logger logd.Logger,
 ) error {
 	pgr := pager.New(pager.SimplePageFunc(
 		func(opts metav1.ListOptions) (runtime.Object, error) {
@@ -306,7 +306,7 @@ func (i *Instrumenter) instrumentDaemonSet(
 	ctx context.Context,
 	daemonSet *appsv1.DaemonSet,
 	namespaceInstrumentationConfig util.NamespaceInstrumentationConfig,
-	reconcileLogger logr.Logger,
+	reconcileLogger logd.Logger,
 ) {
 	i.instrumentWorkload(
 		ctx,
@@ -322,7 +322,7 @@ func (i *Instrumenter) findAndInstrumentDeployments(
 	ctx context.Context,
 	namespace string,
 	namespaceInstrumentationConfig util.NamespaceInstrumentationConfig,
-	logger logr.Logger,
+	logger logd.Logger,
 ) error {
 	pgr := pager.New(pager.SimplePageFunc(
 		func(opts metav1.ListOptions) (runtime.Object, error) {
@@ -345,7 +345,7 @@ func (i *Instrumenter) instrumentDeployment(
 	ctx context.Context,
 	deployment *appsv1.Deployment,
 	namespaceInstrumentationConfig util.NamespaceInstrumentationConfig,
-	reconcileLogger logr.Logger,
+	reconcileLogger logd.Logger,
 ) {
 	i.instrumentWorkload(
 		ctx, &deploymentWorkload{
@@ -360,7 +360,7 @@ func (i *Instrumenter) findAndAddLabelsToImmutableJobsOnInstrumentation(
 	ctx context.Context,
 	namespace string,
 	namespaceInstrumentationConfig util.NamespaceInstrumentationConfig,
-	logger logr.Logger,
+	logger logd.Logger,
 ) error {
 	pgr := pager.New(pager.SimplePageFunc(
 		func(opts metav1.ListOptions) (runtime.Object, error) {
@@ -383,7 +383,7 @@ func (i *Instrumenter) handleJobOnInstrumentation(
 	ctx context.Context,
 	job *batchv1.Job,
 	namespaceInstrumentationConfig util.NamespaceInstrumentationConfig,
-	reconcileLogger logr.Logger,
+	reconcileLogger logd.Logger,
 ) {
 	logger := reconcileLogger.WithValues(
 		workkloadTypeLabel,
@@ -500,7 +500,7 @@ func (i *Instrumenter) findAndInstrumentReplicaSets(
 	ctx context.Context,
 	namespace string,
 	namespaceInstrumentationConfig util.NamespaceInstrumentationConfig,
-	logger logr.Logger,
+	logger logd.Logger,
 ) error {
 	pgr := pager.New(pager.SimplePageFunc(
 		func(opts metav1.ListOptions) (runtime.Object, error) {
@@ -523,7 +523,7 @@ func (i *Instrumenter) instrumentReplicaSet(
 	ctx context.Context,
 	replicaSet *appsv1.ReplicaSet,
 	namespaceInstrumentationConfig util.NamespaceInstrumentationConfig,
-	reconcileLogger logr.Logger,
+	reconcileLogger logd.Logger,
 ) {
 	hasBeenUpdated := i.instrumentWorkload(
 		ctx,
@@ -543,7 +543,7 @@ func (i *Instrumenter) findAndInstrumentStatefulSets(
 	ctx context.Context,
 	namespace string,
 	namespaceInstrumentationConfig util.NamespaceInstrumentationConfig,
-	logger logr.Logger,
+	logger logd.Logger,
 ) error {
 	pgr := pager.New(pager.SimplePageFunc(
 		func(opts metav1.ListOptions) (runtime.Object, error) {
@@ -566,7 +566,7 @@ func (i *Instrumenter) instrumentStatefulSet(
 	ctx context.Context,
 	statefulSet *appsv1.StatefulSet,
 	namespaceInstrumentationConfig util.NamespaceInstrumentationConfig,
-	reconcileLogger logr.Logger,
+	reconcileLogger logd.Logger,
 ) {
 	i.instrumentWorkload(
 		ctx, &statefulSetWorkload{
@@ -581,7 +581,7 @@ func (i *Instrumenter) instrumentWorkload(
 	ctx context.Context,
 	workload instrumentableWorkload,
 	namespaceInstrumentationConfig util.NamespaceInstrumentationConfig,
-	reconcileLogger logr.Logger,
+	reconcileLogger logd.Logger,
 ) bool {
 	workloadMeta := workload.getObjectMeta()
 	containers := workload.getPodSpec().Containers
@@ -679,7 +679,7 @@ func (i *Instrumenter) postProcessInstrumentation(
 	resource runtime.Object,
 	modificationResult workloads.ModificationResult,
 	retryErr error,
-	logger logr.Logger,
+	logger logd.Logger,
 ) bool {
 	if retryErr != nil {
 		e := &ImmutableWorkloadError{}
@@ -741,7 +741,7 @@ func (i *Instrumenter) DelayAfterEachNamespaceMillis() time.Duration {
 func (i *Instrumenter) UninstrumentWorkloadsIfAvailable(
 	ctx context.Context,
 	dash0MonitoringResource *dash0v1beta1.Dash0Monitoring,
-	logger logr.Logger,
+	logger logd.Logger,
 ) error {
 	if dash0MonitoringResource.IsAvailable() {
 		logger.Info("Reverting Dash0's modifications to workloads that have been instrumented to make them send telemetry to Dash0.")
@@ -759,7 +759,7 @@ func (i *Instrumenter) UninstrumentWorkloadsIfAvailable(
 func (i *Instrumenter) uninstrumentAllWorkloads(
 	ctx context.Context,
 	dash0MonitoringResource *dash0v1beta1.Dash0Monitoring,
-	logger logr.Logger,
+	logger logd.Logger,
 ) error {
 	namespace := dash0MonitoringResource.Namespace
 
@@ -787,7 +787,7 @@ func (i *Instrumenter) findAndUninstrumentCronJobs(
 	ctx context.Context,
 	namespace string,
 	namespaceInstrumentationConfig util.NamespaceInstrumentationConfig,
-	logger logr.Logger,
+	logger logd.Logger,
 ) error {
 	pgr := pager.New(pager.SimplePageFunc(
 		func(opts metav1.ListOptions) (runtime.Object, error) {
@@ -809,7 +809,7 @@ func (i *Instrumenter) uninstrumentCronJob(
 	ctx context.Context,
 	cronJob *batchv1.CronJob,
 	namespaceInstrumentationConfig util.NamespaceInstrumentationConfig,
-	reconcileLogger logr.Logger,
+	reconcileLogger logd.Logger,
 ) {
 	i.revertWorkloadInstrumentation(
 		ctx,
@@ -825,7 +825,7 @@ func (i *Instrumenter) findAndUninstrumentDaemonSets(
 	ctx context.Context,
 	namespace string,
 	namespaceInstrumentationConfig util.NamespaceInstrumentationConfig,
-	logger logr.Logger,
+	logger logd.Logger,
 ) error {
 	pgr := pager.New(pager.SimplePageFunc(
 		func(opts metav1.ListOptions) (runtime.Object, error) {
@@ -847,7 +847,7 @@ func (i *Instrumenter) uninstrumentDaemonSet(
 	ctx context.Context,
 	daemonSet *appsv1.DaemonSet,
 	namespaceInstrumentationConfig util.NamespaceInstrumentationConfig,
-	reconcileLogger logr.Logger,
+	reconcileLogger logd.Logger,
 ) {
 	i.revertWorkloadInstrumentation(
 		ctx,
@@ -863,7 +863,7 @@ func (i *Instrumenter) findAndUninstrumentDeployments(
 	ctx context.Context,
 	namespace string,
 	namespaceInstrumentationConfig util.NamespaceInstrumentationConfig,
-	logger logr.Logger,
+	logger logd.Logger,
 ) error {
 	pgr := pager.New(pager.SimplePageFunc(
 		func(opts metav1.ListOptions) (runtime.Object, error) {
@@ -885,7 +885,7 @@ func (i *Instrumenter) uninstrumentDeployment(
 	ctx context.Context,
 	deployment *appsv1.Deployment,
 	namespaceInstrumentationConfig util.NamespaceInstrumentationConfig,
-	reconcileLogger logr.Logger,
+	reconcileLogger logd.Logger,
 ) {
 	i.revertWorkloadInstrumentation(
 		ctx,
@@ -901,7 +901,7 @@ func (i *Instrumenter) findAndHandleJobOnUninstrumentation(
 	ctx context.Context,
 	namespace string,
 	namespaceInstrumentationConfig util.NamespaceInstrumentationConfig,
-	logger logr.Logger,
+	logger logd.Logger,
 ) error {
 	pgr := pager.New(pager.SimplePageFunc(
 		func(opts metav1.ListOptions) (runtime.Object, error) {
@@ -923,7 +923,7 @@ func (i *Instrumenter) handleJobOnUninstrumentation(
 	ctx context.Context,
 	job *batchv1.Job,
 	namespaceInstrumentationConfig util.NamespaceInstrumentationConfig,
-	reconcileLogger logr.Logger,
+	reconcileLogger logd.Logger,
 ) {
 	logger := reconcileLogger.WithValues(
 		workkloadTypeLabel,
@@ -1008,7 +1008,7 @@ func (i *Instrumenter) findAndUninstrumentReplicaSets(
 	ctx context.Context,
 	namespace string,
 	namespaceInstrumentationConfig util.NamespaceInstrumentationConfig,
-	logger logr.Logger,
+	logger logd.Logger,
 ) error {
 	pgr := pager.New(pager.SimplePageFunc(
 		func(opts metav1.ListOptions) (runtime.Object, error) {
@@ -1030,7 +1030,7 @@ func (i *Instrumenter) uninstrumentReplicaSet(
 	ctx context.Context,
 	replicaSet *appsv1.ReplicaSet,
 	namespaceInstrumentationConfig util.NamespaceInstrumentationConfig,
-	reconcileLogger logr.Logger,
+	reconcileLogger logd.Logger,
 ) {
 	hasBeenUpdated := i.revertWorkloadInstrumentation(
 		ctx,
@@ -1050,7 +1050,7 @@ func (i *Instrumenter) findAndUninstrumentStatefulSets(
 	ctx context.Context,
 	namespace string,
 	namespaceInstrumentationConfig util.NamespaceInstrumentationConfig,
-	logger logr.Logger,
+	logger logd.Logger,
 ) error {
 	pgr := pager.New(pager.SimplePageFunc(
 		func(opts metav1.ListOptions) (runtime.Object, error) {
@@ -1072,7 +1072,7 @@ func (i *Instrumenter) uninstrumentStatefulSet(
 	ctx context.Context,
 	statefulSet *appsv1.StatefulSet,
 	namespaceInstrumentationConfig util.NamespaceInstrumentationConfig,
-	reconcileLogger logr.Logger,
+	reconcileLogger logd.Logger,
 ) {
 	i.revertWorkloadInstrumentation(
 		ctx,
@@ -1088,7 +1088,7 @@ func (i *Instrumenter) revertWorkloadInstrumentation(
 	ctx context.Context,
 	workload instrumentableWorkload,
 	namespaceInstrumentationConfig util.NamespaceInstrumentationConfig,
-	reconcileLogger logr.Logger,
+	reconcileLogger logd.Logger,
 ) bool {
 	objectMeta := workload.getObjectMeta()
 	kind := workload.getKind()
@@ -1149,7 +1149,7 @@ func (i *Instrumenter) postProcessUninstrumentation(
 	resource runtime.Object,
 	modificationResult workloads.ModificationResult,
 	retryErr error,
-	logger logr.Logger,
+	logger logd.Logger,
 ) bool {
 	if retryErr != nil {
 		e := &ImmutableWorkloadError{}
@@ -1176,7 +1176,7 @@ func (i *Instrumenter) postProcessUninstrumentation(
 func newWorkloadModifier(
 	clusterInstrumentationConfig *util.ClusterInstrumentationConfig,
 	namespaceInstrumentationConfig util.NamespaceInstrumentationConfig,
-	logger logr.Logger,
+	logger logd.Logger,
 ) *workloads.ResourceModifier {
 	return workloads.NewResourceModifier(
 		clusterInstrumentationConfig,
@@ -1189,7 +1189,7 @@ func newWorkloadModifier(
 func (i *Instrumenter) restartPodsOfReplicaSet(
 	ctx context.Context,
 	replicaSet *appsv1.ReplicaSet,
-	logger logr.Logger,
+	logger logd.Logger,
 ) {
 	// Note: ReplicaSet pods are not restarted automatically by Kubernetes when their spec is changed (for other
 	// resource types like deployments or daemonsets this is managed by Kubernetes automatically). Therefore, we

--- a/internal/instrumentation/instrumenter_test.go
+++ b/internal/instrumentation/instrumenter_test.go
@@ -7,15 +7,14 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	dash0v1beta1 "github.com/dash0hq/dash0-operator/api/operator/v1beta1"
 	"github.com/dash0hq/dash0-operator/internal/util"
+	"github.com/dash0hq/dash0-operator/internal/util/logd"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -35,7 +34,7 @@ var (
 
 var _ = Describe("The instrumenter", Ordered, func() {
 	ctx := context.Background()
-	logger := log.FromContext(ctx)
+	logger := logd.FromContext(ctx)
 	var createdObjectsInstrumenterTest []client.Object
 
 	var instrumenter *Instrumenter
@@ -963,7 +962,7 @@ func checkSettingsAndInstrumentExistingWorkloads(
 	ctx context.Context,
 	instrumenter *Instrumenter,
 	dash0MonitoringResource *dash0v1beta1.Dash0Monitoring,
-	logger logr.Logger,
+	logger logd.Logger,
 ) {
 	Expect(
 		instrumenter.CheckSettingsAndInstrumentExistingWorkloads(
@@ -977,7 +976,7 @@ func uninstrumentWorkloadsIfAvailable(
 	ctx context.Context,
 	instrumenter *Instrumenter,
 	dash0MonitoringResource *dash0v1beta1.Dash0Monitoring,
-	logger logr.Logger,
+	logger logd.Logger,
 ) {
 	Expect(
 		instrumenter.UninstrumentWorkloadsIfAvailable(

--- a/internal/postdelete/operator_post_delete_handler.go
+++ b/internal/postdelete/operator_post_delete_handler.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/go-logr/logr"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -21,6 +20,7 @@ import (
 
 	dash0v1alpha1 "github.com/dash0hq/dash0-operator/api/operator/v1alpha1"
 	dash0v1beta1 "github.com/dash0hq/dash0-operator/api/operator/v1beta1"
+	"github.com/dash0hq/dash0-operator/internal/util/logd"
 )
 
 const (
@@ -46,7 +46,7 @@ var (
 
 type OperatorPostDeleteHandler struct {
 	client  client.WithWatch
-	logger  logr.Logger
+	logger  logd.Logger
 	timeout time.Duration
 }
 
@@ -56,7 +56,7 @@ func NewOperatorPostDeleteHandler() (*OperatorPostDeleteHandler, error) {
 }
 
 func NewOperatorPostDeleteHandlerFromConfig(config *rest.Config) (*OperatorPostDeleteHandler, error) {
-	logger := ctrl.Log.WithName("dash0-remove-allowlist-synchronizer")
+	logger := logd.NewLogger(ctrl.Log.WithName("dash0-remove-allowlist-synchronizer"))
 	s := runtime.NewScheme()
 	if err := dash0v1alpha1.AddToScheme(s); err != nil {
 		return nil, err
@@ -85,7 +85,7 @@ func (h *OperatorPostDeleteHandler) setTimeout(timeout time.Duration) {
 	h.timeout = timeout
 }
 
-func (h *OperatorPostDeleteHandler) DeleteGkeAutopilotAllowlistSynchronizer(ctx context.Context, logger logr.Logger) error {
+func (h *OperatorPostDeleteHandler) DeleteGkeAutopilotAllowlistSynchronizer(ctx context.Context, logger logd.Logger) error {
 	if err := h.client.Get(ctx, client.ObjectKey{
 		Name: gkeAutopilotAllowlistSynchronizerCrdName,
 	}, &apiextensionsv1.CustomResourceDefinition{}); err != nil {

--- a/internal/postinstall/operator_post_install_handler.go
+++ b/internal/postinstall/operator_post_install_handler.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/rest"
@@ -18,13 +17,14 @@ import (
 	dash0v1alpha1 "github.com/dash0hq/dash0-operator/api/operator/v1alpha1"
 	dash0v1beta1 "github.com/dash0hq/dash0-operator/api/operator/v1beta1"
 	"github.com/dash0hq/dash0-operator/internal/util"
+	"github.com/dash0hq/dash0-operator/internal/util/logd"
 )
 
 // OperatorPostInstallHandler handle the post-install Helm hook that is responsible for waiting until the operator
 // configuration auto resource becomes available.
 type OperatorPostInstallHandler struct {
 	client       client.WithWatch
-	logger       logr.Logger
+	logger       logd.Logger
 	retryBackoff wait.Backoff
 }
 
@@ -42,7 +42,7 @@ func NewOperatorPostInstallHandler() (*OperatorPostInstallHandler, error) {
 }
 
 func NewOperatorPostInstallHandlerFromConfig(config *rest.Config) (*OperatorPostInstallHandler, error) {
-	logger := ctrl.Log.WithName("dash0-operator-configuration-readiness")
+	logger := logd.NewLogger(ctrl.Log.WithName("dash0-operator-configuration-readiness"))
 	s := runtime.NewScheme()
 	if err := dash0v1alpha1.AddToScheme(s); err != nil {
 		return nil, err

--- a/internal/predelete/operator_pre_delete_handler.go
+++ b/internal/predelete/operator_pre_delete_handler.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/go-logr/logr"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
@@ -19,6 +18,7 @@ import (
 
 	dash0v1alpha1 "github.com/dash0hq/dash0-operator/api/operator/v1alpha1"
 	dash0v1beta1 "github.com/dash0hq/dash0-operator/api/operator/v1beta1"
+	"github.com/dash0hq/dash0-operator/internal/util/logd"
 )
 
 const (
@@ -27,7 +27,7 @@ const (
 
 type OperatorPreDeleteHandler struct {
 	client  client.WithWatch
-	logger  logr.Logger
+	logger  logd.Logger
 	timeout time.Duration
 }
 
@@ -37,7 +37,7 @@ func NewOperatorPreDeleteHandler() (*OperatorPreDeleteHandler, error) {
 }
 
 func NewOperatorPreDeleteHandlerFromConfig(config *rest.Config) (*OperatorPreDeleteHandler, error) {
-	logger := ctrl.Log.WithName("dash0-uninstrument-all")
+	logger := logd.NewLogger(ctrl.Log.WithName("dash0-uninstrument-all"))
 	s := runtime.NewScheme()
 	if err := dash0v1alpha1.AddToScheme(s); err != nil {
 		return nil, err

--- a/internal/resources/resources_util.go
+++ b/internal/resources/resources_util.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/go-logr/logr"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -20,6 +19,7 @@ import (
 
 	dash0operator "github.com/dash0hq/dash0-operator/api/operator"
 	dash0common "github.com/dash0hq/dash0-operator/api/operator/common"
+	"github.com/dash0hq/dash0-operator/internal/util/logd"
 )
 
 type CheckResourceResult struct {
@@ -46,7 +46,7 @@ func CheckIfNamespaceExists(
 	ctx context.Context,
 	clientset *kubernetes.Clientset,
 	namespace string,
-	logger logr.Logger,
+	logger logd.Logger,
 ) (bool, error) {
 	_, err := clientset.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
 	if err != nil {
@@ -88,7 +88,7 @@ func VerifyThatUniqueNonDegradedResourceExists(
 	req ctrl.Request,
 	resourcePrototype dash0operator.Dash0Resource,
 	updateStatusFailedMessage string,
-	logger logr.Logger,
+	logger logd.Logger,
 ) (CheckResourceResult, error) {
 	checkResourceResult, err := VerifyThatResourceExists(
 		ctx,
@@ -121,7 +121,7 @@ func VerifyThatResourceExists(
 	k8sClient client.Client,
 	req ctrl.Request,
 	resourcePrototype dash0operator.Dash0Resource,
-	logger logr.Logger,
+	logger logd.Logger,
 ) (CheckResourceResult, error) {
 	resource := resourcePrototype.GetReceiver()
 	if err := k8sClient.Get(ctx, req.NamespacedName, resource); err != nil {
@@ -165,7 +165,7 @@ func VerifyThatResourceIsUniqueInScope(
 	req ctrl.Request,
 	resource dash0operator.Dash0Resource,
 	updateStatusFailedMessage string,
-	logger logr.Logger,
+	logger logd.Logger,
 ) (bool, error) {
 	scope, allResourcesInScope, err :=
 		findAllResourceInstancesInScope(ctx, k8sClient, req, resource, logger)
@@ -266,7 +266,7 @@ func VerifyThatResourceIsUniqueInScope(
 	}
 }
 
-func markAsDegradedDueToNonUniqueResource(resource dash0operator.Dash0Resource, scope string, logger logr.Logger) {
+func markAsDegradedDueToNonUniqueResource(resource dash0operator.Dash0Resource, scope string, logger logd.Logger) {
 	logger.Info(fmt.Sprintf("Marking %s (%s) as degraded.", resource.GetName(), resource.GetUID()))
 	resource.EnsureResourceIsMarkedAsDegraded(
 		"NewerResourceIsPresent",
@@ -282,7 +282,7 @@ func findAllResourceInstancesInScope(
 	k8sClient client.Client,
 	req ctrl.Request,
 	resource dash0operator.Dash0Resource,
-	logger logr.Logger,
+	logger logd.Logger,
 ) (string, client.ObjectList, error) {
 	scope := "namespace"
 	listOptions := client.ListOptions{
@@ -319,7 +319,7 @@ func FindUniqueOrMostRecentResourceInScope(
 	k8sClient client.Client,
 	namespace string,
 	resourcePrototype dash0operator.Dash0Resource,
-	logger logr.Logger,
+	logger logd.Logger,
 ) (dash0operator.Dash0Resource, error) {
 	_, allResourcesInScope, err := findAllResourceInstancesInScope(
 		ctx,
@@ -373,7 +373,7 @@ func InitStatusConditions(
 	k8sClient client.Client,
 	resource dash0operator.Dash0Resource,
 	conditions []metav1.Condition,
-	logger logr.Logger,
+	logger logd.Logger,
 ) (bool, error) {
 	firstReconcile := false
 	needsRefresh := false
@@ -403,7 +403,7 @@ func updateResourceStatus(
 	ctx context.Context,
 	k8sClient client.Client,
 	resource dash0operator.Dash0Resource,
-	logger logr.Logger,
+	logger logd.Logger,
 ) error {
 	if err := k8sClient.Status().Update(ctx, resource.Get()); err != nil {
 		logger.Error(err,
@@ -429,7 +429,7 @@ func CheckImminentDeletionAndHandleFinalizers(
 	k8sClient client.Client,
 	resource dash0operator.Dash0Resource,
 	finalizerId string,
-	logger logr.Logger,
+	logger logd.Logger,
 ) (bool, bool, error) {
 	isMarkedForDeletion := resource.IsMarkedForDeletion()
 	if !isMarkedForDeletion {

--- a/internal/resources/resources_util_test.go
+++ b/internal/resources/resources_util_test.go
@@ -11,10 +11,10 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	dash0common "github.com/dash0hq/dash0-operator/api/operator/common"
 	dash0v1beta1 "github.com/dash0hq/dash0-operator/api/operator/v1beta1"
+	"github.com/dash0hq/dash0-operator/internal/util/logd"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -99,7 +99,7 @@ var (
 
 var _ = Describe("resource util functions", Ordered, func() {
 	ctx := context.Background()
-	logger := log.FromContext(ctx)
+	logger := logd.FromContext(ctx)
 
 	var createdObjectsResourcesUtilTest []client.Object
 

--- a/internal/selfmonitoringapiaccess/otel_init_wait.go
+++ b/internal/selfmonitoringapiaccess/otel_init_wait.go
@@ -9,19 +9,18 @@ import (
 	"reflect"
 	"sync/atomic"
 
-	"github.com/go-logr/logr"
 	otelmetric "go.opentelemetry.io/otel/metric"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	dash0common "github.com/dash0hq/dash0-operator/api/operator/common"
 	"github.com/dash0hq/dash0-operator/images/pkg/common"
 	"github.com/dash0hq/dash0-operator/internal/util"
+	"github.com/dash0hq/dash0-operator/internal/util/logd"
 	zaputil "github.com/dash0hq/dash0-operator/internal/util/zap"
 )
 
 type SelfMonitoringMetricsClient interface {
-	InitializeSelfMonitoringMetrics(otelmetric.Meter, string, logr.Logger)
+	InitializeSelfMonitoringMetrics(otelmetric.Meter, string, logd.Logger)
 }
 
 type OTelSdkConfigInput struct {
@@ -89,7 +88,7 @@ func (s *OTelSdkStarter) SetOTelSdkParameters(
 	operatorManagerDeploymentName string,
 	operatorVersion string,
 	developmentMode bool,
-	logger logr.Logger,
+	logger logd.Logger,
 ) {
 	s.oTelSdkConfigInput.Store(
 		&OTelSdkConfigInput{
@@ -107,7 +106,7 @@ func (s *OTelSdkStarter) SetOTelSdkParameters(
 	s.onParametersHaveChanged(ctx, logger)
 }
 
-func (s *OTelSdkStarter) RemoveOTelSdkParameters(ctx context.Context, logger logr.Logger) {
+func (s *OTelSdkStarter) RemoveOTelSdkParameters(ctx context.Context, logger logd.Logger) {
 	s.oTelSdkConfigInput.Store(&OTelSdkConfigInput{})
 	s.onParametersHaveChanged(ctx, logger)
 }
@@ -128,7 +127,7 @@ func (s *OTelSdkStarter) waitForCompleteOTelSDKConfiguration(
 	}
 }
 
-func (s *OTelSdkStarter) onParametersHaveChanged(ctx context.Context, logger logr.Logger) {
+func (s *OTelSdkStarter) onParametersHaveChanged(ctx context.Context, logger logd.Logger) {
 	sdkIsActive := s.sdkIsActive.Load()
 	newOTelSDKConfig, configComplete :=
 		convertExportConfigurationToOTelSDKConfig(
@@ -258,7 +257,7 @@ func startOTelSDK(
 	oTelSdkConfig *common.OTelSdkConfig,
 ) {
 	ctx := context.Background()
-	logger := log.FromContext(ctx)
+	logger := logd.FromContext(ctx)
 	logger.Info("starting (or restarting) the OpenTelemetry SDK for self-monitoring")
 	zapOTelBridge, meter :=
 		common.InitOTelSdkWithConfig(
@@ -287,7 +286,7 @@ func startOTelSDK(
 	}
 }
 
-func (s *OTelSdkStarter) ShutDownOTelSdk(ctx context.Context, logger logr.Logger) {
+func (s *OTelSdkStarter) ShutDownOTelSdk(ctx context.Context, logger logd.Logger) {
 	sdkIsActive := s.sdkIsActive.Load()
 	if sdkIsActive {
 		s.delegatingZapCoreWrapper.RootDelegatingZapCore.UnsetDelegate()
@@ -302,7 +301,7 @@ func (s *OTelSdkStarter) ForTestOnlyGetState() (bool, *common.OTelSdkConfig) {
 	return s.sdkIsActive.Load(), s.activeOTelSdkConfig.Load()
 }
 
-func (s *OTelSdkStarter) ShutDown(ctx context.Context, logger logr.Logger) {
+func (s *OTelSdkStarter) ShutDown(ctx context.Context, logger logd.Logger) {
 	s.ShutDownOTelSdk(ctx, logger)
 	s.shutDownChannel <- true
 }

--- a/internal/selfmonitoringapiaccess/otel_init_wait_test.go
+++ b/internal/selfmonitoringapiaccess/otel_init_wait_test.go
@@ -9,11 +9,10 @@ import (
 
 	"github.com/dash0hq/dash0-operator/images/pkg/common"
 	"github.com/dash0hq/dash0-operator/internal/util"
-	"github.com/go-logr/logr"
 	otelmetric "go.opentelemetry.io/otel/metric"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	dash0common "github.com/dash0hq/dash0-operator/api/operator/common"
+	"github.com/dash0hq/dash0-operator/internal/util/logd"
 	zaputil "github.com/dash0hq/dash0-operator/internal/util/zap"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -30,7 +29,7 @@ const (
 	defaultTimeout = 50 * time.Millisecond
 )
 
-func (c *DummyClient) InitializeSelfMonitoringMetrics(_ otelmetric.Meter, _ string, _ logr.Logger) {
+func (c *DummyClient) InitializeSelfMonitoringMetrics(_ otelmetric.Meter, _ string, _ logd.Logger) {
 	c.hasBeenCalled++
 }
 
@@ -38,7 +37,7 @@ var _ = Describe(
 	"The OTel SDK starter", func() {
 
 		ctx := context.Background()
-		logger := log.FromContext(ctx)
+		logger := logd.FromContext(ctx)
 
 		It(
 			"should start with empty values", func() {

--- a/internal/selfmonitoringapiaccess/self_monitoring_and_api_access.go
+++ b/internal/selfmonitoringapiaccess/self_monitoring_and_api_access.go
@@ -10,7 +10,6 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -19,6 +18,7 @@ import (
 	dash0v1alpha1 "github.com/dash0hq/dash0-operator/api/operator/v1alpha1"
 	"github.com/dash0hq/dash0-operator/images/pkg/common"
 	"github.com/dash0hq/dash0-operator/internal/util"
+	"github.com/dash0hq/dash0-operator/internal/util/logd"
 )
 
 type OtlpProtocol string
@@ -69,7 +69,7 @@ func ConvertOperatorConfigurationResourceToSelfMonitoringConfiguration(
 	k8sClient client.Client,
 	operatorNamespace string,
 	resource *dash0v1alpha1.Dash0OperatorConfiguration,
-	logger logr.Logger,
+	logger logd.Logger,
 ) (SelfMonitoringConfiguration, error) {
 	if resource == nil {
 		return SelfMonitoringConfiguration{}, nil
@@ -127,7 +127,7 @@ func convertResourceToDash0ExportConfiguration(
 	export *dash0common.Export,
 	token *string,
 	selfMonitoringEnabled bool,
-	logger logr.Logger,
+	logger logd.Logger,
 ) (SelfMonitoringConfiguration, error) {
 	if export.Grpc != nil {
 		logger.Info(
@@ -164,7 +164,7 @@ func convertResourceToDash0ExportConfiguration(
 func convertResourceToGrpcExportConfiguration(
 	export *dash0common.Export,
 	selfMonitoringEnabled bool,
-	logger logr.Logger,
+	logger logd.Logger,
 ) (SelfMonitoringConfiguration, error) {
 	if export.Http != nil {
 		logger.Info(
@@ -597,7 +597,7 @@ func GetAuthTokenForDash0Export(
 	k8sClient client.Client,
 	operatorNamespace string, // we always look up the auth secrets in the operator namespace
 	dash0Export dash0common.Dash0Configuration,
-	logger logr.Logger,
+	logger logd.Logger,
 ) (*string, error) {
 	if dash0Export.Authorization.SecretRef != nil {
 		// The operator configuration resource uses a secret ref to provide the Dash0 auth token, exchange the secret
@@ -630,7 +630,7 @@ func ExchangeSecretRefForToken(
 	k8sClient client.Client,
 	operatorNamespace string, // we always look up the auth secrets in the operator namespace
 	dash0Config dash0common.Dash0Configuration,
-	logger logr.Logger,
+	logger logd.Logger,
 ) (*string, error) {
 	if dash0Config.Authorization.SecretRef == nil {
 		return nil, fmt.Errorf("dash0Config has no secret ref")

--- a/internal/selfmonitoringapiaccess/self_monitoring_and_api_access_test.go
+++ b/internal/selfmonitoringapiaccess/self_monitoring_and_api_access_test.go
@@ -9,12 +9,12 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	dash0common "github.com/dash0hq/dash0-operator/api/operator/common"
 	dash0v1alpha1 "github.com/dash0hq/dash0-operator/api/operator/v1alpha1"
 	"github.com/dash0hq/dash0-operator/images/pkg/common"
 	"github.com/dash0hq/dash0-operator/internal/util"
+	"github.com/dash0hq/dash0-operator/internal/util/logd"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -26,7 +26,7 @@ var _ = Describe(
 	"self monitoring and API access", Ordered, func() {
 
 		ctx := context.Background()
-		logger := log.FromContext(ctx)
+		logger := logd.FromContext(ctx)
 
 		Describe(
 			"convert operator configuration resource to self monitoring settings", func() {

--- a/internal/startup/auto_operator_configuration_handler.go
+++ b/internal/startup/auto_operator_configuration_handler.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/go-logr/logr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -16,6 +15,7 @@ import (
 	dash0common "github.com/dash0hq/dash0-operator/api/operator/common"
 	dash0v1alpha1 "github.com/dash0hq/dash0-operator/api/operator/v1alpha1"
 	"github.com/dash0hq/dash0-operator/internal/util"
+	"github.com/dash0hq/dash0-operator/internal/util/logd"
 )
 
 type SecretRef struct {
@@ -62,7 +62,7 @@ func NewAutoOperatorConfigurationResourceHandler(
 
 func (r *AutoOperatorConfigurationResourceHandler) NotifiyOperatorManagerJustBecameLeader(
 	_ context.Context,
-	_ logr.Logger,
+	_ logd.Logger,
 ) {
 	close(r.hasBecomeLeaderChan)
 }
@@ -75,7 +75,7 @@ func (r *AutoOperatorConfigurationResourceHandler) NotifiyOperatorManagerJustBec
 func (r *AutoOperatorConfigurationResourceHandler) CreateOrUpdateOperatorConfigurationResource(
 	ctx context.Context,
 	operatorConfigurationValues *OperatorConfigurationValues,
-	logger logr.Logger,
+	logger logd.Logger,
 ) (*dash0v1alpha1.Dash0OperatorConfiguration, error) {
 	logger.Info("creating/updating the Dash0 operator configuration resource")
 	if err := r.validateOperatorConfiguration(operatorConfigurationValues); err != nil {
@@ -162,7 +162,7 @@ func (r *AutoOperatorConfigurationResourceHandler) validateOperatorConfiguration
 func (r *AutoOperatorConfigurationResourceHandler) createOrUpdateOperatorConfigurationResourceWithRetry(
 	ctx context.Context,
 	operatorConfigurationResource *dash0v1alpha1.Dash0OperatorConfiguration,
-	logger logr.Logger,
+	logger logd.Logger,
 ) error {
 	return util.RetryWithCustomBackoff(
 		"create/update operator configuration resource at startup",
@@ -183,7 +183,7 @@ func (r *AutoOperatorConfigurationResourceHandler) createOrUpdateOperatorConfigu
 func (r *AutoOperatorConfigurationResourceHandler) createOrUpdateOperatorConfigurationResourceOnce(
 	ctx context.Context,
 	operatorConfigurationResource *dash0v1alpha1.Dash0OperatorConfiguration,
-	logger logr.Logger,
+	logger logd.Logger,
 ) error {
 	allOperatorConfigurationResources := &dash0v1alpha1.Dash0OperatorConfigurationList{}
 	if err := r.List(ctx, allOperatorConfigurationResources); err != nil {

--- a/internal/startup/auto_operator_configuration_handler_test.go
+++ b/internal/startup/auto_operator_configuration_handler_test.go
@@ -8,10 +8,10 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/dash0hq/dash0-operator/api/operator/v1alpha1"
 	"github.com/dash0hq/dash0-operator/internal/util"
+	"github.com/dash0hq/dash0-operator/internal/util/logd"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -40,7 +40,7 @@ var _ = Describe(
 	"Create an operator configuration resource at startup", Ordered, func() {
 
 		ctx := context.Background()
-		logger := log.FromContext(ctx)
+		logger := logd.FromContext(ctx)
 		var readyCheckExecuter *ReadyCheckExecuter
 
 		BeforeAll(

--- a/internal/startup/instrument_at_startup.go
+++ b/internal/startup/instrument_at_startup.go
@@ -6,10 +6,10 @@ package startup
 import (
 	"context"
 
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	"github.com/dash0hq/dash0-operator/internal/instrumentation"
+	"github.com/dash0hq/dash0-operator/internal/util/logd"
 )
 
 // InstrumentAtStartupRunnable executes an unconditional apply/update of instrumentation for all workloads in
@@ -38,7 +38,7 @@ func (r *InstrumentAtStartupRunnable) NeedLeaderElection() bool {
 
 // Start runs the instrumentation procedure.
 func (r *InstrumentAtStartupRunnable) Start(ctx context.Context) error {
-	logger := log.FromContext(ctx)
+	logger := logd.FromContext(ctx)
 	r.instrumenter.Client = r.manager.GetClient()
 	r.instrumenter.InstrumentAtStartup(ctx, logger)
 	return nil

--- a/internal/startup/log_config_resources_runnable.go
+++ b/internal/startup/log_config_resources_runnable.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/go-logr/logr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/pager"
@@ -16,6 +15,7 @@ import (
 
 	dash0v1alpha1 "github.com/dash0hq/dash0-operator/api/operator/v1alpha1"
 	dash0v1beta1 "github.com/dash0hq/dash0-operator/api/operator/v1beta1"
+	"github.com/dash0hq/dash0-operator/internal/util/logd"
 )
 
 const (
@@ -59,12 +59,12 @@ func (r *LogConfigurationResourcesRunnable) Start(ctx context.Context) error {
 }
 
 func (r *LogConfigurationResourcesRunnable) logAllResources(ctx context.Context) {
-	logger := log.FromContext(ctx)
+	logger := logd.FromContext(ctx)
 	r.logOperatorConfigurationResources(ctx, logger)
 	r.logMonitoringResources(ctx, logger)
 }
 
-func (r *LogConfigurationResourcesRunnable) logOperatorConfigurationResources(ctx context.Context, logger logr.Logger) {
+func (r *LogConfigurationResourcesRunnable) logOperatorConfigurationResources(ctx context.Context, logger logd.Logger) {
 	allOperatorConfigurationResources := &dash0v1alpha1.Dash0OperatorConfigurationList{}
 	if err := r.client.List(ctx, allOperatorConfigurationResources); err != nil {
 		logger.Error(err, "failed to list Dash0OperatorConfiguration resources for logging")
@@ -75,7 +75,7 @@ func (r *LogConfigurationResourcesRunnable) logOperatorConfigurationResources(ct
 	}
 }
 
-func (r *LogConfigurationResourcesRunnable) logMonitoringResources(ctx context.Context, logger logr.Logger) {
+func (r *LogConfigurationResourcesRunnable) logMonitoringResources(ctx context.Context, logger logd.Logger) {
 	pgr := pager.New(pager.SimplePageFunc(
 		func(opts metav1.ListOptions) (runtime.Object, error) {
 			list := &dash0v1beta1.Dash0MonitoringList{}

--- a/internal/startup/operator_manager_startup.go
+++ b/internal/startup/operator_manager_startup.go
@@ -15,7 +15,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/go-logr/logr"
 	"github.com/go-logr/zapr"
 	persesv1alpha1 "github.com/perses/perses-operator/api/v1alpha1"
 	prometheusv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -52,6 +51,7 @@ import (
 	"github.com/dash0hq/dash0-operator/internal/targetallocator"
 	"github.com/dash0hq/dash0-operator/internal/targetallocator/taresources"
 	"github.com/dash0hq/dash0-operator/internal/util"
+	"github.com/dash0hq/dash0-operator/internal/util/logd"
 	zaputil "github.com/dash0hq/dash0-operator/internal/util/zap"
 	"github.com/dash0hq/dash0-operator/internal/webhooks"
 )
@@ -157,7 +157,7 @@ const (
 )
 
 var (
-	setupLog logr.Logger
+	setupLog logd.Logger
 
 	leaderElectionAwareRunnable     = util.NewLeaderElectionAwareRunnable()
 	startupTasksK8sClient           client.Client
@@ -198,8 +198,10 @@ func Start() {
 	crZapOpts := crzap.UseFlagOptions(&opts)
 
 	// Maintenance note: setupLog is not yet initialized before the call to setUpLogging.
-	delegatingZapCoreWrapper := setUpLogging(crZapOpts)
+	delegatingZapCoreWrapper := setUpLogging(crZapOpts, developmentMode)
 	// setupLog is initialized after this point and can be used
+
+	setupLog.Debug("development/debug mode enabled")
 
 	pprofPort := os.Getenv(pprofPortEnvVarName)
 	if pprofPort != "" {
@@ -528,7 +530,7 @@ func parseCommandLineOptions(cliArgs *commandLineArguments, developmentMode bool
 	return opts
 }
 
-func setUpLogging(crZapOpts crzap.Opts) *zaputil.DelegatingZapCoreWrapper {
+func setUpLogging(crZapOpts crzap.Opts, developmentMode bool) *zaputil.DelegatingZapCoreWrapper {
 	o := zaputil.ConvertOptions([]crzap.Opts{crZapOpts})
 
 	// this basically mimics New<type>Config, but with a custom sink
@@ -538,6 +540,9 @@ func setUpLogging(crZapOpts crzap.Opts) *zaputil.DelegatingZapCoreWrapper {
 	defaultZapCore := zapcore.NewCore(&crzap.KubeAwareEncoder{Encoder: o.Encoder, Verbose: o.Development}, sink, o.Level)
 
 	delegatingZapCoreWrapper := zaputil.NewDelegatingZapCoreWrapper()
+	if developmentMode {
+		delegatingZapCoreWrapper.RootDelegatingZapCore.SetBufferingLevel(zapcore.DebugLevel)
+	}
 
 	// Send log records to stdout (defaultZapCore) and also to the OTel log SDK (delegatingZapCore). Additional plot
 	// twist: The OTel logger will only be initialized later, potentially after the operator configuration has been
@@ -553,12 +558,12 @@ func setUpLogging(crZapOpts crzap.Opts) *zaputil.DelegatingZapCoreWrapper {
 	// Set the created tee logger as the logger for the controller-runtime package.
 	ctrl.SetLogger(zapLogger)
 
-	setupLog = ctrl.Log.WithName("setup")
+	setupLog = logd.NewLogger(ctrl.Log.WithName("setup"))
 
 	return delegatingZapCoreWrapper
 }
 
-func readEnvironmentVariables(logger logr.Logger) error {
+func readEnvironmentVariables(logger logd.Logger) error {
 	operatorNamespace, isSet := os.LookupEnv(operatorNamespaceEnvVarName)
 	if !isSet {
 		return fmt.Errorf(mandatoryEnvVarMissingMessageTemplate, operatorNamespaceEnvVarName)
@@ -733,7 +738,7 @@ func readOptionalPullPolicyFromEnvironmentVariable(envVarName string) corev1.Pul
 	return ""
 }
 
-func initStartupTasksK8sClient(logger logr.Logger) error {
+func initStartupTasksK8sClient(logger logd.Logger) error {
 	cfg := ctrl.GetConfigOrDie()
 	var err error
 	if startupTasksK8sClient, err = client.New(
@@ -750,7 +755,7 @@ func initStartupTasksK8sClient(logger logr.Logger) error {
 func detectDocker(
 	ctx context.Context,
 	k8sClient client.Client,
-	logger logr.Logger,
+	logger logd.Logger,
 ) {
 	nodeList := &corev1.NodeList{}
 	err := k8sClient.List(ctx, nodeList, &client.ListOptions{Limit: 1})
@@ -1290,7 +1295,7 @@ func findDeploymentReference(
 	k8sClient client.Client,
 	operatorNamespace string,
 	deploymentName string,
-	logger logr.Logger,
+	logger logd.Logger,
 ) (*appsv1.Deployment, error) {
 	deploymentReference := &appsv1.Deployment{}
 	fullyQualifiedName := fmt.Sprintf("%s/%s", operatorNamespace, deploymentName)
@@ -1309,6 +1314,7 @@ func findDeploymentReference(
 		logger.Error(err, msg)
 		return nil, err
 	}
+	logger.Debug(fmt.Sprintf("found deployment reference with UID: %s", deploymentReference.UID))
 	return deploymentReference, nil
 }
 
@@ -1316,7 +1322,7 @@ func createOrUpdateAutoOperatorConfigurationResource(
 	ctx context.Context,
 	readyCheckExecuter *ReadyCheckExecuter,
 	operatorConfigurationValues *OperatorConfigurationValues,
-	logger logr.Logger,
+	logger logd.Logger,
 ) *dash0v1alpha1.Dash0OperatorConfiguration {
 	if operatorConfigurationValues == nil {
 		return nil
@@ -1398,7 +1404,7 @@ func triggerSecretRefExchangeAndStartSelfMonitoringIfPossible(
 	)
 }
 
-func deleteMonitoringResourcesInAllNamespaces(logger logr.Logger) error {
+func deleteMonitoringResourcesInAllNamespaces(logger logd.Logger) error {
 	handler, err := predelete.NewOperatorPreDeleteHandler()
 	if err != nil {
 		logger.Error(err, "Failed to create the pre-delete handler.")
@@ -1411,7 +1417,7 @@ func deleteMonitoringResourcesInAllNamespaces(logger logr.Logger) error {
 	return nil
 }
 
-func waitForOperatorConfigurationResourceAvailability(logger logr.Logger) error {
+func waitForOperatorConfigurationResourceAvailability(logger logd.Logger) error {
 	handler, err := postinstall.NewOperatorPostInstallHandler()
 	if err != nil {
 		logger.Error(err, "Failed to create the post-install handler.")
@@ -1424,7 +1430,7 @@ func waitForOperatorConfigurationResourceAvailability(logger logr.Logger) error 
 	return nil
 }
 
-func deleteDash0AllowlistSynchronizer(ctx context.Context, logger logr.Logger) error {
+func deleteDash0AllowlistSynchronizer(ctx context.Context, logger logd.Logger) error {
 	handler, err := postdelete.NewOperatorPostDeleteHandler()
 	if err != nil {
 		logger.Error(err, "Failed to create the post-delete handler.")

--- a/internal/startup/ready_check.go
+++ b/internal/startup/ready_check.go
@@ -10,13 +10,13 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/go-logr/logr"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/dash0hq/dash0-operator/internal/util"
+	"github.com/dash0hq/dash0-operator/internal/util/logd"
 )
 
 type ReadyCheckExecuter struct {
@@ -54,7 +54,7 @@ func NewReadyCheckExecuter(
 
 // start begins polling the webhook endpoint until it gets a port assigned, in a separate Goroutine. It returns
 // immediately. Clients can check the result of the polling via the isReady method.
-func (c *ReadyCheckExecuter) start(ctx context.Context, logger logr.Logger) {
+func (c *ReadyCheckExecuter) start(ctx context.Context, logger logd.Logger) {
 	go func() {
 		if err := c.pollWebhookServiceEndpoint(ctx, logger, false); err != nil {
 			logger.Error(err, "failed to poll the webhook service endpoint, the pod will not be marked as ready")
@@ -73,7 +73,7 @@ func (c *ReadyCheckExecuter) isReady(_ *http.Request) error {
 
 // waitForWebhookServiceEndpointToBecomeReady blocks until the webhook service endpoint has become ready, or until the
 // polling routine for the webhook service gives up.
-func (c *ReadyCheckExecuter) waitForWebhookServiceEndpointToBecomeReady(ctx context.Context, logger logr.Logger) (bool, error) {
+func (c *ReadyCheckExecuter) waitForWebhookServiceEndpointToBecomeReady(ctx context.Context, logger logd.Logger) (bool, error) {
 	if err := c.pollWebhookServiceEndpoint(ctx, logger, true); err != nil {
 		return false, err
 	}
@@ -85,7 +85,7 @@ func (c *ReadyCheckExecuter) waitForWebhookServiceEndpointToBecomeReady(ctx cont
 // (This check needs to be skipped for the operator manager pod's readyness check, since a service endpoint only will be
 // marked ready when its underlying pod is marked as ready). The function also returns when the polling times out after
 // one minute.
-func (c *ReadyCheckExecuter) pollWebhookServiceEndpoint(ctx context.Context, logger logr.Logger, waitForReadyCondition bool) error {
+func (c *ReadyCheckExecuter) pollWebhookServiceEndpoint(ctx context.Context, logger logd.Logger, waitForReadyCondition bool) error {
 	if c.bypassWebhookCheck {
 		logger.Info("bypassing the webhook service endpoint check")
 		c.webhookEndpointHasPortAssigned.Store(true)

--- a/internal/targetallocator/taresources/ta_resources.go
+++ b/internal/targetallocator/taresources/ta_resources.go
@@ -9,13 +9,13 @@ import (
 	"fmt"
 
 	"github.com/cisco-open/k8s-objectmatcher/patch"
-	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/dash0hq/dash0-operator/internal/util"
+	"github.com/dash0hq/dash0-operator/internal/util/logd"
 	"github.com/dash0hq/dash0-operator/internal/util/resources"
 )
 
@@ -44,7 +44,7 @@ func (m *TargetAllocatorResourceManager) CreateOrUpdateTargetAllocatorResources(
 	ctx context.Context,
 	extraConfig util.ExtraConfig,
 	namespacesWithPrometheusScraping []string,
-	logger logr.Logger,
+	logger logd.Logger,
 ) (bool, bool, error) {
 	config := &targetAllocatorConfig{
 		OperatorNamespace:  m.targetAllocatorConfig.OperatorNamespace,
@@ -84,7 +84,7 @@ func (m *TargetAllocatorResourceManager) CreateOrUpdateTargetAllocatorResources(
 func (m *TargetAllocatorResourceManager) createOrUpdateResource(
 	ctx context.Context,
 	desiredResource client.Object,
-	logger logr.Logger,
+	logger logd.Logger,
 ) (bool, bool, error) {
 	existingResource, err := resources.CreateEmptyReceiverFor(desiredResource)
 	if err != nil {
@@ -113,7 +113,7 @@ func (m *TargetAllocatorResourceManager) createOrUpdateResource(
 func (m *TargetAllocatorResourceManager) createResource(
 	ctx context.Context,
 	desiredResource client.Object,
-	logger logr.Logger,
+	logger logd.Logger,
 ) error {
 	if err := resources.SetOwnerReference(m.operatorManagerDeployment, m.scheme, desiredResource, logger); err != nil {
 		return err
@@ -137,7 +137,7 @@ func (m *TargetAllocatorResourceManager) updateResource(
 	ctx context.Context,
 	existingResource client.Object,
 	desiredResource client.Object,
-	logger logr.Logger,
+	logger logd.Logger,
 ) (bool, error) {
 	if err := resources.SetOwnerReference(m.operatorManagerDeployment, m.scheme, desiredResource, logger); err != nil {
 		return false, err
@@ -183,7 +183,7 @@ func (m *TargetAllocatorResourceManager) updateResource(
 func (m *TargetAllocatorResourceManager) DeleteResources(
 	ctx context.Context,
 	extraConfig util.ExtraConfig,
-	logger logr.Logger,
+	logger logd.Logger,
 ) (bool, error) {
 	logger.Info(
 		fmt.Sprintf(

--- a/internal/targetallocator/targetallocator_controller.go
+++ b/internal/targetallocator/targetallocator_controller.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 
 	"github.com/dash0hq/dash0-operator/internal/targetallocator/taresources"
+	"github.com/dash0hq/dash0-operator/internal/util/logd"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -16,7 +17,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -124,7 +124,7 @@ func (r *TargetAllocatorReconciler) Reconcile(
 	ctx context.Context,
 	request reconcile.Request,
 ) (reconcile.Result, error) {
-	logger := log.FromContext(ctx)
+	logger := logd.FromContext(ctx)
 	logger.Info("reconciling target-allocator resources triggered by watch event", "request", request)
 
 	hasBeenReconciled, err := r.targetAllocatorManager.ReconcileTargetAllocator(

--- a/internal/targetallocator/targetallocator_manager.go
+++ b/internal/targetallocator/targetallocator_manager.go
@@ -9,13 +9,12 @@ import (
 	"reflect"
 	"sync/atomic"
 
-	"github.com/go-logr/logr"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	taresources "github.com/dash0hq/dash0-operator/internal/targetallocator/taresources"
 	"github.com/dash0hq/dash0-operator/internal/util"
+	"github.com/dash0hq/dash0-operator/internal/util/logd"
 	"github.com/dash0hq/dash0-operator/internal/util/resources"
 )
 
@@ -52,7 +51,7 @@ func NewTargetAllocatorManager(
 	return m
 }
 
-func (m *TargetAllocatorManager) UpdateExtraConfig(ctx context.Context, newConfig util.ExtraConfig, logger logr.Logger) {
+func (m *TargetAllocatorManager) UpdateExtraConfig(ctx context.Context, newConfig util.ExtraConfig, logger logd.Logger) {
 	previousConfig := m.extraConfig.Swap(&newConfig)
 	if previousConfig == nil || !reflect.DeepEqual(*previousConfig, newConfig) {
 		hasBeenReconciled, err := m.ReconcileTargetAllocator(ctx, TriggeredByWatchEvent)
@@ -80,7 +79,7 @@ func (m *TargetAllocatorManager) ReconcileTargetAllocator(
 	ctx context.Context,
 	trigger TargetAllocatorReconcileTrigger,
 ) (bool, error) {
-	logger := log.FromContext(ctx)
+	logger := logd.FromContext(ctx)
 	logger.Info("ReconcileTargetAllocator", "trigger", trigger)
 
 	if m.updateInProgress.Load() {
@@ -175,7 +174,7 @@ func (m *TargetAllocatorManager) createOrUpdateTargetAllocator(
 	ctx context.Context,
 	namespacesWithPrometheusScraping []string,
 	extraConfig util.ExtraConfig,
-	logger logr.Logger,
+	logger logd.Logger,
 ) error {
 	resourcesHaveBeenCreated, resourcesHaveBeenUpdated, err :=
 		m.targetAllocatorResourceManager.CreateOrUpdateTargetAllocatorResources(
@@ -207,7 +206,7 @@ func (m *TargetAllocatorManager) createOrUpdateTargetAllocator(
 func (m *TargetAllocatorManager) removeTargetAllocator(
 	ctx context.Context,
 	extraConfig util.ExtraConfig,
-	logger logr.Logger,
+	logger logd.Logger,
 ) error {
 	resourcesHaveBeenDeleted, err := m.targetAllocatorResourceManager.DeleteResources(
 		ctx,

--- a/internal/targetallocator/targetallocator_manager_test.go
+++ b/internal/targetallocator/targetallocator_manager_test.go
@@ -11,13 +11,13 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/dash0hq/dash0-operator/api/operator/common"
 	dash0v1alpha1 "github.com/dash0hq/dash0-operator/api/operator/v1alpha1"
 	dash0v1beta1 "github.com/dash0hq/dash0-operator/api/operator/v1beta1"
 	"github.com/dash0hq/dash0-operator/internal/targetallocator/taresources"
 	"github.com/dash0hq/dash0-operator/internal/util"
+	"github.com/dash0hq/dash0-operator/internal/util/logd"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -36,7 +36,7 @@ var (
 
 var _ = Describe("The target-allocator manager", Ordered, func() {
 	ctx := context.Background()
-	logger := log.FromContext(ctx)
+	logger := logd.FromContext(ctx)
 
 	var createdObjectsTargetAllocatorManagerTest []client.Object
 

--- a/internal/util/cluster.go
+++ b/internal/util/cluster.go
@@ -7,13 +7,13 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/go-logr/logr"
+	"github.com/dash0hq/dash0-operator/internal/util/logd"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func ReadPseudoClusterUid(ctx context.Context, k8sClient client.Client, logger logr.Logger) types.UID {
+func ReadPseudoClusterUid(ctx context.Context, k8sClient client.Client, logger logd.Logger) types.UID {
 	if uid, err := ReadPseudoClusterUidOrFail(ctx, k8sClient, logger); err != nil {
 		return "unknown"
 	} else {
@@ -21,7 +21,7 @@ func ReadPseudoClusterUid(ctx context.Context, k8sClient client.Client, logger l
 	}
 }
 
-func ReadPseudoClusterUidOrFail(ctx context.Context, k8sClient client.Client, logger logr.Logger) (types.UID, error) {
+func ReadPseudoClusterUidOrFail(ctx context.Context, k8sClient client.Client, logger logd.Logger) (types.UID, error) {
 	kubeSystemNamespace := &corev1.Namespace{}
 	if err := k8sClient.Get(ctx, client.ObjectKey{Name: "kube-system"}, kubeSystemNamespace); err != nil {
 		msg := "unable to get the kube-system namespace uid"

--- a/internal/util/extra_config.go
+++ b/internal/util/extra_config.go
@@ -10,11 +10,10 @@ import (
 	"time"
 
 	"github.com/bep/debounce"
+	"github.com/dash0hq/dash0-operator/internal/util/logd"
 	"github.com/fsnotify/fsnotify"
-	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/yaml"
 )
 
@@ -68,7 +67,7 @@ type ExtraConfig struct {
 }
 
 type ExtraConfigClient interface {
-	UpdateExtraConfig(context.Context, ExtraConfig, logr.Logger)
+	UpdateExtraConfig(context.Context, ExtraConfig, logd.Logger)
 }
 
 const (
@@ -232,7 +231,7 @@ func NewExtraConfigWatcher() *ExtraConfigWatcher {
 	}
 }
 
-func (w *ExtraConfigWatcher) StartWatch(logger logr.Logger) error {
+func (w *ExtraConfigWatcher) StartWatch(logger logd.Logger) error {
 	return w.watchConfigurationDirectory(extraConfigDir, extraConfigFile, logger)
 }
 
@@ -243,7 +242,7 @@ func (w *ExtraConfigWatcher) AddClient(client ExtraConfigClient) {
 func (w *ExtraConfigWatcher) watchConfigurationDirectory(
 	configurationDir string,
 	extraConfigFile string,
-	setupLogger logr.Logger,
+	setupLogger logd.Logger,
 ) error {
 	var err error
 	w.watcher, err = fsnotify.NewWatcher()
@@ -265,7 +264,7 @@ func (w *ExtraConfigWatcher) watchConfigurationDirectory(
 					return
 				}
 				ctx := context.Background()
-				logger := log.FromContext(ctx)
+				logger := logd.FromContext(ctx)
 				debouncedFileWatchEvents(func() {
 					extraConfig, err := readExtraConfigurationFromFile(extraConfigFile)
 					if err != nil {
@@ -281,7 +280,7 @@ func (w *ExtraConfigWatcher) watchConfigurationDirectory(
 					return
 				}
 				ctx := context.Background()
-				logger := log.FromContext(ctx)
+				logger := logd.FromContext(ctx)
 				logger.Error(fsnotifyErr, "extra config map file watcher error")
 			}
 		}

--- a/internal/util/extra_config_test.go
+++ b/internal/util/extra_config_test.go
@@ -8,11 +8,10 @@ import (
 	"os"
 	"time"
 
-	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 
+	"github.com/dash0hq/dash0-operator/internal/util/logd"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -20,7 +19,7 @@ import (
 var _ = Describe("extra config map", func() {
 
 	ctx := context.Background()
-	logger := log.FromContext(ctx)
+	logger := logd.FromContext(ctx)
 
 	type applyDefaultsTest struct {
 		input    *ResourceRequirementsWithGoMemLimit
@@ -1262,7 +1261,7 @@ type DummyExtraConfigClient struct {
 	updatedConfig          *ExtraConfig
 }
 
-func (c *DummyExtraConfigClient) UpdateExtraConfig(_ context.Context, updatedConfig ExtraConfig, _ logr.Logger) {
+func (c *DummyExtraConfigClient) UpdateExtraConfig(_ context.Context, updatedConfig ExtraConfig, _ logd.Logger) {
 	c.updateExtraConfigCalls += 1
 	c.updatedConfig = &updatedConfig
 }

--- a/internal/util/k8s_events.go
+++ b/internal/util/k8s_events.go
@@ -10,7 +10,7 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/go-logr/logr"
+	"github.com/dash0hq/dash0-operator/internal/util/logd"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -25,7 +25,7 @@ func HandlePotentiallySuccessfulInstrumentationEvent(
 	eventSource WorkloadModifierActor,
 	containersTotal int,
 	instrumentationIssuesPerContainer map[string][]string,
-	logger logr.Logger,
+	logger logd.Logger,
 ) {
 	if len(instrumentationIssuesPerContainer) == 0 {
 		// All containers have been instrumented, no container had instrumentation issues.

--- a/internal/util/leader_election_aware_manager.go
+++ b/internal/util/leader_election_aware_manager.go
@@ -7,12 +7,11 @@ import (
 	"context"
 	"sync/atomic"
 
-	"github.com/go-logr/logr"
-	"sigs.k8s.io/controller-runtime/pkg/log"
+	"github.com/dash0hq/dash0-operator/internal/util/logd"
 )
 
 type LeaderElectionClient interface {
-	NotifiyOperatorManagerJustBecameLeader(context.Context, logr.Logger)
+	NotifiyOperatorManagerJustBecameLeader(context.Context, logd.Logger)
 }
 
 type LeaderElectionAware interface {
@@ -42,7 +41,7 @@ func (r *LeaderElectionAwareRunnable) AddLeaderElectionClient(client LeaderElect
 
 // Start is the signal from controller-runtime for the runnable that this replica has become leader.
 func (r *LeaderElectionAwareRunnable) Start(ctx context.Context) error {
-	logger := log.FromContext(ctx)
+	logger := logd.FromContext(ctx)
 	logger.Info("This operator manager replica has just become leader.")
 	r.isLeader.Store(true)
 	for _, client := range r.clients {

--- a/internal/util/logd/logd.go
+++ b/internal/util/logd/logd.go
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: Copyright 2026 Dash0 Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package logd
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// Logger is a thin wrapper around logr.Logger that adds a Debug method using V(1), which maps to zapcore.DebugLevel
+// (-1) via the zapr bridge (logr V level n maps to zap level -n). Debug messages are only visible when the operator
+// runs in development mode, where the zap logger is configured at debug level (-1).
+// In production mode, the zap logger is configured at info level (0), so V(1) messages are filtered out.
+type Logger struct {
+	logr.Logger
+}
+
+// NewLogger wraps a logr.Logger.
+func NewLogger(logger logr.Logger) Logger {
+	return Logger{Logger: logger}
+}
+
+// LoggerFromContext extracts a logr.Logger from the context and wraps it.
+func FromContext(ctx context.Context) Logger {
+	return NewLogger(log.FromContext(ctx))
+}
+
+// Debug logs a message at V(1) level (zapcore.DebugLevel).
+func (l Logger) Debug(msg string, keysAndValues ...any) {
+	l.Logger.WithCallDepth(1).V(1).Info(msg, keysAndValues...)
+}
+
+// WithValues returns a new Logger with additional key-value pairs.
+func (l Logger) WithValues(keysAndValues ...any) Logger {
+	return NewLogger(l.Logger.WithValues(keysAndValues...))
+}
+
+// WithName returns a new Logger with the specified name appended.
+func (l Logger) WithName(name string) Logger {
+	return NewLogger(l.Logger.WithName(name))
+}
+
+func Discard() Logger {
+	return NewLogger(logr.Discard())
+}

--- a/internal/util/resources/util.go
+++ b/internal/util/resources/util.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/dash0hq/dash0-operator/internal/resources"
-	"github.com/go-logr/logr"
+	"github.com/dash0hq/dash0-operator/internal/util/logd"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -28,7 +28,7 @@ import (
 func FindOperatorConfigurationResource(
 	ctx context.Context,
 	k8sClient client.Client,
-	logger logr.Logger,
+	logger logd.Logger,
 ) (*dash0v1alpha1.Dash0OperatorConfiguration, error) {
 	operatorConfigurationResource, err := resources.FindUniqueOrMostRecentResourceInScope(
 		ctx,
@@ -49,7 +49,7 @@ func FindOperatorConfigurationResource(
 func FindAllMonitoringResources(
 	ctx context.Context,
 	k8sClient client.Client,
-	logger logr.Logger,
+	logger logd.Logger,
 ) ([]dash0v1beta1.Dash0Monitoring, error) {
 	monitoringResourceList := dash0v1beta1.Dash0MonitoringList{}
 	if err := k8sClient.List(
@@ -94,7 +94,7 @@ func SetOwnerReference(
 	operatorManagerDeployment *appsv1.Deployment,
 	scheme *runtime.Scheme,
 	object client.Object,
-	logger logr.Logger,
+	logger logd.Logger,
 ) error {
 	if object.GetNamespace() == "" {
 		// cluster scoped resources like ClusterRole and ClusterRoleBinding cannot have a namespace-scoped owner.

--- a/internal/util/retry.go
+++ b/internal/util/retry.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/go-logr/logr"
+	"github.com/dash0hq/dash0-operator/internal/util/logd"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
 )
@@ -54,7 +54,7 @@ var (
 	}
 )
 
-func Retry(operationLabel string, operation func() error, logger logr.Logger) error {
+func Retry(operationLabel string, operation func() error, logger logd.Logger) error {
 	return RetryWithCustomBackoff(operationLabel, operation, defaultRetryBackoff, true, true, logger)
 }
 
@@ -64,7 +64,7 @@ func RetryWithCustomBackoff(
 	backoff wait.Backoff,
 	logAttempts bool,
 	logFinalFailureAsError bool,
-	logger logr.Logger,
+	logger logd.Logger,
 ) error {
 	attempt := 0
 	return retry.OnError(

--- a/internal/util/zap/delegating_zap_core.go
+++ b/internal/util/zap/delegating_zap_core.go
@@ -66,7 +66,7 @@ func (dc *DelegatingZapCore) With(fields []zapcore.Field) zapcore.Core {
 func (dc *DelegatingZapCore) Enabled(lvl zapcore.Level) bool {
 	delegate := dc.delegate.Load()
 	if delegate != nil {
-		return (*delegate).Enabled(lvl)
+		return lvl >= dc.level && (*delegate).Enabled(lvl)
 	}
 
 	return lvl >= dc.level
@@ -77,6 +77,11 @@ func (dc *DelegatingZapCore) Enabled(lvl zapcore.Level) bool {
 func (dc *DelegatingZapCore) Check(entry zapcore.Entry, ce *zapcore.CheckedEntry) *zapcore.CheckedEntry {
 	delegate := dc.delegate.Load()
 	if delegate != nil {
+		// Respect the configured level so that debug messages are not forwarded to the OTel pipeline when not in
+		// development mode.
+		if entry.Level < dc.level {
+			return ce
+		}
 		if !zapcore.DebugLevel.Enabled(entry.Level) { // this is equivalent to `entry.Level < -1`
 			// There is some unfortunate interaction going on between controller-runtime debug logging and the zap OTel
 			// bridge. When controller-runtime logs with a level below -1, like for example here:

--- a/internal/util/zap/delegating_zap_core_test.go
+++ b/internal/util/zap/delegating_zap_core_test.go
@@ -31,15 +31,35 @@ var _ = Describe("Delegating Zap Core", func() {
 		Expect(delegatingCore.Enabled(zapcore.ErrorLevel)).To(BeTrue())
 	})
 
-	It("Enabled with a delegate", func() {
+	It("Enabled with a delegate (default level)", func() {
 		logMessageBuffer := NewMruWithDefaultSizeLimit[*ZapEntryWithFields]()
 		delegatingCore := NewDelegatingZapCore(logMessageBuffer)
 		e := &oddEvenEnabler{}
 		delegatingCore.SetDelegate(zapcore.NewCore(nil, nil, e))
+		// DebugLevel (-1) is below the default level (InfoLevel = 0), so Enabled short-circuits
+		// without consulting the delegate.
 		Expect(delegatingCore.Enabled(zapcore.DebugLevel)).To(BeFalse())
 		Expect(delegatingCore.Enabled(zapcore.InfoLevel)).To(BeTrue())
 		Expect(delegatingCore.Enabled(zapcore.WarnLevel)).To(BeFalse())
 		Expect(delegatingCore.Enabled(zapcore.ErrorLevel)).To(BeTrue())
+		// DebugLevel was filtered by dc.level before reaching the delegate
+		Expect(e.calledWith).To(HaveLen(3))
+		Expect(e.calledWith[0]).To(Equal(zapcore.InfoLevel))
+		Expect(e.calledWith[1]).To(Equal(zapcore.WarnLevel))
+		Expect(e.calledWith[2]).To(Equal(zapcore.ErrorLevel))
+	})
+
+	It("Enabled with a delegate (debug level)", func() {
+		logMessageBuffer := NewMruWithDefaultSizeLimit[*ZapEntryWithFields]()
+		delegatingCore := NewDelegatingZapCore(logMessageBuffer)
+		delegatingCore.SetBufferingLevel(zapcore.DebugLevel)
+		e := &oddEvenEnabler{}
+		delegatingCore.SetDelegate(zapcore.NewCore(nil, nil, e))
+		// With DebugLevel as the configured level, all levels pass through to the delegate.
+		Expect(delegatingCore.Enabled(zapcore.DebugLevel)).To(BeFalse()) // delegate returns false (odd)
+		Expect(delegatingCore.Enabled(zapcore.InfoLevel)).To(BeTrue())   // delegate returns true (even)
+		Expect(delegatingCore.Enabled(zapcore.WarnLevel)).To(BeFalse())  // delegate returns false (odd)
+		Expect(delegatingCore.Enabled(zapcore.ErrorLevel)).To(BeTrue())  // delegate returns true (even)
 		Expect(e.calledWith).To(HaveLen(4))
 		Expect(e.calledWith[0]).To(Equal(zapcore.DebugLevel))
 		Expect(e.calledWith[1]).To(Equal(zapcore.InfoLevel))

--- a/internal/webhooks/instrumentation_webhook.go
+++ b/internal/webhooks/instrumentation_webhook.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/go-logr/logr"
 	admissionv1 "k8s.io/api/admission/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -26,6 +25,7 @@ import (
 	dash0common "github.com/dash0hq/dash0-operator/api/operator/common"
 	dash0v1beta1 "github.com/dash0hq/dash0-operator/api/operator/v1beta1"
 	"github.com/dash0hq/dash0-operator/internal/util"
+	"github.com/dash0hq/dash0-operator/internal/util/logd"
 	"github.com/dash0hq/dash0-operator/internal/workloads"
 )
 
@@ -40,7 +40,7 @@ type resourceHandler func(
 	request admission.Request,
 	gvkLabel string,
 	namespaceInstrumentationConfig util.NamespaceInstrumentationConfig,
-	logger logr.Logger,
+	logger logd.Logger,
 ) admission.Response
 type routing map[string]map[string]map[string]resourceHandler
 
@@ -90,7 +90,7 @@ var (
 		request admission.Request,
 		gvkLabel string,
 		namespaceInstrumentationConfig util.NamespaceInstrumentationConfig,
-		logger logr.Logger,
+		logger logd.Logger,
 	) admission.Response {
 		return logAndReturnAllowed(fmt.Sprintf("resource type not supported: %s", gvkLabel), logger)
 	}
@@ -125,20 +125,22 @@ func (h *InstrumentationWebhookHandler) SetupWebhookWithManager(mgr ctrl.Manager
 	return nil
 }
 
-func (h *InstrumentationWebhookHandler) UpdateExtraConfig(_ context.Context, extraConfig util.ExtraConfig, _ logr.Logger) {
+func (h *InstrumentationWebhookHandler) UpdateExtraConfig(_ context.Context, extraConfig util.ExtraConfig, _ logd.Logger) {
 	h.ClusterInstrumentationConfig.ExtraConfig.Store(&extraConfig)
 }
 
 func (h *InstrumentationWebhookHandler) Handle(ctx context.Context, request admission.Request) admission.Response {
-	logger := instrumentationWebhookLog.WithValues(
-		"operation",
-		request.Operation,
-		"gvk",
-		request.Kind,
-		"namespace",
-		request.Namespace,
-		"name",
-		request.Name,
+	logger := logd.NewLogger(
+		instrumentationWebhookLog.WithValues(
+			"operation",
+			request.Operation,
+			"gvk",
+			request.Kind,
+			"namespace",
+			request.Namespace,
+			"name",
+			request.Name,
+		),
 	)
 
 	targetNamespace := request.Namespace
@@ -225,7 +227,7 @@ func (h *InstrumentationWebhookHandler) handleCronJob(
 	request admission.Request,
 	gvkLabel string,
 	namespaceInstrumentationConfig util.NamespaceInstrumentationConfig,
-	logger logr.Logger,
+	logger logd.Logger,
 ) admission.Response {
 	cronJob := &batchv1.CronJob{}
 	responseIfFailed, failed := h.preProcess(request, gvkLabel, cronJob, logger)
@@ -267,7 +269,7 @@ func (h *InstrumentationWebhookHandler) handleDaemonSet(
 	request admission.Request,
 	gvkLabel string,
 	namespaceInstrumentationConfig util.NamespaceInstrumentationConfig,
-	logger logr.Logger,
+	logger logd.Logger,
 ) admission.Response {
 	daemonSet := &appsv1.DaemonSet{}
 	responseIfFailed, failed := h.preProcess(request, gvkLabel, daemonSet, logger)
@@ -303,7 +305,7 @@ func (h *InstrumentationWebhookHandler) handleDeployment(
 	request admission.Request,
 	gvkLabel string,
 	namespaceInstrumentationConfig util.NamespaceInstrumentationConfig,
-	logger logr.Logger,
+	logger logd.Logger,
 ) admission.Response {
 	deployment := &appsv1.Deployment{}
 	responseIfFailed, failed := h.preProcess(request, gvkLabel, deployment, logger)
@@ -339,7 +341,7 @@ func (h *InstrumentationWebhookHandler) handleJob(
 	request admission.Request,
 	gvkLabel string,
 	namespaceInstrumentationConfig util.NamespaceInstrumentationConfig,
-	logger logr.Logger,
+	logger logd.Logger,
 ) admission.Response {
 	job := &batchv1.Job{}
 	responseIfFailed, failed := h.preProcess(request, gvkLabel, job, logger)
@@ -377,7 +379,7 @@ func (h *InstrumentationWebhookHandler) handlePod(
 	request admission.Request,
 	gvkLabel string,
 	namespaceInstrumentationConfig util.NamespaceInstrumentationConfig,
-	logger logr.Logger,
+	logger logd.Logger,
 ) admission.Response {
 	pod := &corev1.Pod{}
 	responseIfFailed, failed := h.preProcess(request, gvkLabel, pod, logger)
@@ -416,7 +418,7 @@ func (h *InstrumentationWebhookHandler) handleReplicaSet(
 	request admission.Request,
 	gvkLabel string,
 	namespaceInstrumentationConfig util.NamespaceInstrumentationConfig,
-	logger logr.Logger,
+	logger logd.Logger,
 ) admission.Response {
 	replicaSet := &appsv1.ReplicaSet{}
 	responseIfFailed, failed := h.preProcess(request, gvkLabel, replicaSet, logger)
@@ -452,7 +454,7 @@ func (h *InstrumentationWebhookHandler) handleStatefulSet(
 	request admission.Request,
 	gvkLabel string,
 	namespaceInstrumentationConfig util.NamespaceInstrumentationConfig,
-	logger logr.Logger,
+	logger logd.Logger,
 ) admission.Response {
 	statefulSet := &appsv1.StatefulSet{}
 	responseIfFailed, failed := h.preProcess(request, gvkLabel, statefulSet, logger)
@@ -488,7 +490,7 @@ func (h *InstrumentationWebhookHandler) preProcess(
 	request admission.Request,
 	gvkLabel string,
 	resource runtime.Object,
-	logger logr.Logger,
+	logger logd.Logger,
 ) (admission.Response, bool) {
 	if _, _, err := decoder.Decode(request.Object.Raw, nil, resource); err != nil {
 		wrappedErr := fmt.Errorf("cannot parse resource into a %s: %w", gvkLabel, err)
@@ -503,7 +505,7 @@ func (h *InstrumentationWebhookHandler) postProcessInstrumentation(
 	resource runtime.Object,
 	modificationResult workloads.ModificationResult,
 	isPod bool,
-	logger logr.Logger,
+	logger logd.Logger,
 ) admission.Response {
 	if !modificationResult.IgnoredOnce && !modificationResult.HasBeenModified {
 		msg := modificationResult.RenderReasonMessage(actor)
@@ -546,7 +548,7 @@ func (h *InstrumentationWebhookHandler) postProcessUninstrumentation(
 	request admission.Request,
 	resource runtime.Object,
 	modificationResult workloads.ModificationResult,
-	logger logr.Logger,
+	logger logd.Logger,
 ) admission.Response {
 	if modificationResult.ImmutableWorkload {
 		err := errors.New(modificationResult.RenderReasonMessage(actor))
@@ -577,7 +579,7 @@ func (h *InstrumentationWebhookHandler) postProcessUninstrumentation(
 
 func (h *InstrumentationWebhookHandler) newWorkloadModifier(
 	namespaceInstrumentationConfig util.NamespaceInstrumentationConfig,
-	logger logr.Logger,
+	logger logd.Logger,
 ) *workloads.ResourceModifier {
 	return workloads.NewResourceModifier(
 		h.ClusterInstrumentationConfig,
@@ -603,12 +605,12 @@ func (r *routing) routeFor(group, kind, version string) resourceHandler {
 	return routesForVersion
 }
 
-func logAndReturnAllowed(message string, logger logr.Logger) admission.Response {
+func logAndReturnAllowed(message string, logger logd.Logger) admission.Response {
 	logger.Info(message)
 	return admission.Allowed(message)
 }
 
-func logErrorAndReturnAllowed(err error, logger logr.Logger) admission.Response {
+func logErrorAndReturnAllowed(err error, logger logd.Logger) admission.Response {
 	logger.Error(err, "an error occurred while processing the admission request")
 
 	// Note: We never return admission.Errored or admission.Denied, even in case an error happens, because we do not

--- a/internal/webhooks/monitoring_mutating_webhook.go
+++ b/internal/webhooks/monitoring_mutating_webhook.go
@@ -10,18 +10,17 @@ import (
 	"net/http"
 	"reflect"
 
-	"github.com/go-logr/logr"
 	admissionv1 "k8s.io/api/admission/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	dash0common "github.com/dash0hq/dash0-operator/api/operator/common"
 	dash0v1alpha1 "github.com/dash0hq/dash0-operator/api/operator/v1alpha1"
 	dash0v1beta1 "github.com/dash0hq/dash0-operator/api/operator/v1beta1"
 	"github.com/dash0hq/dash0-operator/internal/util"
+	"github.com/dash0hq/dash0-operator/internal/util/logd"
 )
 
 type MonitoringMutatingWebhookHandler struct {
@@ -60,7 +59,7 @@ func (h *MonitoringMutatingWebhookHandler) Handle(ctx context.Context, request a
 	// api/operator/v1alpha1/dash0monitoring_types.go have already been applied by the time this webhook
 	// is called.
 	// See https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#admission-control-phases.
-	logger := log.FromContext(ctx)
+	logger := logd.FromContext(ctx)
 
 	monitoringResource := &dash0v1beta1.Dash0Monitoring{}
 	if _, _, err := decoder.Decode(request.Object.Raw, nil, monitoringResource); err != nil {
@@ -102,7 +101,7 @@ func (h *MonitoringMutatingWebhookHandler) normalizeMonitoringResourceSpec(
 	request admission.Request,
 	operatorConfigurationSpec *dash0v1alpha1.Dash0OperatorConfigurationSpec,
 	monitoringSpec *dash0v1beta1.Dash0MonitoringSpec,
-	logger logr.Logger,
+	logger logd.Logger,
 ) (bool, *admission.Response) {
 	patchRequired := h.setTelemetryCollectionRelatedDefaults(request, operatorConfigurationSpec, monitoringSpec)
 	patchRequiredForLogCollection := h.overrideLogCollectionDefault(request, monitoringSpec, logger)
@@ -187,7 +186,7 @@ func (h *MonitoringMutatingWebhookHandler) setTelemetryCollectionRelatedDefaults
 func (h *MonitoringMutatingWebhookHandler) overrideLogCollectionDefault(
 	request admission.Request,
 	monitoringSpec *dash0v1beta1.Dash0MonitoringSpec,
-	logger logr.Logger,
+	logger logd.Logger,
 ) bool {
 	if request.Namespace == h.operatorNamespace &&
 		util.ReadBoolPointerWithDefault(monitoringSpec.LogCollection.Enabled, true) {
@@ -214,7 +213,7 @@ func (h *MonitoringMutatingWebhookHandler) overrideLogCollectionDefault(
 func isExportsUnchangedFromOldMonitoringResource(
 	request admission.Request,
 	incomingExports []dash0common.Export,
-	logger logr.Logger,
+	logger logd.Logger,
 ) (bool, *admission.Response) {
 	if request.Operation != admissionv1.Update {
 		return false, nil
@@ -235,7 +234,7 @@ func isExportsUnchangedFromOldMonitoringResource(
 	return reflect.DeepEqual(incomingExports, oldResource.Spec.Exports), nil
 }
 
-func normalizeTransform(transform *dash0common.Transform, logger logr.Logger) (*dash0common.NormalizedTransformSpec, int32, error) {
+func normalizeTransform(transform *dash0common.Transform, logger logd.Logger) (*dash0common.NormalizedTransformSpec, int32, error) {
 	traceTransformGroups, responseStatus, err :=
 		normalizeTransformGroupsForOneSignal(transform.Traces, "trace_statements", logger)
 	if err != nil {
@@ -266,7 +265,7 @@ func normalizeTransform(transform *dash0common.Transform, logger logr.Logger) (*
 func normalizeTransformGroupsForOneSignal(
 	signalTransformSpec []json.RawMessage,
 	signalTypeKey string,
-	logger logr.Logger,
+	logger logd.Logger,
 ) ([]dash0common.NormalizedTransformGroup, int32, error) {
 	var allGroups []dash0common.NormalizedTransformGroup
 	for ctxIdx, transformGroup := range signalTransformSpec {
@@ -384,7 +383,7 @@ func loadAvailableOperatorConfigurationResources(
 	operatorConfigurationList := &dash0v1alpha1.Dash0OperatorConfigurationList{}
 	if err := k8sClient.List(ctx, operatorConfigurationList, &client.ListOptions{}); err != nil {
 		if !apierrors.IsNotFound(err) {
-			log.FromContext(ctx).Error(err, "failed to list operator configuration resources")
+			logd.FromContext(ctx).Error(err, "failed to list operator configuration resources")
 			errorResponse := admission.Errored(http.StatusInternalServerError, err)
 			return nil, &errorResponse
 		}

--- a/internal/webhooks/monitoring_mutating_webhook_test.go
+++ b/internal/webhooks/monitoring_mutating_webhook_test.go
@@ -10,7 +10,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 	"sigs.k8s.io/yaml"
 
@@ -18,6 +17,7 @@ import (
 	dash0v1alpha1 "github.com/dash0hq/dash0-operator/api/operator/v1alpha1"
 	dash0v1beta1 "github.com/dash0hq/dash0-operator/api/operator/v1beta1"
 	"github.com/dash0hq/dash0-operator/internal/util"
+	"github.com/dash0hq/dash0-operator/internal/util/logd"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -63,7 +63,7 @@ const (
 )
 
 var _ = Describe("The mutation webhook for the monitoring resource", func() {
-	logger := log.FromContext(ctx)
+	logger := logd.FromContext(ctx)
 
 	Describe("when mutating the operator configuration resource", func() {
 

--- a/internal/webhooks/monitoring_validation_webhook.go
+++ b/internal/webhooks/monitoring_validation_webhook.go
@@ -17,13 +17,13 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	dash0common "github.com/dash0hq/dash0-operator/api/operator/common"
 	dash0v1alpha1 "github.com/dash0hq/dash0-operator/api/operator/v1alpha1"
 	dash0v1beta1 "github.com/dash0hq/dash0-operator/api/operator/v1beta1"
 	"github.com/dash0hq/dash0-operator/internal/util"
+	"github.com/dash0hq/dash0-operator/internal/util/logd"
 	"github.com/dash0hq/dash0-operator/internal/webhooks/vendored/opentelemetry-collector-contrib/internal_/filter/filterottl"
 	"github.com/dash0hq/dash0-operator/internal/webhooks/vendored/opentelemetry-collector-contrib/processor/transformprocessor/internal_/common"
 	"github.com/dash0hq/dash0-operator/internal/webhooks/vendored/opentelemetry-collector-contrib/processor/transformprocessor/internal_/logs"
@@ -87,7 +87,7 @@ func (h *MonitoringValidationWebhookHandler) Handle(ctx context.Context, request
 	// Note: The mutating webhook is called before the validating webhook, so we can assume the resource has already
 	// been normalized by the mutating webhook.
 	// See https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#admission-control-phases.
-	logger := log.FromContext(ctx)
+	logger := logd.FromContext(ctx)
 
 	monitoringResource := &dash0v1beta1.Dash0Monitoring{}
 	if _, _, err := decoder.Decode(request.Object.Raw, nil, monitoringResource); err != nil {

--- a/internal/webhooks/operator_configuration_mutating_webhook.go
+++ b/internal/webhooks/operator_configuration_mutating_webhook.go
@@ -10,16 +10,15 @@ import (
 	"net/http"
 	"reflect"
 
-	"github.com/go-logr/logr"
 	admissionv1 "k8s.io/api/admission/v1"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	dash0common "github.com/dash0hq/dash0-operator/api/operator/common"
 	dash0v1alpha1 "github.com/dash0hq/dash0-operator/api/operator/v1alpha1"
+	"github.com/dash0hq/dash0-operator/internal/util/logd"
 )
 
 type OperatorConfigurationMutatingWebhookHandler struct {
@@ -55,7 +54,7 @@ func (h *OperatorConfigurationMutatingWebhookHandler) Handle(ctx context.Context
 	// api/operator/v1alpha1/operator_configuration_types.go have already been applied by the time this webhook
 	// is called.
 	// See https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#admission-control-phases.
-	logger := log.FromContext(ctx)
+	logger := logd.FromContext(ctx)
 	operatorConfigurationResource := &dash0v1alpha1.Dash0OperatorConfiguration{}
 	if _, _, err := decoder.Decode(request.Object.Raw, nil, operatorConfigurationResource); err != nil {
 		logger.Info("rejecting invalid operator configuration resource", "error", err)
@@ -88,7 +87,7 @@ func (h *OperatorConfigurationMutatingWebhookHandler) Handle(ctx context.Context
 func (h *OperatorConfigurationMutatingWebhookHandler) normalizeOperatorConfigurationResourceSpec(
 	request admission.Request,
 	spec *dash0v1alpha1.Dash0OperatorConfigurationSpec,
-	logger logr.Logger,
+	logger logd.Logger,
 ) (bool, *admission.Response) {
 	patchRequired := false
 
@@ -161,7 +160,7 @@ func (h *OperatorConfigurationMutatingWebhookHandler) normalizeOperatorConfigura
 func isExportsUnchangedFromOldOperatorConfigurationResource(
 	request admission.Request,
 	incomingExports []dash0common.Export,
-	logger logr.Logger,
+	logger logd.Logger,
 ) (bool, *admission.Response) {
 	if request.Operation != admissionv1.Update {
 		return false, nil

--- a/internal/webhooks/operator_configuration_mutating_webhook_test.go
+++ b/internal/webhooks/operator_configuration_mutating_webhook_test.go
@@ -9,11 +9,11 @@ import (
 	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	dash0common "github.com/dash0hq/dash0-operator/api/operator/common"
 	dash0v1alpha1 "github.com/dash0hq/dash0-operator/api/operator/v1alpha1"
+	"github.com/dash0hq/dash0-operator/internal/util/logd"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -34,7 +34,7 @@ type migrateOperatorConfigExportToExportsTestConfig struct {
 }
 
 var _ = Describe("The mutating webhook for the operator configuration resource", func() {
-	logger := log.FromContext(ctx)
+	logger := logd.FromContext(ctx)
 
 	Describe("when a new operator configuration resource is created", Ordered, func() {
 		AfterEach(func() {

--- a/internal/webhooks/operator_configuration_validation_webhook.go
+++ b/internal/webhooks/operator_configuration_validation_webhook.go
@@ -11,11 +11,11 @@ import (
 	admissionv1 "k8s.io/api/admission/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	dash0v1alpha1 "github.com/dash0hq/dash0-operator/api/operator/v1alpha1"
 	"github.com/dash0hq/dash0-operator/internal/util"
+	"github.com/dash0hq/dash0-operator/internal/util/logd"
 )
 
 const ErrorMessageOperatorConfigurationPrometheusCrdSupportInvalid = "The provided Dash0 operator configuration resource has Prometheus CRD support " +
@@ -61,7 +61,7 @@ func (h *OperatorConfigurationValidationWebhookHandler) Handle(ctx context.Conte
 	// Note: The mutating webhook is called before the validating webhook, so we can assume the resource has already
 	// been normalized by the mutating webhook.
 	// See https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#admission-control-phases.
-	logger := log.FromContext(ctx)
+	logger := logd.FromContext(ctx)
 	operatorConfigurationResource := &dash0v1alpha1.Dash0OperatorConfiguration{}
 	if _, _, err := decoder.Decode(request.Object.Raw, nil, operatorConfigurationResource); err != nil {
 		logger.Info("rejecting invalid operator configuration resource", "error", err)

--- a/internal/workloads/workload_modifier.go
+++ b/internal/workloads/workload_modifier.go
@@ -10,7 +10,6 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -20,6 +19,7 @@ import (
 
 	"github.com/dash0hq/dash0-operator/images/pkg/common"
 	"github.com/dash0hq/dash0-operator/internal/util"
+	"github.com/dash0hq/dash0-operator/internal/util/logd"
 )
 
 type containerHasServiceAttributes struct {
@@ -229,14 +229,14 @@ type ResourceModifier struct {
 	actor util.WorkloadModifierActor
 
 	// the logger to use for logging messages during the resource modification process
-	logger logr.Logger
+	logger logd.Logger
 }
 
 func NewResourceModifier(
 	clusterInstrumentationConfig *util.ClusterInstrumentationConfig,
 	namespaceInstrumentationConfig util.NamespaceInstrumentationConfig,
 	actor util.WorkloadModifierActor,
-	logger logr.Logger,
+	logger logd.Logger,
 ) *ResourceModifier {
 	return &ResourceModifier{
 		clusterInstrumentationConfig:   clusterInstrumentationConfig,
@@ -530,7 +530,7 @@ func (m *ResourceModifier) addEnvironmentVariables(
 	container *corev1.Container,
 	workloadMeta *metav1.ObjectMeta,
 	podMeta *metav1.ObjectMeta,
-	perContainerLogger logr.Logger,
+	perContainerLogger logd.Logger,
 ) []string {
 	var instrumentationIssues []string
 	if container.Env == nil {
@@ -765,7 +765,7 @@ func (m *ResourceModifier) addOtelExporterOtlpEnvVars(
 	container *corev1.Container,
 	otelExporterOtlpEndpointValue string,
 	instrumentationIssues []string,
-	perContainerLogger logr.Logger,
+	perContainerLogger logd.Logger,
 ) []string {
 	otelExporterOtlpEndpointIsSet, otelExporterOtlpEndpointIdx :=
 		envVarIsSetAndNotEmpty(container, envVarOtelExporterOtlpEndpointName)
@@ -835,7 +835,7 @@ func (m *ResourceModifier) addOtelExporterOtlpEnvVars(
 func (m *ResourceModifier) addOrAppendToLdPreloadEnvVar(
 	container *corev1.Container,
 	instrumentationIssues []string,
-	perContainerLogger logr.Logger,
+	perContainerLogger logd.Logger,
 ) []string {
 	idx := findEnvVarIdx(container, envVarLdPreloadName)
 	if idx < 0 {

--- a/internal/workloads/workload_modifier_test.go
+++ b/internal/workloads/workload_modifier_test.go
@@ -11,10 +11,10 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/dash0hq/dash0-operator/images/pkg/common"
 	"github.com/dash0hq/dash0-operator/internal/util"
+	"github.com/dash0hq/dash0-operator/internal/util/logd"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -44,7 +44,7 @@ var (
 var _ = Describe("Dash0 Workload Modification", func() {
 
 	ctx := context.Background()
-	logger := log.FromContext(ctx)
+	logger := logd.FromContext(ctx)
 	workloadModifier := NewResourceModifier(
 		clusterInstrumentationConfig,
 		DefaultNamespaceInstrumentationConfig,
@@ -642,7 +642,7 @@ var _ = Describe("Dash0 Workload Modification", func() {
 
 	Describe("individual modification functions", func() {
 		ctx := context.Background()
-		logger := log.FromContext(ctx)
+		logger := logd.FromContext(ctx)
 		workloadModifier := NewResourceModifier(
 			clusterInstrumentationConfig,
 			DefaultNamespaceInstrumentationConfig,

--- a/test-resources/bin/lib/util
+++ b/test-resources/bin/lib/util
@@ -505,7 +505,9 @@ run_helm() {
   if [[ "${TA_MTLS_ENABLED:-}" = "true" ]]; then
     helm_install_command+=" --values test-resources/cert-manager/ta-mtls-values.yaml"
   fi
+  if [[ "${DEVELOPMENT_MODE:-}" != "false" ]]; then
   helm_install_command+=" --set operator.developmentMode=true"
+  fi
   if [[ "${OTEL_COLLECTOR_DEBUG_VERBOSITY_DETAILED:-}" = "true" ]]; then
     helm_install_command+=" --set operator.collectors.debugVerbosityDetailed=true"
   fi

--- a/test/e2e/dash0_monitoring_resource.go
+++ b/test/e2e/dash0_monitoring_resource.go
@@ -17,6 +17,7 @@ import (
 
 	dash0common "github.com/dash0hq/dash0-operator/api/operator/common"
 	"github.com/dash0hq/dash0-operator/internal/util"
+	"github.com/dash0hq/dash0-operator/internal/util/logd"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -121,7 +122,7 @@ func deployRenderedMonitoringResourceWithRetry(
 	By(fmt.Sprintf(
 		"deploying the Dash0 monitoring resource to namespace %s with values %v from file %s, operator namespace is %s",
 		namespace, dash0MonitoringValues, renderedResourceFileName, operatorNamespace))
-	retryLogger := zap.New()
+	retryLogger := logd.NewLogger(zap.New())
 	err := util.RetryWithCustomBackoff("deploying the Dash0 monitoring resource to namespace", func() error {
 		return runAndIgnoreOutput(exec.Command(
 			"kubectl",

--- a/test/e2e/dash0_operator_configuration_resource.go
+++ b/test/e2e/dash0_operator_configuration_resource.go
@@ -15,6 +15,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/dash0hq/dash0-operator/internal/util"
+	"github.com/dash0hq/dash0-operator/internal/util/logd"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -90,7 +91,7 @@ func deployRenderedOperatorConfigurationResourceWithRetry(
 	}()
 	By(fmt.Sprintf(
 		"deploying the Dash0 operator configuration resource with values %v", dash0OperatorConfigurationValues))
-	retryLogger := zap.New()
+	retryLogger := logd.NewLogger(zap.New())
 	err := util.RetryWithCustomBackoff("deploying the Dash0 operator configuration resource", func() error {
 		return runAndIgnoreOutput(exec.Command(
 			"kubectl",

--- a/test/util/dummy_clients.go
+++ b/test/util/dummy_clients.go
@@ -6,7 +6,7 @@ package util
 import (
 	"context"
 
-	"github.com/go-logr/logr"
+	"github.com/dash0hq/dash0-operator/internal/util/logd"
 	otelmetric "go.opentelemetry.io/otel/metric"
 )
 
@@ -16,12 +16,12 @@ type DummyAuthTokenClient struct {
 	AuthToken            string
 }
 
-func (c *DummyAuthTokenClient) SetDefaultAuthToken(_ context.Context, authToken string, _ logr.Logger) {
+func (c *DummyAuthTokenClient) SetDefaultAuthToken(_ context.Context, authToken string, _ logd.Logger) {
 	c.SetAuthTokenCalls++
 	c.AuthToken = authToken
 }
 
-func (c *DummyAuthTokenClient) RemoveDefaultAuthToken(_ context.Context, _ logr.Logger) {
+func (c *DummyAuthTokenClient) RemoveDefaultAuthToken(_ context.Context, _ logd.Logger) {
 	c.RemoveAuthTokenCalls++
 	c.AuthToken = ""
 }
@@ -43,7 +43,7 @@ type DummySelfMonitoringMetricsClient struct {
 func (c *DummySelfMonitoringMetricsClient) InitializeSelfMonitoringMetrics(
 	_ otelmetric.Meter,
 	_ string,
-	_ logr.Logger,
+	_ logd.Logger,
 ) {
 	c.InitializeSelfMonitoringMetricsCalls++
 }

--- a/test/util/mock_logger.go
+++ b/test/util/mock_logger.go
@@ -3,18 +3,18 @@ package util
 import (
 	"log/slog"
 
+	"github.com/dash0hq/dash0-operator/internal/util/logd"
 	"github.com/go-logr/logr"
-
 	. "github.com/onsi/gomega"
 )
 
-func NewCapturingLogger() (logr.Logger, *CapturingLogSink) {
+func NewCapturingLogger() (logd.Logger, *CapturingLogSink) {
 	logSink := &CapturingLogSink{
 		runtimeInfo: logr.RuntimeInfo{
 			CallDepth: 1,
 		},
 	}
-	return logr.New(logSink), logSink
+	return logd.NewLogger(logr.New(logSink)), logSink
 }
 
 type CapturingLogSink struct {


### PR DESCRIPTION
- adds a thin wrapper around `logr.Logger` called `logd.Logger` that adds support for logging at `debug` level
- `debug` level logs are only enabled when `developmentMode=true`
- references to logr.Logger have been replaced with logd.Logger