### PR TITLE
fix(self-monitoring): do not discard self-monitoring metrics in filter

### DIFF
--- a/internal/collectors/otelcolresources/collector_config_maps.go
+++ b/internal/collectors/otelcolresources/collector_config_maps.go
@@ -225,8 +225,7 @@ func assembleCollectorConfigMap(
 	}
 	namespaceOttlFilter := renderOttlNamespaceFilter(
 		monitoredNamespaces,
-		config.SelfMonitoringConfiguration.SelfMonitoringEnabled,
-		config.PrometheusCrdSupportEnabled,
+		config,
 	)
 	customTelemetryFilters := aggregateCustomFilters(filters)
 	customTelemetryTransforms := aggregateCustomTransforms(transforms)
@@ -317,20 +316,47 @@ func compressContent(collectorConfiguration string) (bytes.Buffer, error) {
 	return compressedConfig, nil
 }
 
-func renderOttlNamespaceFilter(monitoredNamespaces []string, selfMonitoringEnabled bool, prometheusCrdSupportEnabled bool) string {
+func renderOttlNamespaceFilter(
+	monitoredNamespaces []string,
+	config *oTelColConfig,
+) string {
+	selfMonitoringEnabled := config.SelfMonitoringConfiguration.SelfMonitoringEnabled
+
+	// Do not drop metrics from the operator manager or the collectors, even if there isn't a Dash0Monitoring resource in
+	// the operator namespace. Operator manager metrics are considered self-monitoring and therefore controlled via the
+	// global SelfMonitoring config from the Dash0OperatorConfiguration.
+	operatorManagerExclusion := ""
+	if selfMonitoringEnabled && config.OperatorManagerDeploymentName != "" {
+		operatorManagerExclusion = fmt.Sprintf(
+			"(resource.attributes[\"k8s.deployment.name\"] != \"%[2]s\" or "+
+				"resource.attributes[\"k8s.namespace.name\"] != \"%[1]s\") and\n          "+
+				"(resource.attributes[\"k8s.daemonset.name\"] != \"%[3]s\" or "+
+				"resource.attributes[\"k8s.namespace.name\"] != \"%[1]s\") and\n          "+
+				"(resource.attributes[\"k8s.deployment.name\"] != \"%[4]s\" or "+
+				"resource.attributes[\"k8s.namespace.name\"] != \"%[1]s\") and\n          ",
+			config.OperatorNamespace,
+			config.OperatorManagerDeploymentName,
+			DaemonSetName(config.NamePrefix),
+			DeploymentName(config.NamePrefix),
+		)
+	}
 	// Do not drop metrics from the target-allocator even if there isn't a Dash0Monitoring resource in the namespace.
 	// target-allocator metrics are considered self-monitoring and therefore controlled via the global SelfMonitoring
 	// config (and prometheusCrdSupportEnabled) from the Dash0OperatorConfiguration.
 	taExclusion := ""
-	if selfMonitoringEnabled && prometheusCrdSupportEnabled {
-		taExclusion = fmt.Sprintf(
-			"(resource.attributes[\"k8s.pod.label.app.kubernetes.io/instance\"] != \"%s\" and "+
-				"resource.attributes[\"k8s.pod.label.app.kubernetes.io/name\"] != \"%s\") and ",
-			taresources.AppKubernetesIoInstanceValue, taresources.AppKubernetesIoNameValue)
+	if selfMonitoringEnabled && config.PrometheusCrdSupportEnabled {
+		taDeploymentName := taresources.DeploymentName(config.TargetAllocatorNamePrefix)
+		taExclusion = fmt.Sprintf("(resource.attributes[\"k8s.deployment.name\"] != \"%s\" or "+
+			"resource.attributes[\"k8s.namespace.name\"] != \"%s\") and\n          ",
+			taDeploymentName,
+			config.OperatorNamespace,
+		)
 	}
+	selfMonitoringExclusions := operatorManagerExclusion + taExclusion
+
 	// Drop all metrics that have a namespace resource attribute but are from a namespace that is not in the
 	// list of monitored namespaces.
-	namespaceOttlFilter := fmt.Sprintf("%sresource.attributes[\"k8s.namespace.name\"] != nil\n", taExclusion)
+	namespaceOttlFilter := fmt.Sprintf("%sresource.attributes[\"k8s.namespace.name\"] != nil\n", selfMonitoringExclusions)
 	for _, namespace := range monitoredNamespaces {
 		// Be wary of indentation, all lines after the first must start with at least 10 spaces for YAML compliance.
 		namespaceOttlFilter = namespaceOttlFilter +

--- a/internal/collectors/otelcolresources/collector_config_maps_test.go
+++ b/internal/collectors/otelcolresources/collector_config_maps_test.go
@@ -4,10 +4,15 @@
 package otelcolresources
 
 import (
+	"context"
 	"fmt"
 	"maps"
 	"slices"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlmetric"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/ptr"
 
@@ -20,6 +25,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	. "github.com/dash0hq/dash0-operator/test/util"
+	. "github.com/dash0hq/dash0-operator/test/util/targetallocator"
 )
 
 type configMapType string
@@ -2263,17 +2269,27 @@ var _ = Describe("The OpenTelemetry Collector ConfigMaps", func() {
 	Describe("discard metrics from unmonitored namespaces", func() {
 
 		type ottlFilterExpressionTestConfig struct {
-			monitoredNamespaces         []string
-			selfMonitoringEnabled       bool
-			prometheusCrdSupportEnabled bool
-			expectedExpression          string
+			monitoredNamespaces           []string
+			selfMonitoringEnabled         bool
+			prometheusCrdSupportEnabled   bool
+			operatorManagerDeploymentName string
+			expectedExpression            string
 		}
 
-		DescribeTable("should render the namespace filter ottl expression", func(testConfig ottlFilterExpressionTestConfig) {
+		DescribeTable("should render the namespace filter ottl expression correctly", func(testConfig ottlFilterExpressionTestConfig) {
+			colConfig := &oTelColConfig{
+				OperatorNamespace:             OperatorNamespace,
+				NamePrefix:                    namePrefix,
+				OperatorManagerDeploymentName: testConfig.operatorManagerDeploymentName,
+				SelfMonitoringConfiguration: selfmonitoringapiaccess.SelfMonitoringConfiguration{
+					SelfMonitoringEnabled: testConfig.selfMonitoringEnabled,
+				},
+				PrometheusCrdSupportEnabled: testConfig.prometheusCrdSupportEnabled,
+				TargetAllocatorNamePrefix:   TargetAllocatorPrefixTest,
+			}
 			expression := renderOttlNamespaceFilter(
 				testConfig.monitoredNamespaces,
-				testConfig.selfMonitoringEnabled,
-				testConfig.prometheusCrdSupportEnabled,
+				colConfig,
 			)
 			Expect(expression).To(Equal(testConfig.expectedExpression))
 		},
@@ -2303,33 +2319,319 @@ var _ = Describe("The OpenTelemetry Collector ConfigMaps", func() {
 					"          and resource.attributes[\"k8s.namespace.name\"] != \"namespace-2\"\n" +
 					"          and resource.attributes[\"k8s.namespace.name\"] != \"namespace-3\"\n",
 			}),
-			Entry("with no namespaces and self-monitoring enabled", ottlFilterExpressionTestConfig{
-				monitoredNamespaces:         nil,
-				selfMonitoringEnabled:       true,
-				prometheusCrdSupportEnabled: true,
-				expectedExpression: "(resource.attributes[\"k8s.pod.label.app.kubernetes.io/instance\"] != \"dash0-operator\" " +
-					"and resource.attributes[\"k8s.pod.label.app.kubernetes.io/name\"] != \"opentelemetry-target-allocator\") " +
-					"and resource.attributes[\"k8s.namespace.name\"] != nil\n",
+			Entry("with no namespaces, self-monitoring enabled, Prometheus CRD support disabled", ottlFilterExpressionTestConfig{
+				monitoredNamespaces:           nil,
+				selfMonitoringEnabled:         true,
+				prometheusCrdSupportEnabled:   false,
+				operatorManagerDeploymentName: OperatorManagerDeploymentName,
+				expectedExpression: "(resource.attributes[\"k8s.deployment.name\"] != \"" + OperatorManagerDeploymentName + "\" or " +
+					"resource.attributes[\"k8s.namespace.name\"] != \"" + OperatorNamespace + "\") and\n" +
+					"          (resource.attributes[\"k8s.daemonset.name\"] != \"" + ExpectedDaemonSetName + "\" or " +
+					"resource.attributes[\"k8s.namespace.name\"] != \"" + OperatorNamespace + "\") and\n" +
+					"          (resource.attributes[\"k8s.deployment.name\"] != \"" + ExpectedDeploymentName + "\" or " +
+					"resource.attributes[\"k8s.namespace.name\"] != \"" + OperatorNamespace + "\") and\n" +
+					"          resource.attributes[\"k8s.namespace.name\"] != nil\n",
 			}),
-			Entry("with one namespace and self-monitoring enabled", ottlFilterExpressionTestConfig{
-				monitoredNamespaces:         []string{namespace1},
-				selfMonitoringEnabled:       true,
-				prometheusCrdSupportEnabled: true,
-				expectedExpression: "(resource.attributes[\"k8s.pod.label.app.kubernetes.io/instance\"] != \"dash0-operator\" " +
-					"and resource.attributes[\"k8s.pod.label.app.kubernetes.io/name\"] != \"opentelemetry-target-allocator\") " +
-					"and resource.attributes[\"k8s.namespace.name\"] != nil\n" +
+			Entry("with one namespace, self-monitoring enabled, Prometheus CRD support disabled", ottlFilterExpressionTestConfig{
+				monitoredNamespaces:           []string{namespace1},
+				selfMonitoringEnabled:         true,
+				prometheusCrdSupportEnabled:   false,
+				operatorManagerDeploymentName: OperatorManagerDeploymentName,
+				expectedExpression: "(resource.attributes[\"k8s.deployment.name\"] != \"" + OperatorManagerDeploymentName + "\" or " +
+					"resource.attributes[\"k8s.namespace.name\"] != \"" + OperatorNamespace + "\") and\n" +
+					"          (resource.attributes[\"k8s.daemonset.name\"] != \"" + ExpectedDaemonSetName + "\" or " +
+					"resource.attributes[\"k8s.namespace.name\"] != \"" + OperatorNamespace + "\") and\n" +
+					"          (resource.attributes[\"k8s.deployment.name\"] != \"" + ExpectedDeploymentName + "\" or " +
+					"resource.attributes[\"k8s.namespace.name\"] != \"" + OperatorNamespace + "\") and\n" +
+					"          resource.attributes[\"k8s.namespace.name\"] != nil\n" +
 					"          and resource.attributes[\"k8s.namespace.name\"] != \"namespace-1\"\n",
 			}),
-			Entry("with two namespaces and self-monitoring enabled", ottlFilterExpressionTestConfig{
-				monitoredNamespaces:         []string{namespace1, namespace2},
-				selfMonitoringEnabled:       true,
-				prometheusCrdSupportEnabled: true,
-				expectedExpression: "(resource.attributes[\"k8s.pod.label.app.kubernetes.io/instance\"] != \"dash0-operator\" " +
-					"and resource.attributes[\"k8s.pod.label.app.kubernetes.io/name\"] != \"opentelemetry-target-allocator\") " +
-					"and resource.attributes[\"k8s.namespace.name\"] != nil\n" +
+			Entry("with two namespaces, self-monitoring enabled, Prometheus CRD support disabled", ottlFilterExpressionTestConfig{
+				monitoredNamespaces:           []string{namespace1, namespace2},
+				selfMonitoringEnabled:         true,
+				prometheusCrdSupportEnabled:   false,
+				operatorManagerDeploymentName: OperatorManagerDeploymentName,
+				expectedExpression: "(resource.attributes[\"k8s.deployment.name\"] != \"" + OperatorManagerDeploymentName + "\" or " +
+					"resource.attributes[\"k8s.namespace.name\"] != \"" + OperatorNamespace + "\") and\n" +
+					"          (resource.attributes[\"k8s.daemonset.name\"] != \"" + ExpectedDaemonSetName + "\" or " +
+					"resource.attributes[\"k8s.namespace.name\"] != \"" + OperatorNamespace + "\") and\n" +
+					"          (resource.attributes[\"k8s.deployment.name\"] != \"" + ExpectedDeploymentName + "\" or " +
+					"resource.attributes[\"k8s.namespace.name\"] != \"" + OperatorNamespace + "\") and\n" +
+					"          resource.attributes[\"k8s.namespace.name\"] != nil\n" +
 					"          and resource.attributes[\"k8s.namespace.name\"] != \"namespace-1\"\n" +
 					"          and resource.attributes[\"k8s.namespace.name\"] != \"namespace-2\"\n",
 			}),
+			Entry("with no namespaces, self-monitoring enabled, Prometheus CRD support enabled", ottlFilterExpressionTestConfig{
+				monitoredNamespaces:           nil,
+				selfMonitoringEnabled:         true,
+				prometheusCrdSupportEnabled:   true,
+				operatorManagerDeploymentName: OperatorManagerDeploymentName,
+				expectedExpression: "(resource.attributes[\"k8s.deployment.name\"] != \"" + OperatorManagerDeploymentName + "\" or " +
+					"resource.attributes[\"k8s.namespace.name\"] != \"" + OperatorNamespace + "\") and\n" +
+					"          (resource.attributes[\"k8s.daemonset.name\"] != \"" + ExpectedDaemonSetName + "\" or " +
+					"resource.attributes[\"k8s.namespace.name\"] != \"" + OperatorNamespace + "\") and\n" +
+					"          (resource.attributes[\"k8s.deployment.name\"] != \"" + ExpectedDeploymentName + "\" or " +
+					"resource.attributes[\"k8s.namespace.name\"] != \"" + OperatorNamespace + "\") and\n" +
+					"          (resource.attributes[\"k8s.deployment.name\"] != \"" + ExpectedTargetAllocatorDeploymentName + "\" or " +
+					"resource.attributes[\"k8s.namespace.name\"] != \"" + OperatorNamespace + "\") and\n" +
+					"          resource.attributes[\"k8s.namespace.name\"] != nil\n",
+			}),
+			Entry("with one namespace, self-monitoring enabled, Prometheus CRD support enabled", ottlFilterExpressionTestConfig{
+				monitoredNamespaces:           []string{namespace1},
+				selfMonitoringEnabled:         true,
+				prometheusCrdSupportEnabled:   true,
+				operatorManagerDeploymentName: OperatorManagerDeploymentName,
+				expectedExpression: "(resource.attributes[\"k8s.deployment.name\"] != \"" + OperatorManagerDeploymentName + "\" or " +
+					"resource.attributes[\"k8s.namespace.name\"] != \"" + OperatorNamespace + "\") and\n" +
+					"          (resource.attributes[\"k8s.daemonset.name\"] != \"" + ExpectedDaemonSetName + "\" or " +
+					"resource.attributes[\"k8s.namespace.name\"] != \"" + OperatorNamespace + "\") and\n" +
+					"          (resource.attributes[\"k8s.deployment.name\"] != \"" + ExpectedDeploymentName + "\" or " +
+					"resource.attributes[\"k8s.namespace.name\"] != \"" + OperatorNamespace + "\") and\n" +
+					"          (resource.attributes[\"k8s.deployment.name\"] != \"" + ExpectedTargetAllocatorDeploymentName + "\" or " +
+					"resource.attributes[\"k8s.namespace.name\"] != \"" + OperatorNamespace + "\") and\n" +
+					"          resource.attributes[\"k8s.namespace.name\"] != nil\n" +
+					"          and resource.attributes[\"k8s.namespace.name\"] != \"namespace-1\"\n",
+			}),
+			Entry("with two namespaces, self-monitoring enabled, Prometheus CRD support enabled", ottlFilterExpressionTestConfig{
+				monitoredNamespaces:           []string{namespace1, namespace2},
+				selfMonitoringEnabled:         true,
+				prometheusCrdSupportEnabled:   true,
+				operatorManagerDeploymentName: OperatorManagerDeploymentName,
+				expectedExpression: "(resource.attributes[\"k8s.deployment.name\"] != \"" + OperatorManagerDeploymentName + "\" or " +
+					"resource.attributes[\"k8s.namespace.name\"] != \"" + OperatorNamespace + "\") and\n" +
+					"          (resource.attributes[\"k8s.daemonset.name\"] != \"" + ExpectedDaemonSetName + "\" or " +
+					"resource.attributes[\"k8s.namespace.name\"] != \"" + OperatorNamespace + "\") and\n" +
+					"          (resource.attributes[\"k8s.deployment.name\"] != \"" + ExpectedDeploymentName + "\" or " +
+					"resource.attributes[\"k8s.namespace.name\"] != \"" + OperatorNamespace + "\") and\n" +
+					"          (resource.attributes[\"k8s.deployment.name\"] != \"" + ExpectedTargetAllocatorDeploymentName + "\" or " +
+					"resource.attributes[\"k8s.namespace.name\"] != \"" + OperatorNamespace + "\") and\n" +
+					"          resource.attributes[\"k8s.namespace.name\"] != nil\n" +
+					"          and resource.attributes[\"k8s.namespace.name\"] != \"namespace-1\"\n" +
+					"          and resource.attributes[\"k8s.namespace.name\"] != \"namespace-2\"\n",
+			}),
+		)
+
+		type ottlFilterEvaluationTestConfig struct {
+			monitoredNamespaces           []string
+			selfMonitoringEnabled         bool
+			prometheusCrdSupportEnabled   bool
+			operatorManagerDeploymentName string
+			resourceAttributes            map[string]string
+			expectedToBeDropped           bool
+		}
+
+		DescribeTable("should let self-monitoring metrics pass through the OTTL namespace filter", func(testConfig ottlFilterEvaluationTestConfig) {
+			colConfig := &oTelColConfig{
+				OperatorNamespace:             OperatorNamespace,
+				NamePrefix:                    namePrefix,
+				OperatorManagerDeploymentName: testConfig.operatorManagerDeploymentName,
+				SelfMonitoringConfiguration: selfmonitoringapiaccess.SelfMonitoringConfiguration{
+					SelfMonitoringEnabled: testConfig.selfMonitoringEnabled,
+				},
+				PrometheusCrdSupportEnabled: testConfig.prometheusCrdSupportEnabled,
+				TargetAllocatorNamePrefix:   TargetAllocatorPrefixTest,
+			}
+			expression := renderOttlNamespaceFilter(testConfig.monitoredNamespaces, colConfig)
+
+			settings := component.TelemetrySettings{Logger: zap.NewNop()}
+			parser, err := ottlmetric.NewParser(nil, settings)
+			Expect(err).NotTo(HaveOccurred())
+			conditions, err := parser.ParseConditions([]string{expression})
+			Expect(err).NotTo(HaveOccurred())
+			condSeq := ottlmetric.NewConditionSequence(conditions, settings)
+
+			resourceMetrics := pmetric.NewResourceMetrics()
+			for k, v := range testConfig.resourceAttributes {
+				resourceMetrics.Resource().Attributes().PutStr(k, v)
+			}
+			scopeMetrics := resourceMetrics.ScopeMetrics().AppendEmpty()
+			metric := scopeMetrics.Metrics().AppendEmpty()
+			tCtx := ottlmetric.NewTransformContextPtr(resourceMetrics, scopeMetrics, metric)
+			defer tCtx.Close()
+
+			result, err := condSeq.Eval(context.Background(), tCtx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(testConfig.expectedToBeDropped))
+		},
+			Entry("operator manager metrics are not dropped",
+				ottlFilterEvaluationTestConfig{
+					monitoredNamespaces:           []string{namespace1, namespace2},
+					selfMonitoringEnabled:         true,
+					prometheusCrdSupportEnabled:   false,
+					operatorManagerDeploymentName: OperatorManagerDeploymentName,
+					resourceAttributes: map[string]string{
+						"k8s.deployment.name": OperatorManagerDeploymentName,
+						"k8s.namespace.name":  OperatorNamespace,
+					},
+					expectedToBeDropped: false,
+				}),
+			Entry("daemonset collector metrics are not dropped",
+				ottlFilterEvaluationTestConfig{
+					monitoredNamespaces:           []string{namespace1, namespace2},
+					selfMonitoringEnabled:         true,
+					prometheusCrdSupportEnabled:   false,
+					operatorManagerDeploymentName: OperatorManagerDeploymentName,
+					resourceAttributes: map[string]string{
+						"k8s.daemonset.name": ExpectedDaemonSetName,
+						"k8s.namespace.name": OperatorNamespace,
+					},
+					expectedToBeDropped: false,
+				}),
+			Entry("deployment collector metrics are not dropped",
+				ottlFilterEvaluationTestConfig{
+					monitoredNamespaces:           []string{namespace1, namespace2},
+					selfMonitoringEnabled:         true,
+					prometheusCrdSupportEnabled:   false,
+					operatorManagerDeploymentName: OperatorManagerDeploymentName,
+					resourceAttributes: map[string]string{
+						"k8s.deployment.name": ExpectedDeploymentName,
+						"k8s.namespace.name":  OperatorNamespace,
+					},
+					expectedToBeDropped: false,
+				}),
+			Entry("target allocator metrics are not dropped",
+				ottlFilterEvaluationTestConfig{
+					monitoredNamespaces:           []string{namespace1, namespace2},
+					selfMonitoringEnabled:         true,
+					prometheusCrdSupportEnabled:   true,
+					operatorManagerDeploymentName: OperatorManagerDeploymentName,
+					resourceAttributes: map[string]string{
+						"k8s.deployment.name": ExpectedTargetAllocatorDeploymentName,
+						"k8s.namespace.name":  OperatorNamespace,
+					},
+					expectedToBeDropped: false,
+				}),
+			Entry("metrics from a random deployment in a monitored namespace are not dropped (self-monitoring enabled)",
+				ottlFilterEvaluationTestConfig{
+					monitoredNamespaces:           []string{namespace1, namespace2},
+					selfMonitoringEnabled:         true,
+					prometheusCrdSupportEnabled:   false,
+					operatorManagerDeploymentName: OperatorManagerDeploymentName,
+					resourceAttributes: map[string]string{
+						"k8s.deployment.name": "some-deployment",
+						"k8s.namespace.name":  namespace1,
+					},
+					expectedToBeDropped: false,
+				}),
+			Entry("metrics from a random deployment in a monitored namespace are not dropped (self-monitoring disabled)",
+				ottlFilterEvaluationTestConfig{
+					monitoredNamespaces:           []string{namespace1, namespace2},
+					selfMonitoringEnabled:         false,
+					prometheusCrdSupportEnabled:   false,
+					operatorManagerDeploymentName: OperatorManagerDeploymentName,
+					resourceAttributes: map[string]string{
+						"k8s.deployment.name": "some-deployment",
+						"k8s.namespace.name":  namespace1,
+					},
+					expectedToBeDropped: false,
+				}),
+			Entry("metrics from a random workload in a monitored namespace are not dropped",
+				ottlFilterEvaluationTestConfig{
+					monitoredNamespaces:           []string{namespace1, namespace2},
+					selfMonitoringEnabled:         false,
+					prometheusCrdSupportEnabled:   false,
+					operatorManagerDeploymentName: OperatorManagerDeploymentName,
+					resourceAttributes: map[string]string{
+						"k8s.namespace.name": namespace2,
+					},
+					expectedToBeDropped: false,
+				}),
+			Entry("metrics from a random deployment in an unmonitored namespace are dropped",
+				ottlFilterEvaluationTestConfig{
+					monitoredNamespaces:           []string{namespace1, namespace2},
+					selfMonitoringEnabled:         true,
+					prometheusCrdSupportEnabled:   false,
+					operatorManagerDeploymentName: OperatorManagerDeploymentName,
+					resourceAttributes: map[string]string{
+						"k8s.deployment.name": "some-deployment",
+						"k8s.namespace.name":  "some-namespace",
+					},
+					expectedToBeDropped: true,
+				}),
+			Entry("metrics from a random daemonset in an unmonitored namespace are dropped",
+				ottlFilterEvaluationTestConfig{
+					monitoredNamespaces:           []string{namespace1, namespace2},
+					selfMonitoringEnabled:         true,
+					prometheusCrdSupportEnabled:   false,
+					operatorManagerDeploymentName: OperatorManagerDeploymentName,
+					resourceAttributes: map[string]string{
+						"k8s.daemonset.name": "some-daemonset",
+						"k8s.namespace.name": "some-namespace",
+					},
+					expectedToBeDropped: true,
+				}),
+			Entry("metrics from a random deployment in the operator namespace are dropped",
+				ottlFilterEvaluationTestConfig{
+					monitoredNamespaces:           []string{namespace1, namespace2},
+					selfMonitoringEnabled:         true,
+					prometheusCrdSupportEnabled:   true,
+					operatorManagerDeploymentName: OperatorManagerDeploymentName,
+					resourceAttributes: map[string]string{
+						"k8s.deployment.name": "some-deployment",
+						"k8s.namespace.name":  OperatorNamespace,
+					},
+					expectedToBeDropped: true,
+				}),
+			Entry("metrics from a random daemonset in the operator namespace are dropped",
+				ottlFilterEvaluationTestConfig{
+					monitoredNamespaces:           []string{namespace1, namespace2},
+					selfMonitoringEnabled:         true,
+					prometheusCrdSupportEnabled:   true,
+					operatorManagerDeploymentName: OperatorManagerDeploymentName,
+					resourceAttributes: map[string]string{
+						"k8s.daemonset.name": "some-daemonset",
+						"k8s.namespace.name": OperatorNamespace,
+					},
+					expectedToBeDropped: true,
+				}),
+			Entry("metrics from a deployment with the same name as the operator manager in a different namespace are dropped",
+				ottlFilterEvaluationTestConfig{
+					monitoredNamespaces:           []string{namespace1, namespace2},
+					selfMonitoringEnabled:         true,
+					prometheusCrdSupportEnabled:   false,
+					operatorManagerDeploymentName: OperatorManagerDeploymentName,
+					resourceAttributes: map[string]string{
+						"k8s.deployment.name": OperatorManagerDeploymentName,
+						"k8s.namespace.name":  "some-namespace",
+					},
+					expectedToBeDropped: true,
+				}),
+			Entry("metrics from a daemonset with the same name as the collector in a different namespace are dropped",
+				ottlFilterEvaluationTestConfig{
+					monitoredNamespaces:           []string{namespace1, namespace2},
+					selfMonitoringEnabled:         true,
+					prometheusCrdSupportEnabled:   false,
+					operatorManagerDeploymentName: OperatorManagerDeploymentName,
+					resourceAttributes: map[string]string{
+						"k8s.daemonset.name": ExpectedDaemonSetName,
+						"k8s.namespace.name": "some-namespace",
+					},
+					expectedToBeDropped: true,
+				}),
+			Entry("metrics from a deployment with the same name as the collector in a different namespace are dropped",
+				ottlFilterEvaluationTestConfig{
+					monitoredNamespaces:           []string{namespace1, namespace2},
+					selfMonitoringEnabled:         true,
+					prometheusCrdSupportEnabled:   false,
+					operatorManagerDeploymentName: OperatorManagerDeploymentName,
+					resourceAttributes: map[string]string{
+						"k8s.deployment.name": ExpectedDeploymentName,
+						"k8s.namespace.name":  "some-namespace",
+					},
+					expectedToBeDropped: true,
+				}),
+			Entry("metrics from a deployment with the same name as the target allocator in a different namespace are dropped",
+				ottlFilterEvaluationTestConfig{
+					monitoredNamespaces:           []string{namespace1, namespace2},
+					selfMonitoringEnabled:         true,
+					prometheusCrdSupportEnabled:   false,
+					operatorManagerDeploymentName: OperatorManagerDeploymentName,
+					resourceAttributes: map[string]string{
+						"k8s.deployment.name": ExpectedTargetAllocatorDeploymentName,
+						"k8s.namespace.name":  "some-namespace",
+					},
+					expectedToBeDropped: true,
+				}),
 		)
 
 		DescribeTable("should render the namespace filter and add it to the metrics pipeline", func(cmTypeDef configMapTypeDefinition) {

--- a/internal/collectors/otelcolresources/desired_state.go
+++ b/internal/collectors/otelcolresources/desired_state.go
@@ -29,11 +29,13 @@ import (
 type oTelColConfig struct {
 	// OperatorNamespace is the namespace of the Dash0 operator
 	OperatorNamespace string
-
-	// NamePrefix is used as a prefix for OTel collector Kubernetes resources created by the operator, set to value of
-	// the environment variable OTEL_COLLECTOR_NAME_PREFIX, which is set to the Helm release name by the operator Helm
-	// chart.
-	NamePrefix                                       string
+	// NamePrefix is used as a prefix for OTel collector Kubernetes resources created by the operator, set to
+	// value of the environment variable OTEL_COLLECTOR_NAME_PREFIX, which is set to the Helm release name by the operator
+	//Helm chart.
+	NamePrefix string
+	// OperatorManagerDeploymentName is the name of the operator manager deployment, used to exclude the operator
+	// manager's own metrics from namespace-based filtering.
+	OperatorManagerDeploymentName                    string
 	Exporters                                        otlpExporters
 	AllMonitoringResources                           []dash0v1beta1.Dash0Monitoring
 	SendBatchSize                                    *uint32

--- a/internal/collectors/otelcolresources/otelcol_resources.go
+++ b/internal/collectors/otelcolresources/otelcol_resources.go
@@ -155,13 +155,14 @@ func (m *OTelColResourceManager) CreateOrUpdateOpenTelemetryCollectorResources(
 	}
 
 	config := &oTelColConfig{
-		OperatorNamespace:           m.collectorConfig.OperatorNamespace,
-		NamePrefix:                  m.collectorConfig.OTelCollectorNamePrefix,
-		Exporters:                   otlpExporters,
-		AllMonitoringResources:      allMonitoringResources,
-		SendBatchSize:               m.collectorConfig.SendBatchSize,
-		SendBatchMaxSize:            m.collectorConfig.SendBatchMaxSize,
-		SelfMonitoringConfiguration: selfMonitoringConfiguration,
+		OperatorNamespace:             m.collectorConfig.OperatorNamespace,
+		OperatorManagerDeploymentName: m.operatorManagerDeployment.Name,
+		NamePrefix:                    m.collectorConfig.OTelCollectorNamePrefix,
+		Exporters:                     otlpExporters,
+		AllMonitoringResources:        allMonitoringResources,
+		SendBatchSize:                 m.collectorConfig.SendBatchSize,
+		SendBatchMaxSize:              m.collectorConfig.SendBatchMaxSize,
+		SelfMonitoringConfiguration:   selfMonitoringConfiguration,
 		KubernetesInfrastructureMetricsCollectionEnabled: kubernetesInfrastructureMetricsCollectionEnabled,
 		CollectPodLabelsAndAnnotationsEnabled:            collectPodLabelsAndAnnotationsEnabled,
 		CollectNamespaceLabelsAndAnnotationsEnabled:      collectNamespaceLabelsAndAnnotationsEnabled,


### PR DESCRIPTION
The filter for discarding metrics for non-monitored namespaces would previously discard kubeletstat and k8s_receiver metrics from the operator manager and the collectors, even if self-monitoring was enabled. The filter now lets these metrics through.

Additionally, the condition to let target-allocator metrics through relied on pod labels. Collecting those can be disabled in the operator configuration resource. When disabled, the metrics for the target-allocator would have been discarded as well. This now relies on the deployment name resource attributes, which should always be set.