### PR TITLE
feat(chart): reduce RBAC permissions if telemetry collection is disabled

### DIFF
--- a/helm-chart/dash0-operator/templates/operator/cluster-role-bindings.yaml
+++ b/helm-chart/dash0-operator/templates/operator/cluster-role-bindings.yaml
@@ -1,35 +1,78 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ template "dash0-operator.chartName" . }}-manager-rolebinding
+  name: {{ template "dash0-operator.chartName" . }}-manager-base
   labels:
     app.kubernetes.io/name: dash0-operator
     app.kubernetes.io/component: controller
-    app.kubernetes.io/instance: role-binding
+    app.kubernetes.io/instance: cluster-role-binding-base
     {{- include "dash0-operator.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ template "dash0-operator.chartName" . }}-manager-role
+  name: {{ template "dash0-operator.chartName" . }}-manager-base
 subjects:
 - kind: ServiceAccount
   name: {{ template "dash0-operator.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ template "dash0-operator.chartName" . }}-proxy-rolebinding
+  name: {{ template "dash0-operator.chartName" . }}-manager-iac
   labels:
     app.kubernetes.io/name: dash0-operator
-    app.kubernetes.io/component: proxy
-    app.kubernetes.io/instance: role-binding
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: cluster-role-binding-iac
     {{- include "dash0-operator.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: dash0-operator-proxy-role
+  name: {{ template "dash0-operator.chartName" . }}-manager-iac
 subjects:
 - kind: ServiceAccount
   name: {{ template "dash0-operator.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
+
+---
+{{ if .Values.operator.telemetryCollectionEnabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "dash0-operator.chartName" . }}-manager-collector
+  labels:
+    app.kubernetes.io/name: dash0-operator
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: cluster-role-binding-collector
+    {{- include "dash0-operator.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "dash0-operator.chartName" . }}-manager-collector
+subjects:
+- kind: ServiceAccount
+  name: {{ template "dash0-operator.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{ end }}
+
+---
+{{ if .Values.operator.telemetryCollectionEnabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "dash0-operator.chartName" . }}-manager-instrument
+  labels:
+    app.kubernetes.io/name: dash0-operator
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: cluster-role-binding-instrument
+    {{- include "dash0-operator.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "dash0-operator.chartName" . }}-manager-instrument
+subjects:
+- kind: ServiceAccount
+  name: {{ template "dash0-operator.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{ end }}

--- a/helm-chart/dash0-operator/templates/operator/cluster-roles.yaml
+++ b/helm-chart/dash0-operator/templates/operator/cluster-roles.yaml
@@ -1,161 +1,17 @@
+{{/*
+The -manager-base cluster role holds permissions required for basic operator manager tasks.
+*/}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ template "dash0-operator.chartName" . }}-manager-role
+  name: {{ template "dash0-operator.chartName" . }}-manager-base
   labels:
     app.kubernetes.io/name: dash0-operator
     app.kubernetes.io/component: controller
-    app.kubernetes.io/instance: manager-role
+    app.kubernetes.io/instance: cluster-role-base
     {{- include "dash0-operator.labels" . | nindent 4 }}
 
 rules:
-
-# Permissions required to watch for the third-party CRD (Perses dashboards, Prometheus check rules):
-- apiGroups:
-  - apiextensions.k8s.io
-  resources:
-  - customresourcedefinitions
-  verbs:
-  - get
-  - list
-  - watch
-
-# Permissions required to instrument workloads in the apps API group:
-- apiGroups:
-  - apps
-  resources:
-  - daemonsets
-  - deployments
-  - replicasets
-  - statefulsets
-  verbs:
-  - get
-  - list
-  - patch
-  - update
-  - watch
-
-# Permissions required to instrument workloads in the batch API group:
-- apiGroups:
-  - batch
-  resources:
-  - cronjobs
-  - jobs
-  verbs:
-  - get
-  - list
-  - patch
-  - update
-  - watch
-
-# Pmrmissions required to create a Dash0 operator configuration resource:
-- apiGroups:
-  - discovery.k8s.io
-  resources:
-  - endpointslices
-  verbs:
-  - list
-
-# Permissions required to queue events to report about the operator's actions:
-- apiGroups:
-  - events.k8s.io
-  resources:
-  - events
-  verbs:
-  - create
-  - list
-  - patch
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - namespaces
-  verbs:
-  - get
-
-# Permissions for the legacy event API, required to attach dangling events to their respective involved objects:
-- apiGroups:
-    - ""
-  resources:
-    - events
-  verbs:
-    - list
-    - patch
-    - update
-
-# Permissions required to automatically restart (i.e. delete) pods when instrumenting replicasets that are not part of a
-# higher order workload (e.g. a deployment, daemonset):
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  verbs:
-  - delete
-  - get
-  - list
-
-# Permissions required to resolve the secret with the Dash0 auth token:
-- apiGroups:
-    - ""
-  resources:
-    - secrets
-  verbs:
-    - get
-    - list
-    - watch
-
-# Permissions required to watch Perses dashboard resources:
-- apiGroups:
-  - perses.dev
-  resources:
-  - persesdashboards
-  verbs:
-  - get
-  - list
-  - watch
-
-# Permissions required to watch Prometheus rule resources:
-- apiGroups:
-  - monitoring.coreos.com
-  resources:
-  - prometheusrules
-  verbs:
-  - get
-  - list
-  - watch
-
-# Permissions required to manage the Dash0 monitoring resource, its finalizers and status:
-- apiGroups:
-  - operator.dash0.com
-  resources:
-  - dash0monitorings
-  verbs:
-  - create
-  - delete
-  - deletecollection
-  - get
-  - list
-  - patch
-  - update
-  - watch
-
-# Permissions required to manage the Dash0 monitoring resource, its finalizers and status:
-- apiGroups:
-  - operator.dash0.com
-  resources:
-  - dash0monitorings/finalizers
-  verbs:
-  - update
-
-# Permissions required to manage the Dash0 monitoring resource, its finalizers and status:
-- apiGroups:
-  - operator.dash0.com
-  resources:
-  - dash0monitorings/status
-  verbs:
-  - get
-  - patch
-  - update
 
 # Permissions required to manage the Dash0 operator configuration resource, its finalizers and status:
 - apiGroups:
@@ -190,45 +46,177 @@ rules:
   - patch
   - update
 
+# Permissions required to manage the Dash0 monitoring resource, its finalizers and status:
+- apiGroups:
+  - operator.dash0.com
+  resources:
+  - dash0monitorings
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+
+# Permissions required to manage the Dash0 monitoring resource, its finalizers and status:
+- apiGroups:
+  - operator.dash0.com
+  resources:
+  - dash0monitorings/finalizers
+  verbs:
+  - update
+
+# Permissions required to manage the Dash0 monitoring resource, its finalizers and status:
+- apiGroups:
+  - operator.dash0.com
+  resources:
+  - dash0monitorings/status
+  verbs:
+  - get
+  - patch
+  - update
+
+# Permissions required to queue events to report about the operator's actions:
+- apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - list
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+
+# Permissions for the legacy event API, required to attach dangling events to their respective involved objects:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - list
+  - patch
+  - update
+
+# Permissions required to detect the container runtime:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+
+---
+{{/*
+The -manager-iac cluster role holds permissions used for IaC tasks, like synchronizing dashboards and check rules.
+*/}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "dash0-operator.chartName" . }}-manager-iac
+  labels:
+    app.kubernetes.io/name: dash0-operator
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: cluster-role-iac
+    {{- include "dash0-operator.labels" . | nindent 4 }}
+
+rules:
+
+# Permissions required to watch for the third-party CRD (Perses dashboards, Prometheus check rules):
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+
+# Permissions required to watch Perses dashboard resources:
+- apiGroups:
+  - perses.dev
+  resources:
+  - persesdashboards
+  verbs:
+  - get
+  - list
+  - watch
+
+# Permissions required to watch Prometheus rule resources:
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - prometheusrules
+  verbs:
+  - get
+  - list
+  - watch
+
 # Permissions required to watch Dash0 synthetic check resources:
 - apiGroups:
-    - operator.dash0.com
+  - operator.dash0.com
   resources:
-    - dash0syntheticchecks
+  - dash0syntheticchecks
   verbs:
-    - get
-    - list
-    - watch
+  - get
+  - list
+  - watch
 
 # Permissions required to write to Dash0 synthetic check resource status:
 - apiGroups:
-    - operator.dash0.com
+  - operator.dash0.com
   resources:
-    - dash0syntheticchecks/status
+  - dash0syntheticchecks/status
   verbs:
-    - get
-    - patch
-    - update
+  - get
+  - patch
+  - update
 
-  # Permissions required to watch Dash0 view resources:
+# Permissions required to watch Dash0 view resources:
 - apiGroups:
-    - operator.dash0.com
+  - operator.dash0.com
   resources:
-    - dash0views
+  - dash0views
   verbs:
-    - get
-    - list
-    - watch
+  - get
+  - list
+  - watch
 
-  # Permissions required to write to Dash0 view resource status:
+# Permissions required to write to Dash0 view resource status:
 - apiGroups:
-    - operator.dash0.com
+  - operator.dash0.com
   resources:
-    - dash0views/status
+  - dash0views/status
   verbs:
-    - get
-    - patch
-    - update
+  - get
+  - patch
+  - update
+
+---
+{{ if .Values.operator.telemetryCollectionEnabled }}
+{{/*
+The -manager-collector cluster role holds permissions for managing OpenTelemetry collectors and the target allocator.
+*/}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "dash0-operator.chartName" . }}-manager-collector
+  labels:
+    app.kubernetes.io/name: dash0-operator
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: cluster-role-collector
+    {{- include "dash0-operator.labels" . | nindent 4 }}
+
+rules:
 
 # Permissions required to manage OTel collector resources:
 - apiGroups:
@@ -378,6 +366,7 @@ rules:
   - get
   - list
   - watch
+
 # Permissions required due to the fact that the operator needs to create dedicated service accounts/cluster roles/
 # cluster role bindings for the OTel target-allocator and give it a set of permissions; which it can only
 # do if holds these permissions itself.
@@ -401,7 +390,7 @@ rules:
   - get
   - list
   - watch
-- apiGroups: 
+- apiGroups:
   - ""
   resources:
   - namespaces
@@ -435,45 +424,75 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
 - nonResourceURLs:
   - /metrics
   verbs:
   - get
+
+{{ end }}
+
 ---
+{{ if .Values.operator.telemetryCollectionEnabled }}
+{{/*
+The -manager-instrument cluster role holds permissions necessary for auto-instrumenting workloads.
+*/}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ template "dash0-operator.chartName" . }}-metrics-reader
+  name: {{ template "dash0-operator.chartName" . }}-manager-instrument
   labels:
     app.kubernetes.io/name: dash0-operator
     app.kubernetes.io/component: controller
-    app.kubernetes.io/instance: metrics-role
+    app.kubernetes.io/instance: cluster-role-instrument
     {{- include "dash0-operator.labels" . | nindent 4 }}
+
 rules:
-- nonResourceURLs:
-  - /metrics
+
+# Permissions required to instrument workloads in the apps API group:
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  - statefulsets
   verbs:
   - get
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: {{ template "dash0-operator.chartName" . }}-proxy-role
-  labels:
-    app.kubernetes.io/name: dash0-operator
-    app.kubernetes.io/component: controller
-    app.kubernetes.io/instance: proxy-role
-    {{- include "dash0-operator.labels" . | nindent 4 }}
-rules:
+  - list
+  - patch
+  - update
+  - watch
+
+# Permissions required to instrument workloads in the batch API group:
 - apiGroups:
-  - authentication.k8s.io
+  - batch
   resources:
-  - tokenreviews
+  - cronjobs
+  - jobs
   verbs:
-  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+
+# Permissions required to automatically restart (i.e. delete) pods when instrumenting replicasets that are not part of a
+# higher order workload (e.g. a deployment, daemonset):
 - apiGroups:
-  - authorization.k8s.io
+  - ""
   resources:
-  - subjectaccessreviews
+  - pods
   verbs:
-  - create
+  - delete
+  - get
+  - list
+
+{{ end }}

--- a/helm-chart/dash0-operator/templates/operator/role-binding.yaml
+++ b/helm-chart/dash0-operator/templates/operator/role-binding.yaml
@@ -1,17 +1,17 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ template "dash0-operator.chartName" . }}-leader-election-rolebinding
+  name: {{ template "dash0-operator.chartName" . }}-manager
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: dash0-operator
     app.kubernetes.io/component: controller
-    app.kubernetes.io/instance: leader-election-rolebinding
+    app.kubernetes.io/instance: role-binding
     {{- include "dash0-operator.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ template "dash0-operator.chartName" . }}-leader-election-role
+  name: {{ template "dash0-operator.chartName" . }}-manager
 subjects:
 - kind: ServiceAccount
   name: {{ template "dash0-operator.serviceAccountName" . }}

--- a/helm-chart/dash0-operator/templates/operator/role.yaml
+++ b/helm-chart/dash0-operator/templates/operator/role.yaml
@@ -1,14 +1,44 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ template "dash0-operator.chartName" . }}-leader-election-role
+  name: {{ template "dash0-operator.chartName" . }}-manager
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: dash0-operator
     app.kubernetes.io/component: controller
-    app.kubernetes.io/instance: leader-election-role
+    app.kubernetes.io/instance: role
     {{- include "dash0-operator.labels" . | nindent 4 }}
+
 rules:
+
+# Permissions required so the operator can look up its own deployment.
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+
+# Permissions required to create a Dash0 operator configuration resource:
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - list
+
+# Permissions required to resolve the secret with the Dash0 auth token:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+
+# Permissions required for leader election:
 - apiGroups:
   - ""
   resources:

--- a/helm-chart/dash0-operator/tests/operator/__snapshot__/cluster-role-bindings_test.yaml.snap
+++ b/helm-chart/dash0-operator/tests/operator/__snapshot__/cluster-role-bindings_test.yaml.snap
@@ -5,17 +5,17 @@ cluster role bindings should match snapshot:
     metadata:
       labels:
         app.kubernetes.io/component: controller
-        app.kubernetes.io/instance: role-binding
+        app.kubernetes.io/instance: cluster-role-binding-base
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: dash0-operator
         app.kubernetes.io/part-of: dash0-operator
         app.kubernetes.io/version: 0.0.0
         helm.sh/chart: dash0-operator-0.0.0
-      name: dash0-operator-manager-rolebinding
+      name: dash0-operator-manager-base
     roleRef:
       apiGroup: rbac.authorization.k8s.io
       kind: ClusterRole
-      name: dash0-operator-manager-role
+      name: dash0-operator-manager-base
     subjects:
       - kind: ServiceAccount
         name: dash0-operator-controller
@@ -25,18 +25,60 @@ cluster role bindings should match snapshot:
     kind: ClusterRoleBinding
     metadata:
       labels:
-        app.kubernetes.io/component: proxy
-        app.kubernetes.io/instance: role-binding
+        app.kubernetes.io/component: controller
+        app.kubernetes.io/instance: cluster-role-binding-iac
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: dash0-operator
         app.kubernetes.io/part-of: dash0-operator
         app.kubernetes.io/version: 0.0.0
         helm.sh/chart: dash0-operator-0.0.0
-      name: dash0-operator-proxy-rolebinding
+      name: dash0-operator-manager-iac
     roleRef:
       apiGroup: rbac.authorization.k8s.io
       kind: ClusterRole
-      name: dash0-operator-proxy-role
+      name: dash0-operator-manager-iac
+    subjects:
+      - kind: ServiceAccount
+        name: dash0-operator-controller
+        namespace: NAMESPACE
+  3: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      labels:
+        app.kubernetes.io/component: controller
+        app.kubernetes.io/instance: cluster-role-binding-collector
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: dash0-operator
+        app.kubernetes.io/part-of: dash0-operator
+        app.kubernetes.io/version: 0.0.0
+        helm.sh/chart: dash0-operator-0.0.0
+      name: dash0-operator-manager-collector
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: dash0-operator-manager-collector
+    subjects:
+      - kind: ServiceAccount
+        name: dash0-operator-controller
+        namespace: NAMESPACE
+  4: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      labels:
+        app.kubernetes.io/component: controller
+        app.kubernetes.io/instance: cluster-role-binding-instrument
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: dash0-operator
+        app.kubernetes.io/part-of: dash0-operator
+        app.kubernetes.io/version: 0.0.0
+        helm.sh/chart: dash0-operator-0.0.0
+      name: dash0-operator-manager-instrument
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: dash0-operator-manager-instrument
     subjects:
       - kind: ServiceAccount
         name: dash0-operator-controller

--- a/helm-chart/dash0-operator/tests/operator/__snapshot__/cluster-roles_test.yaml.snap
+++ b/helm-chart/dash0-operator/tests/operator/__snapshot__/cluster-roles_test.yaml.snap
@@ -5,107 +5,41 @@ cluster roles should match snapshot:
     metadata:
       labels:
         app.kubernetes.io/component: controller
-        app.kubernetes.io/instance: manager-role
+        app.kubernetes.io/instance: cluster-role-base
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: dash0-operator
         app.kubernetes.io/part-of: dash0-operator
         app.kubernetes.io/version: 0.0.0
         helm.sh/chart: dash0-operator-0.0.0
-      name: dash0-operator-manager-role
+      name: dash0-operator-manager-base
     rules:
       - apiGroups:
-          - apiextensions.k8s.io
+          - operator.dash0.com
         resources:
-          - customresourcedefinitions
-        verbs:
-          - get
-          - list
-          - watch
-      - apiGroups:
-          - apps
-        resources:
-          - daemonsets
-          - deployments
-          - replicasets
-          - statefulsets
-        verbs:
-          - get
-          - list
-          - patch
-          - update
-          - watch
-      - apiGroups:
-          - batch
-        resources:
-          - cronjobs
-          - jobs
-        verbs:
-          - get
-          - list
-          - patch
-          - update
-          - watch
-      - apiGroups:
-          - discovery.k8s.io
-        resources:
-          - endpointslices
-        verbs:
-          - list
-      - apiGroups:
-          - events.k8s.io
-        resources:
-          - events
+          - dash0operatorconfigurations
         verbs:
           - create
-          - list
-          - patch
-          - update
-      - apiGroups:
-          - ""
-        resources:
-          - namespaces
-        verbs:
-          - get
-      - apiGroups:
-          - ""
-        resources:
-          - events
-        verbs:
-          - list
-          - patch
-          - update
-      - apiGroups:
-          - ""
-        resources:
-          - pods
-        verbs:
           - delete
+          - deletecollection
           - get
           - list
-      - apiGroups:
-          - ""
-        resources:
-          - secrets
-        verbs:
-          - get
-          - list
+          - patch
+          - update
           - watch
       - apiGroups:
-          - perses.dev
+          - operator.dash0.com
         resources:
-          - persesdashboards
+          - dash0operatorconfigurations/finalizers
         verbs:
-          - get
-          - list
-          - watch
+          - update
       - apiGroups:
-          - monitoring.coreos.com
+          - operator.dash0.com
         resources:
-          - prometheusrules
+          - dash0operatorconfigurations/status
         verbs:
           - get
-          - list
-          - watch
+          - patch
+          - update
       - apiGroups:
           - operator.dash0.com
         resources:
@@ -134,32 +68,73 @@ cluster roles should match snapshot:
           - patch
           - update
       - apiGroups:
-          - operator.dash0.com
+          - events.k8s.io
         resources:
-          - dash0operatorconfigurations
+          - events
         verbs:
           - create
-          - delete
-          - deletecollection
-          - get
           - list
           - patch
           - update
-          - watch
       - apiGroups:
-          - operator.dash0.com
+          - ""
         resources:
-          - dash0operatorconfigurations/finalizers
-        verbs:
-          - update
-      - apiGroups:
-          - operator.dash0.com
-        resources:
-          - dash0operatorconfigurations/status
+          - namespaces
         verbs:
           - get
+      - apiGroups:
+          - ""
+        resources:
+          - events
+        verbs:
+          - list
           - patch
           - update
+      - apiGroups:
+          - ""
+        resources:
+          - nodes
+        verbs:
+          - get
+          - list
+  2: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      labels:
+        app.kubernetes.io/component: controller
+        app.kubernetes.io/instance: cluster-role-iac
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: dash0-operator
+        app.kubernetes.io/part-of: dash0-operator
+        app.kubernetes.io/version: 0.0.0
+        helm.sh/chart: dash0-operator-0.0.0
+      name: dash0-operator-manager-iac
+    rules:
+      - apiGroups:
+          - apiextensions.k8s.io
+        resources:
+          - customresourcedefinitions
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - perses.dev
+        resources:
+          - persesdashboards
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - monitoring.coreos.com
+        resources:
+          - prometheusrules
+        verbs:
+          - get
+          - list
+          - watch
       - apiGroups:
           - operator.dash0.com
         resources:
@@ -192,6 +167,20 @@ cluster roles should match snapshot:
           - get
           - patch
           - update
+  3: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      labels:
+        app.kubernetes.io/component: controller
+        app.kubernetes.io/instance: cluster-role-collector
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: dash0-operator
+        app.kubernetes.io/part-of: dash0-operator
+        app.kubernetes.io/version: 0.0.0
+        helm.sh/chart: dash0-operator-0.0.0
+      name: dash0-operator-manager-collector
+    rules:
       - apiGroups:
           - ""
         resources:
@@ -382,51 +371,61 @@ cluster roles should match snapshot:
           - get
           - list
           - watch
+      - apiGroups:
+          - ""
+        resources:
+          - secrets
+        verbs:
+          - get
+          - list
+          - watch
       - nonResourceURLs:
           - /metrics
         verbs:
           - get
-  2: |
+  4: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
       labels:
         app.kubernetes.io/component: controller
-        app.kubernetes.io/instance: metrics-role
+        app.kubernetes.io/instance: cluster-role-instrument
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: dash0-operator
         app.kubernetes.io/part-of: dash0-operator
         app.kubernetes.io/version: 0.0.0
         helm.sh/chart: dash0-operator-0.0.0
-      name: dash0-operator-metrics-reader
+      name: dash0-operator-manager-instrument
     rules:
-      - nonResourceURLs:
-          - /metrics
+      - apiGroups:
+          - apps
+        resources:
+          - daemonsets
+          - deployments
+          - replicasets
+          - statefulsets
         verbs:
           - get
-  3: |
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRole
-    metadata:
-      labels:
-        app.kubernetes.io/component: controller
-        app.kubernetes.io/instance: proxy-role
-        app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: dash0-operator
-        app.kubernetes.io/part-of: dash0-operator
-        app.kubernetes.io/version: 0.0.0
-        helm.sh/chart: dash0-operator-0.0.0
-      name: dash0-operator-proxy-role
-    rules:
+          - list
+          - patch
+          - update
+          - watch
       - apiGroups:
-          - authentication.k8s.io
+          - batch
         resources:
-          - tokenreviews
+          - cronjobs
+          - jobs
         verbs:
-          - create
+          - get
+          - list
+          - patch
+          - update
+          - watch
       - apiGroups:
-          - authorization.k8s.io
+          - ""
         resources:
-          - subjectaccessreviews
+          - pods
         verbs:
-          - create
+          - delete
+          - get
+          - list

--- a/helm-chart/dash0-operator/tests/operator/__snapshot__/role-binding_test.yaml.snap
+++ b/helm-chart/dash0-operator/tests/operator/__snapshot__/role-binding_test.yaml.snap
@@ -5,18 +5,18 @@ leader election role binding should match snapshot:
     metadata:
       labels:
         app.kubernetes.io/component: controller
-        app.kubernetes.io/instance: leader-election-rolebinding
+        app.kubernetes.io/instance: role-binding
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: dash0-operator
         app.kubernetes.io/part-of: dash0-operator
         app.kubernetes.io/version: 0.0.0
         helm.sh/chart: dash0-operator-0.0.0
-      name: dash0-operator-leader-election-rolebinding
+      name: dash0-operator-manager
       namespace: NAMESPACE
     roleRef:
       apiGroup: rbac.authorization.k8s.io
       kind: Role
-      name: dash0-operator-leader-election-role
+      name: dash0-operator-manager
     subjects:
       - kind: ServiceAccount
         name: dash0-operator-controller

--- a/helm-chart/dash0-operator/tests/operator/__snapshot__/role_test.yaml.snap
+++ b/helm-chart/dash0-operator/tests/operator/__snapshot__/role_test.yaml.snap
@@ -5,15 +5,36 @@ leader election role should match snapshot:
     metadata:
       labels:
         app.kubernetes.io/component: controller
-        app.kubernetes.io/instance: leader-election-role
+        app.kubernetes.io/instance: role
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: dash0-operator
         app.kubernetes.io/part-of: dash0-operator
         app.kubernetes.io/version: 0.0.0
         helm.sh/chart: dash0-operator-0.0.0
-      name: dash0-operator-leader-election-role
+      name: dash0-operator-manager
       namespace: NAMESPACE
     rules:
+      - apiGroups:
+          - apps
+        resources:
+          - deployments
+        verbs:
+          - get
+          - list
+      - apiGroups:
+          - discovery.k8s.io
+        resources:
+          - endpointslices
+        verbs:
+          - list
+      - apiGroups:
+          - ""
+        resources:
+          - secrets
+        verbs:
+          - get
+          - list
+          - watch
       - apiGroups:
           - ""
         resources:

--- a/helm-chart/dash0-operator/tests/operator/cluster-role-bindings_test.yaml
+++ b/helm-chart/dash0-operator/tests/operator/cluster-role-bindings_test.yaml
@@ -5,3 +5,46 @@ tests:
   - it: cluster role bindings should match snapshot
     asserts:
       - matchSnapshot: {}
+
+  - it: should bind permissions for telemetry collection if telemetry collection is enabled
+    asserts:
+    - hasDocuments:
+        count: 4
+    - containsDocument:
+        kind: ClusterRoleBinding
+        apiVersion: rbac.authorization.k8s.io/v1
+        name: dash0-operator-manager-base
+      documentIndex: 0
+    - containsDocument:
+        kind: ClusterRoleBinding
+        apiVersion: rbac.authorization.k8s.io/v1
+        name: dash0-operator-manager-iac
+      documentIndex: 1
+    - containsDocument:
+        kind: ClusterRoleBinding
+        apiVersion: rbac.authorization.k8s.io/v1
+        name: dash0-operator-manager-collector
+      documentIndex: 2
+    - containsDocument:
+        kind: ClusterRoleBinding
+        apiVersion: rbac.authorization.k8s.io/v1
+        name: dash0-operator-manager-instrument
+      documentIndex: 3
+
+  - it: should not bind permissions for telemetry collection if telemetry collection is disabled
+    set:
+      operator:
+        telemetryCollectionEnabled: false
+    asserts:
+    - hasDocuments:
+        count: 2
+    - containsDocument:
+        kind: ClusterRoleBinding
+        apiVersion: rbac.authorization.k8s.io/v1
+        name: dash0-operator-manager-base
+      documentIndex: 0
+    - containsDocument:
+        kind: ClusterRoleBinding
+        apiVersion: rbac.authorization.k8s.io/v1
+        name: dash0-operator-manager-iac
+      documentIndex: 1

--- a/helm-chart/dash0-operator/tests/operator/cluster-roles_test.yaml
+++ b/helm-chart/dash0-operator/tests/operator/cluster-roles_test.yaml
@@ -5,3 +5,46 @@ tests:
   - it: cluster roles should match snapshot
     asserts:
       - matchSnapshot: {}
+
+  - it: should grant permissions for telemetry collection if telemetry collection is enabled
+    asserts:
+      - hasDocuments:
+          count: 4
+      - containsDocument:
+          kind: ClusterRole
+          apiVersion: rbac.authorization.k8s.io/v1
+          name: dash0-operator-manager-base
+        documentIndex: 0
+      - containsDocument:
+          kind: ClusterRole
+          apiVersion: rbac.authorization.k8s.io/v1
+          name: dash0-operator-manager-iac
+        documentIndex: 1
+      - containsDocument:
+          kind: ClusterRole
+          apiVersion: rbac.authorization.k8s.io/v1
+          name: dash0-operator-manager-collector
+        documentIndex: 2
+      - containsDocument:
+          kind: ClusterRole
+          apiVersion: rbac.authorization.k8s.io/v1
+          name: dash0-operator-manager-instrument
+        documentIndex: 3
+
+  - it: should not grant permissions for telemetry collection if telemetry collection is disabled
+    set:
+      operator:
+        telemetryCollectionEnabled: false
+    asserts:
+    - hasDocuments:
+        count: 2
+    - containsDocument:
+        kind: ClusterRole
+        apiVersion: rbac.authorization.k8s.io/v1
+        name: dash0-operator-manager-base
+      documentIndex: 0
+    - containsDocument:
+        kind: ClusterRole
+        apiVersion: rbac.authorization.k8s.io/v1
+        name: dash0-operator-manager-iac
+      documentIndex: 1

--- a/internal/controller/monitoring_controller.go
+++ b/internal/controller/monitoring_controller.go
@@ -231,16 +231,19 @@ func (r *MonitoringReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	monitoringResource, requiredAction, statusUpdate :=
 		r.manageInstrumentWorkloadsChanges(monitoringResource, isFirstReconcile, logger)
 
-	if isFirstReconcile || requiredAction == util.ModificationModeInstrumentation {
-		if err = r.instrumenter.CheckSettingsAndInstrumentExistingWorkloads(ctx, monitoringResource, logger); err != nil {
-			// The error has already been logged in checkSettingsAndInstrumentExistingWorkloads
-			logger.Info("Requeuing reconcile request.")
-			return ctrl.Result{}, err
-		}
-	} else if requiredAction == util.ModificationModeUninstrumentation {
-		if err = r.instrumenter.UninstrumentWorkloadsIfAvailable(ctx, monitoringResource, logger); err != nil {
-			logger.Error(err, "Failed to uninstrument workloads, requeuing reconcile request.")
-			return ctrl.Result{}, err
+	if r.instrumenter != nil {
+		// If telemetry collection is disabled via Helm, the instrumenter is not initialized.
+		if isFirstReconcile || requiredAction == util.ModificationModeInstrumentation {
+			if err = r.instrumenter.CheckSettingsAndInstrumentExistingWorkloads(ctx, monitoringResource, logger); err != nil {
+				// The error has already been logged in checkSettingsAndInstrumentExistingWorkloads
+				logger.Info("Requeuing reconcile request.")
+				return ctrl.Result{}, err
+			}
+		} else if requiredAction == util.ModificationModeUninstrumentation {
+			if err = r.instrumenter.UninstrumentWorkloadsIfAvailable(ctx, monitoringResource, logger); err != nil {
+				logger.Error(err, "Failed to uninstrument workloads, requeuing reconcile request.")
+				return ctrl.Result{}, err
+			}
 		}
 	}
 
@@ -411,13 +414,15 @@ func (r *MonitoringReconciler) runCleanupActions(
 	monitoringResource *dash0v1beta1.Dash0Monitoring,
 	logger logd.Logger,
 ) error {
-	if err := r.instrumenter.UninstrumentWorkloadsIfAvailable(
-		ctx,
-		monitoringResource,
-		logger,
-	); err != nil {
-		logger.Error(err, "Failed to uninstrument workloads, requeuing reconcile request.")
-		return err
+	if r.instrumenter != nil {
+		if err := r.instrumenter.UninstrumentWorkloadsIfAvailable(
+			ctx,
+			monitoringResource,
+			logger,
+		); err != nil {
+			logger.Error(err, "Failed to uninstrument workloads, requeuing reconcile request.")
+			return err
+		}
 	}
 
 	for _, apiClient := range r.namespacedApiClients {
@@ -560,6 +565,11 @@ func (r *MonitoringReconciler) reconcileOpenTelemetryCollector(
 	ctx context.Context,
 	logger logd.Logger,
 ) error {
+	if r.collectorManager == nil {
+		// If telemetry collection is disabled via Helm, the collector manager is not initialized.
+		return nil
+	}
+
 	// This will look up the operator configuration resource and all monitoring resources in the cluster (including
 	// the one that has just been reconciled, hence we must only do this _after_ this resource has been updated (e.g.
 	// marked as available). Otherwise, the reconciliation of the collectors would work with an outdated state.
@@ -576,6 +586,11 @@ func (r *MonitoringReconciler) reconcileOpenTelemetryTargetAllocator(
 	ctx context.Context,
 	logger logd.Logger,
 ) error {
+	if r.targetAllocatorManager == nil {
+		// If telemetry collection is disabled via Helm, the collector manager is not initialized.
+		return nil
+	}
+
 	// This will look up the operator configuration resource and all monitoring resources in the cluster (including
 	// the one that has just been reconciled, hence we must only do this _after_ this resource has been updated (e.g.
 	// marked as available). Otherwise, the reconciliation of the collectors would work with an outdated state.

--- a/internal/controller/operator_configuration_controller.go
+++ b/internal/controller/operator_configuration_controller.go
@@ -350,6 +350,10 @@ func (r *OperatorConfigurationReconciler) reconcileOpenTelemetryCollector(
 	ctx context.Context,
 	logger logd.Logger,
 ) error {
+	if r.collectorManager == nil {
+		// If telemetry collection is disabled via Helm, the collector manager is not initialized.
+		return nil
+	}
 	if _, err := r.collectorManager.ReconcileOpenTelemetryCollector(
 		ctx,
 	); err != nil {
@@ -363,6 +367,10 @@ func (r *OperatorConfigurationReconciler) reconcileOpenTelemetryTargetAllocator(
 	ctx context.Context,
 	logger logd.Logger,
 ) error {
+	if r.targetAllocatorManager == nil {
+		// If telemetry collection is disabled via Helm, the target allocator manager is not initialized.
+		return nil
+	}
 	logger.Info("Reconciling OpenTelemetry target allocator.")
 	if _, err := r.targetAllocatorManager.ReconcileTargetAllocator(
 		ctx,

--- a/internal/startup/operator_manager_startup.go
+++ b/internal/startup/operator_manager_startup.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	crzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -846,25 +847,43 @@ func startOperatorManager(
 	delegatingZapCoreWrapper *zaputil.DelegatingZapCoreWrapper,
 	developmentMode bool,
 ) error {
-	mgr, err := ctrl.NewManager(
-		ctrl.GetConfigOrDie(), ctrl.Options{
-			Scheme: runtimeScheme,
-			Metrics: metricsserver.Options{
-				BindAddress:   cliArgs.metricsAddr,
-				SecureServing: cliArgs.secureMetrics,
-				TLSOpts:       tlsOpts,
-			},
-			WebhookServer:          webhookServer,
-			HealthProbeBindAddress: cliArgs.probeAddr,
-			LeaderElection:         cliArgs.enableLeaderElection,
-			LeaderElectionID:       "5ae7ac41.dash0.com",
-
-			// We are deliberately not setting LeaderElectionReleaseOnCancel to true, since we cannot guarantee that the
-			// operator manager will terminate immediately, we need to shut down a couple of internal components before
-			// terminating (self monitoring OTel SDK shutdown etc.).
-			LeaderElectionReleaseOnCancel: false,
+	options := ctrl.Options{
+		Scheme: runtimeScheme,
+		Metrics: metricsserver.Options{
+			BindAddress:   cliArgs.metricsAddr,
+			SecureServing: cliArgs.secureMetrics,
+			TLSOpts:       tlsOpts,
 		},
-	)
+		WebhookServer:          webhookServer,
+		HealthProbeBindAddress: cliArgs.probeAddr,
+		LeaderElection:         cliArgs.enableLeaderElection,
+		LeaderElectionID:       "5ae7ac41.dash0.com",
+
+		// We are deliberately not setting LeaderElectionReleaseOnCancel to true, since we cannot guarantee that the
+		// operator manager will terminate immediately, we need to shut down a couple of internal components before
+		// terminating (self monitoring OTel SDK shutdown etc.).
+		LeaderElectionReleaseOnCancel: false,
+	}
+
+	if !cliArgs.telemetryCollectionEnabled {
+		// If telemetry collection is disabled, we do not have the RBAC permissions to read secrects in arbitrary
+		// namespaces. As a consequence, we need to instruct controller-runtime to only list/watch secrets in the operator
+		// namespace. Otherwise, any k8sClient.Get call to fetch a secret (in particular, the Dash0 auth token secret for
+		// self-monitoring) will make controller-runtime execute a list and watch for secrets in the entire cluster, just
+		// to build its internal cache. This fails with
+		// 'User ... cannot list resource "secrets" in API group "" at the cluster scope.'
+		// if we do not have cluster-wide permissions for secrets.
+		options.Cache = cache.Options{
+			ByObject: map[client.Object]cache.ByObject{
+				&corev1.Secret{}: {
+					Namespaces: map[string]cache.Config{
+						envVars.operatorNamespace: {},
+					},
+				},
+			},
+		}
+	}
+	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), options)
 	if err != nil {
 		return fmt.Errorf("unable to create the manager: %w", err)
 	}
@@ -1002,6 +1021,10 @@ func startOperatorManager(
 		}
 	}()
 
+	if err = mgr.Add(leaderElectionAwareRunnable); err != nil {
+		return fmt.Errorf("unable to add the leader election aware runnable: %w", err)
+	}
+
 	setupLog.Info("starting manager (waiting for leader election)")
 	if err = mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 		return fmt.Errorf("unable to set up the signal handler: %w", err)
@@ -1050,31 +1073,6 @@ func startDash0Controllers(
 		return err
 	}
 
-	clusterInstrumentationConfig := util.NewClusterInstrumentationConfig(
-		images,
-		oTelCollectorBaseUrl,
-		extraConfig,
-		cliArgs.instrumentationDelays,
-		envVars.instrumentationDebug,
-		envVars.enablePythonAutoInstrumentation,
-	)
-	startupInstrumenter := instrumentation.NewInstrumenter(
-		// The k8s client will be added later, in internal/startup/instrument_at_startup.go#Start.
-		nil,
-		clientset,
-		mgr.GetEventRecorder("dash0-startup-tasks"),
-		clusterInstrumentationConfig,
-	)
-	// For consistency, we update the extra config map in the startupInstrumenter handler as well if it changes. Since
-	// this instrumenter only runs once at startup, this has no effect whatsoever.
-	extraConfigMapWatcher.AddClient(startupInstrumenter)
-	if err = mgr.Add(leaderElectionAwareRunnable); err != nil {
-		return fmt.Errorf("unable to add the leader election aware runnable: %w", err)
-	}
-	// register the instrument-at-startup task to run once this operator manager becomes leader
-	if err = mgr.Add(NewInstrumentAtStartupRunnable(mgr, startupInstrumenter)); err != nil {
-		return fmt.Errorf("unable to add instrument-at-startup task: %w", err)
-	}
 	operatorConfigurationResource := createOrUpdateAutoOperatorConfigurationResource(
 		ctx,
 		readyCheckExecuter,
@@ -1088,109 +1086,137 @@ func startDash0Controllers(
 		return fmt.Errorf("unable to add log-operator-configuration task: %w", err)
 	}
 
-	instrumenter := instrumentation.NewInstrumenter(
-		k8sClient,
-		clientset,
-		mgr.GetEventRecorder("dash0-monitoring-controller"),
-		clusterInstrumentationConfig,
-	)
-	// For consistency, we update the extra config map in the instrumenter handler as well. However, even if
-	// instrumentation related settings have been changed (e.g. operator.initContainerResources), we will not
-	// re-instrument existing workloads to update the settings. It would make no sense, since the init container
-	// only runs once at pod startup of the workload, so changing resource settings for the init container afterwards
-	// is useless.
-	extraConfigMapWatcher.AddClient(instrumenter)
-
-	pseudoClusterUid := util.ReadPseudoClusterUid(ctx, startupTasksK8sClient, setupLog)
-	collectorConfig := util.CollectorConfig{
-		Images:                                 images,
-		OperatorNamespace:                      envVars.operatorNamespace,
-		OTelCollectorNamePrefix:                envVars.oTelCollectorNamePrefix,
-		TargetAllocatorNamePrefix:              envVars.targetAllocatorNamePrefix,
-		SendBatchSize:                          envVars.sendBatchSize,
-		SendBatchMaxSize:                       envVars.sendBatchMaxSize,
-		K8sAttributesDisableReplicasetInformer: envVars.k8sAttributesDisableReplicasetInformer,
-		K8sAttributesWaitForMetadata:           envVars.k8sAttributesWaitForMetadata,
-		K8sAttributesWaitForMetadataTimeout:    envVars.k8sAttributesWaitForMetadataTimeout,
-		NodeIp:                                 envVars.nodeIp,
-		NodeName:                               envVars.nodeName,
-		PseudoClusterUid:                       pseudoClusterUid,
-		IsIPv6Cluster:                          isIPv6Cluster,
-		IsDocker:                               isDocker,
-		DisableHostPorts:                       cliArgs.disableOpenTelemetryCollectorHostPorts,
-		IsGkeAutopilot:                         cliArgs.isGkeAutopilot,
-		DevelopmentMode:                        developmentMode,
-		DebugVerbosityDetailed:                 envVars.debugVerbosityDetailed,
-		EnableProfExtension:                    envVars.enablePprofExtension,
-		CompressConfigMap:                      envVars.compressConfigMaps,
-	}
-	oTelColResourceManager := otelcolresources.NewOTelColResourceManager(
-		k8sClient,
-		mgr.GetScheme(),
-		operatorDeploymentSelfReference,
-		collectorConfig,
-	)
-	collectorManager := collectors.NewCollectorManager(
-		k8sClient,
-		clientset,
+	clusterInstrumentationConfig := util.NewClusterInstrumentationConfig(
+		images,
+		oTelCollectorBaseUrl,
 		extraConfig,
-		developmentMode,
-		oTelColResourceManager,
+		cliArgs.instrumentationDelays,
+		envVars.instrumentationDebug,
+		envVars.enablePythonAutoInstrumentation,
 	)
-	// We update the extra config map in the collectorManager when the extra config map changes, and also trigger a
-	// reconciliation of the collectors. This makes sure changed resource settings, filelog offset volumes or toleration
-	// taints are applied more or less immediately. (Noticing the changed config map can take a minute or a bit more.)
-	extraConfigMapWatcher.AddClient(collectorManager)
-
-	if !envVars.disableCollectorResourceWatches {
-		collectorReconciler := collectors.NewCollectorReconciler(
-			k8sClient,
-			collectorManager,
-			envVars.operatorNamespace,
-			envVars.oTelCollectorNamePrefix,
-		)
-		if err := collectorReconciler.SetupWithManager(mgr); err != nil {
-			return fmt.Errorf("unable to set up the collector reconciler: %w", err)
-		}
-	} else {
-		setupLog.Info(
-			"Warning: The setting operator.disableCollectorResourceWatches is true, collector resources will not be " +
-				"watched. This setting is intended for troubleshooting the OpenTelemetry collector setup.",
-		)
-	}
-
-	targetAllocatorConfig := util.TargetAllocatorConfig{
-		Images:                    images,
-		OperatorNamespace:         envVars.operatorNamespace,
-		TargetAllocatorNamePrefix: envVars.targetAllocatorNamePrefix,
-		CollectorComponent:        otelcolresources.CollectorDaemonSetServiceComponent(),
-		IsGkeAutopilot:            cliArgs.isGkeAutopilot,
-	}
-	targetallocatorResourceManager := taresources.NewTargetAllocatorResourceManager(
-		k8sClient,
-		mgr.GetScheme(),
-		operatorDeploymentSelfReference,
-		targetAllocatorConfig,
-	)
-	targetallocatorManager := targetallocator.NewTargetAllocatorManager(
-		k8sClient, clientset, extraConfig, developmentMode, targetallocatorResourceManager,
-	)
-	// We update the extra config map in the targetallocatorManager when the extra config map changes, and also trigger a
-	// reconciliation of the target-allocator.
-	extraConfigMapWatcher.AddClient(targetallocatorManager)
-	targetAllocatorReconciler := targetallocator.NewTargetAllocatorReconciler(
-		k8sClient,
-		targetallocatorManager,
-		envVars.operatorNamespace,
-		envVars.targetAllocatorNamePrefix,
-	)
-	if err := targetAllocatorReconciler.SetupWithManager(mgr); err != nil {
-		return fmt.Errorf("unable to set up the target-allocator reconciler: %w", err)
-	}
-
 	clusterUid, err := util.ReadPseudoClusterUidOrFail(ctx, startupTasksK8sClient, setupLog)
 	if err != nil {
 		return err
+	}
+
+	var instrumenter *instrumentation.Instrumenter
+	var collectorManager *collectors.CollectorManager
+	var targetallocatorManager *targetallocator.TargetAllocatorManager
+
+	if cliArgs.telemetryCollectionEnabled {
+		startupInstrumenter := instrumentation.NewInstrumenter(
+			// The k8s client will be added later, in internal/startup/instrument_at_startup.go#Start.
+			nil,
+			clientset,
+			mgr.GetEventRecorder("dash0-startup-tasks"),
+			clusterInstrumentationConfig,
+		)
+		// For consistency, we update the extra config map in the startupInstrumenter handler as well if it changes. Since
+		// this instrumenter only runs once at startup, this has no effect whatsoever.
+		extraConfigMapWatcher.AddClient(startupInstrumenter)
+		// register the instrument-at-startup task to run once this operator manager becomes leader
+		if err = mgr.Add(NewInstrumentAtStartupRunnable(mgr, startupInstrumenter)); err != nil {
+			return fmt.Errorf("unable to add instrument-at-startup task: %w", err)
+		}
+
+		instrumenter = instrumentation.NewInstrumenter(
+			k8sClient,
+			clientset,
+			mgr.GetEventRecorder("dash0-monitoring-controller"),
+			clusterInstrumentationConfig,
+		)
+		// For consistency, we update the extra config map in the instrumenter handler as well. However, even if
+		// instrumentation related settings have been changed (e.g. operator.initContainerResources), we will not
+		// re-instrument existing workloads to update the settings. It would make no sense, since the init container
+		// only runs once at pod startup of the workload, so changing resource settings for the init container afterwards
+		// is useless.
+		extraConfigMapWatcher.AddClient(instrumenter)
+
+		collectorConfig := util.CollectorConfig{
+			Images:                                 images,
+			OperatorNamespace:                      envVars.operatorNamespace,
+			OTelCollectorNamePrefix:                envVars.oTelCollectorNamePrefix,
+			TargetAllocatorNamePrefix:              envVars.targetAllocatorNamePrefix,
+			SendBatchSize:                          envVars.sendBatchSize,
+			SendBatchMaxSize:                       envVars.sendBatchMaxSize,
+			K8sAttributesDisableReplicasetInformer: envVars.k8sAttributesDisableReplicasetInformer,
+			K8sAttributesWaitForMetadata:           envVars.k8sAttributesWaitForMetadata,
+			K8sAttributesWaitForMetadataTimeout:    envVars.k8sAttributesWaitForMetadataTimeout,
+			NodeIp:                                 envVars.nodeIp,
+			NodeName:                               envVars.nodeName,
+			PseudoClusterUid:                       clusterUid,
+			IsIPv6Cluster:                          isIPv6Cluster,
+			IsDocker:                               isDocker,
+			DisableHostPorts:                       cliArgs.disableOpenTelemetryCollectorHostPorts,
+			IsGkeAutopilot:                         cliArgs.isGkeAutopilot,
+			DevelopmentMode:                        developmentMode,
+			DebugVerbosityDetailed:                 envVars.debugVerbosityDetailed,
+			EnableProfExtension:                    envVars.enablePprofExtension,
+			CompressConfigMap:                      envVars.compressConfigMaps,
+		}
+		oTelColResourceManager := otelcolresources.NewOTelColResourceManager(
+			k8sClient,
+			mgr.GetScheme(),
+			operatorDeploymentSelfReference,
+			collectorConfig,
+		)
+		collectorManager = collectors.NewCollectorManager(
+			k8sClient,
+			clientset,
+			extraConfig,
+			developmentMode,
+			oTelColResourceManager,
+		)
+		// We update the extra config map in the collectorManager when the extra config map changes, and also trigger a
+		// reconciliation of the collectors. This makes sure changed resource settings, filelog offset volumes or toleration
+		// taints are applied more or less immediately. (Noticing the changed config map can take a minute or a bit more.)
+		extraConfigMapWatcher.AddClient(collectorManager)
+
+		if !envVars.disableCollectorResourceWatches {
+			collectorReconciler := collectors.NewCollectorReconciler(
+				k8sClient,
+				collectorManager,
+				envVars.operatorNamespace,
+				envVars.oTelCollectorNamePrefix,
+			)
+			if err := collectorReconciler.SetupWithManager(mgr); err != nil {
+				return fmt.Errorf("unable to set up the collector reconciler: %w", err)
+			}
+		} else {
+			setupLog.Info(
+				"Warning: The setting operator.disableCollectorResourceWatches is true, collector resources will not be " +
+					"watched. This setting is intended for troubleshooting the OpenTelemetry collector setup.",
+			)
+		}
+
+		targetAllocatorConfig := util.TargetAllocatorConfig{
+			Images:                    images,
+			OperatorNamespace:         envVars.operatorNamespace,
+			TargetAllocatorNamePrefix: envVars.targetAllocatorNamePrefix,
+			CollectorComponent:        otelcolresources.CollectorDaemonSetServiceComponent(),
+			IsGkeAutopilot:            cliArgs.isGkeAutopilot,
+		}
+		targetallocatorResourceManager := taresources.NewTargetAllocatorResourceManager(
+			k8sClient,
+			mgr.GetScheme(),
+			operatorDeploymentSelfReference,
+			targetAllocatorConfig,
+		)
+		targetallocatorManager = targetallocator.NewTargetAllocatorManager(
+			k8sClient, clientset, extraConfig, developmentMode, targetallocatorResourceManager,
+		)
+		// We update the extra config map in the targetallocatorManager when the extra config map changes, and also trigger a
+		// reconciliation of the target-allocator.
+		extraConfigMapWatcher.AddClient(targetallocatorManager)
+		targetAllocatorReconciler := targetallocator.NewTargetAllocatorReconciler(
+			k8sClient,
+			targetallocatorManager,
+			envVars.operatorNamespace,
+			envVars.targetAllocatorNamePrefix,
+		)
+		if err := targetAllocatorReconciler.SetupWithManager(mgr); err != nil {
+			return fmt.Errorf("unable to set up the target-allocator reconciler: %w", err)
+		}
 	}
 
 	syntheticCheckReconciler := controller.NewSyntheticCheckReconciler(
@@ -1259,7 +1285,7 @@ func startDash0Controllers(
 		},
 		collectorManager,
 		targetallocatorManager,
-		pseudoClusterUid,
+		clusterUid,
 		operatorDeploymentSelfReference.Namespace,
 		operatorDeploymentSelfReference.UID,
 		operatorDeploymentSelfReference.Name,
@@ -1296,31 +1322,34 @@ func startDash0Controllers(
 	}
 	setupLog.Info("The monitoring resource reconciler has been started.")
 
-	setupLog.Info("Creating the auto-namespace-monitoring reconciler.")
-	autoNamespaceMonitoringReconciler := controller.NewAutoNamespaceMonitoringReconciler(
-		k8sClient,
-		envVars.operatorNamespace,
-	)
-	setupLog.Info("Starting the auto-namespace-monitoring reconciler.")
-	if err := autoNamespaceMonitoringReconciler.SetupWithManager(mgr); err != nil {
-		return fmt.Errorf("unable to set up the auto-namespace-monitoring reconciler: %w", err)
-	}
-	setupLog.Info("The auto-namespace-monitoring reconciler has been started.")
+	var autoNamespaceMonitoringReconciler *controller.AutoNamespaceMonitoringReconciler
+	if cliArgs.telemetryCollectionEnabled {
+		setupLog.Info("Creating the auto-namespace-monitoring reconciler.")
+		autoNamespaceMonitoringReconciler = controller.NewAutoNamespaceMonitoringReconciler(
+			k8sClient,
+			envVars.operatorNamespace,
+		)
+		setupLog.Info("Starting the auto-namespace-monitoring reconciler.")
+		if err := autoNamespaceMonitoringReconciler.SetupWithManager(mgr); err != nil {
+			return fmt.Errorf("unable to set up the auto-namespace-monitoring reconciler: %w", err)
+		}
+		setupLog.Info("The auto-namespace-monitoring reconciler has been started.")
 
-	instrumentationWebhookHandler := webhooks.NewInstrumentationWebhookHandler(
-		k8sClient,
-		mgr.GetEventRecorder("dash0-instrumentation-webhook"),
-		clusterInstrumentationConfig,
-	)
-	if err := instrumentationWebhookHandler.SetupWebhookWithManager(mgr); err != nil {
-		return fmt.Errorf("unable to create the instrumentation webhook: %w", err)
+		instrumentationWebhookHandler := webhooks.NewInstrumentationWebhookHandler(
+			k8sClient,
+			mgr.GetEventRecorder("dash0-instrumentation-webhook"),
+			clusterInstrumentationConfig,
+		)
+		if err := instrumentationWebhookHandler.SetupWebhookWithManager(mgr); err != nil {
+			return fmt.Errorf("unable to create the instrumentation webhook: %w", err)
+		}
+		// For consistency, we update the extra config map in the instrumentation webhook handler as well.
+		// In case instrumentation-related settings have been changed (e.g., operator.initContainerResources), _new_
+		// workloads will be instrumented with the updated settings. Existing and already instrumented workloads will not
+		// be reinstrumented, and even if they are changed, the instrumentation webhook will not apply the new settings
+		// due to the HasBeenInstrumentedSuccessfullyByThisVersion check.
+		extraConfigMapWatcher.AddClient(instrumentationWebhookHandler)
 	}
-	// For consistency, we update the extra config map in the instrumentation webhook handler as well.
-	// In case instrumentation-related settings have been changed (e.g., operator.initContainerResources), _new_
-	// workloads will be instrumented with the updated settings. Existing and already instrumented workloads will not
-	// be reinstrumented, and even if they are changed, the instrumentation webhook will not apply the new settings
-	// due to the HasBeenInstrumentedSuccessfullyByThisVersion check.
-	extraConfigMapWatcher.AddClient(instrumentationWebhookHandler)
 
 	if err := webhooks.NewOperatorConfigurationMutatingWebhookHandler(k8sClient).SetupWebhookWithManager(mgr); err != nil {
 		return fmt.Errorf("unable to create the operator configuration mutating webhook: %w", err)
@@ -1341,17 +1370,18 @@ func startDash0Controllers(
 		return fmt.Errorf("unable to create the monitoring conversion webhook: %w", err)
 	}
 
-	oTelSdkStarter.WaitForOTelConfig(
-		[]selfmonitoringapiaccess.SelfMonitoringMetricsClient{
-			operatorConfigurationReconciler,
-			monitoringReconciler,
-			syntheticCheckReconciler,
-			viewReconciler,
-			persesDashboardCrdReconciler,
-			prometheusRuleCrdReconciler,
-			autoNamespaceMonitoringReconciler,
-		},
-	)
+	selfMonitoringClients := []selfmonitoringapiaccess.SelfMonitoringMetricsClient{
+		operatorConfigurationReconciler,
+		monitoringReconciler,
+		syntheticCheckReconciler,
+		viewReconciler,
+		persesDashboardCrdReconciler,
+		prometheusRuleCrdReconciler,
+	}
+	if autoNamespaceMonitoringReconciler != nil {
+		selfMonitoringClients = append(selfMonitoringClients, autoNamespaceMonitoringReconciler)
+	}
+	oTelSdkStarter.WaitForOTelConfig(selfMonitoringClients)
 
 	triggerSecretRefExchangeAndStartSelfMonitoringIfPossible(
 		ctx,
@@ -1359,7 +1389,7 @@ func startDash0Controllers(
 		envVars.operatorNamespace,
 		oTelSdkStarter,
 		operatorConfigurationResource,
-		pseudoClusterUid,
+		clusterUid,
 		images.GetOperatorVersion(),
 		developmentMode,
 	)

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1511,6 +1511,16 @@ trace_statements:
 
 				waitForAutoOperatorConfigurationResourceToBecomeAvailable()
 
+				// Deploy a monitoring resource for the sole purpose of verifying that it can be deployed successfully and
+				// becomes ready.
+				deployDash0MonitoringResourceWithRetry(
+					applicationUnderTestNamespace,
+					dash0MonitoringValues{
+						InstrumentWorkloadsMode: dash0common.InstrumentWorkloadsModeNone,
+					},
+					operatorNamespace,
+				)
+
 				By("verifying that all telemetry-collection-related settings are disabled")
 				Eventually(func(g Gomega) {
 					operatorConfiguration := loadOperatorConfigurationResource(g, util.OperatorConfigurationAutoResourceName)


### PR DESCRIPTION
If telemetry collection is disabled via Helm chart values, only a reduced set of permissions will be set up by the operator Helm chart. RBAC permissions that are only required to manage collectors, the target allocator, or to auto-instrument workloads are not granted. This enables using the operator for IaC purposes (manage dashboards, check rules, synthetic checks and views via the operator) without granting the operator permissions that are not required for this use case.