### PR TITLE
fix(crd): make most status attributes optional

### DIFF
--- a/api/operator/common/common_monitoring_types.go
+++ b/api/operator/common/common_monitoring_types.go
@@ -354,37 +354,55 @@ const (
 )
 
 type PersesDashboardSynchronizationResults struct {
-	SynchronizationStatus  ThirdPartySynchronizationStatus                             `json:"synchronizationStatus"`
-	SynchronizedAt         metav1.Time                                                 `json:"synchronizedAt"`
-	ValidationIssues       []string                                                    `json:"validationIssues,omitempty"`
-	SynchronizationResults []PersesDashboardSynchronizationResultPerEndpointAndDataset `json:"synchronizationResults"`
+	// +kubebuilder:validation:Optional
+	SynchronizationStatus ThirdPartySynchronizationStatus `json:"synchronizationStatus"`
+	// +kubebuilder:validation:Optional
+	SynchronizedAt metav1.Time `json:"synchronizedAt"`
+	// +kubebuilder:validation:Optional
+	ValidationIssues []string `json:"validationIssues,omitempty"`
+	// +kubebuilder:validation:Optional`
+	SynchronizationResults []PersesDashboardSynchronizationResultPerEndpointAndDataset `json:"synchronizationResults,omitempty"`
 }
 
 type PersesDashboardSynchronizationResultPerEndpointAndDataset struct {
 	Dash0ApiEndpoint string `json:"dash0ApiEndpoint"`
-	Dash0Dataset     string `json:"dash0Dataset,omitempty"`
 	// +kubebuilder:validation:Optional
-	Dash0Origin          string `json:"dash0Origin,omitempty"`
+	Dash0Dataset string `json:"dash0Dataset,omitempty"`
+	// +kubebuilder:validation:Optional
+	Dash0Origin string `json:"dash0Origin,omitempty"`
+	// +kubebuilder:validation:Optional
 	SynchronizationError string `json:"synchronizationError,omitempty"`
 }
 
 type PrometheusRuleSynchronizationResult struct {
-	SynchronizationStatus  ThirdPartySynchronizationStatus                            `json:"synchronizationStatus"`
-	SynchronizedAt         metav1.Time                                                `json:"synchronizedAt"`
-	AlertingRulesTotal     int                                                        `json:"alertingRulesTotal"`
-	RecordingRulesTotal    int                                                        `json:"recordingRulesTotal"`
-	InvalidRulesTotal      int                                                        `json:"invalidRulesTotal"`
-	InvalidRules           map[string][]string                                        `json:"invalidRules,omitempty"`
-	SynchronizationResults []PrometheusRuleSynchronizationResultPerEndpointAndDataset `json:"synchronizationResults"`
+	// +kubebuilder:validation:Optional
+	SynchronizationStatus ThirdPartySynchronizationStatus `json:"synchronizationStatus"`
+	// +kubebuilder:validation:Optional
+	SynchronizedAt metav1.Time `json:"synchronizedAt"`
+	// +kubebuilder:validation:Optional
+	AlertingRulesTotal int `json:"alertingRulesTotal"`
+	// +kubebuilder:validation:Optional
+	RecordingRulesTotal int `json:"recordingRulesTotal"`
+	// +kubebuilder:validation:Optional
+	InvalidRulesTotal int `json:"invalidRulesTotal"`
+	// +kubebuilder:validation:Optional
+	InvalidRules map[string][]string `json:"invalidRules,omitempty"`
+	// +kubebuilder:validation:Optional
+	SynchronizationResults []PrometheusRuleSynchronizationResultPerEndpointAndDataset `json:"synchronizationResults,omitempty"`
 }
 
 type PrometheusRuleSynchronizationResultPerEndpointAndDataset struct {
-	Dash0ApiEndpoint            string                                              `json:"dash0ApiEndpoint"`
-	Dash0Dataset                string                                              `json:"dash0Dataset,omitempty"`
-	SynchronizedRulesTotal      int                                                 `json:"synchronizedRulesTotal"`
+	Dash0ApiEndpoint string `json:"dash0ApiEndpoint"`
+	// +kubebuilder:validation:Optional
+	Dash0Dataset string `json:"dash0Dataset,omitempty"`
+	// +kubebuilder:validation:Optional
+	SynchronizedRulesTotal int `json:"synchronizedRulesTotal"`
+	// +kubebuilder:validation:Optional
 	SynchronizedRulesAttributes map[string]PrometheusRuleSynchronizedRuleAttributes `json:"synchronizedRulesAttributes,omitempty"`
-	SynchronizationErrorsTotal  int                                                 `json:"synchronizationErrorsTotal"`
-	SynchronizationErrors       map[string]string                                   `json:"synchronizationErrors,omitempty"`
+	// +kubebuilder:validation:Optional
+	SynchronizationErrorsTotal int `json:"synchronizationErrorsTotal"`
+	// +kubebuilder:validation:Optional
+	SynchronizationErrors map[string]string `json:"synchronizationErrors,omitempty"`
 }
 
 type PrometheusRuleSynchronizedRuleAttributes struct {

--- a/config/crd/bases/operator.dash0.com_dash0monitorings.yaml
+++ b/config/crd/bases/operator.dash0.com_dash0monitorings.yaml
@@ -924,10 +924,6 @@ spec:
                       items:
                         type: string
                       type: array
-                  required:
-                  - synchronizationResults
-                  - synchronizationStatus
-                  - synchronizedAt
                   type: object
                 description: Shows results of synchronizing Perses dashboard resources
                   in this namespace via the Dash0 API.
@@ -979,8 +975,6 @@ spec:
                             type: integer
                         required:
                         - dash0ApiEndpoint
-                        - synchronizationErrorsTotal
-                        - synchronizedRulesTotal
                         type: object
                       type: array
                     synchronizationStatus:
@@ -995,13 +989,6 @@ spec:
                     synchronizedAt:
                       format: date-time
                       type: string
-                  required:
-                  - alertingRulesTotal
-                  - invalidRulesTotal
-                  - recordingRulesTotal
-                  - synchronizationResults
-                  - synchronizationStatus
-                  - synchronizedAt
                   type: object
                 description: Shows results of synchronizing Prometheus rule resources
                   in this namespace via the Dash0 API.
@@ -1999,10 +1986,6 @@ spec:
                       items:
                         type: string
                       type: array
-                  required:
-                  - synchronizationResults
-                  - synchronizationStatus
-                  - synchronizedAt
                   type: object
                 description: Shows results of synchronizing Perses dashboard resources
                   in this namespace via the Dash0 API.
@@ -2161,8 +2144,6 @@ spec:
                             type: integer
                         required:
                         - dash0ApiEndpoint
-                        - synchronizationErrorsTotal
-                        - synchronizedRulesTotal
                         type: object
                       type: array
                     synchronizationStatus:
@@ -2177,13 +2158,6 @@ spec:
                     synchronizedAt:
                       format: date-time
                       type: string
-                  required:
-                  - alertingRulesTotal
-                  - invalidRulesTotal
-                  - recordingRulesTotal
-                  - synchronizationResults
-                  - synchronizationStatus
-                  - synchronizedAt
                   type: object
                 description: Shows results of synchronizing Prometheus rule resources
                   in this namespace via the Dash0 API.

--- a/helm-chart/dash0-operator/templates/operator/deployment-and-webhooks.yaml
+++ b/helm-chart/dash0-operator/templates/operator/deployment-and-webhooks.yaml
@@ -1735,10 +1735,6 @@ spec:
                       items:
                         type: string
                       type: array
-                  required:
-                    - synchronizationResults
-                    - synchronizationStatus
-                    - synchronizedAt
                   type: object
                 description: Shows results of synchronizing Perses dashboard resources
                   in this namespace via the Dash0 API.
@@ -1789,9 +1785,7 @@ spec:
                           synchronizedRulesTotal:
                             type: integer
                         required:
-                          - dash0ApiEndpoint
-                          - synchronizationErrorsTotal
-                          - synchronizedRulesTotal
+                        - dash0ApiEndpoint
                         type: object
                       type: array
                     synchronizationStatus:
@@ -1806,13 +1800,6 @@ spec:
                     synchronizedAt:
                       format: date-time
                       type: string
-                  required:
-                    - alertingRulesTotal
-                    - invalidRulesTotal
-                    - recordingRulesTotal
-                    - synchronizationResults
-                    - synchronizationStatus
-                    - synchronizedAt
                   type: object
                 description: Shows results of synchronizing Prometheus rule resources
                   in this namespace via the Dash0 API.
@@ -2818,10 +2805,6 @@ spec:
                       items:
                         type: string
                       type: array
-                  required:
-                    - synchronizationResults
-                    - synchronizationStatus
-                    - synchronizedAt
                   type: object
                 description: Shows results of synchronizing Perses dashboard resources
                   in this namespace via the Dash0 API.
@@ -2979,9 +2962,7 @@ spec:
                           synchronizedRulesTotal:
                             type: integer
                         required:
-                          - dash0ApiEndpoint
-                          - synchronizationErrorsTotal
-                          - synchronizedRulesTotal
+                        - dash0ApiEndpoint
                         type: object
                       type: array
                     synchronizationStatus:
@@ -2996,13 +2977,6 @@ spec:
                     synchronizedAt:
                       format: date-time
                       type: string
-                  required:
-                    - alertingRulesTotal
-                    - invalidRulesTotal
-                    - recordingRulesTotal
-                    - synchronizationResults
-                    - synchronizationStatus
-                    - synchronizedAt
                   type: object
                 description: Shows results of synchronizing Prometheus rule resources
                   in this namespace via the Dash0 API.

--- a/helm-chart/dash0-operator/tests/operator/__snapshot__/deployment-and-webhooks_test.yaml.snap
+++ b/helm-chart/dash0-operator/tests/operator/__snapshot__/deployment-and-webhooks_test.yaml.snap
@@ -1227,10 +1227,6 @@ monitoring resource CRD should match snapshot:
                         items:
                           type: string
                         type: array
-                    required:
-                      - synchronizationResults
-                      - synchronizationStatus
-                      - synchronizedAt
                     type: object
                   description: Shows results of synchronizing Perses dashboard resources in this namespace via the Dash0 API.
                   type: object
@@ -1280,8 +1276,6 @@ monitoring resource CRD should match snapshot:
                               type: integer
                           required:
                             - dash0ApiEndpoint
-                            - synchronizationErrorsTotal
-                            - synchronizedRulesTotal
                           type: object
                         type: array
                       synchronizationStatus:
@@ -1296,13 +1290,6 @@ monitoring resource CRD should match snapshot:
                       synchronizedAt:
                         format: date-time
                         type: string
-                    required:
-                      - alertingRulesTotal
-                      - invalidRulesTotal
-                      - recordingRulesTotal
-                      - synchronizationResults
-                      - synchronizationStatus
-                      - synchronizedAt
                     type: object
                   description: Shows results of synchronizing Prometheus rule resources in this namespace via the Dash0 API.
                   type: object
@@ -2267,10 +2254,6 @@ monitoring resource CRD should match snapshot:
                         items:
                           type: string
                         type: array
-                    required:
-                      - synchronizationResults
-                      - synchronizationStatus
-                      - synchronizedAt
                     type: object
                   description: Shows results of synchronizing Perses dashboard resources in this namespace via the Dash0 API.
                   type: object
@@ -2426,8 +2409,6 @@ monitoring resource CRD should match snapshot:
                               type: integer
                           required:
                             - dash0ApiEndpoint
-                            - synchronizationErrorsTotal
-                            - synchronizedRulesTotal
                           type: object
                         type: array
                       synchronizationStatus:
@@ -2442,13 +2423,6 @@ monitoring resource CRD should match snapshot:
                       synchronizedAt:
                         format: date-time
                         type: string
-                    required:
-                      - alertingRulesTotal
-                      - invalidRulesTotal
-                      - recordingRulesTotal
-                      - synchronizationResults
-                      - synchronizationStatus
-                      - synchronizedAt
                     type: object
                   description: Shows results of synchronizing Prometheus rule resources in this namespace via the Dash0 API.
                   type: object


### PR DESCRIPTION
This fixes an issue where status updates are blocked by stale entries in prometheusRuleSynchronizationResults. The stale entries are associated with PrometheusRule resources that no longer exist in the cluster, and written in a format from before commit 0db2157f4571989adc11b97fb59f95e13e1c603f (release 0.100.0).

Then release 0.137.0 added a new mandatory field that triggered the validation for these old entries when writing to the status.

There is little benefit in validation for status attributes. Hence this commit makes most fields optional.

This commit does _not_ clean up the mentioned stale entries. This is outside the scope of this change and will be handled later.