### PR TITLE
chore(chart): remove secret validation

### DIFF
--- a/helm-chart/dash0-operator/README.md
+++ b/helm-chart/dash0-operator/README.md
@@ -982,10 +982,6 @@ helm install \
   dash0-operator/dash0-operator
 ```
 
-The Helm chart will validate whether the referenced secret exists and contains the required key.
-You can disable this check by setting `--set operator.dash0Export.disableSecretValidation=true`.
-This can be useful if you want to render the manifests via the Helm chart without accessing a live Kubernetes cluster.
-
 If you do not want to install the operator configuration resource via `helm install` but instead deploy it manually,
 and use a secret reference for the auth token, the following example YAML file would work with the secret created
 above:

--- a/helm-chart/dash0-operator/templates/operator/deployment-and-webhooks.yaml
+++ b/helm-chart/dash0-operator/templates/operator/deployment-and-webhooks.yaml
@@ -120,16 +120,6 @@ spec:
 {{- if .Values.operator.dash0Export.token }}
         - --operator-configuration-token={{ .Values.operator.dash0Export.token }}
 {{- else if (and .Values.operator.dash0Export.secretRef.name .Values.operator.dash0Export.secretRef.key) }}
-{{- if not .Values.operator.dash0Export.disableSecretValidation }}
-{{- $secret := lookup "v1" "Secret" .Release.Namespace .Values.operator.dash0Export.secretRef.name -}}
-{{- if $secret -}}
-{{- if not (index $secret.data .Values.operator.dash0Export.secretRef.key) -}}
-{{- fail (printf "Error: There is a secret named \"%s\" in the target namespace \"%s\", but it does not have the required key \"%s\". Please refer to the installation instructions at https://github.com/dash0hq/dash0-operator/tree/main/helm-chart/dash0-operator." .Values.operator.dash0Export.secretRef.name .Release.Namespace .Values.operator.dash0Export.secretRef.key) -}}
-{{- end -}}{{/* closes "if not (index $secret.data .Values.operator.dash0Export.secretRef.key) -}}" */}}
-{{- else -}}{{/* else for "if $secret" */}}
-{{- fail (printf "Error: There is no secret named \"%s\" in the target namespace \"%s\". Please refer to the installation instructions at https://github.com/dash0hq/dash0-operator/tree/main/helm-chart/dash0-operator." .Values.operator.dash0Export.secretRef.name .Release.Namespace) -}}
-{{- end }}{{/*closes "if $secret" */}}
-{{- end }}{{/*closes "not .Values.operator.dash0Export.disableSecretValidation" */}}
         - --operator-configuration-secret-ref-name={{ .Values.operator.dash0Export.secretRef.name }}
         - --operator-configuration-secret-ref-key={{ .Values.operator.dash0Export.secretRef.key }}
 {{- else }}{{/*else for "Values.operator.dash0Export.token" / "else if (and .Values.operator.dash0Export.secretRef.name .Values.operator.dash0Export.secretRef.key)" */}}

--- a/helm-chart/dash0-operator/tests/operator/deployment-and-webhooks_test.yaml
+++ b/helm-chart/dash0-operator/tests/operator/deployment-and-webhooks_test.yaml
@@ -824,8 +824,6 @@ tests:
           secretRef:
             name: secret-name
             key: secret-key
-          # Disabling secret validation is necessary in Helm unit tests since there is no live cluster to check against.
-          disableSecretValidation: true
           apiEndpoint: https://api.dash0.com
     asserts:
       - equal:

--- a/helm-chart/dash0-operator/values.yaml
+++ b/helm-chart/dash0-operator/values.yaml
@@ -76,11 +76,6 @@ operator:
       # secret with the command above (see property "name"), then you would set the property to "token".
       key:
 
-    # If secretRef is used, the Helm chart will check if the provided secret actually exists. Set this to true to
-    # disable this check. This can be useful if you want to render the manifests via the Helm charts without accessing a
-    # live Kubernetes cluster.
-    disableSecretValidation: false
-
     # The client-side gRPC keepalive configuration for the connection to the Dash0 backend.
     # See https://pkg.go.dev/google.golang.org/grpc/keepalive#ClientParameters
     # This setting is optional and there should usually be no need to configure it.


### PR DESCRIPTION
This feature produced more friction than value, it fails in a number of cases:
- when rendering the manifests from the Helm chart without a connection to the live cluster, then deploying the rendered manifests
- apparently incompatible with Porter