### PR TITLE
chore(ie): move IE flag into helm values file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -555,7 +555,7 @@ to the source code).
 ### Testing
 
 - Set `IMAGE_REPOSITORY_PREFIX` to a repo containing the images or set the individual images explicitly via helm values.
-- Install the operator helm chart with `operator.development.intelligentEdge.enabled=true`
+- Install the operator helm chart with `operator.intelligentEdge.enabled=true`
   - This will instruct helm to set the right collector image and also install the IE CRDs.
 - You can now create a `Dash0IntelligentEdge` CR and add `Dash0SamplingRule`s.
 

--- a/helm-chart/dash0-operator/templates/_helpers.tpl
+++ b/helm-chart/dash0-operator/templates/_helpers.tpl
@@ -141,12 +141,3 @@ securityContext:
   seccompProfile:
     type: RuntimeDefault
 {{- end }}
-
-{{/* development settings */}}
-{{/* note: defaults are defined here instead of values.yaml, since they should usually not be overridden by users. */}}
-
-{{/* Enable/Disable IntelligentEdge features. When IE is disabled, no IE-related CRDs will be created and the collector
-image will not include any IE components. */}}
-{{- define "dash0-operator.development.intelligentEdge.enabled" -}}
-{{- if ((((.Values.operator).development).intelligentEdge).enabled) -}}true{{- else -}}false{{- end -}}
-{{- end }}

--- a/helm-chart/dash0-operator/templates/operator/custom-resource-definition-intelligent-edge.yaml
+++ b/helm-chart/dash0-operator/templates/operator/custom-resource-definition-intelligent-edge.yaml
@@ -1,4 +1,4 @@
-{{- if eq (include "dash0-operator.development.intelligentEdge.enabled" .) "true" }}
+{{- if .Values.operator.intelligentEdge.enabled }}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/helm-chart/dash0-operator/templates/operator/custom-resource-definition-sampling-rules.yaml
+++ b/helm-chart/dash0-operator/templates/operator/custom-resource-definition-sampling-rules.yaml
@@ -1,4 +1,4 @@
-{{- if eq (include "dash0-operator.development.intelligentEdge.enabled" .) "true" }}
+{{- if .Values.operator.intelligentEdge.enabled }}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/helm-chart/dash0-operator/templates/operator/deployment-and-webhooks.yaml
+++ b/helm-chart/dash0-operator/templates/operator/deployment-and-webhooks.yaml
@@ -157,7 +157,7 @@ spec:
         - --operator-configuration-instrumentation-delivery={{ .Values.operator.instrumentation.delivery }}
 {{- end }}{{/*closes "if .Values.operator.dash0Export.enabled" */}}
         - --dash0-telemetry-collection-enabled={{ .Values.operator.telemetryCollectionEnabled }}
-{{- if eq (include "dash0-operator.development.intelligentEdge.enabled" .) "true" }}
+{{- if .Values.operator.intelligentEdge.enabled }}
         - --dash0-feature-intelligent-edge-enabled=true
 {{- end }}
         - --dash0-force-use-otel-collector-service-url={{ .Values.operator.collectors.forceUseServiceUrl }}
@@ -202,7 +202,7 @@ spec:
         - name: DASH0_INSTRUMENTATION_IMAGE_PULL_POLICY
           value: {{ .Values.operator.instrumentationImage.pullPolicy }}
         {{- end }}
-        {{- if eq (include "dash0-operator.development.intelligentEdge.enabled" .) "true" }}
+        {{- if .Values.operator.intelligentEdge.enabled }}
         - name: DASH0_COLLECTOR_IMAGE
           value: {{ include "dash0-operator.intelligentEdgeCollectorImage" . | quote }}
         {{- if .Values.operator.intelligentEdgeCollectorImage.pullPolicy }}
@@ -241,7 +241,7 @@ spec:
         - name: DASH0_FILELOG_OFFSET_VOLUME_OWNERSHIP_IMAGE_PULL_POLICY
           value: {{ .Values.operator.filelogOffsetVolumeOwnershipImage.pullPolicy }}
         {{- end }}
-        {{- if eq (include "dash0-operator.development.intelligentEdge.enabled" .) "true" }}
+        {{- if .Values.operator.intelligentEdge.enabled }}
         - name: DASH0_BARKER_IMAGE
           value: {{ include "dash0-operator.barkerImage" . | quote }}
         {{- if .Values.operator.barkerImage.pullPolicy }}
@@ -620,7 +620,7 @@ webhooks:
         scope: Cluster
     sideEffects: None
     timeoutSeconds: 5
-{{- if eq (include "dash0-operator.development.intelligentEdge.enabled" .) "true" }}
+{{- if .Values.operator.intelligentEdge.enabled }}
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration

--- a/helm-chart/dash0-operator/tests/operator/custom-resource-definition-intelligent-edge_test.yaml
+++ b/helm-chart/dash0-operator/tests/operator/custom-resource-definition-intelligent-edge_test.yaml
@@ -10,9 +10,8 @@ tests:
   - it: should render the intelligent edge CRD when IE is enabled
     set:
       operator:
-        development:
-          intelligentEdge:
-            enabled: true
+        intelligentEdge:
+          enabled: true
     asserts:
       - hasDocuments:
           count: 1

--- a/helm-chart/dash0-operator/tests/operator/custom-resource-definition-sampling-rules_test.yaml
+++ b/helm-chart/dash0-operator/tests/operator/custom-resource-definition-sampling-rules_test.yaml
@@ -10,9 +10,8 @@ tests:
   - it: should render the sampling rules CRD when IE is enabled
     set:
       operator:
-        development:
-          intelligentEdge:
-            enabled: true
+        intelligentEdge:
+          enabled: true
     asserts:
       - hasDocuments:
           count: 1

--- a/helm-chart/dash0-operator/tests/operator/deployment-and-webhooks_test.yaml
+++ b/helm-chart/dash0-operator/tests/operator/deployment-and-webhooks_test.yaml
@@ -1029,9 +1029,8 @@ tests:
       value: dash0-operator-controller
     set:
       operator:
-        development:
-          intelligentEdge:
-            enabled: true
+        intelligentEdge:
+          enabled: true
     asserts:
       - equal:
           path: spec.template.spec.containers[0].args[4]
@@ -1064,9 +1063,8 @@ tests:
       value: dash0-operator-controller
     set:
       operator:
-        development:
-          intelligentEdge:
-            enabled: true
+        intelligentEdge:
+          enabled: true
         intelligentEdgeCollectorImage:
           repository: custom-ie-collector
           tag: "9.9.9"

--- a/helm-chart/dash0-operator/values.yaml
+++ b/helm-chart/dash0-operator/values.yaml
@@ -959,3 +959,9 @@ operator:
   #      enabled: true
   #    synchronizePersesDashboards: true
   #    synchronizePrometheusRules: true
+
+  # Settings related to Intelligent Edge. This feature is currently under development and should
+  # not be enabled.
+  intelligentEdge:
+    # Whether to enable Intelligent Edge features for this operator install.
+    enabled: false

--- a/test-resources/bin/lib/util
+++ b/test-resources/bin/lib/util
@@ -736,7 +736,7 @@ run_helm() {
       helm_install_command+=" --set operator.telemetryCollectionEnabled=false"
     fi
     if [[ "${FEATURE_INTELLIGENT_EDGE_ENABLED:-}" = "true" ]]; then
-      helm_install_command+=" --set operator.development.intelligentEdge.enabled=true"
+      helm_install_command+=" --set operator.intelligentEdge.enabled=true"
     fi
     helm_install_command+=" --set operator.clusterName=$(kubectl config current-context)"
   fi

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1590,7 +1590,7 @@ trace_statements:
 					&images,
 					false,
 					map[string]string{
-						"operator.development.intelligentEdge.enabled": "true",
+						"operator.intelligentEdge.enabled": "true",
 					},
 				)
 


### PR DESCRIPTION
The motivation for this change is that a follow-up PR will add configuration of resource request/limits, tolerations, node affinities,... for barker and so it makes sense to introduce an `intelligentEdge` section in the values file and also move the `enabled` flag there.