### PR TITLE
test(e2e): fix operator upgrade test

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -441,6 +441,7 @@ OPERATOR_HELM_CHART=dash0-operator/dash0-operator \
 ```
 
 When running with a remote Helm chart like this, the images from the chart are used by default, instead of local images.
+Running the end-to-end tests against a specific version of the Helm chart is not supported.
 
 When an end-to-end test case fails, the test suite automatically collects pod descriptions, config maps and pod logs
 from the Kubernetes cluster at the time of the failure.

--- a/test/e2e/container_images.go
+++ b/test/e2e/container_images.go
@@ -34,8 +34,7 @@ const (
 	filelogOffsetVolumeOwnershipImageName = "filelog-offset-volume-ownership"
 	targetAllocatorImageName              = "target-allocator"
 
-	tagLatest  = "latest"
-	tagMainDev = "main-dev"
+	tagLatest = "latest"
 
 	productionImageRepositoryPrefix = "ghcr.io/dash0hq/"
 	defaultImageRepositoryPrefix    = ""
@@ -44,53 +43,12 @@ const (
 )
 
 var (
-	emptyImages = Images{
-		operator: ImageSpec{
-			repository: "",
-			tag:        "",
-			pullPolicy: "",
-		},
-		instrumentation: ImageSpec{
-			repository: "",
-			tag:        "",
-			pullPolicy: "",
-		},
-		collector: ImageSpec{
-			repository: "",
-			tag:        "",
-			pullPolicy: "",
-		},
-		configurationReloader: ImageSpec{
-			repository: "",
-			tag:        "",
-			pullPolicy: "",
-		},
-		fileLogOffsetSync: ImageSpec{
-			repository: "",
-			tag:        "",
-			pullPolicy: "",
-		},
-		fileLogOffsetVolumeOwnership: ImageSpec{
-			repository: "",
-			tag:        "",
-			pullPolicy: "",
-		},
-		targetAllocator: ImageSpec{
-			repository: "",
-			tag:        "",
-			pullPolicy: "",
-		},
-	}
-
 	images Images
 )
 
 func determineContainerImages() {
-	operatorHelmChart = getEnvOrDefault("OPERATOR_HELM_CHART", operatorHelmChart)
-	operatorHelmChartUrl = getEnvOrDefault("OPERATOR_HELM_CHART_URL", operatorHelmChartUrl)
-
-	if !isLocalHelmChart() {
-		images = emptyImages
+	if !isLocalHelmChart(operatorHelmChart) {
+		images = Images{}
 		e2ePrint("Using a non-local Helm chart (%s). Image settings will come from the chart. "+
 			"Ignoring IMAGE_REPOSITORY_PREFIX, IMAGE_TAG, PULL_POLICY, and per-image environment variables.\n",
 			operatorHelmChart)
@@ -100,63 +58,65 @@ func determineContainerImages() {
 	repositoryPrefix := getEnvOrDefault("IMAGE_REPOSITORY_PREFIX", defaultImageRepositoryPrefix)
 	imageTag := getEnvOrDefault("IMAGE_TAG", defaultImageTag)
 	pullPolicy := getEnvOrDefault("PULL_POLICY", defaultPullPolicy)
+	images = createContainerImages(repositoryPrefix, imageTag, pullPolicy)
+}
 
-	images.operator =
-		determineContainerImage(
+func createContainerImagesForHelmChartVersion(version string) Images {
+	return createContainerImages(productionImageRepositoryPrefix, version, "")
+}
+
+func createContainerImages(repositoryPrefix string, imageTag string, pullPolicy string) Images {
+	return Images{
+		operator: determineContainerImage(
 			"CONTROLLER",
 			repositoryPrefix,
 			operatorControllerImageName,
 			imageTag,
 			pullPolicy,
-		)
-	images.instrumentation =
-		determineContainerImage(
+		),
+		instrumentation: determineContainerImage(
 			"INSTRUMENTATION",
 			repositoryPrefix,
 			instrumentationImageName,
 			imageTag,
 			pullPolicy,
-		)
-	images.collector =
-		determineContainerImage(
+		),
+		collector: determineContainerImage(
 			"COLLECTOR",
 			repositoryPrefix,
 			collectorImageName,
 			imageTag,
 			pullPolicy,
-		)
-	images.configurationReloader =
-		determineContainerImage(
+		),
+		configurationReloader: determineContainerImage(
 			"CONFIGURATION_RELOADER",
 			repositoryPrefix,
 			configurationReloaderImageName,
 			imageTag,
 			pullPolicy,
-		)
-	images.fileLogOffsetSync =
-		determineContainerImage(
+		),
+		fileLogOffsetSync: determineContainerImage(
 			"FILELOG_OFFSET_SYNC",
 			repositoryPrefix,
 			filelogOffsetSyncImageName,
 			imageTag,
 			pullPolicy,
-		)
-	images.fileLogOffsetVolumeOwnership =
-		determineContainerImage(
+		),
+		fileLogOffsetVolumeOwnership: determineContainerImage(
 			"FILELOG_OFFSET_VOLUME_OWNERSHIP",
 			repositoryPrefix,
 			filelogOffsetVolumeOwnershipImageName,
 			imageTag,
 			pullPolicy,
-		)
-	images.targetAllocator =
-		determineContainerImage(
+		),
+		targetAllocator: determineContainerImage(
 			"TARGET_ALLOCATOR",
 			repositoryPrefix,
 			targetAllocatorImageName,
 			imageTag,
 			pullPolicy,
-		)
+		),
+	}
 }
 
 func determineContainerImage(
@@ -181,62 +141,4 @@ func getEnvOrDefault(name string, defaultValue string) string {
 		return value
 	}
 	return defaultValue
-}
-
-func deriveAlternativeImagesForUpdateTest(images Images) Images {
-	return Images{
-		// Deliberately not using a different image for the operator manager itself. Replacing the operator manager
-		// image with say, ghcr.io/dash0hq/operator-controller:latest (i.e., the most recently published release) or
-		// ghcr.io/dash0hq/operator-controller:main-dev (the most recent build on main) would lead to the operator
-		// manager crashing at startup with "flag provided but not defined: -new-command-line-argument" if the current
-		// branch adds new command line flags (which is of course unknown in those operator manager image versions).
-		operator: images.operator,
-		instrumentation: deriveAlternativeImageForUpdateTest(
-			images.instrumentation,
-			instrumentationImageName,
-		),
-		// Deliberately not using a different image for the collector. Replacing the collector image with say,
-		// ghcr.io/dash0hq/collector:latest (i.e., the most recently published release) but combining this with the config
-		// maps generated by the current operator (because we always use the locally built operator) can lead to invalid
-		// combinations; that is, config maps that are not valid for the collector version we run.
-		collector: images.collector,
-		configurationReloader: deriveAlternativeImageForUpdateTest(
-			images.configurationReloader,
-			configurationReloaderImageName,
-		),
-		fileLogOffsetSync: deriveAlternativeImageForUpdateTest(
-			images.fileLogOffsetSync,
-			filelogOffsetSyncImageName,
-		),
-		fileLogOffsetVolumeOwnership: deriveAlternativeImageForUpdateTest(
-			images.fileLogOffsetVolumeOwnership,
-			filelogOffsetVolumeOwnershipImageName,
-		),
-		targetAllocator: deriveAlternativeImageForUpdateTest(
-			images.targetAllocator,
-			targetAllocatorImageName,
-		),
-	}
-}
-
-func deriveAlternativeImageForUpdateTest(image ImageSpec, imageName string) ImageSpec {
-	productionImage := productionImageRepositoryPrefix + imageName
-	// For the "should update instrumentation modifications at startup" test case, we need to come up with an
-	// alternative fully qualified image name, one that is different from the image name that is being used for the
-	// regular "helm install" invocations in this e2e test suite run.
-	if image.repository != productionImage || image.tag != tagLatest {
-		// Use "ghcr.io/dash0hq/$image:latest", if that is different from the original image.
-		// (The "latest" tag is built with every release, although it is not used in the Helm chart.)
-		return ImageSpec{
-			repository: productionImage,
-			tag:        tagLatest,
-		}
-	} else {
-		// Otherwise, as a fallback, use "ghcr.io/dash0hq/$image:main-dev".
-		// (The "main-dev" tag is built for every commit pushed to the main branch.)
-		return ImageSpec{
-			repository: productionImage,
-			tag:        tagMainDev,
-		}
-	}
 }

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -82,6 +82,7 @@ var _ = Describe("Dash0 Operator", Ordered, ContinueOnFailure, func() {
 		recreateNamespaceWithLabel(applicationUnderTestNamespace, map[string]string{"dash0.com/enable": "\"false\""})
 		cleanupSteps.removeTestApplicationNamespace = true
 
+		determineOperatorHelmChart()
 		determineContainerImages()
 		determineTestAppImages()
 		determineDash0ApiMockImage()
@@ -153,7 +154,8 @@ var _ = Describe("Dash0 Operator", Ordered, ContinueOnFailure, func() {
 				operatorNamespace,
 				operatorHelmChart,
 				operatorHelmChartUrl,
-				images,
+				"",
+				&images,
 				true,
 				map[string]string{
 					"operator.instrumentation.enablePythonAutoInstrumentation": "true",
@@ -1378,7 +1380,8 @@ trace_statements:
 				operatorNamespace,
 				operatorHelmChart,
 				operatorHelmChartUrl,
-				images,
+				"",
+				&images,
 				nil,
 			)
 		})
@@ -1412,7 +1415,8 @@ trace_statements:
 					operatorNamespace,
 					operatorHelmChart,
 					operatorHelmChartUrl,
-					images,
+					"",
+					&images,
 					// We are verifying that no namespaced metrics are collected later on in this test, but
 					// self-monitoring metrics are namespaced, so we are deliberately disabling self-monitoring for this
 					// test.
@@ -1446,7 +1450,8 @@ trace_statements:
 					operatorNamespace,
 					operatorHelmChart,
 					operatorHelmChartUrl,
-					images,
+					"",
+					&images,
 					nil,
 				)
 				By("create an operator configuration resource with telemetryCollection.enabled=false")
@@ -1499,7 +1504,8 @@ trace_statements:
 					operatorNamespace,
 					operatorHelmChart,
 					operatorHelmChartUrl,
-					images,
+					"",
+					&images,
 					&startup.OperatorConfigurationValues{
 						Endpoint:                   defaultEndpoint,
 						ApiEndpoint:                dash0ApiMockServiceBaseUrl,
@@ -1550,7 +1556,8 @@ trace_statements:
 					operatorNamespace,
 					operatorHelmChart,
 					operatorHelmChartUrl,
-					images,
+					"",
+					&images,
 					true,
 					map[string]string{
 						"operator.certManager.useCertManager": "true",
@@ -1611,7 +1618,8 @@ trace_statements:
 					operatorNamespace,
 					operatorHelmChart,
 					operatorHelmChartUrl,
-					images,
+					"",
+					&images,
 					true,
 					nil,
 				)
@@ -1678,7 +1686,8 @@ trace_statements:
 					operatorNamespace,
 					operatorHelmChart,
 					operatorHelmChartUrl,
-					images,
+					"",
+					&images,
 					true,
 					map[string]string{
 						"operator.collectors.compressConfigMaps": "true",
@@ -1717,58 +1726,52 @@ trace_statements:
 			})
 		})
 
-		Describe("operator startup", func() {
+		Describe("operator upgrade", func() {
 			AfterAll(func() {
 				undeployOperator(operatorNamespace)
 			})
 
-			It("should update instrumentation modifications at startup", func() {
+			// This test initially deploys the most recently published Helm chart (unless that is what this test suite run
+			// tests, then it will install the previous version). Then, in a second step we upgrade the operator with the
+			// chart and image names that are used throughout the whole test suite. That is usually the chart and images built
+			// from local sources, or alternatively the most recently published release. This simulates updating the operator
+			// to a new release.
+			It("should update instrumentations of workloads at startup", func() {
 				testId := generateNewTestId(runtimeTypeNodeJs, workloadTypeDeployment)
 				By("installing the Node.js deployment")
 				Expect(installNodeJsDeployment(applicationUnderTestNamespace)).To(Succeed())
 
-				// We initially deploy the operator with alternative image tags to simulate the workloads having
-				// been instrumented by outdated images. Then (later) we will redeploy the operator with the actual
-				// image names that are used throughout the whole test suite (defined by environment variables), to
-				// simulate updating the instrumentation.
-				initialAlternativeImages := deriveAlternativeImagesForUpdateTest(images)
-				deployOperatorWithDefaultAutoOperationConfiguration(
-					operatorNamespace,
-					operatorHelmChart,
-					operatorHelmChartUrl,
-					initialAlternativeImages,
-					true,
-					nil,
-				)
+				By("installing the previous operator release")
+				previousChartVersion := deployPreviousOperatorRelease()
+
 				deployDash0MonitoringResourceWithRetry(
 					applicationUnderTestNamespace,
 					dash0MonitoringValuesDefault,
 					operatorNamespace,
 				)
 
-				By("verifying that the Node.js deployment has been instrumented by the controller")
+				By("verifying that the Node.js deployment has been instrumented by the previous operator release")
 				verifyThatWorkloadHasBeenInstrumented(
 					applicationUnderTestNamespace,
 					runtimeTypeNodeJs,
 					workloadTypeDeployment,
 					testId,
-					initialAlternativeImages,
+					createContainerImagesForHelmChartVersion(previousChartVersion),
 					"controller",
 				)
 
-				// Now update the operator with the actual image names that are used throughout the whole test suite.
+				// Now upgrade the operator.
 				Expect(upgradeOperator(
 					operatorNamespace,
 					operatorHelmChart,
 					operatorHelmChartUrl,
-					// now we use :latest (or :main-dev or whatever has been provided via env vars) instead of
-					// :e2e-test to trigger an actual change
-					images,
+					"",
+					&images,
 					nil,
 					nil,
 				)).To(Succeed())
 
-				By("verifying that the Node.js deployment's instrumentation settings have been updated by the controller")
+				By("verifying that the Node.js deployment's instrumentation has been updated by the controller")
 				verifyThatWorkloadHasBeenInstrumented(
 					applicationUnderTestNamespace,
 					runtimeTypeNodeJs,
@@ -1788,7 +1791,8 @@ trace_statements:
 					operatorNamespace,
 					operatorHelmChart,
 					operatorHelmChartUrl,
-					images,
+					"",
+					&images,
 					nil,
 				)
 				time.Sleep(10 * time.Second)
@@ -1903,7 +1907,8 @@ trace_statements:
 					operatorNamespace,
 					operatorHelmChart,
 					operatorHelmChartUrl,
-					images,
+					"",
+					&images,
 					nil,
 				)
 				time.Sleep(10 * time.Second)
@@ -1938,7 +1943,8 @@ trace_statements:
 					operatorNamespace,
 					operatorHelmChart,
 					operatorHelmChartUrl,
-					images,
+					"",
+					&images,
 					&startup.OperatorConfigurationValues{
 						Endpoint: testUtil.EndpointDash0Test,
 						// no token, no secret ref
@@ -2022,7 +2028,8 @@ trace_statements:
 						operatorNamespace,
 						operatorHelmChart,
 						operatorHelmChartUrl,
-						images,
+						"",
+						&images,
 						true,
 						nil,
 					)
@@ -2160,7 +2167,8 @@ trace_statements:
 					operatorNamespace,
 					operatorHelmChart,
 					operatorHelmChartUrl,
-					images,
+					"",
+					&images,
 					nil,
 				)
 
@@ -2489,7 +2497,8 @@ trace_statements:
 					operatorNamespace,
 					operatorHelmChart,
 					operatorHelmChartUrl,
-					images,
+					"",
+					&images,
 					&operatorConfigurationValues,
 					map[string]string{
 						"operator.autoMonitorNamespaces.enabled":       "true",
@@ -2534,7 +2543,8 @@ trace_statements:
 					operatorNamespace,
 					operatorHelmChart,
 					operatorHelmChartUrl,
-					images,
+					"",
+					&images,
 					&operatorConfigurationValues,
 					map[string]string{
 						"operator.autoMonitorNamespaces.enabled":                    "true",
@@ -2569,7 +2579,8 @@ trace_statements:
 				operatorNamespace,
 				operatorHelmChart,
 				operatorHelmChartUrl,
-				images,
+				"",
+				&images,
 				true,
 				map[string]string{
 					"operator.prometheusCrdSupportEnabled": "true",
@@ -2667,7 +2678,8 @@ trace_statements:
 				operatorNamespace,
 				operatorHelmChart,
 				operatorHelmChartUrl,
-				images,
+				"",
+				&images,
 				false,
 				map[string]string{
 					"operator.profilingEnabled": "true",

--- a/test/e2e/operator.go
+++ b/test/e2e/operator.go
@@ -19,9 +19,16 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+type helmSearchResult struct {
+	Version string `json:"version"`
+}
+
 const (
 	localHelmChart          = "helm-chart/dash0-operator"
 	operatorHelmReleaseName = "e2e-tests-operator-hr"
+
+	publishedChart    = "dash0-operator/dash0-operator"
+	publishedChartUrl = "https://dash0hq.github.io/dash0-operator"
 )
 
 var (
@@ -30,15 +37,21 @@ var (
 	operatorNamespace    = "e2e-operator-namespace"
 )
 
-func isLocalHelmChart() bool {
-	return operatorHelmChart == localHelmChart
+func determineOperatorHelmChart() {
+	operatorHelmChart = getEnvOrDefault("OPERATOR_HELM_CHART", operatorHelmChart)
+	operatorHelmChartUrl = getEnvOrDefault("OPERATOR_HELM_CHART_URL", operatorHelmChartUrl)
+}
+
+func isLocalHelmChart(chart string) bool {
+	return chart == localHelmChart
 }
 
 func deployOperatorWithDefaultAutoOperationConfiguration(
 	operatorNamespace string,
 	operatorHelmChart string,
 	operatorHelmChartUrl string,
-	images Images,
+	operatorHelmChartVersion string,
+	images *Images,
 	selfMonitoringEnabled bool,
 	additionalHelmParameters map[string]string,
 ) {
@@ -46,6 +59,7 @@ func deployOperatorWithDefaultAutoOperationConfiguration(
 		operatorNamespace,
 		operatorHelmChart,
 		operatorHelmChartUrl,
+		operatorHelmChartVersion,
 		images,
 		&startup.OperatorConfigurationValues{
 			Endpoint:              defaultEndpoint,
@@ -67,13 +81,15 @@ func deployOperatorWithoutAutoOperationConfiguration(
 	operatorNamespace string,
 	operatorHelmChart string,
 	operatorHelmChartUrl string,
-	images Images,
+	operatorHelmChartVersion string,
+	images *Images,
 	additionalHelmParameters map[string]string,
 ) {
 	err := deployOperator(
 		operatorNamespace,
 		operatorHelmChart,
 		operatorHelmChartUrl,
+		operatorHelmChartVersion,
 		images,
 		nil,
 		additionalHelmParameters,
@@ -85,7 +101,8 @@ func deployOperator(
 	operatorNamespace string,
 	operatorHelmChart string,
 	operatorHelmChartUrl string,
-	images Images,
+	operatorHelmChartVersion string,
+	images *Images,
 	operatorConfigurationValues *startup.OperatorConfigurationValues,
 	additionalHelmParameters map[string]string,
 ) error {
@@ -94,17 +111,96 @@ func deployOperator(
 		operatorNamespace,
 		operatorHelmChart,
 		operatorHelmChartUrl,
+		operatorHelmChartVersion,
 		images,
 		operatorConfigurationValues,
 		additionalHelmParameters,
 	)
 }
 
+// deployPreviousOperatorRelease deploys the "previous" chart release from the published Helm chart and returns the
+// version it has deployed. The term "previous" has a slightly different meaning, depending on whether the test suite as
+// a whole is running with the local Helm chart or the published Helm chart.
+//   - When running the test suite with the local Helm chart, it will install the most recent release. For the
+//     "operator upgrade" test suite, this verifies that users running the currently published release can upgrade
+//     to the next release, which will be built from the current state of local source code.
+//   - When running the test suite with the published Helm chart, it will install the release before the most recent
+//     release. For the "operator upgrade" test suite, this verifies that users running the previous release can upgrade
+//     to the current release.
+//
+// The version of the installed release is returned as a string.
+func deployPreviousOperatorRelease() string {
+	version := ""
+	// check whether the test suite generally runs with the local Helm chart the published Helm chart
+	if isLocalHelmChart(operatorHelmChart) {
+		// The test suite is running against a local Helm chart. The "previous release" is the most recently
+		// published chart happens to be.
+		version = readLatestPublishedChartVersion(publishedChart, publishedChartUrl)
+	} else {
+		// The test suite is already running against the published chart. We need to install the version before the most
+		// recently published version.
+		version = readPreviousPublishedChartVersion(publishedChart, publishedChartUrl)
+	}
+
+	By("installing version " + version + " of the operator Helm chart")
+	deployOperatorWithDefaultAutoOperationConfiguration(
+		operatorNamespace,
+		publishedChart,
+		publishedChartUrl,
+		version,
+		nil, // no image overrides, use the images from the published Helm chart
+		true,
+		nil,
+	)
+	return version
+}
+
+func readLatestPublishedChartVersion(chart string, chartUrl string) string {
+	return readHelmChartVersion(chart, chartUrl, 0)
+}
+
+func readPreviousPublishedChartVersion(chart string, chartUrl string) string {
+	return readHelmChartVersion(chart, chartUrl, 1)
+}
+
+func readHelmChartVersion(chart string, chartUrl string, index int64) string {
+	// "helm search repo" searches local repositories; and "helm search repo $chart --versions --output json" will
+	// return process exit code 0 and simply output "[]" if the repository is not installed locally. We need to make
+	// sure the dash0-operator repository has been installed locally.
+	ensureDash0OperatorHelmRepoIsInstalledAndUpToDate(chart, chartUrl)
+	output, err := run(exec.Command("helm", "search", "repo", chart, "--versions", "--output", "json"))
+	Expect(err).ToNot(HaveOccurred())
+	var results []helmSearchResult
+	Expect(json.Unmarshal([]byte(output), &results)).To(
+		Succeed(),
+		"cannot parse helm search repo output for %s\n%s",
+		chart,
+		output,
+	)
+	Expect(len(results)).To(
+		BeNumerically(">=", index+1),
+		"expected at least %d published version(s) of %s to be available, but found only %d; full output of helm "+
+			"repository search command: %s",
+		index+1,
+		chart,
+		len(results),
+		output,
+	)
+
+	// helm search repo returns versions sorted by semver descending; index 0 is the latest, index 1 is the previous.
+	version := results[index].Version
+	e2ePrint("found helm chart version %s.\n", version)
+	Expect(version).ToNot(BeEmpty())
+	Expect(version).To(MatchRegexp("\\d+\\.\\d+\\.\\d+"))
+	return version
+}
+
 func upgradeOperator(
 	operatorNamespace string,
 	operatorHelmChart string,
 	operatorHelmChartUrl string,
-	images Images,
+	operatorHelmChartVersion string,
+	images *Images,
 	operatorConfigurationValues *startup.OperatorConfigurationValues,
 	additionalHelmParameters map[string]string,
 ) error {
@@ -113,6 +209,7 @@ func upgradeOperator(
 		operatorNamespace,
 		operatorHelmChart,
 		operatorHelmChartUrl,
+		operatorHelmChartVersion,
 		images,
 		operatorConfigurationValues,
 		additionalHelmParameters,
@@ -124,11 +221,12 @@ func executeOperatorHelmChart(
 	operatorNamespace string,
 	operatorHelmChart string,
 	operatorHelmChartUrl string,
-	images Images,
+	operatorHelmChartVersion string,
+	images *Images,
 	operatorConfigurationValues *startup.OperatorConfigurationValues,
 	additionalHelmParameters map[string]string,
 ) error {
-	ensureDash0OperatorHelmRepoIsInstalled(operatorHelmChart, operatorHelmChartUrl)
+	ensureDash0OperatorHelmRepoIsInstalledAndUpToDate(operatorHelmChart, operatorHelmChartUrl)
 
 	By(
 		fmt.Sprintf(
@@ -146,7 +244,9 @@ func executeOperatorHelmChart(
 		arguments = append(arguments, "--create-namespace")
 	}
 	arguments = append(arguments, "--set", "operator.developmentMode=true")
-	arguments = addHelmParametersForImages(arguments, images)
+	if images != nil {
+		arguments = addHelmParametersForImages(arguments, *images)
+	}
 
 	if operatorConfigurationValues != nil {
 		arguments = setHelmParameter(arguments, "operator.dash0Export.enabled", "true")
@@ -176,9 +276,11 @@ func executeOperatorHelmChart(
 	if additionalHelmParameters != nil {
 		arguments = setAdditionalHelmParameters(arguments, additionalHelmParameters)
 	}
-
 	arguments = append(arguments, operatorHelmReleaseName)
 	arguments = append(arguments, operatorHelmChart)
+	if operatorHelmChartVersion != "" {
+		arguments = append(arguments, "--version", operatorHelmChartVersion)
+	}
 
 	output, err := run(exec.Command("helm", arguments...))
 	if err != nil {
@@ -267,34 +369,36 @@ func setHelmParameter(arguments []string, key string, value interface{}) []strin
 	return arguments
 }
 
-func ensureDash0OperatorHelmRepoIsInstalled(
-	operatorHelmChart string,
-	operatorHelmChartUrl string,
+func ensureDash0OperatorHelmRepoIsInstalledAndUpToDate(
+	chart string,
+	chartUrl string,
 ) {
-	if isLocalHelmChart() && operatorHelmChartUrl == "" {
-		// installing from local Helm chart sources, no action required
+	isLocal := isLocalHelmChart(chart)
+	if isLocal && chartUrl == "" {
+		// local Helm chart sources, no further action required
 		return
-	} else if isLocalHelmChart() && operatorHelmChartUrl != "" {
+	} else if isLocal {
 		Fail("Invalid test setup: When setting a URL for the Helm chart (OPERATOR_HELM_CHART_URL), you also need to " +
 			"provide a custom name (OPERATOR_HELM_CHART).")
-	} else if !isLocalHelmChart() && operatorHelmChartUrl == "" {
+	} else if chartUrl == "" {
 		Fail("Invalid test setup: When setting a non-standard name for the operator Helm chart " +
 			"(OPERATOR_HELM_CHART), you also need to provide a URL from where to install it (OPERATOR_HELM_CHART_URL).")
-	} else if operatorHelmChartUrl != "" && !strings.Contains(operatorHelmChart, "/") {
+	} else if !strings.Contains(chart, "/") {
 		Fail("Invalid test setup: When using a Helm chart URL (OPERATOR_HELM_CHART_URL), the provided Helm chart " +
 			"name (OPERATOR_HELM_CHART) needs to have the format ${repository}/${chart_name}.")
 	}
-	repositoryName := operatorHelmChart[:strings.LastIndex(operatorHelmChart, "/")]
+
+	repositoryName := chart[:strings.LastIndex(chart, "/")]
 	By(fmt.Sprintf("checking whether the operator Helm chart repo %s (%s) has been installed",
-		repositoryName, operatorHelmChartUrl))
+		repositoryName, chartUrl))
 	repoList, err := run(exec.Command("helm", "repo", "list"))
 	Expect(err).To(Or(Not(HaveOccurred()), MatchError(ContainSubstring("no repositories to show"))))
 	if !regexp.MustCompile(
-		fmt.Sprintf("%s\\s+%s", repositoryName, operatorHelmChartUrl)).MatchString(repoList) {
+		fmt.Sprintf("%s\\s+%s", repositoryName, chartUrl)).MatchString(repoList) {
 		e2ePrint(
 			"The helm repo %s (%s) has not been found, adding it now.\n",
 			repositoryName,
-			operatorHelmChartUrl,
+			chartUrl,
 		)
 		Expect(runAndIgnoreOutput(
 			exec.Command(
@@ -302,7 +406,7 @@ func ensureDash0OperatorHelmRepoIsInstalled(
 				"repo",
 				"add",
 				repositoryName,
-				operatorHelmChartUrl,
+				chartUrl,
 				"--force-update",
 			))).To(Succeed())
 		Expect(runAndIgnoreOutput(exec.Command("helm", "repo", "update"))).To(Succeed())
@@ -310,7 +414,7 @@ func ensureDash0OperatorHelmRepoIsInstalled(
 		e2ePrint(
 			"The helm repo %s (%s) is already installed, updating it now.\n",
 			repositoryName,
-			operatorHelmChartUrl,
+			chartUrl,
 		)
 		Expect(runAndIgnoreOutput(
 			exec.Command(


### PR DESCRIPTION
Previously, the e2e test for upgrading the operator emulated installing an older version by using the local Helm chart sources with different image versions. That approach turned out to be not sustainable.

Pairing an older operator manager image version with the current Helm chart sources could fail if command line arguments had changed, e.g. the manager process would sometimes crash at startup with "flag provided but not defined: -new-command-line-argument".

Pairing an operator image with a different instrumentation image could also lead to issue when the instrumentation image had changes that needed to be accompanied by changes in the operator (e.g. workload_modifier.go).

This is fixed by installing the previous Helm release wholesale, then upgrading the operator to the current release. This way, the Helm chart and all images are always in sync and match each other.