### PR TITLE
feat(workloads): resource.opentelemetry.io/* > app.kubernetes.io/*

### DIFF
--- a/internal/workloads/workload_modifier.go
+++ b/internal/workloads/workload_modifier.go
@@ -53,8 +53,13 @@ const (
 	envVarOTelInjectorResourceAttributesName       = "OTEL_INJECTOR_RESOURCE_ATTRIBUTES"
 	otelInjectorLogLevelEnvVarName                 = "OTEL_INJECTOR_LOG_LEVEL"
 
+	serviceName      = "service.name"
+	serviceNamespace = "service.namespace"
+	serviceVersion   = "service.version"
+
 	defaultOtelExporterOtlpProtocol = common.ProtocolHttpProtobuf
 
+	resourcesOpenTelemetryIoLabelPrefix   = "resource.opentelemetry.io/"
 	safeToEviceLocalVolumesAnnotationName = "cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes"
 
 	// legacy environment variables
@@ -72,6 +77,8 @@ var (
 	initContainerAllowPrivilegeEscalation       = false
 	initContainerPrivileged                     = false
 	initContainerReadOnlyRootFilesystem         = true
+
+	serviceAttributes = []string{serviceName, serviceNamespace, serviceVersion}
 
 	otelExporterOtlpNoOverwriteMsg = fmt.Sprintf(
 		"Dash0 will not set %s/%s since the container already has at least one of those environment "+
@@ -644,18 +651,18 @@ func (m *ResourceModifier) addEnvironmentVariables(
 		if !hasServiceAttributes.serviceName {
 			m.addEnvVarFromLabelFieldSelector(container, envVarOTelInjectorServiceName, util.AppKubernetesIoNameLabel)
 		}
-		if !hasServiceAttributes.serviceNamespace {
-			m.conditionallyAddEnvVarFromLabelFieldSelector(
+		_, podMetaHasPartOfLabel := podMeta.Labels[util.AppKubernetesIoPartOfLabel]
+		if !hasServiceAttributes.serviceNamespace && podMetaHasPartOfLabel {
+			m.addEnvVarFromLabelFieldSelector(
 				container,
-				podMeta,
 				envVarOTelInjectorServiceNamespace,
 				util.AppKubernetesIoPartOfLabel,
 			)
 		}
-		if !hasServiceAttributes.serviceVersion {
-			m.conditionallyAddEnvVarFromLabelFieldSelector(
+		_, podMetaVersionLabel := podMeta.Labels[util.AppKubernetesIoVersionLabel]
+		if !hasServiceAttributes.serviceVersion && podMetaVersionLabel {
+			m.addEnvVarFromLabelFieldSelector(
 				container,
-				podMeta,
 				envVarOTelInjectorServiceVersionName,
 				util.AppKubernetesIoVersionLabel,
 			)
@@ -694,22 +701,31 @@ func (m *ResourceModifier) addEnvironmentVariables(
 		}
 	}
 
-	// Map annotations resource.opentelemetry.io/your-key: "your-value" to resource attributes.
+	// Last but not least, look for annotations that match the pattern "resource.opentelemetry.io/*" and turn those into
+	// resource attributes. If there are "resource.opentelemetry.io/*" annotations for service.name, service.namespace or
+	// service.version, they take priority over attributes derived from app.kubernetes.io/name etc.
+
 	resourceAttributes := map[string]string{}
-	for annotationName, annotationValue := range workloadMeta.Annotations {
-		if after, ok := strings.CutPrefix(annotationName, "resource.opentelemetry.io/"); ok {
-			resourceAttributeKey := after
-			resourceAttributes[resourceAttributeKey] = annotationValue
-		}
-	}
+	serviceAttributesFromResourcesOpenTelemetryIoAnnotation := make(map[string]string, 3)
+
+	// Map any workload annotation `resource.opentelemetry.io/some.key: "value"` to a corresponding resource attribute
+	// some.key=value.
+	m.deriveResourceAttributesFromAnnotations(
+		workloadMeta.Annotations,
+		resourceAttributes,
+		serviceAttributesFromResourcesOpenTelemetryIoAnnotation,
+	)
+
+	// Same thing as above, this time for pod annotations. That is, map any pod annotation
+	// `resource.opentelemetry.io/some.key: "value"` to a corresponding resource attribute some.key=value.
 	// By iterating over the pod annotations _after_ the workload annotations, we ensure that the pod annotations take
 	// precedence over the workload annotations.
-	for annotationName, annotationValue := range podMeta.Annotations {
-		if after, ok := strings.CutPrefix(annotationName, "resource.opentelemetry.io/"); ok {
-			resourceAttributeKey := after
-			resourceAttributes[resourceAttributeKey] = annotationValue
-		}
-	}
+	m.deriveResourceAttributesFromAnnotations(
+		podMeta.Annotations,
+		resourceAttributes,
+		serviceAttributesFromResourcesOpenTelemetryIoAnnotation,
+	)
+
 	if len(resourceAttributes) > 0 {
 		//nolint:prealloc
 		var resourceAttributeList []string
@@ -727,6 +743,34 @@ func (m *ResourceModifier) addEnvironmentVariables(
 			})
 	}
 
+	if value, ok := serviceAttributesFromResourcesOpenTelemetryIoAnnotation[serviceName]; ok && !hasServiceAttributes.serviceName {
+		addOrReplaceEnvironmentVariable(
+			container,
+			corev1.EnvVar{
+				Name:  envVarOTelInjectorServiceName,
+				Value: value,
+			},
+		)
+	}
+	if value, ok := serviceAttributesFromResourcesOpenTelemetryIoAnnotation[serviceNamespace]; ok && !hasServiceAttributes.serviceNamespace {
+		addOrReplaceEnvironmentVariable(
+			container,
+			corev1.EnvVar{
+				Name:  envVarOTelInjectorServiceNamespace,
+				Value: value,
+			},
+		)
+	}
+	if value, ok := serviceAttributesFromResourcesOpenTelemetryIoAnnotation[serviceVersion]; ok && !hasServiceAttributes.serviceVersion {
+		addOrReplaceEnvironmentVariable(
+			container,
+			corev1.EnvVar{
+				Name:  envVarOTelInjectorServiceVersionName,
+				Value: value,
+			},
+		)
+	}
+
 	if m.clusterInstrumentationConfig.InstrumentationDebug {
 		addOrReplaceEnvironmentVariable(
 			container,
@@ -739,6 +783,27 @@ func (m *ResourceModifier) addEnvironmentVariables(
 	m.migrateLegacyInjectorLogLevel(container)
 
 	return instrumentationIssues
+}
+
+func (m *ResourceModifier) deriveResourceAttributesFromAnnotations(
+	annotations map[string]string,
+	resourceAttributes map[string]string,
+	serviceAttributesFromResourcesOpenTelemetryIoAnnotation map[string]string,
+) {
+	for annotationName, annotationValue := range annotations {
+		if after, ok := strings.CutPrefix(annotationName, resourcesOpenTelemetryIoLabelPrefix); ok {
+			resourceAttributeKey := after
+			resourceAttributes[resourceAttributeKey] = annotationValue
+
+			// Check if this is one of resource.opentelemetry.io/service.name, resource.opentelemetry.io/service.namespace or
+			// resource.opentelemetry.io/service.version.
+			for _, k := range serviceAttributes {
+				if resourceAttributeKey == k {
+					serviceAttributesFromResourcesOpenTelemetryIoAnnotation[k] = annotationValue
+				}
+			}
+		}
+	}
 }
 
 func (m *ResourceModifier) prependDash0NodeIp(container *corev1.Container) {
@@ -1014,6 +1079,9 @@ func otelInjectorConfEnvVarWillBeUpdatedForAtLeastOneContainer(
 	return false
 }
 
+// checkContainerForServiceAttributes checks whether the container sets service attributes (service.name etc.) directly,
+// via OTEL_SERVICE_NAME or OTEL_RESOURCE_ATTRIBUTES. If that is the case, the respective service attribute is not
+// derived from Kubernetes labels or annotations (e.g. container environment variables win over everything else).
 func (m *ResourceModifier) checkContainerForServiceAttributes(container *corev1.Container) containerHasServiceAttributes {
 	hasServiceAttributes := containerHasServiceAttributes{}
 	otelServiceName := util.GetEnvVar(container, util.OtelServiceNameEnvVarName)
@@ -1083,17 +1151,6 @@ func replaceExistingEnvironmentVariable(container *corev1.Container, idx int, en
 	} else {
 		container.Env[idx].Value = ""
 		container.Env[idx].ValueFrom = envVar.ValueFrom
-	}
-}
-
-func (m *ResourceModifier) conditionallyAddEnvVarFromLabelFieldSelector(
-	container *corev1.Container,
-	podMeta *metav1.ObjectMeta,
-	envVarName string,
-	labelName string,
-) {
-	if _, podMetaHasLabel := podMeta.Labels[labelName]; podMetaHasLabel {
-		m.addEnvVarFromLabelFieldSelector(container, envVarName, labelName)
 	}
 }
 

--- a/internal/workloads/workload_modifier_test.go
+++ b/internal/workloads/workload_modifier_test.go
@@ -57,7 +57,7 @@ var _ = Describe("Dash0 Workload Modification", func() {
 		expectations map[string]*EnvVarExpectation
 	}
 
-	Describe("when instrumenting workloads", func() {
+	Context("when instrumenting workloads", func() {
 		It("should instrument a basic cron job", func() {
 			workload := BasicCronJob(TestNamespaceName, CronJobNamePrefix)
 			modificationResult := workloadModifier.ModifyCronJob(workload)
@@ -443,7 +443,7 @@ var _ = Describe("Dash0 Workload Modification", func() {
 		})
 	})
 
-	Describe("when instrumenting workloads multiple times (instrumentation needs to be idempotent)", func() {
+	Context("when instrumenting workloads multiple times (instrumentation needs to be idempotent)", func() {
 		It("cron job instrumentation needs to be idempotent", func() {
 			workload := BasicCronJob(TestNamespaceName, CronJobNamePrefix)
 			modificationResult := workloadModifier.ModifyCronJob(workload)
@@ -535,7 +535,7 @@ var _ = Describe("Dash0 Workload Modification", func() {
 		})
 	})
 
-	Describe("when reverting workloads", func() {
+	Context("when reverting workloads", func() {
 		It("should remove Dash0 from an instrumented cron job", func() {
 			workload := InstrumentedCronJob(TestNamespaceName, CronJobNamePrefix)
 			modificationResult := workloadModifier.RevertCronJob(workload)
@@ -640,7 +640,7 @@ var _ = Describe("Dash0 Workload Modification", func() {
 		})
 	})
 
-	Describe("individual modification functions", func() {
+	Context("individual modification functions", func() {
 		ctx := context.Background()
 		logger := logd.FromContext(ctx)
 		workloadModifier := NewResourceModifier(
@@ -1761,6 +1761,99 @@ var _ = Describe("Dash0 Workload Modification", func() {
 					envVarOTelInjectorServiceName:        {Value: "workload-name"},
 					envVarOTelInjectorServiceNamespace:   {Value: "workload-part-of"},
 					envVarOTelInjectorServiceVersionName: nil,
+				},
+			}),
+			Entry("resource.opentelemetry.io/service.name should win over app.kubernetes.io/name", objectMetaResourceAttributesTest{
+				workloadLabels: map[string]string{
+					util.AppKubernetesIoNameLabel:    "app.kubernetes.io/name-value",
+					util.AppKubernetesIoPartOfLabel:  "app.kubernetes.io/part-of-value",
+					util.AppKubernetesIoVersionLabel: "app.kubernetes.io/version-value",
+				},
+				workloadAnnotations: map[string]string{
+					"resource.opentelemetry.io/service.name": "resource.opentelemetry.io/service.name-value",
+				},
+				expectedEnvVars: map[string]*EnvVarExpectation{
+					envVarOTelInjectorServiceName:        {Value: "resource.opentelemetry.io/service.name-value"},
+					envVarOTelInjectorServiceNamespace:   {Value: "app.kubernetes.io/part-of-value"},
+					envVarOTelInjectorServiceVersionName: {Value: "app.kubernetes.io/version-value"},
+				},
+				expectedResourceAttributeEnvVar: []string{
+					"service.name=resource.opentelemetry.io/service.name-value",
+				},
+			}),
+			Entry("resource.opentelemetry.io/service.namespace should win over app.kubernetes.io/part-of", objectMetaResourceAttributesTest{
+				workloadLabels: map[string]string{
+					util.AppKubernetesIoNameLabel:    "app.kubernetes.io/name-value",
+					util.AppKubernetesIoPartOfLabel:  "app.kubernetes.io/part-of-value",
+					util.AppKubernetesIoVersionLabel: "app.kubernetes.io/version-value",
+				},
+				workloadAnnotations: map[string]string{
+					"resource.opentelemetry.io/service.namespace": "resource.opentelemetry.io/service.namespace-value",
+				},
+				expectedEnvVars: map[string]*EnvVarExpectation{
+					envVarOTelInjectorServiceName:        {Value: "app.kubernetes.io/name-value"},
+					envVarOTelInjectorServiceNamespace:   {Value: "resource.opentelemetry.io/service.namespace-value"},
+					envVarOTelInjectorServiceVersionName: {Value: "app.kubernetes.io/version-value"},
+				},
+				expectedResourceAttributeEnvVar: []string{
+					"service.namespace=resource.opentelemetry.io/service.namespace-value",
+				},
+			}),
+			Entry("resource.opentelemetry.io/service.version should win over app.kubernetes.io/version", objectMetaResourceAttributesTest{
+				workloadLabels: map[string]string{
+					util.AppKubernetesIoNameLabel:    "app.kubernetes.io/name-value",
+					util.AppKubernetesIoPartOfLabel:  "app.kubernetes.io/part-of-value",
+					util.AppKubernetesIoVersionLabel: "app.kubernetes.io/version-value",
+				},
+				workloadAnnotations: map[string]string{
+					"resource.opentelemetry.io/service.version": "resource.opentelemetry.io/service.version-value",
+				},
+				expectedEnvVars: map[string]*EnvVarExpectation{
+					envVarOTelInjectorServiceName:        {Value: "app.kubernetes.io/name-value"},
+					envVarOTelInjectorServiceNamespace:   {Value: "app.kubernetes.io/part-of-value"},
+					envVarOTelInjectorServiceVersionName: {Value: "resource.opentelemetry.io/service.version-value"},
+				},
+				expectedResourceAttributeEnvVar: []string{
+					"service.version=resource.opentelemetry.io/service.version-value",
+				},
+			}),
+			Entry("resource.opentelemetry.io/service.* should win over app.kubernetes.io/*", objectMetaResourceAttributesTest{
+				workloadLabels: map[string]string{
+					util.AppKubernetesIoNameLabel:    "app.kubernetes.io/name-value",
+					util.AppKubernetesIoPartOfLabel:  "app.kubernetes.io/part-of-value",
+					util.AppKubernetesIoVersionLabel: "app.kubernetes.io/version-value",
+				},
+				workloadAnnotations: map[string]string{
+					"resource.opentelemetry.io/service.name":      "resource.opentelemetry.io/service.name-value",
+					"resource.opentelemetry.io/service.namespace": "resource.opentelemetry.io/service.namespace-value",
+					"resource.opentelemetry.io/service.version":   "resource.opentelemetry.io/service.version-value",
+				},
+				expectedEnvVars: map[string]*EnvVarExpectation{
+					envVarOTelInjectorServiceName:        {Value: "resource.opentelemetry.io/service.name-value"},
+					envVarOTelInjectorServiceNamespace:   {Value: "resource.opentelemetry.io/service.namespace-value"},
+					envVarOTelInjectorServiceVersionName: {Value: "resource.opentelemetry.io/service.version-value"},
+				},
+				expectedResourceAttributeEnvVar: []string{
+					"service.name=resource.opentelemetry.io/service.name-value",
+					"service.namespace=resource.opentelemetry.io/service.namespace-value",
+					"service.version=resource.opentelemetry.io/service.version-value",
+				},
+			}),
+			Entry("resource.opentelemetry.io/service.* should be set independently of app.kubernetes.io/*", objectMetaResourceAttributesTest{
+				workloadAnnotations: map[string]string{
+					"resource.opentelemetry.io/service.name":      "resource.opentelemetry.io/service.name-value",
+					"resource.opentelemetry.io/service.namespace": "resource.opentelemetry.io/service.namespace-value",
+					"resource.opentelemetry.io/service.version":   "resource.opentelemetry.io/service.version-value",
+				},
+				expectedEnvVars: map[string]*EnvVarExpectation{
+					envVarOTelInjectorServiceName:        {Value: "resource.opentelemetry.io/service.name-value"},
+					envVarOTelInjectorServiceNamespace:   {Value: "resource.opentelemetry.io/service.namespace-value"},
+					envVarOTelInjectorServiceVersionName: {Value: "resource.opentelemetry.io/service.version-value"},
+				},
+				expectedResourceAttributeEnvVar: []string{
+					"service.name=resource.opentelemetry.io/service.name-value",
+					"service.namespace=resource.opentelemetry.io/service.namespace-value",
+					"service.version=resource.opentelemetry.io/service.version-value",
 				},
 			}),
 			Entry("should ignore workload labels if name is not set", objectMetaResourceAttributesTest{


### PR DESCRIPTION
Give resource.opentelemetry.io/* annotations priority over app.kubernetes.io/* labels for service.name, service.namespace, and service.version.
