### PR TITLE
chore(checkrules): remove deprecated idPrefix parameter

### DIFF
--- a/internal/controller/prometheus_rules_controller.go
+++ b/internal/controller/prometheus_rules_controller.go
@@ -603,16 +603,12 @@ func (r *PrometheusRuleReconciler) renderCheckRuleListUrl(
 	endpoint string,
 	dataset string,
 ) string {
-	// 08.09.2025: Start sending the prefix already as originPrefix, the Dash0 API will rename the parameter
-	// soon-ish. We can remove the (misnamed) idPrefix query parameter as soon as the Dash0 API has rolled out the
-	// rename. Then, ~1 year later, the Dash0 API can remove support for the legacy query parameter idPrefix.
 	originPrefix :=
 		r.renderCheckRuleOriginPrefix(preconditionChecksResult, url.QueryEscape(dataset))
 	return fmt.Sprintf(
-		"%sapi/alerting/check-rules?dataset=%s&idPrefix=%s&originPrefix=%s",
+		"%sapi/alerting/check-rules?dataset=%s&originPrefix=%s",
 		endpoint,
 		url.QueryEscape(dataset),
-		originPrefix,
 		originPrefix,
 	)
 }

--- a/internal/controller/prometheus_rules_controller_test.go
+++ b/internal/controller/prometheus_rules_controller_test.go
@@ -2228,7 +2228,7 @@ func expectFetchOriginsGetRequestCustom(clusterId string, endpoint string, authH
 		Get("/api/alerting/check-rules").
 		MatchHeader("Authorization", authHeader).
 		MatchParam("dataset", dataset).
-		ParamPresent("idPrefix").
+		ParamPresent("originPrefix").
 		Times(1).
 		Reply(200).
 		JSON(

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -756,7 +756,7 @@ var _ = Describe("Dash0 Operator", Ordered, ContinueOnFailure, func() {
 					)
 
 					routeRegexes := []string{
-						"/api/alerting/check-rules\\?dataset=default&idPrefix=dash0-operator_.*_default_e2e-test-ns_prometheus-rules-e2e-test_",
+						"/api/alerting/check-rules\\?dataset=default&originPrefix=dash0-operator_.*_default_e2e-test-ns_prometheus-rules-e2e-test_",
 						"/api/alerting/check-rules/dash0-operator_.*_default_e2e-test-ns_prometheus-rules-e2e-test_dash0%7Ck8s_K8s%20Deployment%20replicas%20mismatch\\?dataset=default",
 						"/api/alerting/check-rules/dash0-operator_.*_default_e2e-test-ns_prometheus-rules-e2e-test_dash0%7Ck8s_K8s%20pod%20crash%20looping\\?dataset=default",
 						"/api/alerting/check-rules/dash0-operator_.*_default_e2e-test-ns_prometheus-rules-e2e-test_dash0%7Ccollector_exporter%20send%20failed%20spans\\?dataset=default",
@@ -831,7 +831,7 @@ var _ = Describe("Dash0 Operator", Ordered, ContinueOnFailure, func() {
 				//nolint:lll
 				It("should resync Prometheus rules when synchronizePrometheusRules transitions from false to true", func() {
 					routeRegexes := []string{
-						"/api/alerting/check-rules\\?dataset=default&idPrefix=dash0-operator_.*_default_e2e-test-ns_prometheus-rules-e2e-test_",
+						"/api/alerting/check-rules\\?dataset=default&originPrefix=dash0-operator_.*_default_e2e-test-ns_prometheus-rules-e2e-test_",
 						"/api/alerting/check-rules/dash0-operator_.*_default_e2e-test-ns_prometheus-rules-e2e-test_dash0%7Ck8s_K8s%20Deployment%20replicas%20mismatch\\?dataset=default",
 						"/api/alerting/check-rules/dash0-operator_.*_default_e2e-test-ns_prometheus-rules-e2e-test_dash0%7Ck8s_K8s%20pod%20crash%20looping\\?dataset=default",
 						"/api/alerting/check-rules/dash0-operator_.*_default_e2e-test-ns_prometheus-rules-e2e-test_dash0%7Ccollector_exporter%20send%20failed%20spans\\?dataset=default",


### PR DESCRIPTION
The Dash0 API uses and understands originPrefix since quite a while already, we do not need to send idPrefix anymore.