### PR TITLE
feat(workloads): don't instrument workloads w. low storage limits

### DIFF
--- a/internal/controller/signal_to_metrics_controller_test.go
+++ b/internal/controller/signal_to_metrics_controller_test.go
@@ -17,7 +17,7 @@ import (
 
 	dash0common "github.com/dash0hq/dash0-operator/api/operator/common"
 	dash0v1alpha1 "github.com/dash0hq/dash0-operator/api/operator/v1alpha1"
-	"github.com/dash0hq/dash0-operator/internal/util"
+	"github.com/dash0hq/dash0-operator/internal/util/cluster"
 	"github.com/dash0hq/dash0-operator/internal/util/logd"
 
 	"github.com/h2non/gock"
@@ -57,7 +57,7 @@ var _ = Describe(
 			func() {
 				EnsureTestNamespaceExists(ctx, k8sClient)
 				EnsureOperatorNamespaceExists(ctx, k8sClient)
-				clusterId = string(util.ReadPseudoClusterUid(ctx, k8sClient, logger))
+				clusterId = string(cluster.ReadPseudoClusterUid(ctx, k8sClient, logger))
 			},
 		)
 

--- a/internal/workloads/workload_modifier.go
+++ b/internal/workloads/workload_modifier.go
@@ -8,6 +8,7 @@ import (
 	"maps"
 	"reflect"
 	"slices"
+	"strconv"
 	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -88,6 +89,15 @@ var (
 		envVarOtelExporterOtlpEndpointName,
 		envVarOtelExporterOtlpProtocolName,
 	)
+
+	// Do not instrument workloads via init container and EmptyDir instrumentation volume when one of its containers has
+	// an ephemeral storage limit below this threshold. The EmptyDir adds about 400 MB of ephemeral storage; on top of
+	// that, the container's ephemeral-storage budget also has to cover its own writable layer plus logs, we budget ~100M
+	// for that.  Containers with a tighter limit are skipped to avoid evictions caused by adding the instrumentation
+	// volume.
+	ephemeralStorageLimitThresholdMB    int64 = 500
+	ephemeralStorageLimitThresholdBytes       = ephemeralStorageLimitThresholdMB * 1000 * 1000
+	ephemeralStorageLimitThresholdLabel       = strconv.FormatInt(ephemeralStorageLimitThresholdMB, 10) + "M"
 )
 
 var (
@@ -153,6 +163,17 @@ func NewNotModifiedUnsupportedOperatingSystemResult(details string) Modification
 		return fmt.Sprintf(
 			"The %s has not modified this workload since it seems to be targeting a non-Linux operating system, workload "+
 				"modifications are only supported for Linux workloads. Details: %s", actor, details)
+	})
+}
+
+func NewNotModifiedEphemeralStorageLimitTooLowResult(containerName string, limit string) ModificationResult {
+	return newNotModifiedResult(func(actor util.WorkloadModifierActor) string {
+		return fmt.Sprintf(
+			"The %s has not modified this workload since container %q has an ephemeral-storage limit of %s, which is below "+
+				"the required threshold of %s. The Dash0 init-container instrumentation requires at least %s of ephemeral "+
+				"storage, raise the limit or remove it to enable instrumentation, or use image volume instrumentation "+
+				"delivery.",
+			actor, containerName, limit, ephemeralStorageLimitThresholdLabel, ephemeralStorageLimitThresholdLabel)
 	})
 }
 
@@ -1626,8 +1647,8 @@ func (m *ResourceModifier) removeLegacyEnvVarNodeOptions(container *corev1.Conta
 
 // checkEligibleForModification checks whether the given PodTemplateSpec is eligible for modification.
 // If it is, the function returns nil, otherwise it returns a ModificationResult describing why it is not eligible.
-// In particular, this function checks whether the pod spec template is a non-Linux workload. (Other checks might be
-// added in the future.)
+// In particular, this function checks whether the pod spec template is a non-Linux workload, or whether any container
+// has an ephemeral-storage limit too low to accommodate the Dash0 instrumentation volume.
 func (m *ResourceModifier) checkEligibleForModification(podSpec *corev1.PodSpec) *ModificationResult {
 	if podSpec.OS != nil && podSpec.OS.Name != "" && podSpec.OS.Name != corev1.Linux {
 		return new(NewNotModifiedUnsupportedOperatingSystemResult(fmt.Sprintf("pod.spec.os.name: \"%s\"", podSpec.OS.Name)))
@@ -1654,6 +1675,32 @@ func (m *ResourceModifier) checkEligibleForModification(podSpec *corev1.PodSpec)
 					)))
 				}
 			}
+		}
+	}
+	if m.clusterInstrumentationConfig.IsInstrumentationDeliveryInitContainer() {
+		if notModifiedResult := m.checkEphemeralStorageLimit(podSpec); notModifiedResult != nil {
+			return notModifiedResult
+		}
+	}
+	return nil
+}
+
+// checkEphemeralStorageLimit returns a not-modified result if any container in the pod spec declares an ephemeral
+// storage limit below the threshold (to not cause pod eviction once we add the instrumentation volume). Init containers
+// and ephemeral containers are not checked, since we do not instrument them. A telemetry-collection-issue warning is
+// logged for the first offending container; subsequent offenders are not reported.
+func (m *ResourceModifier) checkEphemeralStorageLimit(podSpec *corev1.PodSpec) *ModificationResult {
+	for i := range podSpec.Containers {
+		container := &podSpec.Containers[i]
+		limit, hasLimit := container.Resources.Limits[corev1.ResourceEphemeralStorage]
+		if !hasLimit {
+			continue
+		}
+		if limit.Value() < ephemeralStorageLimitThresholdBytes {
+			result := NewNotModifiedEphemeralStorageLimitTooLowResult(container.Name, limit.String())
+			m.logger.WithValues("container", container.Name).
+				WarnTelemetryCollectionIssue(result.RenderReasonMessage(m.actor))
+			return &result
 		}
 	}
 	return nil

--- a/internal/workloads/workload_modifier_test.go
+++ b/internal/workloads/workload_modifier_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	dash0v1beta1 "github.com/dash0hq/dash0-operator/api/operator/v1beta1"
@@ -480,6 +481,58 @@ var _ = Describe("Dash0 Workload Modification", func() {
 					"system, workload modifications are only supported for Linux workloads. " +
 					"Details: pod.spec.nodeSelector: \"kubernetes.io/os=windows\""))
 			VerifyUnmodifiedDeployment(workload)
+		})
+
+		It("should not instrument workloads with init container where a container's ephemeral-storage limit is below the threshold", func() {
+			workload := BasicDeployment(TestNamespaceName, DeploymentNamePrefix)
+			workload.Spec.Template.Spec.Containers[0].Resources.Limits = corev1.ResourceList{
+				corev1.ResourceEphemeralStorage: resource.MustParse("100M"),
+			}
+			modificationResult := workloadModifierInitCnt.ModifyDeployment(workload)
+
+			Expect(modificationResult.HasBeenModified).To(BeFalse())
+			Expect(modificationResult.RenderReasonMessage(testActor)).To(Equal(
+				"The actor has not modified this workload since container \"test-container-0\" has an ephemeral-storage " +
+					"limit of 100M, which is below the required threshold of 500M. The Dash0 init-container instrumentation " +
+					"requires at least 500M of ephemeral storage, raise the limit or remove it to enable instrumentation, or " +
+					"use image volume instrumentation delivery."))
+			VerifyUnmodifiedDeployment(workload)
+		})
+
+		It("should instrument workloads with image volume even if a container's ephemeral-storage limit is below the threshold", func() {
+			workload := BasicDeployment(TestNamespaceName, DeploymentNamePrefix)
+			workload.Spec.Template.Spec.Containers[0].Resources.Limits = corev1.ResourceList{
+				corev1.ResourceEphemeralStorage: resource.MustParse("100M"),
+			}
+			modificationResult := workloadModifierImgVol.ModifyDeployment(workload)
+
+			Expect(modificationResult.HasBeenModified).To(BeTrue())
+		})
+
+		It("should instrument workloads where the ephemeral-storage limit equals the threshold", func() {
+			workload := BasicDeployment(TestNamespaceName, DeploymentNamePrefix)
+			workload.Spec.Template.Spec.Containers[0].Resources.Limits = corev1.ResourceList{
+				corev1.ResourceEphemeralStorage: resource.MustParse("500M"),
+			}
+			modificationResult := workloadModifierInitCnt.ModifyDeployment(workload)
+
+			Expect(modificationResult.HasBeenModified).To(BeTrue())
+		})
+
+		It("should instrument workloads where the ephemeral-storage limit is only set on an init container", func() {
+			workload := BasicDeployment(TestNamespaceName, DeploymentNamePrefix)
+			workload.Spec.Template.Spec.InitContainers = []corev1.Container{{
+				Name:  "user-init-container",
+				Image: "ubuntu",
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						corev1.ResourceEphemeralStorage: resource.MustParse("10M"),
+					},
+				},
+			}}
+			modificationResult := workloadModifierInitCnt.ModifyDeployment(workload)
+
+			Expect(modificationResult.HasBeenModified).To(BeTrue())
 		})
 	})
 
@@ -1008,6 +1061,81 @@ var _ = Describe("Dash0 Workload Modification", func() {
 						"Details: pod.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution." +
 						"nodeSelectorTerms.matchExpression: key: \"kubernetes.io/os\", operator: \"NotIn\", " +
 						"values: \"[linux some-operating-system]\"",
+				),
+			}),
+		)
+
+		type ephemeralStorageLimitTest struct {
+			// Per-container ephemeral-storage limit, parsed via resource.MustParse. Empty string means "no limit set".
+			containerLimits []string
+			expectedMessage *string
+		}
+
+		buildPodSpec := func(containerLimits []string) corev1.PodSpec {
+			containers := make([]corev1.Container, len(containerLimits))
+			for i, limitStr := range containerLimits {
+				containers[i] = corev1.Container{
+					Name:  fmt.Sprintf("c%d", i),
+					Image: "ubuntu",
+				}
+				if limitStr != "" {
+					containers[i].Resources.Limits = corev1.ResourceList{
+						corev1.ResourceEphemeralStorage: resource.MustParse(limitStr),
+					}
+				}
+			}
+			return corev1.PodSpec{Containers: containers}
+		}
+
+		DescribeTable("should detect containers with too-low ephemeral-storage limits",
+			func(testConfig ephemeralStorageLimitTest) {
+				podSpec := buildPodSpec(testConfig.containerLimits)
+				result := workloadModifier.checkEligibleForModification(&podSpec)
+				if testConfig.expectedMessage == nil {
+					Expect(result).To(BeNil())
+				} else {
+					Expect(result).ToNot(BeNil())
+					Expect(result.HasBeenModified).To(BeFalse())
+					Expect(result.RenderReasonMessage(testActor)).To(Equal(*testConfig.expectedMessage))
+				}
+			},
+			Entry("no ephemeral-storage limit set is eligible", ephemeralStorageLimitTest{
+				containerLimits: []string{""},
+				expectedMessage: nil,
+			}),
+			Entry("ephemeral-storage limit equal to the threshold is eligible", ephemeralStorageLimitTest{
+				containerLimits: []string{"500M"},
+				expectedMessage: nil,
+			}),
+			Entry("ephemeral-storage limit above the threshold is eligible", ephemeralStorageLimitTest{
+				containerLimits: []string{"1Gi"},
+				expectedMessage: nil,
+			}),
+			Entry("ephemeral-storage limit below the threshold is non-eligible", ephemeralStorageLimitTest{
+				containerLimits: []string{"100M"},
+				expectedMessage: new(
+					"The actor has not modified this workload since container \"c0\" has an ephemeral-storage limit " +
+						"of 100M, which is below the required threshold of 500M. The Dash0 init-container instrumentation " +
+						"requires at least 500M of ephemeral storage, raise the limit or remove it to enable " +
+						"instrumentation, or use image volume instrumentation delivery.",
+				),
+			}),
+			Entry("ephemeral-storage limit just below the threshold is non-eligible", ephemeralStorageLimitTest{
+				containerLimits: []string{"499999999"},
+				expectedMessage: new(
+					"The actor has not modified this workload since container \"c0\" has an ephemeral-storage limit " +
+						"of 499999999, which is below the required threshold of 500M. The Dash0 init-container instrumentation " +
+						"requires at least 500M of ephemeral storage, raise the limit or remove it to enable instrumentation, " +
+						"or use image volume instrumentation delivery.",
+				),
+			}),
+			Entry("only the second container has a too-low limit; workload is non-eligible", ephemeralStorageLimitTest{
+				containerLimits: []string{"1Gi", "50M"},
+				expectedMessage: new(
+					"The actor has not modified this workload since container \"c1\" has an ephemeral-storage limit " +
+						"of 50M, which is below the required threshold of 500M. The Dash0 init-container instrumentation " +
+						"requires at least 500M of ephemeral storage, raise the limit or remove it to enable " +
+						"instrumentation, or use image volume instrumentation delivery.",
 				),
 			}),
 		)


### PR DESCRIPTION
Adding the dash0-instrumentation volume to workloads with tight ephemeral storage limits will cause pod eviction.