### PR TITLE
feat: use pick_first lb for dash0 export and make lb configurable for custom grpc exporters

### DIFF
--- a/api/operator/common/common_shared_types.go
+++ b/api/operator/common/common_shared_types.go
@@ -158,6 +158,12 @@ type GrpcConfiguration struct {
 	//
 	// +kubebuilder:validation:Optional
 	Keepalive *KeepaliveClientConfig `json:"keepalive,omitempty"`
+
+	// The name of the load balancer to use. Can be either round_robin or pick_first. Optional; when omitted, the
+	// collector's default (round_robin) is used.
+	//
+	// +kubebuilder:validation:Optional
+	BalancerName BalancerName `json:"balancer_name,omitempty"`
 }
 
 // OtlpEncoding describes the encoding of the OTLP data when sent via HTTP.
@@ -191,6 +197,17 @@ type KeepaliveClientConfig struct {
 	// +kubebuilder:validation:Optional
 	PermitWithoutStream *bool `json:"permit_without_stream,omitempty"`
 }
+
+// BalancerName describes the load balancer used by the OTLP gRPC exporter.
+// See https://github.com/grpc/grpc-go/blob/master/examples/features/load_balancing/README.md
+//
+// +kubebuilder:validation:Enum=round_robin;pick_first
+type BalancerName string
+
+const (
+	RoundRobin BalancerName = "round_robin"
+	PickFirst  BalancerName = "pick_first"
+)
 
 func (e *Export) HasDash0ExportConfigured() bool {
 	return e != nil && e.Dash0 != nil

--- a/config/crd/bases/operator.dash0.com_dash0monitorings.yaml
+++ b/config/crd/bases/operator.dash0.com_dash0monitorings.yaml
@@ -252,6 +252,14 @@ spec:
                     description: The settings for an exporter to send telemetry to
                       an arbitrary OTLP-compatible receiver via gRPC.
                     properties:
+                      balancer_name:
+                        description: |-
+                          The name of the load balancer to use. Can be either round_robin or pick_first. Optional; when omitted, the
+                          collector's default (round_robin) is used.
+                        enum:
+                        - round_robin
+                        - pick_first
+                        type: string
                       endpoint:
                         description: The URL of the OTLP-compatible receiver to which
                           telemetry data will be sent. This property is mandatory.
@@ -443,6 +451,14 @@ spec:
                       description: The settings for an exporter to send telemetry
                         to an arbitrary OTLP-compatible receiver via gRPC.
                       properties:
+                        balancer_name:
+                          description: |-
+                            The name of the load balancer to use. Can be either round_robin or pick_first. Optional; when omitted, the
+                            collector's default (round_robin) is used.
+                          enum:
+                          - round_robin
+                          - pick_first
+                          type: string
                         endpoint:
                           description: The URL of the OTLP-compatible receiver to
                             which telemetry data will be sent. This property is mandatory.
@@ -1273,6 +1289,14 @@ spec:
                     description: The settings for an exporter to send telemetry to
                       an arbitrary OTLP-compatible receiver via gRPC.
                     properties:
+                      balancer_name:
+                        description: |-
+                          The name of the load balancer to use. Can be either round_robin or pick_first. Optional; when omitted, the
+                          collector's default (round_robin) is used.
+                        enum:
+                        - round_robin
+                        - pick_first
+                        type: string
                       endpoint:
                         description: The URL of the OTLP-compatible receiver to which
                           telemetry data will be sent. This property is mandatory.
@@ -1464,6 +1488,14 @@ spec:
                       description: The settings for an exporter to send telemetry
                         to an arbitrary OTLP-compatible receiver via gRPC.
                       properties:
+                        balancer_name:
+                          description: |-
+                            The name of the load balancer to use. Can be either round_robin or pick_first. Optional; when omitted, the
+                            collector's default (round_robin) is used.
+                          enum:
+                          - round_robin
+                          - pick_first
+                          type: string
                         endpoint:
                           description: The URL of the OTLP-compatible receiver to
                             which telemetry data will be sent. This property is mandatory.

--- a/config/crd/bases/operator.dash0.com_dash0operatorconfigurations.yaml
+++ b/config/crd/bases/operator.dash0.com_dash0operatorconfigurations.yaml
@@ -250,6 +250,14 @@ spec:
                     description: The settings for an exporter to send telemetry to
                       an arbitrary OTLP-compatible receiver via gRPC.
                     properties:
+                      balancer_name:
+                        description: |-
+                          The name of the load balancer to use. Can be either round_robin or pick_first. Optional; when omitted, the
+                          collector's default (round_robin) is used.
+                        enum:
+                        - round_robin
+                        - pick_first
+                        type: string
                       endpoint:
                         description: The URL of the OTLP-compatible receiver to which
                           telemetry data will be sent. This property is mandatory.
@@ -443,6 +451,14 @@ spec:
                       description: The settings for an exporter to send telemetry
                         to an arbitrary OTLP-compatible receiver via gRPC.
                       properties:
+                        balancer_name:
+                          description: |-
+                            The name of the load balancer to use. Can be either round_robin or pick_first. Optional; when omitted, the
+                            collector's default (round_robin) is used.
+                          enum:
+                          - round_robin
+                          - pick_first
+                          type: string
                         endpoint:
                           description: The URL of the OTLP-compatible receiver to
                             which telemetry data will be sent. This property is mandatory.
@@ -842,6 +858,14 @@ spec:
                             description: The settings for an exporter to send telemetry
                               to an arbitrary OTLP-compatible receiver via gRPC.
                             properties:
+                              balancer_name:
+                                description: |-
+                                  The name of the load balancer to use. Can be either round_robin or pick_first. Optional; when omitted, the
+                                  collector's default (round_robin) is used.
+                                enum:
+                                - round_robin
+                                - pick_first
+                                type: string
                               endpoint:
                                 description: The URL of the OTLP-compatible receiver
                                   to which telemetry data will be sent. This property
@@ -1041,6 +1065,14 @@ spec:
                               description: The settings for an exporter to send telemetry
                                 to an arbitrary OTLP-compatible receiver via gRPC.
                               properties:
+                                balancer_name:
+                                  description: |-
+                                    The name of the load balancer to use. Can be either round_robin or pick_first. Optional; when omitted, the
+                                    collector's default (round_robin) is used.
+                                  enum:
+                                  - round_robin
+                                  - pick_first
+                                  type: string
                                 endpoint:
                                   description: The URL of the OTLP-compatible receiver
                                     to which telemetry data will be sent. This property
@@ -1877,6 +1909,14 @@ spec:
                             description: The settings for an exporter to send telemetry
                               to an arbitrary OTLP-compatible receiver via gRPC.
                             properties:
+                              balancer_name:
+                                description: |-
+                                  The name of the load balancer to use. Can be either round_robin or pick_first. Optional; when omitted, the
+                                  collector's default (round_robin) is used.
+                                enum:
+                                - round_robin
+                                - pick_first
+                                type: string
                               endpoint:
                                 description: The URL of the OTLP-compatible receiver
                                   to which telemetry data will be sent. This property
@@ -2076,6 +2116,14 @@ spec:
                               description: The settings for an exporter to send telemetry
                                 to an arbitrary OTLP-compatible receiver via gRPC.
                               properties:
+                                balancer_name:
+                                  description: |-
+                                    The name of the load balancer to use. Can be either round_robin or pick_first. Optional; when omitted, the
+                                    collector's default (round_robin) is used.
+                                  enum:
+                                  - round_robin
+                                  - pick_first
+                                  type: string
                                 endpoint:
                                   description: The URL of the OTLP-compatible receiver
                                     to which telemetry data will be sent. This property

--- a/helm-chart/dash0-operator/templates/operator/custom-resource-definition-operator-configuration.yaml
+++ b/helm-chart/dash0-operator/templates/operator/custom-resource-definition-operator-configuration.yaml
@@ -255,6 +255,14 @@ spec:
                     description: The settings for an exporter to send telemetry to
                       an arbitrary OTLP-compatible receiver via gRPC.
                     properties:
+                      balancer_name:
+                        description: |-
+                          The name of the load balancer to use. Can be either round_robin or pick_first. Optional; when omitted, the
+                          collector's default (round_robin) is used.
+                        enum:
+                        - round_robin
+                        - pick_first
+                        type: string
                       endpoint:
                         description: The URL of the OTLP-compatible receiver to which
                           telemetry data will be sent. This property is mandatory.
@@ -448,6 +456,14 @@ spec:
                       description: The settings for an exporter to send telemetry
                         to an arbitrary OTLP-compatible receiver via gRPC.
                       properties:
+                        balancer_name:
+                          description: |-
+                            The name of the load balancer to use. Can be either round_robin or pick_first. Optional; when omitted, the
+                            collector's default (round_robin) is used.
+                          enum:
+                          - round_robin
+                          - pick_first
+                          type: string
                         endpoint:
                           description: The URL of the OTLP-compatible receiver to
                             which telemetry data will be sent. This property is mandatory.
@@ -847,6 +863,14 @@ spec:
                             description: The settings for an exporter to send telemetry
                               to an arbitrary OTLP-compatible receiver via gRPC.
                             properties:
+                              balancer_name:
+                                description: |-
+                                  The name of the load balancer to use. Can be either round_robin or pick_first. Optional; when omitted, the
+                                  collector's default (round_robin) is used.
+                                enum:
+                                - round_robin
+                                - pick_first
+                                type: string
                               endpoint:
                                 description: The URL of the OTLP-compatible receiver
                                   to which telemetry data will be sent. This property
@@ -1046,6 +1070,14 @@ spec:
                               description: The settings for an exporter to send telemetry
                                 to an arbitrary OTLP-compatible receiver via gRPC.
                               properties:
+                                balancer_name:
+                                  description: |-
+                                    The name of the load balancer to use. Can be either round_robin or pick_first. Optional; when omitted, the
+                                    collector's default (round_robin) is used.
+                                  enum:
+                                  - round_robin
+                                  - pick_first
+                                  type: string
                                 endpoint:
                                   description: The URL of the OTLP-compatible receiver
                                     to which telemetry data will be sent. This property
@@ -1858,6 +1890,14 @@ spec:
                             description: The settings for an exporter to send telemetry
                               to an arbitrary OTLP-compatible receiver via gRPC.
                             properties:
+                              balancer_name:
+                                description: |-
+                                  The name of the load balancer to use. Can be either round_robin or pick_first. Optional; when omitted, the
+                                  collector's default (round_robin) is used.
+                                enum:
+                                - round_robin
+                                - pick_first
+                                type: string
                               endpoint:
                                 description: The URL of the OTLP-compatible receiver
                                   to which telemetry data will be sent. This property
@@ -2057,6 +2097,14 @@ spec:
                               description: The settings for an exporter to send telemetry
                                 to an arbitrary OTLP-compatible receiver via gRPC.
                               properties:
+                                balancer_name:
+                                  description: |-
+                                    The name of the load balancer to use. Can be either round_robin or pick_first. Optional; when omitted, the
+                                    collector's default (round_robin) is used.
+                                  enum:
+                                  - round_robin
+                                  - pick_first
+                                  type: string
                                 endpoint:
                                   description: The URL of the OTLP-compatible receiver
                                     to which telemetry data will be sent. This property

--- a/helm-chart/dash0-operator/templates/operator/deployment-and-webhooks.yaml
+++ b/helm-chart/dash0-operator/templates/operator/deployment-and-webhooks.yaml
@@ -1064,6 +1064,14 @@ spec:
                     description: The settings for an exporter to send telemetry to
                       an arbitrary OTLP-compatible receiver via gRPC.
                     properties:
+                      balancer_name:
+                        description: |-
+                          The name of the load balancer to use. Can be either round_robin or pick_first. Optional; when omitted, the
+                          collector's default (round_robin) is used.
+                        enum:
+                        - round_robin
+                        - pick_first
+                        type: string
                       endpoint:
                         description: The URL of the OTLP-compatible receiver to which
                           telemetry data will be sent. This property is mandatory.
@@ -1255,6 +1263,14 @@ spec:
                       description: The settings for an exporter to send telemetry
                         to an arbitrary OTLP-compatible receiver via gRPC.
                       properties:
+                        balancer_name:
+                          description: |-
+                            The name of the load balancer to use. Can be either round_robin or pick_first. Optional; when omitted, the
+                            collector's default (round_robin) is used.
+                          enum:
+                          - round_robin
+                          - pick_first
+                          type: string
                         endpoint:
                           description: The URL of the OTLP-compatible receiver to
                             which telemetry data will be sent. This property is mandatory.
@@ -2093,6 +2109,14 @@ spec:
                     description: The settings for an exporter to send telemetry to
                       an arbitrary OTLP-compatible receiver via gRPC.
                     properties:
+                      balancer_name:
+                        description: |-
+                          The name of the load balancer to use. Can be either round_robin or pick_first. Optional; when omitted, the
+                          collector's default (round_robin) is used.
+                        enum:
+                        - round_robin
+                        - pick_first
+                        type: string
                       endpoint:
                         description: The URL of the OTLP-compatible receiver to which
                           telemetry data will be sent. This property is mandatory.
@@ -2284,6 +2308,14 @@ spec:
                       description: The settings for an exporter to send telemetry
                         to an arbitrary OTLP-compatible receiver via gRPC.
                       properties:
+                        balancer_name:
+                          description: |-
+                            The name of the load balancer to use. Can be either round_robin or pick_first. Optional; when omitted, the
+                            collector's default (round_robin) is used.
+                          enum:
+                          - round_robin
+                          - pick_first
+                          type: string
                         endpoint:
                           description: The URL of the OTLP-compatible receiver to
                             which telemetry data will be sent. This property is mandatory.

--- a/helm-chart/dash0-operator/tests/operator/__snapshot__/custom-resource-definition-operator-configuration_test.yaml.snap
+++ b/helm-chart/dash0-operator/tests/operator/__snapshot__/custom-resource-definition-operator-configuration_test.yaml.snap
@@ -242,6 +242,14 @@ custom resource definition for operator configuration should match snapshot:
                         grpc:
                           description: The settings for an exporter to send telemetry to an arbitrary OTLP-compatible receiver via gRPC.
                           properties:
+                            balancer_name:
+                              description: |-
+                                The name of the load balancer to use. Can be either round_robin or pick_first. Optional; when omitted, the
+                                collector's default (round_robin) is used.
+                              enum:
+                                - round_robin
+                                - pick_first
+                              type: string
                             endpoint:
                               description: The URL of the OTLP-compatible receiver to which telemetry data will be sent. This property is mandatory.
                               type: string
@@ -415,6 +423,14 @@ custom resource definition for operator configuration should match snapshot:
                           grpc:
                             description: The settings for an exporter to send telemetry to an arbitrary OTLP-compatible receiver via gRPC.
                             properties:
+                              balancer_name:
+                                description: |-
+                                  The name of the load balancer to use. Can be either round_robin or pick_first. Optional; when omitted, the
+                                  collector's default (round_robin) is used.
+                                enum:
+                                  - round_robin
+                                  - pick_first
+                                type: string
                               endpoint:
                                 description: The URL of the OTLP-compatible receiver to which telemetry data will be sent. This property is mandatory.
                                 type: string
@@ -789,6 +805,14 @@ custom resource definition for operator configuration should match snapshot:
                                 grpc:
                                   description: The settings for an exporter to send telemetry to an arbitrary OTLP-compatible receiver via gRPC.
                                   properties:
+                                    balancer_name:
+                                      description: |-
+                                        The name of the load balancer to use. Can be either round_robin or pick_first. Optional; when omitted, the
+                                        collector's default (round_robin) is used.
+                                      enum:
+                                        - round_robin
+                                        - pick_first
+                                      type: string
                                     endpoint:
                                       description: The URL of the OTLP-compatible receiver to which telemetry data will be sent. This property is mandatory.
                                       type: string
@@ -960,6 +984,14 @@ custom resource definition for operator configuration should match snapshot:
                                   grpc:
                                     description: The settings for an exporter to send telemetry to an arbitrary OTLP-compatible receiver via gRPC.
                                     properties:
+                                      balancer_name:
+                                        description: |-
+                                          The name of the load balancer to use. Can be either round_robin or pick_first. Optional; when omitted, the
+                                          collector's default (round_robin) is used.
+                                        enum:
+                                          - round_robin
+                                          - pick_first
+                                        type: string
                                       endpoint:
                                         description: The URL of the OTLP-compatible receiver to which telemetry data will be sent. This property is mandatory.
                                         type: string
@@ -1735,6 +1767,14 @@ custom resource definition for operator configuration should match snapshot:
                                 grpc:
                                   description: The settings for an exporter to send telemetry to an arbitrary OTLP-compatible receiver via gRPC.
                                   properties:
+                                    balancer_name:
+                                      description: |-
+                                        The name of the load balancer to use. Can be either round_robin or pick_first. Optional; when omitted, the
+                                        collector's default (round_robin) is used.
+                                      enum:
+                                        - round_robin
+                                        - pick_first
+                                      type: string
                                     endpoint:
                                       description: The URL of the OTLP-compatible receiver to which telemetry data will be sent. This property is mandatory.
                                       type: string
@@ -1906,6 +1946,14 @@ custom resource definition for operator configuration should match snapshot:
                                   grpc:
                                     description: The settings for an exporter to send telemetry to an arbitrary OTLP-compatible receiver via gRPC.
                                     properties:
+                                      balancer_name:
+                                        description: |-
+                                          The name of the load balancer to use. Can be either round_robin or pick_first. Optional; when omitted, the
+                                          collector's default (round_robin) is used.
+                                        enum:
+                                          - round_robin
+                                          - pick_first
+                                        type: string
                                       endpoint:
                                         description: The URL of the OTLP-compatible receiver to which telemetry data will be sent. This property is mandatory.
                                         type: string

--- a/helm-chart/dash0-operator/tests/operator/__snapshot__/deployment-and-webhooks_test.yaml.snap
+++ b/helm-chart/dash0-operator/tests/operator/__snapshot__/deployment-and-webhooks_test.yaml.snap
@@ -588,6 +588,14 @@ monitoring resource CRD should match snapshot:
                     grpc:
                       description: The settings for an exporter to send telemetry to an arbitrary OTLP-compatible receiver via gRPC.
                       properties:
+                        balancer_name:
+                          description: |-
+                            The name of the load balancer to use. Can be either round_robin or pick_first. Optional; when omitted, the
+                            collector's default (round_robin) is used.
+                          enum:
+                            - round_robin
+                            - pick_first
+                          type: string
                         endpoint:
                           description: The URL of the OTLP-compatible receiver to which telemetry data will be sent. This property is mandatory.
                           type: string
@@ -759,6 +767,14 @@ monitoring resource CRD should match snapshot:
                       grpc:
                         description: The settings for an exporter to send telemetry to an arbitrary OTLP-compatible receiver via gRPC.
                         properties:
+                          balancer_name:
+                            description: |-
+                              The name of the load balancer to use. Can be either round_robin or pick_first. Optional; when omitted, the
+                              collector's default (round_robin) is used.
+                            enum:
+                              - round_robin
+                              - pick_first
+                            type: string
                           endpoint:
                             description: The URL of the OTLP-compatible receiver to which telemetry data will be sent. This property is mandatory.
                             type: string
@@ -1575,6 +1591,14 @@ monitoring resource CRD should match snapshot:
                     grpc:
                       description: The settings for an exporter to send telemetry to an arbitrary OTLP-compatible receiver via gRPC.
                       properties:
+                        balancer_name:
+                          description: |-
+                            The name of the load balancer to use. Can be either round_robin or pick_first. Optional; when omitted, the
+                            collector's default (round_robin) is used.
+                          enum:
+                            - round_robin
+                            - pick_first
+                          type: string
                         endpoint:
                           description: The URL of the OTLP-compatible receiver to which telemetry data will be sent. This property is mandatory.
                           type: string
@@ -1746,6 +1770,14 @@ monitoring resource CRD should match snapshot:
                       grpc:
                         description: The settings for an exporter to send telemetry to an arbitrary OTLP-compatible receiver via gRPC.
                         properties:
+                          balancer_name:
+                            description: |-
+                              The name of the load balancer to use. Can be either round_robin or pick_first. Optional; when omitted, the
+                              collector's default (round_robin) is used.
+                            enum:
+                              - round_robin
+                              - pick_first
+                            type: string
                           endpoint:
                             description: The URL of the OTLP-compatible receiver to which telemetry data will be sent. This property is mandatory.
                             type: string

--- a/internal/collectors/otelcolresources/collector_config_maps_test.go
+++ b/internal/collectors/otelcolresources/collector_config_maps_test.go
@@ -274,6 +274,38 @@ func cmTestGrpcExporterWithPartialKeepalive() otlpExporters {
 	}
 }
 
+func cmTestGrpcExporterWithBalancerName() otlpExporters {
+	grpcExporter, err := convertGrpcExporterToOtlpExporter(&dash0common.GrpcConfiguration{
+		Endpoint:     grpcEndpointTest,
+		BalancerName: dash0common.PickFirst,
+	}, "default")
+	Expect(err).ToNot(HaveOccurred())
+	return otlpExporters{
+		Default:    []otlpExporter{*grpcExporter},
+		Namespaced: make(map[string][]otlpExporter),
+	}
+}
+
+func cmTestNamespacedExportersWithBalancerName() otlpExporters {
+	export := Dash0ExportWithEndpointAndToken()
+	auth, _ := dash0ExporterAuthorizationForExport(*export, 0, true, nil)
+	dash0ExporterDefault, err := convertDash0ExporterToOtlpExporter(export.Dash0, "default", auth)
+	Expect(err).ToNot(HaveOccurred())
+
+	grpcExporterNs1, err := convertGrpcExporterToOtlpExporter(&dash0common.GrpcConfiguration{
+		Endpoint:     grpcEndpointTest,
+		BalancerName: dash0common.PickFirst,
+	}, "ns/"+namespace1)
+	Expect(err).ToNot(HaveOccurred())
+
+	return otlpExporters{
+		Default: []otlpExporter{*dash0ExporterDefault},
+		Namespaced: map[string][]otlpExporter{
+			namespace1: {*grpcExporterNs1},
+		},
+	}
+}
+
 func cmTestNamespacedExportersWithKeepalive() otlpExporters {
 	export := Dash0ExportWithEndpointAndToken()
 	auth, _ := dash0ExporterAuthorizationForExport(*export, 0, true, nil)
@@ -941,6 +973,89 @@ var _ = Describe("The OpenTelemetry Collector ConfigMaps", func() {
 			Expect(keepalive2["time"]).To(Equal("45s"))
 			Expect(keepalive2).ToNot(HaveKey("timeout"))
 			Expect(keepalive2).ToNot(HaveKey("permit_without_stream"))
+		}, daemonSetAndDeployment)
+
+		DescribeTable("should always render balancer_name: pick_first on the Dash0 exporter", func(cmTypeDef configMapTypeDefinition) {
+			configMap, err := cmTypeDef.assembleConfigMapFunction(&oTelColConfig{
+				OperatorNamespace: OperatorNamespace,
+				NamePrefix:        namePrefix,
+				Exporters:         cmTestSingleDefaultOtlpExporter(),
+				KubernetesInfrastructureMetricsCollectionEnabled: true,
+			}, monitoredNamespaces, nil, nil, false)
+
+			Expect(err).ToNot(HaveOccurred())
+			collectorConfig := parseConfigMapContent(configMap)
+			exportersRaw := collectorConfig["exporters"]
+			Expect(exportersRaw).ToNot(BeNil())
+			exporters := exportersRaw.(map[string]any)
+
+			dash0Exporter := exporters["otlp_grpc/dash0/default"]
+			Expect(dash0Exporter).ToNot(BeNil())
+			dash0OtlpExporter := dash0Exporter.(map[string]any)
+			Expect(dash0OtlpExporter["balancer_name"]).To(Equal("pick_first"))
+		}, daemonSetAndDeployment)
+
+		DescribeTable("should render balancer_name on gRPC exporter when configured", func(cmTypeDef configMapTypeDefinition) {
+			configMap, err := cmTypeDef.assembleConfigMapFunction(&oTelColConfig{
+				OperatorNamespace: OperatorNamespace,
+				NamePrefix:        namePrefix,
+				Exporters:         cmTestGrpcExporterWithBalancerName(),
+				KubernetesInfrastructureMetricsCollectionEnabled: true,
+			}, monitoredNamespaces, nil, nil, false)
+
+			Expect(err).ToNot(HaveOccurred())
+			collectorConfig := parseConfigMapContent(configMap)
+			exportersRaw := collectorConfig["exporters"]
+			Expect(exportersRaw).ToNot(BeNil())
+			exporters := exportersRaw.(map[string]any)
+
+			grpcExporter := exporters["otlp_grpc/default"]
+			Expect(grpcExporter).ToNot(BeNil())
+			grpcOtlpExporter := grpcExporter.(map[string]any)
+			Expect(grpcOtlpExporter["balancer_name"]).To(Equal("pick_first"))
+		}, daemonSetAndDeployment)
+
+		DescribeTable("should not render balancer_name on gRPC exporter when not configured", func(cmTypeDef configMapTypeDefinition) {
+			configMap, err := cmTypeDef.assembleConfigMapFunction(&oTelColConfig{
+				OperatorNamespace: OperatorNamespace,
+				NamePrefix:        namePrefix,
+				Exporters:         cmTestGrpcExporterWithKeepalive(),
+				KubernetesInfrastructureMetricsCollectionEnabled: true,
+			}, monitoredNamespaces, nil, nil, false)
+
+			Expect(err).ToNot(HaveOccurred())
+			collectorConfig := parseConfigMapContent(configMap)
+			exportersRaw := collectorConfig["exporters"]
+			Expect(exportersRaw).ToNot(BeNil())
+			exporters := exportersRaw.(map[string]any)
+
+			grpcExporter := exporters["otlp_grpc/default"]
+			Expect(grpcExporter).ToNot(BeNil())
+			grpcOtlpExporter := grpcExporter.(map[string]any)
+			Expect(grpcOtlpExporter).ToNot(HaveKey("balancer_name"))
+		}, daemonSetAndDeployment)
+
+		DescribeTable("should render balancer_name in namespaced exporters", func(cmTypeDef configMapTypeDefinition) {
+			configMap, err := cmTypeDef.assembleConfigMapFunction(&oTelColConfig{
+				OperatorNamespace: OperatorNamespace,
+				NamePrefix:        namePrefix,
+				Exporters:         cmTestNamespacedExportersWithBalancerName(),
+				KubernetesInfrastructureMetricsCollectionEnabled: true,
+			}, monitoredNamespaces, nil, nil, false)
+
+			Expect(err).ToNot(HaveOccurred())
+			collectorConfig := parseConfigMapContent(configMap)
+			exportersRaw := collectorConfig["exporters"]
+			Expect(exportersRaw).ToNot(BeNil())
+			exporters := exportersRaw.(map[string]any)
+
+			// Default Dash0 exporter always pick_first
+			defaultDash0 := exporters["otlp_grpc/dash0/default"].(map[string]any)
+			Expect(defaultDash0["balancer_name"]).To(Equal("pick_first"))
+
+			// Namespaced gRPC exporter with the configured value
+			grpcNs1 := exporters["otlp_grpc/ns/"+namespace1].(map[string]any)
+			Expect(grpcNs1["balancer_name"]).To(Equal("pick_first"))
 		}, daemonSetAndDeployment)
 
 		DescribeTable("should render namespaced OTLP exporters", func(cmTypeDef configMapTypeDefinition) {

--- a/internal/collectors/otelcolresources/daemonset.config.yaml.template
+++ b/internal/collectors/otelcolresources/daemonset.config.yaml.template
@@ -1105,6 +1105,9 @@ exporters:
       permit_without_stream: {{ $exporter.Keepalive.PermitWithoutStream }}
       {{- end }}
     {{- end }}
+    {{- if $exporter.BalancerName }}
+    balancer_name: "{{ $exporter.BalancerName }}"
+    {{- end }}
   {{- end }}
 
   {{- range $ns := .Exporters.AllNamespaceKeys }}
@@ -1139,6 +1142,9 @@ exporters:
       {{- if $exporter.Keepalive.PermitWithoutStream }}
       permit_without_stream: {{ $exporter.Keepalive.PermitWithoutStream }}
       {{- end }}
+    {{- end }}
+    {{- if $exporter.BalancerName }}
+    balancer_name: "{{ $exporter.BalancerName }}"
     {{- end }}
   {{- end }}
   {{- end }}

--- a/internal/collectors/otelcolresources/deployment.config.yaml.template
+++ b/internal/collectors/otelcolresources/deployment.config.yaml.template
@@ -423,6 +423,9 @@ exporters:
       permit_without_stream: {{ $exporter.Keepalive.PermitWithoutStream }}
       {{- end }}
     {{- end }}
+    {{- if $exporter.BalancerName }}
+    balancer_name: "{{ $exporter.BalancerName }}"
+    {{- end }}
   {{- end }}
 
   {{- range $ns := .Exporters.AllNamespaceKeys }}
@@ -457,6 +460,9 @@ exporters:
       {{- if $exporter.Keepalive.PermitWithoutStream }}
       permit_without_stream: {{ $exporter.Keepalive.PermitWithoutStream }}
       {{- end }}
+    {{- end }}
+    {{- if $exporter.BalancerName }}
+    balancer_name: "{{ $exporter.BalancerName }}"
     {{- end }}
   {{- end }}
   {{- end }}

--- a/internal/collectors/otelcolresources/exporter.go
+++ b/internal/collectors/otelcolresources/exporter.go
@@ -24,6 +24,7 @@ type otlpExporter struct {
 	Insecure           bool
 	InsecureSkipVerify bool
 	Keepalive          *dash0common.KeepaliveClientConfig
+	BalancerName       string
 }
 
 type defaultOtlpExporters = []otlpExporter
@@ -204,6 +205,11 @@ func convertDash0ExporterToOtlpExporter(
 		Headers:       headers,
 		Authorization: auth,
 		Keepalive:     d0.Keepalive,
+		// For the dash0 exporter we always use pick_first, since client-side load balancing is
+		// not needed and it avoids the issue of the exporter trying both the IPv4 and IPv6
+		// addresses continuously, which leads to excessive warning logs since one will fail.
+		// (Which one will fail, depends on whether the cluster has IPv4 or IPv6 networking.)
+		BalancerName: string(dash0common.PickFirst),
 	}
 	setGrpcTlsFromPrefix(d0.Endpoint, &dash0Exporter)
 	return &dash0Exporter, nil
@@ -214,10 +220,11 @@ func convertGrpcExporterToOtlpExporter(grpc *dash0common.GrpcConfiguration, name
 		return nil, fmt.Errorf("no endpoint provided for the gRPC exporter, unable to create the OpenTelemetry collector")
 	}
 	grpcExporter := otlpExporter{
-		Name:      fmt.Sprintf("%s/%s", grpcExporterNamePrefix, nameSuffix),
-		Endpoint:  grpc.Endpoint,
-		Headers:   grpc.Headers,
-		Keepalive: grpc.Keepalive,
+		Name:         fmt.Sprintf("%s/%s", grpcExporterNamePrefix, nameSuffix),
+		Endpoint:     grpc.Endpoint,
+		Headers:      grpc.Headers,
+		Keepalive:    grpc.Keepalive,
+		BalancerName: string(grpc.BalancerName),
 	}
 	if grpc.Insecure != nil {
 		grpcExporter.Insecure = *grpc.Insecure

--- a/internal/collectors/otelcolresources/exporter_test.go
+++ b/internal/collectors/otelcolresources/exporter_test.go
@@ -186,6 +186,26 @@ var _ = Describe("Exporter Conversion", func() {
 			Expect(exporter.Keepalive.Timeout).To(BeNil())
 			Expect(exporter.Keepalive.PermitWithoutStream).To(BeNil())
 		})
+
+		It("should always set balancer_name to pick_first", func() {
+			d0Config := &dash0common.Dash0Configuration{
+				Endpoint: EndpointDash0Test,
+				Authorization: dash0common.Authorization{
+					Token: &AuthorizationTokenTest,
+				},
+			}
+			auth := &dash0ExporterAuthorization{
+				EnvVarName: authEnvVarNameDefault,
+				Authorization: dash0common.Authorization{
+					Token: &AuthorizationTokenTest,
+				},
+			}
+
+			exporter, err := convertDash0ExporterToOtlpExporter(d0Config, "default", auth)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(exporter.BalancerName).To(Equal(string(dash0common.PickFirst)))
+		})
 	})
 
 	Describe("ConvertGrpcExporterToOtlpExporter", func() {
@@ -329,6 +349,29 @@ var _ = Describe("Exporter Conversion", func() {
 			Expect(exporter.Keepalive.Time).To(BeNil())
 			Expect(exporter.Keepalive.Timeout).To(BeNil())
 			Expect(*exporter.Keepalive.PermitWithoutStream).To(BeTrue())
+		})
+
+		It("should propagate balancer_name when configured", func() {
+			grpcConfig := &dash0common.GrpcConfiguration{
+				Endpoint:     EndpointGrpcTest,
+				BalancerName: dash0common.PickFirst,
+			}
+
+			exporter, err := convertGrpcExporterToOtlpExporter(grpcConfig, "default")
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(exporter.BalancerName).To(Equal(string(dash0common.PickFirst)))
+		})
+
+		It("should leave balancer_name empty when not configured", func() {
+			grpcConfig := &dash0common.GrpcConfiguration{
+				Endpoint: EndpointGrpcTest,
+			}
+
+			exporter, err := convertGrpcExporterToOtlpExporter(grpcConfig, "default")
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(exporter.BalancerName).To(BeEmpty())
 		})
 	})
 


### PR DESCRIPTION
- uses the `pick_first` balancer for the dash0 exporter since client-side load balancing is not needed and the `round_robin` balancer that the otel collector uses by default since [0.145.0](https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.145.0) causes excessive warnings when the dns returns both an A and AAAA record
- for custom grpc exporters the balancer is configurable and by default uses `round_robin` to be consistent with the otel collector