### PR TITLE
ci: remove trivy

### DIFF
--- a/.github/actions/build-image/action.yaml
+++ b/.github/actions/build-image/action.yaml
@@ -5,12 +5,6 @@ inputs:
   githubToken:
     description: "github token"
     required: true
-  slackBotToken:
-    description: "slackbot token"
-    required: true
-  slackChannelId:
-    description: "slack channel id"
-    required: true
   imageName:
     description: "name of the container image (without registry prefix)"
     required: true
@@ -30,18 +24,6 @@ inputs:
     description: "path to dockerfile, defaults to ${context}/Dockerfile"
     required: false
     default: ''
-  scan:
-    description: "whether to scan the built image with Trivy"
-    required: false
-    default: 'false'
-  scanSeverity:
-    description: "severity setting for the Trivy scanner, see https://trivy.dev/docs/latest/guide/configuration/filtering/#by-severity"
-    required: false
-    default: 'UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL'
-  exitCode:
-    description: "the exit code in case a cve is found, use this setting to control whether the build should fail or not"
-    required: false
-    default: '0'
 
 runs:
   using: "composite"
@@ -103,77 +85,6 @@ runs:
         cache-to: type=gha,mode=max,scope=${{ inputs.imageName }}
         load: true
         push: false
-
-    # optionally scan the built container image with Trivy and upload the results
-    - name: run Trivy vulnerability scanner
-      if: ${{ inputs.scan == 'true' }}
-      uses: aquasecurity/trivy-action@0.35.0
-      with:
-        image-ref: '${{ steps.docker-build.outputs.imageid }}'
-        format: 'sarif'
-        output: 'trivy-results.sarif'
-        exit-code: ${{ inputs.exitCode }}
-        severity: ${{ inputs.scanSeverity }}
-        limit-severities-for-sarif: true
-
-    # The scan results are also available at https://github.com/dash0hq/dash0-operator/security/code-scanning with
-    # query "is:open pr:xyz", but having them in the build log is just also handy sometimes.
-    - name: echo sarif file
-      if: ${{ always() && inputs.scan == 'true' }}
-      shell: bash
-      run: |
-        cat trivy-results.sarif
-
-    - name: upload Trivy scan results to GitHub Security tab
-      if: ${{ always() && inputs.scan == 'true' }}
-      uses: github/codeql-action/upload-sarif@v3
-      with:
-        sarif_file: 'trivy-results.sarif'
-        category: ".github/workflows/ci.yaml:build_and_push_images/${{ inputs.imageName }}"
-
-    - name: check Trivy results for vulnerabilities
-      id: trivy-check
-      if: ${{ always() && inputs.scan == 'true' }}
-      shell: bash
-      run: |
-        if ! command -v jq &> /dev/null; then
-          echo "jq not found"
-          exit 1
-        fi
-        VULN_COUNT=$(jq '[.runs[]?.results[]?] | length' trivy-results.sarif)
-        echo "vulnerability_count=$VULN_COUNT" >> "$GITHUB_OUTPUT"
-        echo "has_vulnerabilities=$( [ "$VULN_COUNT" -gt 0 ] && echo true || echo false )" >> "$GITHUB_OUTPUT"
-
-    - name: send Slack notification in case of vulnerabilities
-      if: ${{ always() && steps.trivy-check.outputs.has_vulnerabilities == 'true' }}
-      uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a
-      with:
-        errors: true
-        method: chat.postMessage
-        token: ${{ inputs.slackBotToken }}
-        # language=YAML
-        payload: |
-          channel: ${{ inputs.slackChannelId }}
-          text: 'Trivy scan: vulnerabilities found'
-          blocks:
-            - type: header
-              text:
-                type: plain_text
-                text: ':x: Trivy scan: vulnerabilities found'
-            - type: context
-              elements:
-                - type: mrkdwn
-                  text: ':github: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Workflow run #${{ github.run_id }}>'
-                - type: mrkdwn
-                  text: ':diff: <${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}|Commit>'
-                - type: mrkdwn
-                  text: ':seedling: <${{ github.server_url }}/${{ github.repository }}/tree/${{ github.head_ref || github.ref_name }}|${{ github.head_ref || github.ref_name }}>'
-                - type: mrkdwn
-                  text: ':package: ${{ inputs.imageName }}'
-                - type: mrkdwn
-                  text: ':warning: ${{ steps.trivy-check.outputs.vulnerability_count }} CVE(s) found'
-                - type: mrkdwn
-                  text: ':mag: <${{ github.server_url }}/${{ github.repository }}/security/code-scanning?query=${{ github.event.pull_request.number && format('pr%3A{0}', github.event.pull_request.number) || format('branch%3A{0}', github.ref_name) }}+tool%3ATrivy+is%3Aopen|Scan result>'
 
     - name: push container image
       if: ${{ env.PUSH_ENABLED == 'true' }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -138,54 +138,42 @@ jobs:
         uses: ./.github/actions/build-image
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
-          slackBotToken: ${{ secrets.SLACK_BOT_TOKEN }}
-          slackChannelId: ${{ secrets.SLACK_CHANNEL_ID }}
           imageName: operator-controller
           imageTitle: Dash0 Kubernetes Operator Controller
           imageDescription: the controller for the Dash0 operator for Kubernetes
           imageUrl: https://github.com/dash0hq/dash0-operator/tree/main
           context: .
-          scan: 'true'
 
       - name: build instrumentation image
         uses: ./.github/actions/build-image
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
-          slackBotToken: ${{ secrets.SLACK_BOT_TOKEN }}
-          slackChannelId: ${{ secrets.SLACK_CHANNEL_ID }}
           imageName: instrumentation
           imageTitle: Dash0 Instrumentation
           imageDescription: contains Dash0 OpenTelemetry distributions for multiple runtimes
           imageUrl: https://github.com/dash0hq/dash0-operator/tree/main/images/instrumentation
           context: images/instrumentation
-          scan: 'true'
 
       - name: build collector image
         uses: ./.github/actions/build-image
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
-          slackBotToken: ${{ secrets.SLACK_BOT_TOKEN }}
-          slackChannelId: ${{ secrets.SLACK_CHANNEL_ID }}
           imageName: collector
           imageTitle: Dash0 Kubernetes Collector
           imageDescription: the OpenTelemetry collector for the Dash0 operator for Kubernetes
           imageUrl: https://github.com/dash0hq/dash0-operator/tree/main/images/collector
           context: images/collector
-          scan: 'true'
 
       - name: build configuration reloader image
         uses: ./.github/actions/build-image
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
-          slackBotToken: ${{ secrets.SLACK_BOT_TOKEN }}
-          slackChannelId: ${{ secrets.SLACK_CHANNEL_ID }}
           imageName: configuration-reloader
           imageTitle: Dash0 Kubernetes Configuration Reloader
           imageDescription: the configuration reloader for the Dash0 operator for Kubernetes
           imageUrl: https://github.com/dash0hq/dash0-operator/tree/main/images/configreloader
           context: images
           file: images/configreloader/Dockerfile
-          scan: 'true'
 
       - name: build filelog offset sync image
         uses: ./.github/actions/build-image
@@ -205,28 +193,22 @@ jobs:
         uses: ./.github/actions/build-image
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
-          slackBotToken: ${{ secrets.SLACK_BOT_TOKEN }}
-          slackChannelId: ${{ secrets.SLACK_CHANNEL_ID }}
           imageName: filelog-offset-volume-ownership
           imageTitle: Dash0 Kubernetes Filelog Offset Volume Ownership
           imageDescription: the filelog offset volume ownership init container for the Dash0 operator for Kubernetes
           imageUrl: https://github.com/dash0hq/dash0-operator/tree/main
           context: images
           file: images/filelogoffsetvolumeownership/Dockerfile
-          scan: 'true'
 
       - name: build target-allocator image
         uses: ./.github/actions/build-image
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
-          slackBotToken: ${{ secrets.SLACK_BOT_TOKEN }}
-          slackChannelId: ${{ secrets.SLACK_CHANNEL_ID }}
           imageName: target-allocator
           imageTitle: Dash0 OpenTelemetry Target Allocator
           imageDescription: the OpenTelemetry target-allocator for the Dash0 operator for Kubernetes
           imageUrl: https://github.com/dash0hq/dash0-operator/tree/main/images/target-allocator
           context: images/target-allocator
-          scan: 'true'
 
   e2e_tests:
     name: End-to-end Tests


### PR DESCRIPTION
Due to another security incident at Trivy, we are removing the action from our workflow.

From what is known so far, version 0.35.0 of `aquasecurity/trivy-action` (used in this repo to scan the built images) has not been compromised.