### PR TITLE
fix(chart): align cli param for telemetry-collection with GKE allowlist

### DIFF
--- a/helm-chart/dash0-operator/templates/operator/deployment-and-webhooks.yaml
+++ b/helm-chart/dash0-operator/templates/operator/deployment-and-webhooks.yaml
@@ -162,7 +162,7 @@ spec:
         - --operator-configuration-auto-monitor-namespaces-enabled={{ .Values.operator.autoMonitorNamespaces.enabled }}
         - --operator-configuration-auto-monitor-namespaces-label-selector={{ .Values.operator.autoMonitorNamespaces.labelSelector }}
 {{- end }}{{/*closes "if .Values.operator.dash0Export.enabled" */}}
-        - --telemetry-collection-enabled={{ .Values.operator.telemetryCollectionEnabled }}
+        - --operator-configuration-telemetry-collection-enabled={{ .Values.operator.telemetryCollectionEnabled }}
         - --force-use-otel-collector-service-url={{ .Values.operator.collectors.forceUseServiceUrl }}
         - --gke-autopilot={{ .Values.operator.gke.autopilot.enabled }}
         - --disable-otel-collector-host-ports={{ .Values.operator.collectors.disableHostPorts }}

--- a/helm-chart/dash0-operator/tests/operator/__snapshot__/deployment-and-webhooks_test.yaml.snap
+++ b/helm-chart/dash0-operator/tests/operator/__snapshot__/deployment-and-webhooks_test.yaml.snap
@@ -48,7 +48,7 @@ deployment should match snapshot (default values):
                 - --health-probe-bind-address=:8081
                 - --metrics-bind-address=127.0.0.1:8080
                 - --leader-elect
-                - --telemetry-collection-enabled=true
+                - --operator-configuration-telemetry-collection-enabled=true
                 - --force-use-otel-collector-service-url=false
                 - --gke-autopilot=false
                 - --disable-otel-collector-host-ports=false
@@ -209,7 +209,7 @@ deployment should match snapshot when using cert-manager:
                 - --health-probe-bind-address=:8081
                 - --metrics-bind-address=127.0.0.1:8080
                 - --leader-elect
-                - --telemetry-collection-enabled=true
+                - --operator-configuration-telemetry-collection-enabled=true
                 - --force-use-otel-collector-service-url=false
                 - --gke-autopilot=false
                 - --disable-otel-collector-host-ports=false

--- a/helm-chart/dash0-operator/tests/operator/deployment-and-webhooks_test.yaml
+++ b/helm-chart/dash0-operator/tests/operator/deployment-and-webhooks_test.yaml
@@ -364,7 +364,7 @@ tests:
           value: --leader-elect
       - equal:
           path: spec.template.spec.containers[0].args[3]
-          value: --telemetry-collection-enabled=true
+          value: --operator-configuration-telemetry-collection-enabled=true
       - equal:
           path: spec.template.spec.containers[0].args[4]
           value: --force-use-otel-collector-service-url=true
@@ -972,7 +972,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].args[3]
-          value: --telemetry-collection-enabled=false
+          value: --operator-configuration-telemetry-collection-enabled=false
 
   - it: should render the "dash0.com/cert-digest" label
     documentSelector:

--- a/internal/startup/operator_manager_startup.go
+++ b/internal/startup/operator_manager_startup.go
@@ -495,7 +495,7 @@ func defineCommandLineArguments() *commandLineArguments {
 	)
 	flag.BoolVar(
 		&cliArgs.telemetryCollectionEnabled,
-		"telemetry-collection-enabled",
+		"operator-configuration-telemetry-collection-enabled",
 		true,
 		"The value for telemetryCollection.enabled on the operator configuration resource.",
 	)


### PR DESCRIPTION
The new command line parameter for the operator manager process --telemetry-collection-enabled=true/false does not match the current GKE Autopilot workload allowlist, hence we need to choose a parameter name that matches the currently published workload allowlist.

The most sensible workaround for now is to prefix the new parameter with --operator-configuration-, even though the new paramater does not only influence the auto-created operator configuration resource. (The allowlist has a pattern matcher for `^--operator-configuration-.*=.*$`)