### PR TITLE
chore(collectors): mark signals collected by operator managed collectors

### DIFF
--- a/internal/collectors/otelcolresources/collector_config_maps.go
+++ b/internal/collectors/otelcolresources/collector_config_maps.go
@@ -104,6 +104,7 @@ type collectorConfigurationTemplateValues struct {
 	IsGkeAutopilot                                   bool
 	PseudoClusterUid                                 string
 	ClusterName                                      string
+	OperatorVersion                                  string
 	NamespacesWithLogCollection                      []string
 	NamespacesWithEventCollection                    []string
 	NamespaceOttlFilter                              string
@@ -265,6 +266,7 @@ func assembleCollectorConfigMap(
 			IsGkeAutopilot:                                   config.IsGkeAutopilot,
 			PseudoClusterUid:                                 string(config.PseudoClusterUid),
 			ClusterName:                                      config.ClusterName,
+			OperatorVersion:                                  config.Images.GetOperatorVersion(),
 			NamespacesWithLogCollection:                      namespacesWithLogCollection,
 			NamespacesWithEventCollection:                    namespacesWithEventCollection,
 			NamespaceOttlFilter:                              namespaceOttlFilter,

--- a/internal/collectors/otelcolresources/daemonset.config.yaml.template
+++ b/internal/collectors/otelcolresources/daemonset.config.yaml.template
@@ -817,6 +817,21 @@ processors:
         action: insert
   {{- end }}
 
+  resource/dash0_operator_attributes:
+    attributes:
+      - key: dash0.operator.collector_managed_by
+        value: "dash0-operator"
+        action: upsert
+      - key: dash0.operator.collector_role
+        value: "daemonset"
+        action: upsert
+      - key: dash0.operator.version
+        value: "{{ .OperatorVersion }}"
+        action: upsert
+      - key: dash0.operator.uid
+        value: "{{ .PseudoClusterUid }}"
+        action: upsert
+
   {{- if .NamespaceOttlFilter }}
   # This is a standard filter which is always on; metrics collection receivers generate metrics for all namespaces in
   # the cluster, however, we only want to collect metrics from monitored namespaces, hence this filter.
@@ -1130,6 +1145,7 @@ service:
         {{- if .ClusterName }}
         - resource/clustername
         {{- end }}
+        - resource/dash0_operator_attributes
         {{- if .CustomFilters.HasTraceFilters }}
         - filter/traces/custom_telemetry_filter
         {{- end }}
@@ -1250,6 +1266,7 @@ service:
         {{- if .ClusterName }}
         - resource/clustername
         {{- end }}
+        - resource/dash0_operator_attributes
         {{- if .NamespaceOttlFilter }}
         - filter/metrics/only_monitored_namespaces
         {{- end }}
@@ -1343,6 +1360,7 @@ service:
         {{- if .ClusterName }}
         - resource/clustername
         {{- end }}
+        - resource/dash0_operator_attributes
         {{- if .CustomFilters.HasLogFilters }}
         - filter/logs/custom_telemetry_filter
         {{- end }}
@@ -1407,6 +1425,7 @@ service:
         {{- if .ClusterName }}
         - resource/clustername
         {{- end }}
+        - resource/dash0_operator_attributes
         {{- if .NamespaceOttlFilter }}
         - filter/profiles/only_monitored_namespaces
         {{- end }}

--- a/internal/collectors/otelcolresources/deployment.config.yaml.template
+++ b/internal/collectors/otelcolresources/deployment.config.yaml.template
@@ -302,6 +302,21 @@ processors:
         action: insert
   {{- end }}
 
+  resource/dash0_operator_attributes:
+    attributes:
+      - key: dash0.operator.collector_managed_by
+        value: "dash0-operator"
+        action: upsert
+      - key: dash0.operator.collector_role
+        value: "deployment"
+        action: upsert
+      - key: dash0.operator.version
+        value: "{{ .OperatorVersion }}"
+        action: upsert
+      - key: dash0.operator.uid
+        value: "{{ .PseudoClusterUid }}"
+        action: upsert
+
 {{ if (and .KubernetesInfrastructureMetricsCollectionEnabled .NamespaceOttlFilter) }}
   filter/metrics/only_monitored_namespaces:
     metrics:
@@ -465,6 +480,7 @@ service:
         {{- if .ClusterName }}
         - resource/clustername
         {{- end }}
+        - resource/dash0_operator_attributes
         {{- if .NamespaceOttlFilter }}
         - filter/metrics/only_monitored_namespaces
         {{- end }}
@@ -525,6 +541,7 @@ service:
         {{- if .ClusterName }}
         - resource/clustername
         {{- end }}
+        - resource/dash0_operator_attributes
         - batch
         - transform/resources
       exporters:


### PR DESCRIPTION
Add the following fixed resources attributes to all collected telemetry:
- dash0.operator.collector_managed_by
- dash0.operator.collector_role
- dash0.operator.version
- dash0.operator.uid

This is useful to improve the troubleshooting experience, in particular in mixed setups (operator and other telemetry sources in the same cluster). Potentially it can also be helpful for alerting.