### PR TITLE
chore(test-resources): clean up Prometheus CRDs correctly

### DIFF
--- a/test-resources/bin/test-cleanup.sh
+++ b/test-resources/bin/test-cleanup.sh
@@ -59,7 +59,7 @@ if [[ "$wait_for_third_party_resource_deletion" = "true" ]]; then
   sleep 2
 fi
 
-helm uninstall --namespace "$target_namespace" prometheus-crds --ignore-not-found || true
+helm uninstall --namespace "$operator_namespace" prometheus-crds --ignore-not-found || true
 
 kubectl delete -n "$target_namespace" -f test-resources/customresources/dash0monitoring/dash0monitoring.yaml --wait=false || true
 kubectl delete -n test-namespace-1 -f test-resources/customresources/dash0monitoring/dash0monitoring.yaml --wait=false || true


### PR DESCRIPTION
test-resources/bin/lib/util#install_prometheus_crds installs the Helm release prometheus-crds into the operator namespace, the cleanup script tried to remove it from the test app namespace. The Helm release was deleted anyway later when deleting the operator namespace entirely during cleanup, but this mismatch would leave the Prometheus CRDs behind in the cluster. This in turn created conflicts when running e2e tests locally after running test-resources scripts.