### PR TITLE
chore: add Aikido security scanner configuration

### DIFF
--- a/.aikido
+++ b/.aikido
@@ -16,6 +16,7 @@ exclude:
     # Test directories
     - /test/
     - /test-resources/
+    - /images/instrumentation/test
 
     # Vendored code (excluded in SonarCloud and golangci-lint)
     - /internal/webhooks/vendored/


### PR DESCRIPTION
Add .aikido config file with exclusions for test files, generated code, vendored dependencies, and other paths already excluded in SonarCloud and golangci-lint.