### PR TITLE
chore(collectors): rename filelog receiver to file_log

### DIFF
--- a/helm-chart/dash0-operator/values.yaml
+++ b/helm-chart/dash0-operator/values.yaml
@@ -403,7 +403,7 @@ operator:
     # override the default image pull policy
     pullPolicy:
 
-  # the container image to use for synchronizing the offset files for the filelog receiver to the filelog offset config
+  # the container image to use for synchronizing the offset files for the file_log receiver to the filelog offset config
   # map; will not be used if a filelog offset storage volume is provided via
   # operator.collectors.filelogOffsetSyncStorageVolume
   # (there should usually be no reason to override this)

--- a/images/filelogoffsetsync/README.md
+++ b/images/filelogoffsetsync/README.md
@@ -4,7 +4,7 @@ Filelog Receiver Offset Synchronization
 See opentelemetry-collector-contrib/receiver/filelogreceiver/README.md#offset-tracking.
 
 This container is added to the daemonset OTel collector pod, to keep track of log file offsets.
-Its main purpose is to ensure that log records are not emitted multiple times by the filelog receiver when the collector
+Its main purpose is to ensure that log records are not emitted multiple times by the file_log receiver when the collector
 pod is restarted.
 
 *Note:* If a user-provided volume is configured via the Helm chart property
@@ -19,7 +19,7 @@ the help of this container image.
 Since the whole mechanism requires a couple of components to work together, here is a description of how everything is
 connected:
 
-- The configuration for the filelog receiver (see `daemonset.config.yaml.template`) sets the property
+- The configuration for the file_log receiver (see `daemonset.config.yaml.template`) sets the property
   `storage: file_storage/filelogreceiver_offsets` and also defines a file storage extension with the same name,
   backed by the directory `/var/otelcol/filelogreceiver_offsets`.
 - This directory in turn is backed by a volume mount (`desired_state.go#filelogReceiverOffsetsVolumeMount`), which
@@ -28,11 +28,11 @@ connected:
 - The volume mounts all refer to the volume named `filelogreceiver-offsets` of that pod
   (`desired_state.go#assembleCollectorDaemonSetVolumes`), which is an `EmptyDir` type volume with a limit of 10 MB.
 - This way, the filelog offset sync container as well as the filelog offset sync init container have access to the
-  filelog offset files which the collector container's filelog receiver component writes.
+  filelog offset files which the collector container's file_log receiver component writes.
 
 The `EmptyDir` volume only exists for the lifetime of the pod.
 The purpose of storing the offsets in the first place is to have them available across pod restarts, so we need to
-synchronize them in some kind of permanent storage after the filelog receiver writes them to the
+synchronize them in some kind of permanent storage after the file_log receiver writes them to the
 `filelogreceiver-offsets` volume.
 For that purpose, the operator creates a config map named `${helm release name}-filelogoffsets-cm` (see `desired_state.go#assembleFilelogOffsetsConfigMap`).
 

--- a/images/filelogoffsetvolumeownership/README.md
+++ b/images/filelogoffsetvolumeownership/README.md
@@ -2,13 +2,13 @@ Filelog Offset Volume Ownership
 ===============================
 
 This image is attached as an init container to the OpenTelemetry collector DaemonSet pods, when a volume is used to
-store filelog offsets for the filelog receiver.
+store filelog offsets for the file_log receiver.
 The user-provided volume is mounted at /var/otelcol/filelogreceiver_offsets, both for the collector containerand also
 for this init container.
 
 We use the file_storage extension to store log file offsets. This is configured in daemonset.config.yaml.template
 in the section extensions.file_storage/filelogreceiver_offsets.
-The extension is attached to receivers.filelog via the storage attribute.
+The extension is attached to receivers.file_log via the storage attribute.
 The storage directory configured for file_storage/filelogreceiver is /var/otelcol/filelogreceiver_offsets, that is,
 the extension uses the volume mount's directory.
 
@@ -40,8 +40,8 @@ spec:
 Failure to set the ownership correctly will result in `/var/otelcol/filelogreceiver_offsets` to be owned by `root:root`,
 which in turn will result in a CrashLoopBackOff for the DaemonSet collector's `opentelemetry-collector` container:
 ```
-opentelemetry-collector Error: cannot start pipelines: failed to start "filelog" receiver: storage client: open /var/otelcol/filelogreceiver_offsets/receiver_filelog_: permission denied
-opentelemetry-collector 2025/11/19 14:56:38 collector server run finished with error: cannot start pipelines: failed to start "filelog" receiver: storage client: open /var/otelcol/filelogreceiver_offsets/receiver_filelog_: permission denied
+opentelemetry-collector Error: cannot start pipelines: failed to start "file_log" receiver: storage client: open /var/otelcol/filelogreceiver_offsets/receiver_filelog_: permission denied
+opentelemetry-collector 2025/11/19 14:56:38 collector server run finished with error: cannot start pipelines: failed to start "file_log" receiver: storage client: open /var/otelcol/filelogreceiver_offsets/receiver_filelog_: permission denied
 ```
 
 For this reason, we attach this init container, running as root, and executing the following actions:

--- a/internal/collectors/collector_controller.go
+++ b/internal/collectors/collector_controller.go
@@ -52,7 +52,7 @@ func (r *CollectorReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			r.withNamePredicate([]string{
 				otelcolresources.DaemonSetCollectorConfigConfigMapName(r.oTelCollectorNamePrefix),
 				otelcolresources.DeploymentCollectorConfigConfigMapName(r.oTelCollectorNamePrefix),
-				// Note: We are deliberately not watching the filelog receiver offsets ConfigMap, since it is updated
+				// Note: We are deliberately not watching the file_log receiver offsets ConfigMap, since it is updated
 				// frequently by the filelog offset sync container and does not require reconciliation.
 			}, true)).
 		Watches(

--- a/internal/collectors/otelcolresources/collector_config_maps_test.go
+++ b/internal/collectors/otelcolresources/collector_config_maps_test.go
@@ -1902,7 +1902,7 @@ var _ = Describe("The OpenTelemetry Collector ConfigMaps", func() {
 			Expect(serviceExtensions).To(ContainElement("dash0settingsonedgeextension"))
 		})
 
-		It("should collect barker logs via filelog/selfmonitoring when IE + barker + self-monitoring enabled [DaemonSet]", func() {
+		It("should collect barker logs via file_log/selfmonitoring when IE + barker + self-monitoring enabled [DaemonSet]", func() {
 			configMap, err := assembleDaemonSetCollectorConfigMap(&oTelColConfig{
 				OperatorNamespace: OperatorNamespace,
 				NamePrefix:        namePrefix,
@@ -1925,10 +1925,10 @@ var _ = Describe("The OpenTelemetry Collector ConfigMaps", func() {
 			Expect(err).ToNot(HaveOccurred())
 			collectorConfig := parseConfigMapContent(configMap)
 
-			// filelog/selfmonitoring should include barker pod log path
+			// file_log/selfmonitoring should include barker pod log path
 			receivers := collectorConfig["receivers"].(map[string]interface{})
-			Expect(receivers).To(HaveKey("filelog/selfmonitoring"))
-			filelogConfig := receivers["filelog/selfmonitoring"].(map[string]interface{})
+			Expect(receivers).To(HaveKey("file_log/selfmonitoring"))
+			filelogConfig := receivers["file_log/selfmonitoring"].(map[string]interface{})
 			includePaths := filelogConfig["include"].([]interface{})
 			barkerPathFound := false
 			for _, p := range includePaths {
@@ -1938,14 +1938,14 @@ var _ = Describe("The OpenTelemetry Collector ConfigMaps", func() {
 					}
 				}
 			}
-			Expect(barkerPathFound).To(BeTrue(), "barker pod log path not found in filelog/selfmonitoring include list")
+			Expect(barkerPathFound).To(BeTrue(), "barker pod log path not found in file_log/selfmonitoring include list")
 
 			// logs/selfmonitoring-filelog-to-forwarder pipeline should exist
 			pipelines := readPipelines(collectorConfig)
 			Expect(pipelines).To(HaveKey("logs/selfmonitoring-filelog-to-forwarder"))
 		})
 
-		It("should not include barker logs in filelog/selfmonitoring when barker is disabled [DaemonSet]", func() {
+		It("should not include barker logs in file_log/selfmonitoring when barker is disabled [DaemonSet]", func() {
 			configMap, err := assembleDaemonSetCollectorConfigMap(&oTelColConfig{
 				OperatorNamespace: OperatorNamespace,
 				NamePrefix:        namePrefix,
@@ -1989,7 +1989,7 @@ var _ = Describe("The OpenTelemetry Collector ConfigMaps", func() {
 			Expect(err).ToNot(HaveOccurred())
 			configContent := configMap.Data["config.yaml"]
 			Expect(configContent).ToNot(ContainSubstring(namePrefix + "-barker"))
-			Expect(configContent).ToNot(ContainSubstring("filelog/selfmonitoring"))
+			Expect(configContent).ToNot(ContainSubstring("file_log/selfmonitoring"))
 		})
 
 		It("should drop barker-originated OTLP logs when IE + barker + self-monitoring are enabled [DaemonSet]", func() {
@@ -3302,25 +3302,25 @@ var _ = Describe("The OpenTelemetry Collector ConfigMaps", func() {
 			Exporters:         cmTestSingleDefaultOtlpExporter(),
 		}
 
-		It("should not render the filelog receiver if no namespace has log collection enabled", func() {
+		It("should not render the file_log receiver if no namespace has log collection enabled", func() {
 			configMap, err := assembleDaemonSetCollectorConfigMap(config, []string{}, []string{}, []string{}, nil, nil, emptyTargetAllocatorMtlsConfig, false)
 
 			Expect(err).ToNot(HaveOccurred())
 			collectorConfig := parseConfigMapContent(configMap)
-			Expect(ReadFromMap(collectorConfig, []string{"receivers", "filelog"})).To(BeNil())
+			Expect(ReadFromMap(collectorConfig, []string{"receivers", "file_log"})).To(BeNil())
 
 			filelogServiceAttributeProcessor :=
 				ReadFromMap(collectorConfig, []string{"processors", "transform/logs/filelog_service_attributes"})
 			Expect(filelogServiceAttributeProcessor).To(BeNil())
 
 			pipelines := readPipelines(collectorConfig)
-			Expect(pipelines["logs/filelog"]).To(BeNil())
+			Expect(pipelines["logs/file_log"]).To(BeNil())
 			logsCommonProcessorsPipelineProcessors := readPipelineProcessors(pipelines, "logs/common-processors")
 			Expect(logsCommonProcessorsPipelineProcessors).ToNot(BeNil())
 			Expect(logsCommonProcessorsPipelineProcessors).ToNot(ContainElement("transform/logs/filelog_service_attributes"))
 		})
 
-		It("should render the filelog config with all namespaces for which log collection is enabled", func() {
+		It("should render the file_log config with all namespaces for which log collection is enabled", func() {
 			configMap, err := assembleDaemonSetCollectorConfigMap(
 				config,
 				[]string{"namespace-1", "namespace-2", "namespace-3"},
@@ -3333,7 +3333,7 @@ var _ = Describe("The OpenTelemetry Collector ConfigMaps", func() {
 			)
 			Expect(err).ToNot(HaveOccurred())
 			collectorConfig := parseConfigMapContent(configMap)
-			fileLogReceiverRaw := ReadFromMap(collectorConfig, []string{"receivers", "filelog"})
+			fileLogReceiverRaw := ReadFromMap(collectorConfig, []string{"receivers", "file_log"})
 			Expect(fileLogReceiverRaw).ToNot(BeNil())
 			fileLogReceiver := fileLogReceiverRaw.(map[string]any)
 			filePatterns := fileLogReceiver["include"].([]any)
@@ -3348,7 +3348,7 @@ var _ = Describe("The OpenTelemetry Collector ConfigMaps", func() {
 			pipelines := readPipelines(collectorConfig)
 			logsFilelogReceivers := readPipelineReceivers(pipelines, "logs/filelog-to-forwarder")
 			Expect(logsFilelogReceivers).ToNot(BeNil())
-			Expect(logsFilelogReceivers).To(ContainElement("filelog"))
+			Expect(logsFilelogReceivers).To(ContainElement("file_log"))
 			logsFilelogProcessors := readPipelineProcessors(pipelines, "logs/filelog-to-forwarder")
 			Expect(logsFilelogProcessors).ToNot(BeNil())
 			logsFilelogExporters := readPipelineExporters(pipelines, "logs/filelog-to-forwarder")
@@ -4659,7 +4659,7 @@ var _ = Describe("The OpenTelemetry Collector ConfigMaps", func() {
 	})
 
 	Describe("target-allocator self-monitoring", func() {
-		It("should render the filelog/selfmonitoring receiver and pipeline when both SelfMonitoringEnabled and PrometheusCrdSupportEnabled are true", func() {
+		It("should render the file_log/selfmonitoring receiver and pipeline when both SelfMonitoringEnabled and PrometheusCrdSupportEnabled are true", func() {
 			config := &oTelColConfig{
 				OperatorNamespace:           OperatorNamespace,
 				NamePrefix:                  namePrefix,
@@ -4674,7 +4674,7 @@ var _ = Describe("The OpenTelemetry Collector ConfigMaps", func() {
 			Expect(err).ToNot(HaveOccurred())
 			collectorConfig := parseConfigMapContent(configMap)
 
-			filelogReceiverRaw := ReadFromMap(collectorConfig, []string{"receivers", "filelog/selfmonitoring"})
+			filelogReceiverRaw := ReadFromMap(collectorConfig, []string{"receivers", "file_log/selfmonitoring"})
 			Expect(filelogReceiverRaw).ToNot(BeNil())
 			filelogReceiver, ok := filelogReceiverRaw.(map[string]interface{})
 			Expect(ok).To(BeTrue())
@@ -4689,12 +4689,12 @@ var _ = Describe("The OpenTelemetry Collector ConfigMaps", func() {
 			Expect(filelogReceiver["start_at"]).To(Equal("beginning"))
 
 			pipelines := readPipelines(collectorConfig)
-			Expect(readPipelineReceivers(pipelines, "logs/selfmonitoring-filelog-to-forwarder")).To(ConsistOf("filelog/selfmonitoring"))
+			Expect(readPipelineReceivers(pipelines, "logs/selfmonitoring-filelog-to-forwarder")).To(ConsistOf("file_log/selfmonitoring"))
 			Expect(readPipelineProcessors(pipelines, "logs/selfmonitoring-filelog-to-forwarder")).To(ConsistOf("memory_limiter"))
 			Expect(readPipelineExporters(pipelines, "logs/selfmonitoring-filelog-to-forwarder")).To(ConsistOf("forward/logs-processors"))
 		})
 
-		It("should not render the filelog/selfmonitoring receiver and pipeline when SelfMonitoringEnabled is false", func() {
+		It("should not render the file_log/selfmonitoring receiver and pipeline when SelfMonitoringEnabled is false", func() {
 			config := &oTelColConfig{
 				OperatorNamespace:           OperatorNamespace,
 				NamePrefix:                  namePrefix,
@@ -4709,7 +4709,7 @@ var _ = Describe("The OpenTelemetry Collector ConfigMaps", func() {
 			Expect(err).ToNot(HaveOccurred())
 			collectorConfig := parseConfigMapContent(configMap)
 
-			Expect(ReadFromMap(collectorConfig, []string{"receivers", "filelog/selfmonitoring"})).To(BeNil())
+			Expect(ReadFromMap(collectorConfig, []string{"receivers", "file_log/selfmonitoring"})).To(BeNil())
 			Expect(ReadFromMap(collectorConfig, []string{
 				"service",
 				"pipelines",
@@ -4717,7 +4717,7 @@ var _ = Describe("The OpenTelemetry Collector ConfigMaps", func() {
 			})).To(BeNil())
 		})
 
-		It("should not render the filelog/selfmonitoring receiver and pipeline when PrometheusCrdSupportEnabled is false", func() {
+		It("should not render the file_log/selfmonitoring receiver and pipeline when PrometheusCrdSupportEnabled is false", func() {
 			config := &oTelColConfig{
 				OperatorNamespace:           OperatorNamespace,
 				NamePrefix:                  namePrefix,
@@ -4732,7 +4732,7 @@ var _ = Describe("The OpenTelemetry Collector ConfigMaps", func() {
 			Expect(err).ToNot(HaveOccurred())
 			collectorConfig := parseConfigMapContent(configMap)
 
-			Expect(ReadFromMap(collectorConfig, []string{"receivers", "filelog/selfmonitoring"})).To(BeNil())
+			Expect(ReadFromMap(collectorConfig, []string{"receivers", "file_log/selfmonitoring"})).To(BeNil())
 			Expect(ReadFromMap(collectorConfig, []string{
 				"service",
 				"pipelines",

--- a/internal/collectors/otelcolresources/daemonset.config.yaml.template
+++ b/internal/collectors/otelcolresources/daemonset.config.yaml.template
@@ -507,7 +507,7 @@ receivers:
   {{- end }}
 
   {{- if .NamespacesWithLogCollection }}
-  filelog:
+  file_log:
     include:
     {{- range $i, $namespace := .NamespacesWithLogCollection }}
       - /var/log/pods/{{ $namespace }}_*/*/*.log
@@ -527,7 +527,7 @@ receivers:
   target-allocator is running even though it shouldn't.
   */}}
   {{- if and .SelfMonitoringEnabled (or .PrometheusCrdSupportEnabled (and .IntelligentEdge.Enabled .IntelligentEdge.BarkerEnabled)) }}
-  filelog/selfmonitoring:
+  file_log/selfmonitoring:
     include:
       {{- if .PrometheusCrdSupportEnabled }}
       - /var/log/pods/{{ .OperatorNamespace }}_{{ .OperatorResourcesNamePrefix }}-opentelemetry-target-allocator*/*/*.log
@@ -850,10 +850,10 @@ processors:
         - {{ .NamespaceOttlFilter }}
   {{- end }}
   {{- if and .SelfMonitoringEnabled .IntelligentEdge.Enabled .IntelligentEdge.BarkerEnabled }}
-  # Barker's stdout logs are already collected by filelog/selfmonitoring, but the shared OpenTelemetry init helper also
+  # Barker's stdout logs are already collected by file_log/selfmonitoring, but the shared OpenTelemetry init helper also
   # installs an OTLP log exporter whenever OTEL_EXPORTER_OTLP_ENDPOINT is set (no per-signal toggle), so barker also
   # pushes its logs via OTLP. Drop those SDK-originated records to avoid duplicates. telemetry.sdk.language is set by
-  # the OTel SDK and absent on filelog-scraped records.
+  # the OTel SDK and absent on file_log-scraped records.
   filter/logs/drop_barker_otlp_selfmonitoring:
     logs:
       log_record:
@@ -1331,7 +1331,7 @@ service:
     {{- if .NamespacesWithLogCollection }}
     logs/filelog-to-forwarder:
       receivers:
-        - filelog
+        - file_log
       processors:
         - memory_limiter
       exporters:
@@ -1341,7 +1341,7 @@ service:
     {{- if and .SelfMonitoringEnabled (or .PrometheusCrdSupportEnabled (and .IntelligentEdge.Enabled .IntelligentEdge.BarkerEnabled)) }}
     logs/selfmonitoring-filelog-to-forwarder:
       receivers:
-        - filelog/selfmonitoring
+        - file_log/selfmonitoring
       processors:
         - memory_limiter
       exporters:

--- a/internal/util/types.go
+++ b/internal/util/types.go
@@ -166,7 +166,7 @@ type NamespaceInstrumentationConfig struct {
 	InstrumentationLabelSelector    string
 	TraceContextPropagators         *string
 	PreviousTraceContextPropagators *string
-	// LogCollectionEnabled is true if the operator collects pod logs from this namespace via the collector's filelog
+	// LogCollectionEnabled is true if the operator collects pod logs from this namespace via the collector's file_log
 	// receiver. When true, the workload modifier sets OTEL_LOGS_EXPORTER=none on instrumented containers to prevent
 	// the workload's own OTel SDK from also exporting logs via OTLP (which would result in duplicates).
 	LogCollectionEnabled bool

--- a/internal/webhooks/monitoring_mutating_webhook.go
+++ b/internal/webhooks/monitoring_mutating_webhook.go
@@ -198,7 +198,7 @@ func (h *MonitoringMutatingWebhookHandler) overrideLogCollectionDefault(
 				"Automatically disabling log collection in the operator namespace %s. Logs from the operator can be "+
 					"collected via self monitoring, see "+
 					"https://github.com/dash0hq/dash0-operator/tree/main/helm-chart/dash0-operator#operatorconfigurationresource.spec.selfMonitoring.enabled. "+
-					"Collecting them via the filelog receiver is not supported. You can get rid of this log message "+
+					"Collecting them via the file_log receiver is not supported. You can get rid of this log message "+
 					"by explicitly disabling log collection for this namespace, see "+
 					"https://github.com/dash0hq/dash0-operator/tree/main/helm-chart/dash0-operator#monitoringresource.spec.logCollection.enabled.",
 				h.operatorNamespace))

--- a/internal/workloads/workload_modifier.go
+++ b/internal/workloads/workload_modifier.go
@@ -849,7 +849,7 @@ func (m *ResourceModifier) prependDash0NodeIp(container *corev1.Container) {
 }
 
 // addOtelLogsExporterEnvVar sets OTEL_LOGS_EXPORTER=none when log collection is enabled for the namespace, so the
-// workload's own OTel SDK does not also export logs via OTLP (the collector's filelog receiver already tails stdout,
+// workload's own OTel SDK does not also export logs via OTLP (the collector's file_log receiver already tails stdout,
 // which would result in duplicate log records). If the user has already set OTEL_LOGS_EXPORTER explicitly, we preserve
 // their value.
 //

--- a/test/e2e/logs.go
+++ b/test/e2e/logs.go
@@ -161,7 +161,7 @@ func compileTelemetryMatcherUrlForLogRecords(
 	//   lower bound: 2026-01-05 12:59:44.90783     +0000 UTC (1767617984907830000) vs.
 	//    log record: 2026-01-05 12:59:44.907778513 +0000 UTC (1767617984907778513)
 	//
-	// Maybe this is related to the way the filelog receiver determines the log record's timestamp after reading it from
+	// Maybe this is related to the way the file_log receiver determines the log record's timestamp after reading it from
 	// the pod log.
 	timestampLowerBound = timestampLowerBound.Add(-1 * time.Millisecond)
 	params.Add(shared.QueryParamTimestampLowerBoundStr, strconv.FormatInt(timestampLowerBound.UnixNano(), 10))


### PR DESCRIPTION
Starting with OpenTelemetry collector release 0.149.0, the filelog receiver has been renamed to file_log, with filelog becoming a deprecated alias.

This commit introduces the new name in the collector configuration templates.

- the receiver is referred to by "file_log" now
- named pipelines referring to that name use "file-log", since they use hyphens as separators (e.g. logs/file-log-to-forwarder)
- the filelog offset container images and containers or anything related to the offset mechanism has not been renamed

Unfortunately this introduces a mix of file_log, file-log and filelog for now, but renaming the offset-related container images and containers is out of scope for this commit.