### PR TITLE
test(iac): fix flaky tests

### DIFF
--- a/internal/controller/notification_channel_controller_test.go
+++ b/internal/controller/notification_channel_controller_test.go
@@ -84,6 +84,8 @@ var _ = Describe(
 
 		AfterEach(
 			func() {
+				VerifyNoUnmatchedGockRequests()
+
 				DeleteMonitoringResource(ctx, k8sClient)
 				for _, name := range extraMonitoringResourceNames {
 					DeleteMonitoringResourceByName(ctx, k8sClient, name, true)

--- a/internal/controller/perses_dashboards_controller_test.go
+++ b/internal/controller/perses_dashboards_controller_test.go
@@ -414,6 +414,14 @@ var _ = Describe(
 
 				AfterEach(
 					func() {
+						VerifyNoUnmatchedGockRequests()
+
+						// Make sure the work queue is empty before tearing down the monitoring resource so an in-flight synchronization job
+						// from a previous test cannot write its (potentially stale) result to the next test's monitoring resource.
+						Eventually(func(g Gomega) {
+							g.Expect(testQueuePersesDashboards.Len()).To(Equal(0))
+						}, 3*time.Second, 20*time.Millisecond).Should(Succeed())
+
 						DeleteMonitoringResourceIfItExists(ctx, k8sClient)
 						persesDashboardCrdReconciler.RemoveNamespacedApiConfigs(ctx, TestNamespaceName, logger)
 					},
@@ -1158,6 +1166,7 @@ func deletePersesDashboardCrdIfItExists(ctx context.Context) {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
 			},
+			3*time.Second, 20*time.Millisecond,
 		).Should(Succeed())
 
 		persesDashboardCrd = nil

--- a/internal/controller/prometheus_rules_controller_test.go
+++ b/internal/controller/prometheus_rules_controller_test.go
@@ -420,8 +420,17 @@ var _ = Describe(
 
 				AfterEach(
 					func() {
+						VerifyNoUnmatchedGockRequests()
+
+						// Make sure the work queue is empty before tearing down the monitoring resource so an in-flight synchronization job
+						// from a previous test cannot write its (potentially stale) result to the next test's monitoring resource.
+						Eventually(func(g Gomega) {
+							g.Expect(testQueuePrometheusRules.Len()).To(Equal(0))
+						}, 3*time.Second, 20*time.Millisecond).Should(Succeed())
+
 						DeleteMonitoringResourceIfItExists(ctx, k8sClient)
 						prometheusRuleCrdReconciler.RemoveNamespacedApiConfigs(ctx, TestNamespaceName, logger)
+
 					},
 				)
 
@@ -746,6 +755,25 @@ var _ = Describe(
 								Reply(503).
 								JSON(map[string]string{})
 						}
+						// Recording rule PUT also fails on the second config
+						for _, expectedRequest := range defaultRecordingRuleRequests() {
+							origin :=
+								fmt.Sprintf(
+									"dash0-operator_%s_%s_test-namespace_test-rule_%s_%s",
+									clusterId,
+									DatasetCustomTestAlternative,
+									strings.ReplaceAll(expectedRequest.group, "/", "|"),
+									expectedRequest.alert,
+								)
+							expectedPath := fmt.Sprintf("%s.*%s", recordingRuleApiBasePath, origin)
+							gock.New(ApiEndpointTestAlternative).
+								Put(expectedPath).
+								MatchHeader("Authorization", AuthorizationHeaderTestAlternative).
+								MatchParam("dataset", DatasetCustomTestAlternative).
+								Times(3). // 3 retries
+								Reply(503).
+								JSON(map[string]string{})
+						}
 						defer gock.Off()
 
 						prometheusRuleCrdReconciler.SetDefaultApiConfigs(
@@ -796,12 +824,21 @@ var _ = Describe(
 
 						// Expect DELETE requests for both API configs
 						expectCheckRuleDeleteRequests(clusterId, defaultCheckRuleRequests())
+						expectRecordingRuleDeleteRequests(clusterId, defaultRecordingRuleRequests())
 						expectCheckRuleDeleteRequestsCustom(
 							clusterId,
 							ApiEndpointTestAlternative,
 							AuthorizationHeaderTestAlternative,
 							DatasetCustomTestAlternative,
 							defaultCheckRuleRequests(),
+							http.StatusOK,
+						)
+						expectRecordingRuleDeleteRequestsCustom(
+							clusterId,
+							ApiEndpointTestAlternative,
+							AuthorizationHeaderTestAlternative,
+							DatasetCustomTestAlternative,
+							defaultRecordingRuleRequests(),
 							http.StatusOK,
 						)
 						defer gock.Off()
@@ -832,9 +869,18 @@ var _ = Describe(
 
 						Eventually(
 							func(g Gomega) {
-								g.Expect(gock.IsDone()).To(BeTrue())
+								monRes := LoadMonitoringResourceOrFail(ctx, k8sClient, g)
+								results := monRes.Status.PrometheusRuleSynchronizationResults
+								g.Expect(results).NotTo(BeNil())
+								g.Expect(results).To(HaveLen(1))
+								result := results[fmt.Sprintf("%s/%s", TestNamespaceName, "test-rule")]
+								g.Expect(result.SynchronizationStatus).To(
+									Equal(dash0common.ThirdPartySynchronizationStatusSuccessful),
+								)
+								g.Expect(result.SynchronizationResults).To(HaveLen(2))
 							},
 						).Should(Succeed())
+						Expect(gock.IsDone()).To(BeTrue())
 					},
 				)
 
@@ -2673,6 +2719,7 @@ func deletePrometheusRuleCrdIfItExists(ctx context.Context) {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
 			},
+			3*time.Second, 20*time.Millisecond,
 		).Should(Succeed())
 
 		prometheusRuleCrd = nil
@@ -2835,6 +2882,33 @@ func expectCheckRuleDeleteRequestsCustom(
 				expectedRequest.alert,
 			)
 		expectedPath := fmt.Sprintf("%s.*%s", checkRuleApiBasePath, origin)
+		gock.New(endpoint).
+			Delete(expectedPath).
+			MatchHeader("Authorization", authHeader).
+			MatchParam("dataset", dataset).
+			Times(1).
+			Reply(status)
+	}
+}
+
+func expectRecordingRuleDeleteRequestsCustom(
+	clusterId string,
+	endpoint string,
+	authHeader string,
+	dataset string,
+	expectedRequests []checkRuleRequestExpectation,
+	status int,
+) {
+	for _, expectedRequest := range expectedRequests {
+		origin :=
+			fmt.Sprintf(
+				"dash0-operator_%s_%s_test-namespace_test-rule_%s_%s",
+				clusterId,
+				dataset,
+				strings.ReplaceAll(expectedRequest.group, "/", "|"),
+				expectedRequest.alert,
+			)
+		expectedPath := fmt.Sprintf("%s.*%s", recordingRuleApiBasePath, origin)
 		gock.New(endpoint).
 			Delete(expectedPath).
 			MatchHeader("Authorization", authHeader).

--- a/internal/controller/sampling_rule_controller_test.go
+++ b/internal/controller/sampling_rule_controller_test.go
@@ -96,6 +96,8 @@ var _ = Describe(
 
 				AfterEach(
 					func() {
+						VerifyNoUnmatchedGockRequests()
+
 						deleteSamplingRuleResourceIfItExists(ctx, k8sClient, samplingRuleName)
 						deleteSamplingRuleResourceIfItExists(ctx, k8sClient, samplingRuleName2)
 					},

--- a/internal/controller/synthetic_check_controller_test.go
+++ b/internal/controller/synthetic_check_controller_test.go
@@ -124,6 +124,8 @@ var _ = Describe(
 
 				AfterEach(
 					func() {
+						VerifyNoUnmatchedGockRequests()
+
 						DeleteMonitoringResourceIfItExists(ctx, k8sClient)
 						deleteSyntheticCheckResourceIfItExists(ctx, k8sClient, TestNamespaceName, syntheticCheckName)
 						deleteSyntheticCheckResourceIfItExists(ctx, k8sClient, extraNamespaceSyntheticChecks, syntheticCheckName2)

--- a/internal/controller/view_controller_test.go
+++ b/internal/controller/view_controller_test.go
@@ -124,6 +124,8 @@ var _ = Describe(
 
 				AfterEach(
 					func() {
+						VerifyNoUnmatchedGockRequests()
+
 						DeleteMonitoringResourceIfItExists(ctx, k8sClient)
 						deleteViewResourceIfItExists(ctx, k8sClient, TestNamespaceName, viewName)
 						deleteViewResourceIfItExists(ctx, k8sClient, extraNamespaceViews, viewName2)

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -73,6 +73,8 @@ require (
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/pprof v0.0.0-20260402051712-545e8a4df936 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
+	github.com/h2non/gock v1.2.0 // indirect
+	github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542 // indirect
 	github.com/hashicorp/go-version v1.9.0 // indirect
 	github.com/hashicorp/golang-lru v1.0.2 // indirect
 	github.com/huandu/xstrings v1.5.0 // indirect

--- a/test/e2e/go.sum
+++ b/test/e2e/go.sum
@@ -210,6 +210,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f h1:KUppIJq7/+SVif2QVs3tOP0zanoHgBEVAwHxUSIzRqU=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
+github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32 h1:W6apQkHrMkS0Muv8G/TipAy/FJl/rCYT0+EuS8+Z0z4=
+github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32/go.mod h1:9wM+0iRr9ahx58uYLpLIr5fm8diHn0JbqRycJi6w0Ms=
 github.com/nexucis/lamenv v0.5.2 h1:tK/u3XGhCq9qIoVNcXsK9LZb8fKopm0A5weqSRvHd7M=
 github.com/nexucis/lamenv v0.5.2/go.mod h1:HusJm6ltmmT7FMG8A750mOLuME6SHCsr2iFYxp5fFi0=
 github.com/oapi-codegen/runtime v1.4.0 h1:KLOSFOp7UzkbS7Cs1ms6NBEKYr0WmH2wZG0KKbd2er4=

--- a/test/util/gock.go
+++ b/test/util/gock.go
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: Copyright 2026 Dash0 Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package util
+
+import (
+	"fmt"
+
+	"github.com/h2non/gock"
+	. "github.com/onsi/gomega"
+)
+
+// VerifyNoUnmatchedGockRequests makes sure that gock did not silently swallow any unmatched requests during a test.
+// Such requests indicate missing or wrong mocks and previously caused tests to be flaky, when leftover processing
+// and/or HTTP retries wrote bogus status while the next test had already started.
+func VerifyNoUnmatchedGockRequests() {
+	unmatched := gock.GetUnmatchedRequests()
+	unmatchedDescriptions := make([]string, 0, len(unmatched))
+	for _, req := range unmatched {
+		unmatchedDescriptions = append(
+			unmatchedDescriptions,
+			fmt.Sprintf("%s %s", req.Method, req.URL.String()),
+		)
+	}
+	gock.CleanUnmatchedRequest()
+	Expect(unmatchedDescriptions).To(
+		BeEmpty(),
+		"gock recorded HTTP requests that did not match any mock",
+	)
+}


### PR DESCRIPTION
The test "deletes check rules with two API configs (multi-export)" bled over into "updates check rules", after introducing IaC support for recording rules in commit 856ae9e7f37d182be9c98a633a1f9624e553f0cb.

The delete test was missing gock mocks for new HTTP delete calls introduced for recording rules, hence these failed with "gock: cannot match any request", without failing the test. The next test case would already start, while the goroutine trying to delete the recording rule and writing the monitoring resource status were still running.

Fixed by:
- add missing gock expectations
- wait for the status to be written to the monitoring resource at the end of the test
- verify there are no unmatched gock requests after each test