### PR TITLE
chore(filelogoffset): remove duplicate log

### DIFF
--- a/images/filelogoffsetsync/src/filelogoffsetsync.go
+++ b/images/filelogoffsetsync/src/filelogoffsetsync.go
@@ -311,7 +311,6 @@ func doSyncOffsetsAndMeasure(ctx context.Context, settings *Settings) error {
 	elapsed := time.Since(start)
 
 	if err != nil {
-		logger.Info("cannot update offset files", errorLabel, err)
 		updateErrors.Add(ctx, 1, otelmetric.WithAttributes(
 			attribute.String("error.type", "CannotUpdateOffsetFiles"),
 			attribute.String("error.message", common.TruncateErrorForMetricAttribute(err)),


### PR DESCRIPTION
very tiny fix: `cannot update offset files` was logged twice, once as `INFO` and once as `WARN`

kept the log on the call site since we have a bit more info there (whether it happened during normal operation or during shutdown)