### PR TITLE
chore(collectors): use declarative config for internal telemetry

### DIFF
--- a/internal/collectors/otelcolresources/daemonset.config.yaml.template
+++ b/internal/collectors/otelcolresources/daemonset.config.yaml.template
@@ -1477,17 +1477,27 @@ service:
   {{- if .InternalTelemetryEnabled }}
   telemetry:
     resource:
-      "k8s.cluster.uid": "{{- .PseudoClusterUid }}"
-      {{- if .ClusterName }}
-      "k8s.cluster.name": "{{- .ClusterName }}"
-      {{- end }}
-      "k8s.node.name": "${env:K8S_NODE_NAME}"
-      "k8s.namespace.name": "${env:DASH0_OPERATOR_NAMESPACE}"
-      "k8s.daemonset.uid": "${env:K8S_DAEMONSET_UID}"
-      "k8s.daemonset.name": "${env:K8S_DAEMONSET_NAME}"
-      "k8s.pod.uid": "${env:K8S_POD_UID}"
-      "k8s.pod.name": "${env:K8S_POD_NAME}"
-      "k8s.container.name": "opentelemetry-collector"
+      attributes:
+        - name: k8s.cluster.uid
+          value: "{{ .PseudoClusterUid }}"
+        {{- if .ClusterName }}
+        - name: k8s.cluster.name
+          value: "{{ .ClusterName }}"
+        {{- end }}
+        - name: k8s.node.name
+          value: ${env:K8S_NODE_NAME}
+        - name: k8s.namespace.name
+          value: ${env:DASH0_OPERATOR_NAMESPACE}
+        - name: k8s.daemonset.uid
+          value: ${env:K8S_DAEMONSET_UID}
+        - name: k8s.daemonset.name
+          value: ${env:K8S_DAEMONSET_NAME}
+        - name: k8s.pod.uid
+          value: ${env:K8S_POD_UID}
+        - name: k8s.pod.name
+          value: ${env:K8S_POD_NAME}
+        - name: k8s.container.name
+          value: opentelemetry-collector
 
   {{- if .SelfMonitoringMetricsConfig }}
   {{- .SelfMonitoringMetricsConfig }}

--- a/internal/collectors/otelcolresources/deployment.config.yaml.template
+++ b/internal/collectors/otelcolresources/deployment.config.yaml.template
@@ -584,17 +584,27 @@ service:
 {{- if .InternalTelemetryEnabled }}
   telemetry:
     resource:
-      "k8s.cluster.uid": "{{- .PseudoClusterUid }}"
-      {{- if .ClusterName }}
-      "k8s.cluster.name": "{{- .ClusterName }}"
-      {{- end }}
-      "k8s.node.name": "${env:K8S_NODE_NAME}"
-      "k8s.namespace.name": "${env:DASH0_OPERATOR_NAMESPACE}"
-      "k8s.deployment.uid": "${env:K8S_DEPLOYMENT_UID}"
-      "k8s.deployment.name": "${env:K8S_DEPLOYMENT_NAME}"
-      "k8s.pod.uid": "${env:K8S_POD_UID}"
-      "k8s.pod.name": "${env:K8S_POD_NAME}"
-      "k8s.container.name": "opentelemetry-collector"
+      attributes:
+        - name: k8s.cluster.uid
+          value: "{{ .PseudoClusterUid }}"
+        {{- if .ClusterName }}
+        - name: k8s.cluster.name
+          value: "{{ .ClusterName }}"
+        {{- end }}
+        - name: k8s.node.name
+          value: ${env:K8S_NODE_NAME}
+        - name: k8s.namespace.name
+          value: ${env:DASH0_OPERATOR_NAMESPACE}
+        - name: k8s.deployment.uid
+          value: ${env:K8S_DEPLOYMENT_UID}
+        - name: k8s.deployment.name
+          value: ${env:K8S_DEPLOYMENT_NAME}
+        - name: k8s.pod.uid
+          value: ${env:K8S_POD_UID}
+        - name: k8s.pod.name
+          value: ${env:K8S_POD_NAME}
+        - name: k8s.container.name
+          value: "opentelemetry-collector"
 
 {{- if .SelfMonitoringMetricsConfig }}
 {{- .SelfMonitoringMetricsConfig }}


### PR DESCRIPTION
Release 0.151.0 of the OpenTelemetry collector allows using declarative schema with explicit name/value pairs, and declares the previous inline attribute map format as legacy.

See https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.151.0.