### PR TITLE
fix: race condition in sync controllers

### DIFF
--- a/internal/controller/notification_channel_controller.go
+++ b/internal/controller/notification_channel_controller.go
@@ -42,6 +42,7 @@ type NotificationChannelReconciler struct {
 	defaultApiConfigs     selfmonitoringapiaccess.SynchronizedSlice[ApiConfig]
 	namespacedApiConfigs  selfmonitoringapiaccess.SynchronizedMapSlice[ApiConfig]
 	initialSyncMutex      sync.Mutex
+	initialSyncInProgress atomic.Bool
 	initialSyncHasHappend atomic.Bool
 	namespacedSyncMutex   selfmonitoringapiaccess.NamespaceMutex
 }
@@ -187,7 +188,7 @@ func (r *NotificationChannelReconciler) maybeDoInitialSynchronizationOfAllResour
 	r.initialSyncMutex.Lock()
 	defer r.initialSyncMutex.Unlock()
 
-	if r.initialSyncHasHappend.Load() {
+	if r.initialSyncHasHappend.Load() || r.initialSyncInProgress.Load() {
 		return
 	}
 
@@ -212,8 +213,11 @@ func (r *NotificationChannelReconciler) maybeDoInitialSynchronizationOfAllResour
 	}
 
 	logger.Info("Running initial synchronization of notification channels now.")
+	r.initialSyncInProgress.Store(true)
 
 	go func() {
+		defer r.initialSyncInProgress.Store(false)
+
 		allResources := dash0v1beta1.Dash0NotificationChannelList{}
 		if err := r.List(
 			ctx,

--- a/internal/controller/sampling_rule_controller.go
+++ b/internal/controller/sampling_rule_controller.go
@@ -43,6 +43,7 @@ type SamplingRuleReconciler struct {
 	httpClient             *http.Client
 	defaultApiConfigs      selfmonitoringapiaccess.SynchronizedSlice[ApiConfig]
 	initialSyncMutex       sync.Mutex
+	initialSyncInProgress  atomic.Bool
 	initialSyncHasHappened atomic.Bool
 }
 
@@ -145,7 +146,7 @@ func (r *SamplingRuleReconciler) maybeDoInitialSynchronizationOfAllResources(
 	r.initialSyncMutex.Lock()
 	defer r.initialSyncMutex.Unlock()
 
-	if r.initialSyncHasHappened.Load() {
+	if r.initialSyncHasHappened.Load() || r.initialSyncInProgress.Load() {
 		return
 	}
 
@@ -168,8 +169,11 @@ func (r *SamplingRuleReconciler) maybeDoInitialSynchronizationOfAllResources(
 	}
 
 	logger.Info("Running initial synchronization of sampling rules now.")
+	r.initialSyncInProgress.Store(true)
 
 	go func() {
+		defer r.initialSyncInProgress.Store(false)
+
 		allSamplingRuleResourcesInCluster := dash0v1alpha1.Dash0SamplingRuleList{}
 		if err := r.List(
 			ctx,

--- a/internal/controller/synthetic_check_controller.go
+++ b/internal/controller/synthetic_check_controller.go
@@ -44,6 +44,7 @@ type SyntheticCheckReconciler struct {
 	defaultApiConfigs     selfmonitoringapiaccess.SynchronizedSlice[ApiConfig]
 	namespacedApiConfigs  selfmonitoringapiaccess.SynchronizedMapSlice[ApiConfig]
 	initialSyncMutex      sync.Mutex
+	initialSyncInProgress atomic.Bool
 	initialSyncHasHappend atomic.Bool
 	namespacedSyncMutex   selfmonitoringapiaccess.NamespaceMutex
 }
@@ -186,7 +187,7 @@ func (r *SyntheticCheckReconciler) maybeDoInitialSynchronizationOfAllResources(
 	r.initialSyncMutex.Lock()
 	defer r.initialSyncMutex.Unlock()
 
-	if r.initialSyncHasHappend.Load() {
+	if r.initialSyncHasHappend.Load() || r.initialSyncInProgress.Load() {
 		return
 	}
 
@@ -211,8 +212,11 @@ func (r *SyntheticCheckReconciler) maybeDoInitialSynchronizationOfAllResources(
 	}
 
 	logger.Info("Running initial synchronization of synthetic checks now.")
+	r.initialSyncInProgress.Store(true)
 
 	go func() {
+		defer r.initialSyncInProgress.Store(false)
+
 		allSyntheticCheckResourcesInCluster := dash0v1alpha1.Dash0SyntheticCheckList{}
 		if err := r.List(
 			ctx,

--- a/internal/controller/view_controller.go
+++ b/internal/controller/view_controller.go
@@ -44,6 +44,7 @@ type ViewReconciler struct {
 	defaultApiConfigs     selfmonitoringapiaccess.SynchronizedSlice[ApiConfig]
 	namespacedApiConfigs  selfmonitoringapiaccess.SynchronizedMapSlice[ApiConfig]
 	initialSyncMutex      sync.Mutex
+	initialSyncInProgress atomic.Bool
 	initialSyncHasHappend atomic.Bool
 	namespacedSyncMutex   selfmonitoringapiaccess.NamespaceMutex
 }
@@ -175,7 +176,7 @@ func (r *ViewReconciler) maybeDoInitialSynchronizationOfAllResources(ctx context
 	r.initialSyncMutex.Lock()
 	defer r.initialSyncMutex.Unlock()
 
-	if r.initialSyncHasHappend.Load() {
+	if r.initialSyncHasHappend.Load() || r.initialSyncInProgress.Load() {
 		return
 	}
 
@@ -200,8 +201,11 @@ func (r *ViewReconciler) maybeDoInitialSynchronizationOfAllResources(ctx context
 	}
 
 	logger.Info("Running initial synchronization of views now.")
+	r.initialSyncInProgress.Store(true)
 
 	go func() {
+		defer r.initialSyncInProgress.Store(false)
+
 		allViewResourcesInCluster := dash0v1alpha1.Dash0ViewList{}
 		if err := r.List(
 			ctx,


### PR DESCRIPTION
There was a potential race condition since the `defer` released the lock as soon as the go routine was entered and there was a brief period that allowed a second call to run past the `if r.initialSyncHasHappened.Load()` check before the sync had happened (so the flag wasn't true yet).

This triggered for sampling rules more frequently than the other sync resources and caused the tests to be flaky.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Added atomic in-progress flag to prevent initial sync race


<sup>[More info](https://app.aikido.dev/featurebranch/scan/107468256?groupId=48107)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->