### PR TITLE
test(e2e): find reload timestamp across all pods

### DIFF
--- a/test/e2e/collector.go
+++ b/test/e2e/collector.go
@@ -242,23 +242,93 @@ func verifyConfigMapDoesNotContainStrings(operatorNamespace string, configMapNam
 	)
 }
 
-func findMostRecentCollectorReadyLogLine(g Gomega, collectorName string) time.Time {
-	allCollectorReadyLogLines := getMatchingLogLinesFomCollectorContainerLog(
-		g,
-		operatorNamespace,
-		collectorName,
-		"opentelemetry-collector",
-		collectorReadyLogMessage,
-	)
-	g.Expect(allCollectorReadyLogLines).ToNot(BeEmpty(),
-		"Expected to find a log line containing the string \"%s\", but no such line has been found.",
-		collectorReadyLogMessage)
+func verifyCollectorHasReloadedItsConfiguration(collectorNameQualified string, minTimestamp time.Time) {
+	// nolint:lll
+	// Note: It can take up to a minute until the config change can be detected by the configreloader, due to the
+	// default of 1 minute for kubelet's syncFrequency setting, see
+	// https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/#kubelet-config-k8s-io-v1beta1-KubeletConfiguration.
+	// And then it also takes a couple of seconds until the collector has actually reloaded its configuration after
+	// receiving SIGHUB. Hence, we use a 2-minute timeout here.
+	By(fmt.Sprintf("verify that %s has reloaded its configuration", collectorNameQualified))
+	Eventually(func(g Gomega) {
+		mostRecentCollectorReadyTimeStamp := findCollectorReadyLogTimestamp(g, collectorNameQualified)
+		g.Expect(mostRecentCollectorReadyTimeStamp).To(BeTemporally(">", minTimestamp))
+	}, 2*time.Minute, time.Second).Should(Succeed())
+}
 
-	mostRecentCollectorReadyLogLine := allCollectorReadyLogLines[len(allCollectorReadyLogLines)-1]
-	timeStampRaw := strings.Split(mostRecentCollectorReadyLogLine, "\t")[0]
-	timeStamp, err := time.Parse(time.RFC3339, timeStampRaw)
-	Expect(err).ToNot(HaveOccurred(), "could not parse time stamp from collector startup log line")
-	return timeStamp
+// findCollectorReadyLogTimestamp searches through the pod logs of all pods belonging to the given collector
+// workload. For each pod, it looks for the most recent timestamp of the log line
+// "Everything is ready. Begin running and processing data."
+// It then returns the oldest of all these timestamps. By returning the oldest of the per-pod most-recent timestamps,
+// callers can use this function to wait until every pod has reported readiness (for example after the initial start, or
+// after a hot-reloaded of the collector configuration).
+func findCollectorReadyLogTimestamp(g Gomega, collectorNameQualified string) time.Time {
+	podNames := getCollectorPodNames(g, collectorNameQualified)
+	g.Expect(podNames).ToNot(BeEmpty(),
+		"Expected to find at least one pod for collector %s, but found none.", collectorNameQualified)
+
+	mostRecentPerPod := map[string]time.Time{}
+	for _, podName := range podNames {
+		allCollectorReadyLogLines := getMatchingLogLinesFomCollectorContainerLog(
+			g,
+			operatorNamespace,
+			podName,
+			"opentelemetry-collector",
+			collectorReadyLogMessage,
+		)
+		g.Expect(allCollectorReadyLogLines).ToNot(BeEmpty(),
+			"Expected to find a log line containing the string \"%s\" in pod %s, but no such line has been found.",
+			collectorReadyLogMessage, podName)
+
+		mostRecentCollectorReadyLogLine := allCollectorReadyLogLines[len(allCollectorReadyLogLines)-1]
+		timeStampRaw := strings.Split(mostRecentCollectorReadyLogLine, "\t")[0]
+		timeStamp, err := time.Parse(time.RFC3339, timeStampRaw)
+		g.Expect(err).ToNot(HaveOccurred(), "could not parse time stamp from collector startup log line")
+		mostRecentPerPod[podName] = timeStamp
+	}
+
+	var oldestTimestampAcrossAllPods time.Time
+	first := true
+	for _, ts := range mostRecentPerPod {
+		if first || ts.Before(oldestTimestampAcrossAllPods) {
+			oldestTimestampAcrossAllPods = ts
+			first = false
+		}
+	}
+	return oldestTimestampAcrossAllPods
+}
+
+func getCollectorPodNames(g Gomega, collectorNameQualified string) []string {
+	labelSelector := labelSelectorForCollector(collectorNameQualified)
+	g.Expect(labelSelector).ToNot(BeEmpty(),
+		"no label selector known for collector workload %q", collectorNameQualified)
+
+	output, err := run(
+		exec.Command(
+			"kubectl",
+			"get",
+			"pods",
+			"--namespace",
+			operatorNamespace,
+			"-l",
+			labelSelector,
+			"-o",
+			"jsonpath={.items[*].metadata.name}",
+		),
+		false,
+	)
+	g.Expect(err).ToNot(HaveOccurred())
+	return strings.Fields(strings.TrimSpace(output))
+}
+
+func labelSelectorForCollector(collectorNameQualified string) string {
+	switch collectorNameQualified {
+	case collectorDaemonSetNameQualified:
+		return "app.kubernetes.io/name=opentelemetry-collector,app.kubernetes.io/component=agent-collector"
+	case collectorDeploymentNameQualified:
+		return "app.kubernetes.io/name=opentelemetry-collector,app.kubernetes.io/component=cluster-metrics-collector"
+	}
+	return ""
 }
 
 func getMatchingLogLinesFomCollectorContainerLog(

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1449,7 +1449,7 @@ traces:
   span:
   - 'attributes["http.route"] == "/ready"'
 `
-					minTimestampCollectorRestart := time.Now()
+					minTimestampCollectorConfigReload := time.Now()
 					deployDash0MonitoringResourceWithRetry(
 						applicationUnderTestNamespace,
 						dash0MonitoringValues{
@@ -1465,11 +1465,7 @@ traces:
 						// nolint:lll
 						`- 'resource.attributes["k8s.namespace.name"] == "e2e-test-ns" and (attributes["http.route"] == "/ready")'`,
 					)
-					By("verify that the collector has reloaded its configuration")
-					Eventually(func(g Gomega) {
-						mostRecentCollectorReadyTimeStamp := findMostRecentCollectorReadyLogLine(g, collectorDaemonSetNameQualified)
-						g.Expect(mostRecentCollectorReadyTimeStamp).To(BeTemporally(">", minTimestampCollectorRestart))
-					}, 2*time.Minute, time.Second).Should(Succeed())
+					verifyCollectorHasReloadedItsConfiguration(collectorDaemonSetNameQualified, minTimestampCollectorConfigReload)
 
 					testId := uuid.New().String()
 					timestampLowerBound := time.Now()
@@ -1518,7 +1514,7 @@ traces:
 trace_statements:
 - truncate_all(span.attributes, 10)
 `
-					minTimestampCollectorRestart := time.Now()
+					minTimestampCollectorConfigReload := time.Now()
 					deployDash0MonitoringResourceWithRetry(
 						applicationUnderTestNamespace,
 						dash0MonitoringValues{
@@ -1537,11 +1533,7 @@ trace_statements:
 						operatorNamespace,
 						`- 'resource.attributes["k8s.namespace.name"] == "e2e-test-ns"'`,
 					)
-					By("verify that the collector has reloaded its configuration")
-					Eventually(func(g Gomega) {
-						mostRecentCollectorReadyTimeStamp := findMostRecentCollectorReadyLogLine(g, collectorDaemonSetNameQualified)
-						g.Expect(mostRecentCollectorReadyTimeStamp).To(BeTemporally(">", minTimestampCollectorRestart))
-					}, 2*time.Minute, time.Second).Should(Succeed())
+					verifyCollectorHasReloadedItsConfiguration(collectorDaemonSetNameQualified, minTimestampCollectorConfigReload)
 
 					testId := uuid.New().String()
 					timestampLowerBound := time.Now()
@@ -2566,10 +2558,10 @@ trace_statements:
 				var firstDaemonSetCollectorReadyTimeStamp time.Time
 				var firstDeploymentCollectorReadyTimeStamp time.Time
 				Eventually(func(g Gomega) {
-					firstDaemonSetCollectorReadyTimeStamp = findMostRecentCollectorReadyLogLine(g, collectorDaemonSetNameQualified)
+					firstDaemonSetCollectorReadyTimeStamp = findCollectorReadyLogTimestamp(g, collectorDaemonSetNameQualified)
 				}, 30*time.Second, time.Second).Should(Succeed())
 				Eventually(func(g Gomega) {
-					firstDeploymentCollectorReadyTimeStamp = findMostRecentCollectorReadyLogLine(g, collectorDeploymentNameQualified)
+					firstDeploymentCollectorReadyTimeStamp = findCollectorReadyLogTimestamp(g, collectorDeploymentNameQualified)
 				}, 30*time.Second, time.Second).Should(Succeed())
 
 				daemonSetRestartCountsBeforeConfigChange := getDaemonSetCollectorPodRestartCounts(operatorNamespace)
@@ -2583,20 +2575,14 @@ trace_statements:
 				verifyDaemonSetCollectorConfigMapContainsString(operatorNamespace, newEndpoint)
 				verifyDeploymentCollectorConfigMapContainsString(operatorNamespace, newEndpoint)
 
-				By("verify that the collectors have reloaded their configuration")
-				// Note: It can take up to a minute until the config change can be detected by the configreloader, due to the
-				// default of 1 minute for kubelet's syncFrequency setting, see
-				// https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/#kubelet-config-k8s-io-v1beta1-KubeletConfiguration.
-				// And then it also takes a couple of seconds until the collector has actually reloaded its configuration after
-				// receiving SIGHUB. Hence, we use a 2 minute timeout here.
-				Eventually(func(g Gomega) {
-					secondDaemonSetCollectorReadyTimeStamp := findMostRecentCollectorReadyLogLine(g, collectorDaemonSetNameQualified)
-					g.Expect(secondDaemonSetCollectorReadyTimeStamp).To(BeTemporally(">", firstDaemonSetCollectorReadyTimeStamp))
-				}, 2*time.Minute, time.Second).Should(Succeed())
-				Eventually(func(g Gomega) {
-					secondDeploymentCollectorReadyTimeStamp := findMostRecentCollectorReadyLogLine(g, collectorDaemonSetNameQualified)
-					g.Expect(secondDeploymentCollectorReadyTimeStamp).To(BeTemporally(">", firstDeploymentCollectorReadyTimeStamp))
-				}, 2*time.Minute, time.Second).Should(Succeed())
+				verifyCollectorHasReloadedItsConfiguration(
+					collectorDaemonSetNameQualified,
+					firstDaemonSetCollectorReadyTimeStamp,
+				)
+				verifyCollectorHasReloadedItsConfiguration(
+					collectorDeploymentNameQualified,
+					firstDeploymentCollectorReadyTimeStamp,
+				)
 
 				// Verify that the collector has reloaded the configuration in-process, instead of restarting the process.
 				By("verify that the collectors have not restarted")

--- a/test/e2e/run_command.go
+++ b/test/e2e/run_command.go
@@ -19,7 +19,15 @@ func runAndIgnoreOutput(cmd *exec.Cmd, logCommandArgs ...bool) error {
 	return err
 }
 
-// run executes the provided command and returns the combined output from stdout and stderr
+// run executes the provided command and returns the combined output from stdout and stderr.
+//
+// The command takes optional boolean flags that control what is logged while executing the command:
+//   - argument 1 is the command to be executed
+//   - argument 2 determines whether the command is logged (default: true)
+//   - argument 3 determines whether the output is logged when the command has been successful (default: false);
+//     even when this is set to false, the output will still be logged in case the command has failed
+//     (but see argument 4)
+//   - argument 4 determines whether the command is logged when the command has failed (default: true)
 func run(cmd *exec.Cmd, logCommandArgs ...bool) (string, error) {
 	logCommand := true
 	logOutputOnSuccess := false
@@ -50,7 +58,16 @@ func run(cmd *exec.Cmd, logCommandArgs ...bool) (string, error) {
 	return string(output), nil
 }
 
-// runAndReturnStdoutStderr executes the provided command and returns stdout and stderr as separate strings
+// runAndReturnStdoutStderr executes the provided command, similar to the run function, but it returns stdout and stderr
+// as separate strings.
+//
+// The command takes optional boolean flags that control what is logged while executing the command:
+//   - argument 1 is the command to be executed
+//   - argument 2 determines whether the command is logged (default: true)
+//   - argument 3 determines whether the output is logged when the command has been successful (default: false);
+//     even when this is set to false, the output will still be logged in case the command has failed
+//     (but see argument 4)
+//   - argument 4 determines whether the command is logged when the command has failed (default: true)
 func runAndReturnStdoutStderr(cmd *exec.Cmd, logCommandArgs ...bool) (string, string, error) {
 	logCommand := true
 	logOutputOnSuccess := false


### PR DESCRIPTION
Should fix the flaky "does not emit health check spans when filter is active" test case. Previously, we looked for the collector config reload log line in one arbitrary collector pod, hence there was no clear guarantee that all daemonset collector pods would have reloaded the config when the test progressed.