### PR TITLE
chore(chart): reject operator.autoMonitorNamespaces.monitoringTemplate

### DIFF
--- a/helm-chart/dash0-operator/templates/operator/extra-config-map.yaml
+++ b/helm-chart/dash0-operator/templates/operator/extra-config-map.yaml
@@ -94,6 +94,9 @@ data:
     targetAllocatorNodeAffinity:
       {{- toYaml .Values.operator.targetAllocator.nodeAffinity | nindent 6 }}
 
+    {{- if .Values.operator.autoMonitorNamespaces.monitoringTemplate }}
+    {{- fail "Error: operator.autoMonitorNamespaces.monitoringTemplate is not a valid setting. The monitoring template is a top-level operator setting; please use operator.monitoringTemplate instead." -}}
+    {{- end }}
     {{- if .Values.operator.monitoringTemplate }}
     {{- if and .Values.operator.monitoringTemplate.spec .Values.operator.monitoringTemplate.spec.export }}
     {{- fail "Error: operator.monitoringTemplate.spec.export: Providing custom export settings in the monitoring template is not allowed, please remove the field." -}}

--- a/helm-chart/dash0-operator/tests/operator/extra-config-map_test.yaml
+++ b/helm-chart/dash0-operator/tests/operator/extra-config-map_test.yaml
@@ -748,3 +748,15 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: "Error: operator.monitoringTemplate.spec.exports: Providing custom export settings in the monitoring template is not allowed, please remove the field."
+
+  - it: should disallow monitoringTemplate nested under autoMonitorNamespaces
+    set:
+      operator:
+        autoMonitorNamespaces:
+          monitoringTemplate:
+            spec:
+              instrumentWorkloads:
+                mode: created-and-updated
+    asserts:
+      - failedTemplate:
+          errorMessage: "Error: operator.autoMonitorNamespaces.monitoringTemplate is not a valid setting. The monitoring template is a top-level operator setting; please use operator.monitoringTemplate instead."

--- a/helm-chart/dash0-operator/values.yaml
+++ b/helm-chart/dash0-operator/values.yaml
@@ -925,9 +925,8 @@ operator:
   # false. If omitted, the Dash0 operator will use default values for automatically created Dash0Monitoring resources.
   # The commeted out monitoringTemplate below shows the default values.
   #
-  # Note: This is a top level value, e.g. it's operator.monitoringTemplate, not
-  # operator.autoMonitorNamespaces.monitoringTemplate.
-  #
+  # NOTE: This is a top level value, e.g. it is **operator.monitoringTemplate**,
+  #       _not_ **operator.autoMonitorNamespaces.monitoringTemplate**.
   #monitoringTemplate:
   #  spec:
   #    instrumentWorkloads:


### PR DESCRIPTION
operator.autoMonitorNamespaces.monitoringTemplate is an invalid setting, the setting is supposed to be in operator.monitoringTemplate. However, due to both concepts being related and the way it is listed in the default values.yaml, users occasionally use the wrong nesting, which then gets silently ignored.