### PR TITLE
chore: mark telemetry collection issues for easy filtering

### DIFF
--- a/images/instrumentation/python/sitecustomize.py
+++ b/images/instrumentation/python/sitecustomize.py
@@ -9,7 +9,6 @@ from os.path import dirname
 import sys
 from sys import path, version, version_info, stderr
 
-# Note: We might need to tweak the list of offending opentelemetry-* packages.
 double_instrumentation_check_packages = [
     "opentelemetry-distro",
     "opentelemetry-exporter-otlp",
@@ -26,27 +25,35 @@ double_instrumentation_check_packages = [
 debug_enabled = os.environ.get("OTEL_INJECTOR_LOG_LEVEL") == "debug"
 
 
-def _print_to_stderr(message):
-    message = "[dash0] " + message
-    print(message, file=stderr)
+def _log_as_json_to_stderr(level, message):
+    log_body = "{\"level\": \"" + level + "\", \"message\": \"" + message + "\", \"logger_name\": \"dash0\""
+    if level == "warn":
+        # All warnings are Dash0 telemetry collection issues, hence adding the respective marker.
+        log_body += ", \"dash0.monitoring.telemetry_collection_issue\": true"
+    log_body += "}"
+    print(log_body, file=stderr)
 
 
-def _print_debug_msg(message):
+def _log_warn(message):
+     _log_as_json_to_stderr("warn", message)
+
+
+def _log_debug(message):
     if debug_enabled:
-        _print_to_stderr(message)
+        _log_as_json_to_stderr("debug", message)
 
 
-_print_debug_msg("running sitecustomize.py")
-_print_debug_msg("PYTHONPATH: {}".format(os.environ.get("PYTHONPATH")))
+_log_debug("running sitecustomize.py")
+_log_debug("PYTHONPATH: {}".format(os.environ.get("PYTHONPATH")))
 
 
 def _print_cannot_auto_instrument_message(reason):
     if hasattr(sys, "argv"):
         # If sys.argv is available, add the full command line (" ".join(sys.argv)) to the log message, so users know
         # which Python process this is about.
-        _print_to_stderr("warning: cannot auto-instrument Python process: {} [{}]".format(reason, " ".join(sys.argv)))
+        _log_warn("cannot auto-instrument Python process: {} [{}]".format(reason, " ".join(sys.argv)))
     else:
-        _print_to_stderr("warning: cannot auto-instrument Python process: {}".format(reason))
+        _log_warn("cannot auto-instrument Python process: {}".format(reason))
 
 
 def _self_deactivate(current_site):
@@ -69,12 +76,12 @@ def _self_deactivate(current_site):
     current_pythonpath = os.environ.get("PYTHONPATH", "")
     pythonpath_entries = [entry for entry in current_pythonpath.split(",") if entry != current_site]
     new_pythonpath = ",".join(pythonpath_entries)
-    _print_debug_msg("setting PYTHONPATH in _self_deactivate: \"{}\"".format(new_pythonpath))
+    _log_debug("setting PYTHONPATH in _self_deactivate: \"{}\"".format(new_pythonpath))
     os.environ["PYTHONPATH"] = new_pythonpath
 
     # The OpenTelemetry injector will also run for child processes, and it would bring back the PYTHONPATH modification
     # which we have just removed. Instruct it to not do that by disabling Python auto-instrumentation.
-    _print_debug_msg("clearing PYTHON_AUTO_INSTRUMENTATION_AGENT_PATH_PREFIX in _self_deactivate")
+    _log_debug("clearing PYTHON_AUTO_INSTRUMENTATION_AGENT_PATH_PREFIX in _self_deactivate")
     os.environ["PYTHON_AUTO_INSTRUMENTATION_AGENT_PATH_PREFIX"] = ""
 
     if current_site in path:
@@ -130,7 +137,7 @@ def _check_dependency_version_conflict(req_string, version_conflicts):
     from packaging.requirements import Requirement
     from packaging.version import Version
 
-    _print_debug_msg("_check_dependency_version_conflict({})".format(req_string))
+    _log_debug("_check_dependency_version_conflict({})".format(req_string))
     req = Requirement(req_string)
 
     # Skip extras/markers for simplicity in conflict detection
@@ -145,22 +152,22 @@ def _check_dependency_version_conflict(req_string, version_conflicts):
     try:
         installed_distribution = importlib.metadata.distribution(req.name)
         installed_version = Version(installed_distribution.version)
-        _print_debug_msg("installed_version: {}".format(installed_version))
+        _log_debug("installed_version: {}".format(installed_version))
 
         # Check if installed version satisfies the requirement
         if req.specifier and installed_version not in req.specifier:
-            _print_debug_msg("adding version conflict for {}".format(req.name))
+            _log_debug("adding version conflict for {}".format(req.name))
             version_conflicts[req.name] = {
                 "version_required": str(req.specifier),
                 "version_found": str(installed_version),
             }
     except importlib.metadata.PackageNotFoundError:
-        _print_debug_msg("adding version error for {}".format(req.name))
+        _log_debug("adding version error for {}".format(req.name))
         version_conflicts[req.name] = {"error": "required package not found"}
 
 
 def import_distro():
-    _print_debug_msg("checking Python version")
+    _log_debug("checking Python version")
     current_site = dirname(__file__)
 
     # We cannot use `sys.version_info.major` or other named attributes, as they only got introduced only in Python 3.1.
@@ -168,8 +175,8 @@ def import_distro():
         _self_deactivate(current_site)
         _print_cannot_auto_instrument_message("unsupported Python version: {}".format(version))
         return
-    _print_debug_msg("found eligible Python version: {}".format(version_info))
-    _print_debug_msg("checking OTEL_EXPORTER_OTLP_PROTOCOL")
+    _log_debug("found eligible Python version: {}".format(version_info))
+    _log_debug("checking OTEL_EXPORTER_OTLP_PROTOCOL")
 
     otlp_protocol = os.environ.get("OTEL_EXPORTER_OTLP_PROTOCOL")
     if otlp_protocol is None:
@@ -196,8 +203,8 @@ def import_distro():
             "to use Python auto-instrumentation.)"
         )
         return
-    _print_debug_msg("found eligible OTEL_EXPORTER_OTLP_PROTOCOL value: {}".format(otlp_protocol))
-    _print_debug_msg("checking for double instrumentation")
+    _log_debug("found eligible OTEL_EXPORTER_OTLP_PROTOCOL value: {}".format(otlp_protocol))
+    _log_debug("checking for double instrumentation")
 
     # Temporarily remove this site to be able to check for problematic dependencies in all other available sites.
     # Without the current site it is easier to differentiate between "our" dependencies and dependencies brought in by
@@ -210,8 +217,8 @@ def import_distro():
     if _check_for_double_instrumentation(current_site):
         return
 
-    _print_debug_msg("no double instrumentation detected")
-    _print_debug_msg("checking for dependency conflicts")
+    _log_debug("no double instrumentation detected")
+    _log_debug("checking for dependency conflicts")
 
     # This "path.append(current_site)" together with "path.remove(current_site)" executed a couple of lines above
     # effectively reorders sys.path to put this site last. This is necessary to evaluate potential conflicting
@@ -237,7 +244,7 @@ def import_distro():
 
     if not version_conflicts:
         try:
-            _print_debug_msg("importing and initializing the Python auto-instrumentation now")
+            _log_debug("importing and initializing the Python auto-instrumentation now")
             from opentelemetry.instrumentation import auto_instrumentation
             auto_instrumentation.initialize()
         except Exception as e:

--- a/images/instrumentation/python/test_sitecustomize.py
+++ b/images/instrumentation/python/test_sitecustomize.py
@@ -78,9 +78,10 @@ class TestImportDistro(unittest.TestCase):
             with patch('sys.path', [mock_site]):
                 module, spec = load_sitecustomize_module()
                 spec.loader.exec_module(module)
+                spec.loader.exec_module(module)
 
         output = mock_stderr.getvalue()
-        self.assertIn("[dash0] warning: cannot auto-instrument Python process: unsupported Python version: 2.7.0",
+        self.assertIn("\"level\": \"warn\", \"message\": \"cannot auto-instrument Python process: unsupported Python version: 2.7.0",
                       output)
 
     @patch('sys.stderr', new_callable=StringIO)
@@ -96,7 +97,7 @@ class TestImportDistro(unittest.TestCase):
                 spec.loader.exec_module(module)
 
         output = mock_stderr.getvalue()
-        self.assertIn("[dash0] warning: cannot auto-instrument Python process: unsupported Python version: 3.8.0",
+        self.assertIn("\"level\": \"warn\", \"message\": \"cannot auto-instrument Python process: unsupported Python version: 3.8.0",
                       output)
 
     @patch('sys.stderr', new_callable=StringIO)
@@ -144,7 +145,7 @@ class TestImportDistro(unittest.TestCase):
                 spec.loader.exec_module(module)
 
         output = mock_stderr.getvalue()
-        self.assertIn("[dash0] warning: cannot auto-instrument Python process: OTEL_EXPORTER_OTLP_PROTOCOL is not set",
+        self.assertIn("\"level\": \"warn\", \"message\": \"cannot auto-instrument Python process: OTEL_EXPORTER_OTLP_PROTOCOL is not set",
                       output)
 
     @patch('sys.stderr', new_callable=StringIO)
@@ -161,7 +162,7 @@ class TestImportDistro(unittest.TestCase):
 
         output = mock_stderr.getvalue()
         self.assertIn(
-            "[dash0] warning: cannot auto-instrument Python process: OTEL_EXPORTER_OTLP_PROTOCOL=grpc is not supported",
+            "\"level\": \"warn\", \"message\": \"cannot auto-instrument Python process: OTEL_EXPORTER_OTLP_PROTOCOL=grpc is not supported",
             output)
 
     @patch('sys.stderr', new_callable=StringIO)
@@ -196,7 +197,7 @@ class TestImportDistro(unittest.TestCase):
         output = mock_stderr.getvalue()
         # Should report dependency conflicts
         self.assertIn(
-            "[dash0] warning: cannot auto-instrument Python process: dependency conflicts: {'packaging': {'version_required': '>=20.0', 'version_found': '19.0'}}",
+            "\"level\": \"warn\", \"message\": \"cannot auto-instrument Python process: dependency conflicts: {'packaging': {'version_required': '>=20.0', 'version_found': '19.0'}}",
             output)
 
     @patch('sys.stderr', new_callable=StringIO)
@@ -226,7 +227,7 @@ class TestImportDistro(unittest.TestCase):
                             spec.loader.exec_module(module)
 
         output = mock_stderr.getvalue()
-        self.assertIn("[dash0] importing and initializing the Python auto-instrumentation now", output)
+        self.assertIn("\"level\": \"debug\", \"message\": \"importing and initializing the Python auto-instrumentation now", output)
 
     @patch('sys.stderr', new_callable=StringIO)
     @patch('sys.version_info', (3, 9, 0, 'final', 0))
@@ -256,7 +257,7 @@ class TestImportDistro(unittest.TestCase):
 
         output = mock_stderr.getvalue()
         # Should report dependency conflicts for the missing required package
-        self.assertIn("[dash0] warning: cannot auto-instrument Python process: dependency conflicts", output)
+        self.assertIn("\"level\": \"warn\", \"message\": \"cannot auto-instrument Python process: dependency conflicts", output)
 
     @patch('sys.stderr', new_callable=StringIO)
     @patch('sys.version_info', (3, 9, 0, 'final', 0))
@@ -277,7 +278,7 @@ class TestImportDistro(unittest.TestCase):
 
         output = mock_stderr.getvalue()
         self.assertIn(
-            "[dash0] warning: cannot auto-instrument Python process: The application has OpenTelemetry dependencies which indicate that it is already instrumented. The following problematic dependencies have been found: /app/site-packages/opentelemetry_sdk-1.0.0.dist-info. Skipping the Dash0 Python auto-instrumentation to avoid double instrumentation.",
+            "\"level\": \"warn\", \"message\": \"cannot auto-instrument Python process: The application has OpenTelemetry dependencies which indicate that it is already instrumented. The following problematic dependencies have been found: /app/site-packages/opentelemetry_sdk-1.0.0.dist-info. Skipping the Dash0 Python auto-instrumentation to avoid double instrumentation.",
             output)
         self.assertIn("/app/site-packages/opentelemetry_sdk-1.0.0.dist-info", output)
         # Verify self-deactivation happened
@@ -306,7 +307,7 @@ class TestImportDistro(unittest.TestCase):
 
         output = mock_stderr.getvalue()
         self.assertIn(
-            "[dash0] warning: cannot auto-instrument Python process: The application has OpenTelemetry dependencies which indicate that it is already instrumented. The following problematic dependencies have been found:",
+            "\"level\": \"warn\", \"message\": \"cannot auto-instrument Python process: The application has OpenTelemetry dependencies which indicate that it is already instrumented. The following problematic dependencies have been found:",
             output)
         self.assertIn("/app/site-packages/opentelemetry_sdk-1.0.0.dist-info", output)
         self.assertIn("/app/site-packages/opentelemetry_distro-1.0.0.dist-info", output)
@@ -341,8 +342,8 @@ class TestImportDistro(unittest.TestCase):
                                 spec.loader.exec_module(module)
 
         output = mock_stderr.getvalue()
-        self.assertIn("no double instrumentation detected", output)
-        self.assertIn("importing and initializing the Python auto-instrumentation now", output)
+        self.assertIn("\"level\": \"debug\", \"message\": \"no double instrumentation detected", output)
+        self.assertIn("\"level\": \"debug\", \"message\": \"importing and initializing the Python auto-instrumentation now", output)
 
 
 if __name__ == '__main__':

--- a/internal/collectors/collector_controller.go
+++ b/internal/collectors/collector_controller.go
@@ -138,7 +138,7 @@ func (r *CollectorReconciler) Reconcile(
 		ctx,
 	)
 	if err != nil {
-		logger.Error(err, "Failed to create/update collector resources.")
+		logger.ErrorTelemetryCollectionIssue(err, "Failed to create/update collector resources.")
 		return reconcile.Result{}, err
 	}
 	if hasBeenReconciled {

--- a/internal/collectors/collector_manager.go
+++ b/internal/collectors/collector_manager.go
@@ -72,7 +72,7 @@ func (m *CollectorManager) UpdateExtraConfig(ctx context.Context, newConfig util
 	if previousConfig == nil || !reflect.DeepEqual(*previousConfig, newConfig) {
 		hasBeenReconciled, err := m.ReconcileOpenTelemetryCollector(ctx)
 		if err != nil {
-			logger.Error(err, "Failed to create/update collector resources after extra config map update.")
+			logger.ErrorTelemetryCollectionIssue(err, "Failed to create/update collector resources after extra config map update.")
 		}
 		if hasBeenReconciled {
 			logger.Info("successfully reconciled collector resources after extra config map update")
@@ -141,7 +141,7 @@ func (m *CollectorManager) ReconcileOpenTelemetryCollector(
 	}
 
 	if operatorConfigurationResource == nil {
-		logger.Warn(logMsgOperatorConfigMissing)
+		logger.WarnTelemetryCollectionIssue(logMsgOperatorConfigMissing)
 		err = m.removeOpenTelemetryCollector(ctx, *extraConfig, logger)
 		return err == nil, err
 	} else if !util.ReadBoolPointerWithDefault(operatorConfigurationResource.Spec.TelemetryCollection.Enabled, true) {
@@ -189,7 +189,7 @@ func (m *CollectorManager) createOrUpdateOpenTelemetryCollector(
 			logger,
 		)
 	if err != nil {
-		logger.Error(
+		logger.ErrorTelemetryCollectionIssue(
 			err,
 			"failed to create one or more of the OpenTelemetry collector DaemonSet/Deployment resources, some or "+
 				"all telemetry will be missing",
@@ -283,7 +283,7 @@ func (m *CollectorManager) findAllMonitoringResources(
 		&monitoringResourceList,
 		&client.ListOptions{},
 	); err != nil {
-		logger.Error(err, "Failed to list all Dash0 monitoring resources, requeuing reconcile request.")
+		logger.ErrorTelemetryCollectionIssue(err, "Failed to list all Dash0 monitoring resources, requeuing reconcile request.")
 		return nil, err
 	}
 

--- a/internal/collectors/otelcolresources/exporter.go
+++ b/internal/collectors/otelcolresources/exporter.go
@@ -99,7 +99,7 @@ func getNamespacedOtlpExporters(
 		for i, export := range monitoringResource.EffectiveExports() {
 			exp, err := convertExportSettingsToExporterList(&export, i, false, &ns)
 			if err != nil {
-				logger.Error(err, fmt.Sprintf("Custom exporters for namespace %s could not be applied. "+
+				logger.ErrorTelemetryCollectionIssue(err, fmt.Sprintf("Custom exporters for namespace %s could not be applied. "+
 					"Default exporters will be used for this namespace.", ns))
 				break
 			} else {

--- a/internal/collectors/otelcolresources/otelcol_resources.go
+++ b/internal/collectors/otelcolresources/otelcol_resources.go
@@ -723,7 +723,7 @@ func isTlsError(err error) bool {
 }
 
 func (m *OTelColResourceManager) logErrorAndDisableKubeletStatsReceiver(logger logd.Logger) KubeletStatsReceiverConfig {
-	logger.Error(
+	logger.ErrorTelemetryCollectionIssue(
 		fmt.Errorf("cannot determine viable endpoint for kubeletstats receiver endpoint, see above"),
 		"The operator ran out of options when trying to find a viable kubeletstats receiver endpoint. The "+
 			"kubeletstats receiver will be disabled. Some Kubernetes infrastructure metrics will be missing.",
@@ -760,7 +760,7 @@ func intelligentEdgeConfigFromResource(
 		apiEndpoint = resource.Spec.ControlPlaneApiEndpoint
 	}
 	if !hasDash0Export {
-		logger.Warn("No Dash0 export is configured in the operator configuration resource. The " +
+		logger.WarnTelemetryCollectionIssue("No Dash0 export is configured in the operator configuration resource. The " +
 			"sampling processor and barker will not have an authorization token for the Decision Maker. " +
 			"Configure a Dash0 export with an auth token in the operator configuration resource.")
 	}

--- a/internal/instrumentation/instrumenter.go
+++ b/internal/instrumentation/instrumenter.go
@@ -159,9 +159,9 @@ func (i *Instrumenter) InstrumentAtStartup(
 			&dash0MonitoringResource,
 			logger,
 		); err != nil {
-			logger.Error(
+			logger.ErrorAsWarnTelemetryCollectionIssue(
 				err,
-				"Failed to apply/update instrumentation instrumentation at startup in one namespace.",
+				"Failed to apply/update instrumentation at startup in one namespace.",
 				"namespace",
 				dash0MonitoringResource.Namespace,
 				"name",
@@ -207,7 +207,7 @@ func (i *Instrumenter) CheckSettingsAndInstrumentExistingWorkloads(
 
 	logger.Info("Now instrumenting existing workloads in namespace so they send telemetry to Dash0.")
 	if err := i.instrumentAllWorkloads(ctx, dash0MonitoringResource, logger); err != nil {
-		logger.ErrorAsWarn(err, "Instrumenting existing workloads failed.")
+		logger.ErrorAsWarnTelemetryCollectionIssue(err, "Instrumenting existing workloads failed.")
 		return err
 	}
 
@@ -688,7 +688,7 @@ func (i *Instrumenter) postProcessInstrumentation(
 		if errors.As(retryErr, e) {
 			logger.Info(e.Error())
 		} else {
-			logger.ErrorAsWarn(retryErr, "Dash0 instrumentation by controller has not been successful.")
+			logger.ErrorAsWarnTelemetryCollectionIssue(retryErr, "Dash0 instrumentation by controller has not been successful.")
 		}
 		util.QueueFailedInstrumentationEvent(i.Recorder, resource, actor, retryErr)
 		return false
@@ -750,12 +750,13 @@ func (i *Instrumenter) UninstrumentWorkloadsIfAvailable(
 	if dash0MonitoringResource.IsAvailable() {
 		logger.Info("Reverting Dash0's modifications to workloads that have been instrumented to make them send telemetry to Dash0.")
 		if err := i.uninstrumentAllWorkloads(ctx, dash0MonitoringResource, logger); err != nil {
-			logger.ErrorAsWarn(err, "Uninstrumenting existing workloads failed.")
+			logger.ErrorAsWarnTelemetryCollectionIssue(err, "Uninstrumenting existing workloads failed.")
 			return err
 		}
 	} else {
-		logger.Info("Removing the Dash0 monitoring resource and running finalizers, but the Dash0 monitoring resource is not " +
-			"marked as available. Instrumentation will not be removed from workloads.")
+		logger.WarnTelemetryCollectionIssue(
+			"Removing the Dash0 monitoring resource and running finalizers, but the Dash0 monitoring resource is not " +
+				"marked as available. Instrumentation will not be removed from workloads.")
 	}
 	return nil
 }
@@ -1161,7 +1162,10 @@ func (i *Instrumenter) postProcessUninstrumentation(
 		if errors.As(retryErr, e) {
 			logger.Info(e.Error())
 		} else {
-			logger.ErrorAsWarn(retryErr, "Dash0's removal of instrumentation by controller has not been successful.")
+			logger.ErrorAsWarnTelemetryCollectionIssue(
+				retryErr,
+				"Dash0's removal of instrumentation by controller has not been successful.",
+			)
 		}
 		util.QueueFailedUninstrumentationEvent(i.Recorder, resource, actor, retryErr)
 		return false
@@ -1207,7 +1211,7 @@ func (i *Instrumenter) restartPodsOfReplicaSet(
 				TimeoutSeconds: &timeoutForListingPods,
 			})
 	if err != nil {
-		logger.Error(
+		logger.ErrorAsWarnTelemetryCollectionIssue(
 			err,
 			fmt.Sprintf(
 				"Failed to list all pods in the namespaces for the purpose of restarting the pods owned by the "+
@@ -1234,7 +1238,7 @@ func (i *Instrumenter) restartPodsOfReplicaSet(
 	logger.Debug(fmt.Sprintf("found %d pod(s) to restart for replica set %s/%s", len(podsOfReplicaSet), replicaSet.Namespace, replicaSet.Name))
 	for _, pod := range podsOfReplicaSet {
 		if err := i.Delete(ctx, &pod); err != nil {
-			logger.Warn(
+			logger.WarnTelemetryCollectionIssue(
 				fmt.Sprintf(
 					"Failed to restart pod owned by the replica "+
 						"set %s/%s (%s), this pod will not be restarted automatically.",

--- a/internal/targetallocator/targetallocator_controller.go
+++ b/internal/targetallocator/targetallocator_controller.go
@@ -132,7 +132,7 @@ func (r *TargetAllocatorReconciler) Reconcile(
 		TriggeredByWatchEvent,
 	)
 	if err != nil {
-		logger.Error(err, "Failed to create/update target-allocator resources.")
+		logger.ErrorTelemetryCollectionIssue(err, "Failed to create/update target-allocator resources.")
 		return reconcile.Result{}, err
 	}
 	if hasBeenReconciled {

--- a/internal/targetallocator/targetallocator_manager.go
+++ b/internal/targetallocator/targetallocator_manager.go
@@ -56,10 +56,10 @@ func (m *TargetAllocatorManager) UpdateExtraConfig(ctx context.Context, newConfi
 	if previousConfig == nil || !reflect.DeepEqual(*previousConfig, newConfig) {
 		hasBeenReconciled, err := m.ReconcileTargetAllocator(ctx, TriggeredByWatchEvent)
 		if err != nil {
-			logger.Error(err, "Failed to create/update collector resources after extra config map update.")
+			logger.ErrorTelemetryCollectionIssue(err, "Failed to create/update target-allocator resources after extra config map update.")
 		}
 		if hasBeenReconciled {
-			logger.Info("successfully reconciled collector resources after extra config map update")
+			logger.Info("successfully reconciled target-allocator resources after extra config map update")
 		}
 	} else {
 		logger.Info("ignoring extra config map update, both the new and the old extra config map have the same content")
@@ -84,7 +84,7 @@ func (m *TargetAllocatorManager) ReconcileTargetAllocator(
 
 	if m.updateInProgress.Load() {
 		if m.developmentMode {
-			logger.Info("creation/update of the OpenTelemetry collector resources is already in progress, skipping " +
+			logger.Info("creation/update of the OpenTelemetry target-allocator resources is already in progress, skipping " +
 				"additional reconciliation request.")
 		}
 		return false, nil
@@ -191,7 +191,7 @@ func (m *TargetAllocatorManager) createOrUpdateTargetAllocator(
 			logger)
 
 	if err != nil {
-		logger.Error(
+		logger.ErrorTelemetryCollectionIssue(
 			err,
 			"failed to create one or more of the OpenTelemetry target-allocator resources, "+
 				"support for Prometheus CRDs might not work",
@@ -225,12 +225,12 @@ func (m *TargetAllocatorManager) removeTargetAllocator(
 	if err != nil {
 		logger.Error(
 			err,
-			"Failed to delete the OpenTelemetry collector Kubernetes resources, requeuing reconcile request.",
+			"Failed to delete the OpenTelemetry target-allocator Kubernetes resources, requeuing reconcile request.",
 		)
 		return err
 	}
 	if resourcesHaveBeenDeleted {
-		logger.Info("OpenTelemetry collector Kubernetes resources have been deleted.")
+		logger.Info("OpenTelemetry target-allocator Kubernetes resources have been deleted.")
 	} else {
 		logger.Debug("no OpenTelemetry target-allocator Kubernetes resources to delete")
 	}

--- a/internal/util/logd/logd.go
+++ b/internal/util/logd/logd.go
@@ -12,6 +12,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
+const (
+	telemetryCollectionIssueMarker = "dash0.monitoring.telemetry_collection_issue"
+)
+
 // Logger is a thin wrapper around logr.Logger that adds
 //   - a Debug method using V(1), which maps to zapcore.DebugLevel (-1) via the zapr bridge
 //     (logr V level n maps to zap level -n).
@@ -50,6 +54,21 @@ func (l Logger) Warn(msg string, keysAndValues ...any) {
 // ErrorAsWarn logs an error at level at zapcore.WarnLevel.
 func (l Logger) ErrorAsWarn(err error, msg string, keysAndValues ...any) {
 	l.Warn(msg, append([]any{"error", err}, keysAndValues...)...)
+}
+
+// WarnTelemetryCollectionIssue logs a telemetry collection issue at level at zapcore.WarnLevel.
+func (l Logger) WarnTelemetryCollectionIssue(msg string, keysAndValues ...any) {
+	l.Warn(msg, append([]any{telemetryCollectionIssueMarker, true}, keysAndValues...)...)
+}
+
+// ErrorAsWarnTelemetryCollectionIssue logs an error as a telemetry collection issue at level at zapcore.WarnLevel.
+func (l Logger) ErrorAsWarnTelemetryCollectionIssue(err error, msg string, keysAndValues ...any) {
+	l.ErrorAsWarn(err, msg, append([]any{telemetryCollectionIssueMarker, true}, keysAndValues...)...)
+}
+
+// ErrorTelemetryCollectionIssue logs an error as a telemetry collection issue at level at zapcore.ErrorLevel.
+func (l Logger) ErrorTelemetryCollectionIssue(err error, msg string, keysAndValues ...any) {
+	l.ErrorAsWarn(err, msg, append([]any{telemetryCollectionIssueMarker, true}, keysAndValues...)...)
 }
 
 // WithValues returns a new Logger with additional key-value pairs.

--- a/internal/workloads/workload_modifier.go
+++ b/internal/workloads/workload_modifier.go
@@ -956,7 +956,7 @@ func (m *ResourceModifier) addOtelExporterOtlpEnvVars(
 	//   an OTel SDK is set up manually in the workload's code.
 	// * It will also break for OTel SDKs that only support the GRPC exporter, but not HTTP (Python & nginx for
 	//   example).
-	perContainerLogger.Warn(otelExporterOtlpNoOverwriteMsg)
+	perContainerLogger.WarnTelemetryCollectionIssue(otelExporterOtlpNoOverwriteMsg)
 	instrumentationIssues = append(instrumentationIssues, otelExporterOtlpNoOverwriteMsg)
 	return instrumentationIssues
 }
@@ -980,7 +980,7 @@ func (m *ResourceModifier) addOrAppendToLdPreloadEnvVar(
 				"Dash0 cannot prepend anything to the environment variable %s as it is specified via "+
 					"ValueFrom, this container will not be instrumented to send telemetry to Dash0.",
 				envVarLdPreloadName)
-			perContainerLogger.Warn(msg)
+			perContainerLogger.WarnTelemetryCollectionIssue(msg)
 			instrumentationIssues = append(instrumentationIssues, msg)
 			return instrumentationIssues
 		}


### PR DESCRIPTION
This enables easily aggregating all telemetry collection issues in a log view.

Also: use structured logging in sitecustomize.py.
This enables including the messages from sitecustomize.py to be included in the telemetry collection issues log view.
