### PR TITLE
chore: add ignore for python pre-releases

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -61,10 +61,16 @@ updates:
     groups:
       production-dependencies:
         dependency-type: "production"
-    # enable the following `ignore` to prevent upgrades to RCs
-    # ignore:
-    #   - dependency-name: "golang"
-    #     update-types: ["version-update:semver-minor"]
+    # The following 'ignore' rules are workarounds to prevent noisy/repeated dependabot PRs
+    # that update dependencies to pre-release versions.
+    # The rules need to be manually disabled when a new stable minor version is available.
+    ignore:
+      # enable the following `ignore` to prevent upgrades to golang pre-releases
+      # - dependency-name: "golang"
+      #   update-types: ["version-update:semver-minor"]
+      # enable the following `ignore` to prevent upgrades to python pre-releases
+      - dependency-name: "python"
+        update-types: ["version-update:semver-minor"]
 
   # -----------------------
   # -- Test applications --


### PR DESCRIPTION
Looking at the timeline mentioned in  https://www.python.org/downloads/release/python-3150a8/, we're still months from a stable 3.15 release, so I propose we ignore the version similar to the workaround we had for the golang RC.

> During the alpha phase, features may be added up until the start of the beta phase (2026-05-05) and, if necessary, may be modified or deleted up until the release candidate phase (2026-07-28). Please keep in mind that this is a preview release and its use is not recommended for production environments.