### PR TITLE
docs(README): backport changes from dash0.com/docs

### DIFF
--- a/helm-chart/dash0-operator/README.md
+++ b/helm-chart/dash0-operator/README.md
@@ -28,27 +28,29 @@ Other features like metrics and log collection are independent of the runtime of
 
 ## Prerequisites
 
-- [Kubernetes](https://kubernetes.io/) 1.25.16 or later.
-- [Helm](https://helm.sh) >= 3.x, please refer to Helm's [documentation](https://helm.sh/docs/) for more information
-  on installing Helm.
+* [Kubernetes](https://kubernetes.io/) 1.25.16 or later.
+* [Helm](https://helm.sh) >= 3.x, please refer to [Helm's documentation](https://helm.sh/docs/) for more information on
+  installing Helm.
 
 To use the operator, you will need provide two configuration values:
-* `endpoint`: The URL of the Dash0 ingress endpoint backend to which telemetry data will be sent.
+
+* **`endpoint`**: The URL of the Dash0 ingress endpoint backend to which telemetry data will be sent.
   This property is mandatory when installing the operator.
   This is the OTLP/gRPC endpoint of your Dash0 organization.
-  The correct OTLP/gRPC endpoint can be copied fom https://app.dash0.com -> organization settings -> "Endpoints"
-  -> "OTLP/gRPC".
+  The correct OTLP/gRPC endpoint can be copied from https://app.dash0.com → organization settings → "Endpoints" →
+  "OTLP/gRPC".
   Note that the correct endpoint value will always start with `ingress.` and end in `dash0.com:4317`.
   Including a protocol prefix (e.g. `https://`) is optional.
-* Either `token` or `secretRef`: Exactly one of these two properties needs to be provided when installing the operator.
-    * `token`: This is the Dash0 authorization token of your organization.
-      The authorization token for your Dash0 organization can be copied from https://app.dash0.com -> organization
-      settings -> "Auth Tokens".
-      The prefix `Bearer ` must *not* be included in the value.
+* Either **`token`** or **`secretRef`**: Exactly one of these two properties needs to be provided when installing the
+  operator.
+    * **`token`**: This is the Dash0 authorization token of your organization.
+      The authorization token for your Dash0 organization can be copied from https://app.dash0.com → organization
+      settings → "Auth Tokens".
+      The prefix `Bearer ` must not be included in the value.
       Note that when you provide a token, it will be rendered verbatim into a Kubernetes ConfigMap object.
       Anyone with API access to the Kubernetes cluster will be able to read the value.
       Use a secret reference and a Kubernetes secret if you want to avoid that.
-    * `secretRef`: A reference to an existing Kubernetes secret in the Dash0 operator's namespace.
+    * **`secretRef`**: A reference to an existing Kubernetes secret in the Dash0 operator's namespace.
       The secret needs to contain the Dash0 authorization token.
       See below for details on how exactly the secret should be created and configured.
 
@@ -125,9 +127,10 @@ That is, providing `--set operator.dash0Export.enabled=true` and the other backe
 
 On its own, the operator will only collect Kubernetes metrics.
 To actually have the operator properly monitor your workloads, two more things need to be set up:
-1. a [Dash0 backend connection](#configuring-the-dash0-backend-connection) has to be configured (unless you did that
+
+1. A [Dash0 backend connection](#configuring-the-dash0-backend-connection) has to be configured (unless you did that
    already with the Helm values `operator.dash0Export.*`), and
-2. monitoring namespaces and their workloads to collect logs, traces and metrics has to be
+2. Monitoring namespaces and their workloads to collect logs, traces and metrics has to be
    [enabled per namespace](#enable-dash0-monitoring-for-a-namespace), or configure namespace auto-monitoring.
 
 Both steps are described in the following sections.
@@ -197,14 +200,13 @@ operator:
         memory: 128Mi
 ```
 
-
-
 ## Configuration
 
 ### Configuring the Dash0 Backend Connection
 
 **You can skip this step if you provided `--set operator.dash0Export.enabled=true` together with the endpoint and either
-a token or a secret reference when running `helm install`.** In that case, proceed to the next section,
+a token or a secret reference when running `helm install`.**
+In that case, proceed to the next section,
 [Enable Dash0 Monitoring For a Namespace](#enable-dash0-monitoring-for-a-namespace).
 
 Otherwise, configure the backend connection now by creating a file `dash0-operator-configuration.yaml` with the
@@ -231,27 +233,31 @@ spec:
 ```
 
 Here is a list of configuration options for this resource:
-* <a href="#operatorconfigurationresource.spec.exports[]"><span id="operatorconfigurationresource.spec.exports[]">`spec.exports[]`</span></a>: One or more `export` configs defining endpoints and authorization (see below for details).
-  If multiple exports are defined, the telemetry will be exported to all defined exports and CRs (views, synthetic checks, dashboards, check rules, notification channels, spam filters, signal-to-metrics rules) will be synced to all defined Dash0 exports.
-* <a href="#operatorconfigurationresource.spec.exports[].dash0.endpoint"><span id="operatorconfigurationresource.spec.exports[].dash0.endpoint">`spec.exports[].dash0.endpoint`</span></a>: The URL of the Dash0 ingress endpoint to which telemetry data will be sent.
+* <a href="#operatorconfigurationresource.spec.exports[]"><span id="operatorconfigurationresource.spec.exports[]">**`spec.exports[]`**</span></a>:
+  One or more `export` configs defining endpoints and authorization (see below for details).
+  If multiple exports are defined, the telemetry will be exported to all defined exports and CRs (views, synthetic
+  checks, dashboards, check rules, notification channels, spam filters, signal-to-metrics rules) will be synced to all
+  defined Dash0 exports.
+* <a href="#operatorconfigurationresource.spec.exports[].dash0.endpoint"><span id="operatorconfigurationresource.spec.exports[].dash0.endpoint">**`spec.exports[].dash0.endpoint`**</span></a>:
+  The URL of the Dash0 ingress endpoint to which telemetry data will be sent.
   This property is mandatory.
   Replace the value in the example above with the OTLP/gRPC endpoint of your Dash0 organization.
-  The correct OTLP/gRPC endpoint can be copied fom https://app.dash0.com -> organization settings -> "Endpoints"
-  -> "OTLP/gRPC".
+  The correct OTLP/gRPC endpoint can be copied from https://app.dash0.com → organization settings → "Endpoints" →
+  "OTLP/gRPC".
   Note that the correct endpoint value will always start with `ingress.` and end in `dash0.com:4317`.
   Including a protocol prefix (e.g. `https://`) is optional.
-* `spec.exports[].dash0.authorization.token` or `spec.exports[].dash0.authorization.secretRef`:
+* **`spec.exports[].dash0.authorization.token`** or **`spec.exports[].dash0.authorization.secretRef`**:
   Exactly one of these two properties needs to be provided.
   Providing both will cause a validation error when installing the Dash0Monitoring resource.
-    * <a href="#operatorconfigurationresource.spec.export.dash0.authorization.token"><span id="operatorconfigurationresource.spec.export.dash0.authorization.token">`spec.export.dash0.authorization.token`</span></a>:
+    * <a href="#operatorconfigurationresource.spec.export.dash0.authorization.token"><span id="operatorconfigurationresource.spec.export.dash0.authorization.token">**`spec.export.dash0.authorization.token`**</span></a>:
       Replace the value in the example above with the Dash0 authorization token of your organization.
-      The authorization token for your Dash0 organization can be copied from https://app.dash0.com -> organization
-      settings -> "Auth Tokens".
-      The prefix `Bearer ` must *not* be included in the value.
+      The authorization token for your Dash0 organization can be copied from https://app.dash0.com → organization
+      settings → "Auth Tokens".
+      The prefix `Bearer ` must not be included in the value.
       Note that the value will be rendered verbatim into a Kubernetes ConfigMap object.
       Anyone with API access to the Kubernetes cluster will be able to read the value.
       Use the `secretRef` property and a Kubernetes secret if you want to avoid that.
-    * <a href="#operatorconfigurationresource.spec.export.dash0.authorization.secretRef"><span id="operatorconfigurationresource.spec.export.dash0.authorization.secretRef">`spec.export.dash0.authorization.secretRef`</span></a>:
+    * <a href="#operatorconfigurationresource.spec.export.dash0.authorization.secretRef"><span id="operatorconfigurationresource.spec.export.dash0.authorization.secretRef">**`spec.export.dash0.authorization.secretRef`**</span></a>:
       A reference to an existing Kubernetes secret in the Dash0 operator's namespace.
       See the section [Using a Kubernetes Secret for the Dash0 Authorization Token](#using-a-kubernetes-secret-for-the-dash0-authorization-token)
       for an example file that uses a `secretRef`.
@@ -261,26 +267,26 @@ Here is a list of configuration options for this resource:
       cluster will be able to read the value.
       Additional steps are required to make sure secret values are encrypted.
       See https://kubernetes.io/docs/concepts/configuration/secret/ for more information on Kubernetes secrets.
-* <a href="#operatorconfigurationresource.spec.exports[].dash0.apiEndpoint"><span id="operatorconfigurationresource.spec.exports[].dash0.apiEndpoint">`spec.exports[].dash0.apiEndpoint`</span></a>:
+* <a href="#operatorconfigurationresource.spec.exports[].dash0.apiEndpoint"><span id="operatorconfigurationresource.spec.exports[].dash0.apiEndpoint">**`spec.exports[].dash0.apiEndpoint`**</span></a>:
   The base URL of the Dash0 API to talk to. This is not where telemetry will be sent, but it is used for managing
   dashboards, check rules, synthetic checks, views, notification channels, spam filters and signal-to-metrics rules via the operator.
   This property is optional.
   The value needs to be the API endpoint of your Dash0 organization.
-  The correct API endpoint can be copied fom https://app.dash0.com -> organization settings -> "Endpoints" -> "API".
+  The correct API endpoint can be copied from https://app.dash0.com → organization settings → "Endpoints" → "API".
   The correct endpoint value will always start with "https://api." and end in ".dash0.com".
   If this property is omitted, managing dashboards, check rules, synthetic checks, views, notification channels, spam
   filters and signal-to-metrics rules via the operator will not work.
-* <a href="#operatorconfigurationresource.spec.selfMonitoring.enabled"><span id="operatorconfigurationresource.spec.selfMonitoring.enabled">`spec.selfMonitoring.enabled`</span></a>:
+* <a href="#operatorconfigurationresource.spec.selfMonitoring.enabled"><span id="operatorconfigurationresource.spec.selfMonitoring.enabled">**`spec.selfMonitoring.enabled`**</span></a>:
   An opt-out for self-monitoring for the operator.
   If enabled, the operator will collect self-monitoring telemetry and send it to the configured Dash0 backend.
   This setting is optional, it defaults to true.
-* <a href="#operatorconfigurationresource.spec.kubernetesInfrastructureMetricsCollection.enabled"><span id="operatorconfigurationresource.spec.kubernetesInfrastructureMetricsCollection.enabled">`spec.kubernetesInfrastructureMetricsCollection.enabled`</span></a>:
+* <a href="#operatorconfigurationresource.spec.kubernetesInfrastructureMetricsCollection.enabled"><span id="operatorconfigurationresource.spec.kubernetesInfrastructureMetricsCollection.enabled">**`spec.kubernetesInfrastructureMetricsCollection.enabled`**</span></a>:
   If enabled, the operator will collect Kubernetes infrastructure metrics.
   This setting is optional, it defaults to true; unless `telemetryCollection.enabled` is set to `false`, then
   `kubernetesInfrastructureMetricsCollection.enabled` defaults to `false` as well.
   It is a validation error to set `telemetryCollection.enabled=false` and
   `kubernetesInfrastructureMetricsCollection.enabled=true` at the same time.
-* <a href="#operatorconfigurationresource.spec.collectPodLabelsAndAnnotations.enabled"><span id="operatorconfigurationresource.spec.collectPodLabelsAndAnnotations.enabled">`spec.collectPodLabelsAndAnnotations.enabled`</span></a>:
+* <a href="#operatorconfigurationresource.spec.collectPodLabelsAndAnnotations.enabled"><span id="operatorconfigurationresource.spec.collectPodLabelsAndAnnotations.enabled">**`spec.collectPodLabelsAndAnnotations.enabled`**</span></a>:
   If enabled, the operator will collect all Kubernetes pod labels and annotations and convert them to resource attributes
   for all spans, log records and metrics.
   The resulting resource attributes are prefixed with `k8s.pod.label.` or `k8s.pod.annotation.` respectively.
@@ -288,10 +294,10 @@ Here is a list of configuration options for this resource:
   `collectPodLabelsAndAnnotations.enabled` defaults to `false` as well.
   It is a validation error to set `telemetryCollection.enabled=false` and `collectPodLabelsAndAnnotations.enabled=true`
   at the same time.
-* <a href="#operatorconfigurationresource.spec.clusterName"><span id="operatorconfigurationresource.spec.clusterName">`spec.clusterName`</span></a>:
+* <a href="#operatorconfigurationresource.spec.clusterName"><span id="operatorconfigurationresource.spec.clusterName">**`spec.clusterName`**</span></a>:
   If set, the value will be added as the resource attribute `k8s.cluster.name` to all telemetry.
   This setting is optional. By default, `k8s.cluster.name` will not be added to telemetry.
-* <a href="#operatorconfigurationresource.spec.telemetryCollection.enabled"><span id="operatorconfigurationresource.spec.telemetryCollection.enabled">`spec.telemetryCollection.enabled`</span></a>:
+* <a href="#operatorconfigurationresource.spec.telemetryCollection.enabled"><span id="operatorconfigurationresource.spec.telemetryCollection.enabled">**`spec.telemetryCollection.enabled`**</span></a>:
   An opt-out switch for all telemetry collection, and to avoid having the operator deploy OpenTelemetry collectors in
   the cluster.
   This setting is optional, it defaults to true (that is, by default, OpenTelemetry collectors will be deployed and
@@ -300,18 +306,18 @@ Here is a list of configuration options for this resource:
   will not deploy any OpenTelemetry collectors in the cluster.
   This is useful if you want to use the operator for infrastructure-as-code (e.g. to synchronize dashboards & check
   rules), but do not want it to deploy the OpenTelemetry collector.
-  Note that setting this to false does not disable the operator's self-monitoring telemetry, use the setting
+  Note that setting this to `false` does not disable the operator's self-monitoring telemetry, use the setting
   `spec.selfMonitoring.enabled` to disable self-monitoring if required (self-monitoring does not require an
   OpenTelemetry collector).
   Also note that this setting is not exposed via Helm, i.e. if you want to set this to false you need to deploy the
   operator configuration resource manually, i.e. omit the Helm value `operator.dash0Export.enabled` or set it to false,
   then deploy an operator configuration resource via `kubectl apply -f` or similar.
-* <a href="#operatorconfigurationresource.spec.prometheusCrdSupport.enabled"><span id="operatorconfigurationresource.spec.prometheusCrdSupport.enabled">`spec.prometheusCrdSupport.enabled`</span></a>:
+* <a href="#operatorconfigurationresource.spec.prometheusCrdSupport.enabled"><span id="operatorconfigurationresource.spec.prometheusCrdSupport.enabled">**`spec.prometheusCrdSupport.enabled`**</span></a>:
   A flag controlling whether support for Prometheus CRDs will be enabled. This setting is optional and the default is `false`.
   Setting it to `true` and having at least one namespace with `prometheusScraping` enabled, will deploy the OpenTelemetry
   target-allocator and update the `prometheusreceiver` in the OpenTelemetry collectors, so they query the allocator for targets
   to be scraped.
-* <a href="#operatorconfigurationresource.spec.instrumentWorkloads.instrumentationDelivery"><span id="operatorconfigurationresource.spec.instrumentWorkloads.instrumentationDelivery">`spec.instrumentWorkloads.instrumentationDelivery`</span></a>:
+* <a href="#operatorconfigurationresource.spec.instrumentWorkloads.instrumentationDelivery"><span id="operatorconfigurationresource.spec.instrumentWorkloads.instrumentationDelivery">**`spec.instrumentWorkloads.instrumentationDelivery`**</span></a>:
   Whether to use an image volume or an init container plus an emptyDir volume to provide instrumentation files to
   workloads when applying auto-instrumentation.
   See [Using Image Volumes for Auto-Instrumentation Files](#using-image-volumes-for-auto-instrumentation-files).
@@ -325,7 +331,7 @@ Here is a list of configuration options for this resource:
     your cluster, since image volumes are disabled by default in versions older than 1.35.
   - `init-container`: always use the init container approach, regardless of the Kubernetes version.
     This is the default.
-* <a href="#operatorconfigurationresource.spec.autoMonitorNamespaces.enabled"><span id="operatorconfigurationresource.spec.autoMonitorNamespaces.enabled">`spec.autoMonitorNamespaces.enabled`</span></a>: Controls whether monitoring is set up for namespaces
+* <a href="#operatorconfigurationresource.spec.autoMonitorNamespaces.enabled"><span id="operatorconfigurationresource.spec.autoMonitorNamespaces.enabled">**`spec.autoMonitorNamespaces.enabled`**</span></a>: Controls whether monitoring is set up for namespaces
   automatically.
   By default, a Dash0Monitoring resource has to be added to each namespace that you want to monitor.
   With automatic namespace monitoring, you can let the Dash0 operator automate this.
@@ -339,7 +345,7 @@ Here is a list of configuration options for this resource:
   Even when enabled, individual namespaces can opt out of automatic monitoring via [label selectors](#operatorconfigurationresource.spec.autoMonitorNamespaces.labelSelector).
   Namespaces which are subject to automatic namespace monitoring will be monitored according to the settings of the
   [monitoringTemplate](#operatorconfigurationresource.spec.monitoringTemplate).
-* <a href="#operatorconfigurationresource.spec.autoMonitorNamespaces.labelSelector"><span id="operatorconfigurationresource.spec.autoMonitorNamespaces.labelSelector">`operatorconfigurationresource.spec.autoMonitorNamespaces.labelSelector`</span></a>:
+* <a href="#operatorconfigurationresource.spec.autoMonitorNamespaces.labelSelector"><span id="operatorconfigurationresource.spec.autoMonitorNamespaces.labelSelector">**`operatorconfigurationresource.spec.autoMonitorNamespaces.labelSelector`**</span></a>:
   An optional configurable label selector for controlling which namespaces are automatically monitored.
   Namespaces which match this label selector will be monitored automatically (if `autoMonitorNamespaces.enabled` is
   set to `true`).
@@ -351,7 +357,7 @@ Here is a list of configuration options for this resource:
     * namespaces which have the label dash0.com/enable with a value other than "false".
   Namespaces which are subject to automatic namespace monitoring will be monitored according to the settings of the
   [monitoringTemplate](#operatorconfigurationresource.spec.monitoringTemplate).
-* <a href="#operatorconfigurationresource.spec.monitoringTemplate"><span id="operatorconfigurationresource.spec.monitoringTemplate">`operatorconfigurationresource.spec.monitoringTemplate`</span></a>:
+* <a href="#operatorconfigurationresource.spec.monitoringTemplate"><span id="operatorconfigurationresource.spec.monitoringTemplate">**`operatorconfigurationresource.spec.monitoringTemplate`**</span></a>:
   Specification of the desired settings for automatically monitoring namespaces.
 
 After providing the required values (at least `endpoint` and `authorization`), save the file and apply the resource to
@@ -364,14 +370,15 @@ kubectl apply -f dash0-operator-configuration.yaml
 The Dash0 operator configuration resource is cluster-scoped, so a specific namespace should not be provided when
 applying it.
 
-Note: All configuration options available in the operator configuration resource can also be configured when letting the
-Helm chart auto-create this resource, as explained in the section [Installation](#installation). You can consult the
-chart's [values.yaml](https://github.com/dash0hq/dash0-operator/blob/main/helm-chart/dash0-operator/values.yaml) file
-for a complete list of available configuration settings.
+> **Note:** All configuration options available in the operator configuration resource can also be configured when
+> letting the Helm chart auto-create this resource, as explained in the section [Installation](#installation).
+> You can consult the chart's
+> [values.yaml](https://github.com/dash0hq/dash0-operator/blob/main/helm-chart/dash0-operator/values.yaml) file for a
+> complete list of available configuration settings.
 
 ### Notes on Creating the Operator Configuration Resource Via Helm
 
-Providing the backend connection settings to the operator via Helm parameters is a _convenience mechanism_ to get
+Providing the backend connection settings to the operator via Helm parameters is a convenience mechanism to get
 monitoring started right away when installing the operator.
 Setting `operator.dash0Export.enabled` to `true` and providing other necessary `operator.dash0Export.*` values like
 `operator.dash0Export.endpoint` will instruct the operator manager to create an operator configuration resource with the
@@ -391,10 +398,10 @@ Manual changes to the `dash0-operator-configuration-auto-resource` are permissib
 configuration changes, without an operator restart, but you need to be aware that they will be overwritten with the
 settings provided via Helm the next time the operator manager pod is restarted.
 Possible reasons for a restart of the operator manager pod include upgrading to a new operator version, running
-`helm upgrade ...  dash0-operator dash0-operator/dash0-operator`, or Kubernetes moving the operator manager pod to a
+`helm upgrade ... dash0-operator dash0-operator/dash0-operator`, or Kubernetes moving the operator manager pod to a
 different node.
 
-For this reason, when using this feature, it is recommended to treat the _Helm values_ as the source of truth for the
+For this reason, when using this feature, it is recommended to treat the Helm values as the source of truth for the
 operator configuration.
 Any changes you want to be permanent should be applied via Helm and the `operator.dash0Export.*` settings.
 
@@ -404,17 +411,17 @@ kubectl, ArgoCD etc.).
 
 ### Enable Dash0 Monitoring For a Namespace
 
-*Note:* As an alternative to enabling monitoring per namespace, you can also
-[monitor all namespaces automatically](#automatic-namespace-monitoring).
+> **Note:** As an alternative to enabling monitoring per namespace, you can also
+> [monitor all namespaces automatically](#automatic-namespace-monitoring).
 
-*Note:* By default, when enabling Dash0 monitoring for a namespace, all workloads in this namespace will be restarted
-to apply the Dash0 instrumentation.
-If you want to avoid this, set the `instrumentWorkloads` property in the monitoring resource spec to
-`created-and-updated`.
-See below for more information on the `instrumentWorkloads` modes.
+> **Note:** By default, when enabling Dash0 monitoring for a namespace, all workloads in this namespace will be
+> restarted to apply the Dash0 instrumentation.
+> If you want to avoid this, set the `instrumentWorkloads` property in the monitoring resource spec to
+> `created-and-updated`.
+> See below for more information on the `instrumentWorkloads` modes.
 
-For _each namespace_ that you want to monitor with Dash0, enable monitoring by installing a _Dash0 monitoring
-resource_ into that namespace:
+For each namespace that you want to monitor with Dash0, enable monitoring by installing a Dash0 monitoring resource into
+that namespace:
 
 Create a file `dash0-monitoring.yaml` with the following content:
 
@@ -438,48 +445,49 @@ If you want to monitor the `default` namespace with Dash0, use the following com
 kubectl apply -f dash0-monitoring.yaml
 ```
 
-Note: Even when no monitoring resources has been installed and no namespace is being monitored by Dash0, the Dash0
-operator's collector will collect Kubernetes infrastructure metrics that are not namespace scoped, like node-related
-metrics. The only prerequisite for this is an [operator configuration](#configuring-the-dash0-backend-connection) with
-exports settings.
+> **Note:** Even when no monitoring resources has been installed and no namespace is being monitored by Dash0, the Dash0
+> operator's collector will collect Kubernetes infrastructure metrics that are not namespace scoped, like node-related
+> metrics.
+> The only prerequisite for this is an [operator configuration](#configuring-the-dash0-backend-connection) with
+> exports settings.
 
 ### Additional Configuration Per Namespace
 
 The Dash0 monitoring resource supports additional configuration settings:
 
-* <a href="#monitoringresource.spec.instrumentWorkloads.mode"><span id="monitoringresource.spec.instrumentWorkloads.mode"><span id="monitoringresource.spec.instrumentWorkloads">`spec.instrumentWorkloads.mode`</span></span></a>:
+* <a href="#monitoringresource.spec.instrumentWorkloads.mode"><span id="monitoringresource.spec.instrumentWorkloads.mode"><span id="monitoringresource.spec.instrumentWorkloads">**`spec.instrumentWorkloads.mode`**</span></span></a>:
   A namespace-wide configuration for the workload instrumentation strategy for the target namespace.
   There are three possible settings: `all`, `created-and-updated` and `none`.
-  By default, the setting `all` is assumed; unless there is an operator
-  configuration resource with `telemetryCollection.enabled=false`, then the setting `none` is assumed by default.
+  By default, the setting `all` is assumed; unless there is an operator configuration resource with
+  `telemetryCollection.enabled=false`, then the setting `none` is assumed by default.
   Note that `spec.instrumentWorkloads.mode` is the path for this setting starting with version `v1beta1` of the Dash0
   monitoring resource; when using `v1alpha1`, the path is `spec.instrumentWorkloads`.
 
-  * `all`: If set to `all`, the operator will:
-      * instrument existing workloads in the target namespace (i.e. workloads already running in the namespace) when
-        the Dash0 monitoring resource is deployed,
-      * instrument existing workloads or update the instrumentation of already instrumented workloads in the target
-        namespace when the Dash0 operator is first started or updated to a newer version,,
-      * instrument new workloads in the target namespace when they are deployed, and
-      * instrument changed workloads in the target namespace when changes are applied to them.
-    **Note that the first two actions (instrumenting existing workloads) will result in restarting the pods of the
-    affected workloads.**
-    Use `created-and-updated` if you want to avoid pod restarts.
+    * **`all`**: If set to `all`, the operator will:
+        * instrument existing workloads in the target namespace (i.e. workloads already running in the namespace) when
+          the Dash0 monitoring resource is deployed,
+        * instrument existing workloads or update the instrumentation of already instrumented workloads in the target
+          namespace when the Dash0 operator is first started or updated to a newer version,
+        * instrument new workloads in the target namespace when they are deployed, and
+        * instrument changed workloads in the target namespace when changes are applied to them.
+        * **Note that the first two actions (instrumenting existing workloads) will result in restarting the pods of the
+          affected workloads.**
+          Use `created-and-updated` if you want to avoid pod restarts.
 
-  * `created-and-updated`: If set to `created-and-updated`, the operator will not instrument existing workloads in the
-    target namespace.
-    Instead, it will only:
-      * instrument new workloads in the target namespace when they are deployed, and
-      * instrument changed workloads in the target namespace when changes are applied to them.
-    This setting is useful if you want to avoid pod restarts as a side effect of deploying the Dash0 monitoring
-    resource or restarting the Dash0 operator.
+    * **`created-and-updated`**: If set to `created-and-updated`, the operator will not instrument existing workloads in
+      the target namespace.
+      Instead, it will only:
+        * instrument new workloads in the target namespace when they are deployed, and
+        * instrument changed workloads in the target namespace when changes are applied to them.
+      This setting is useful if you want to avoid pod restarts as a side effect of deploying the Dash0 monitoring
+      resource or restarting the Dash0 operator.
 
-  * `none`: You can opt out of instrumenting workloads entirely by setting this option to `none`.
-     With `spec.instrumentWorkloads: none`, workloads in the target namespace will never be instrumented to emit
-     telemetry.
+    * **`none`**: You can opt out of instrumenting workloads entirely by setting this option to `none`.
+      With `spec.instrumentWorkloads: none`, workloads in the target namespace will never be instrumented to emit
+      telemetry.
 
-  If this setting is omitted, the value `all` is assumed and new/updated as well as existing Kubernetes workloads
-  will be intrumented by the operator to emit telemetry, as described above.
+  If this setting is omitted, the value `all` is assumed and new/updated as well as existing Kubernetes workloads will
+  be instrumented by the operator to emit telemetry, as described above.
   There is one exception to this rule: If there is an operator configuration resource with
   `telemetryCollection.enabled=false`, then the default setting is `none` instead of `all`, and no workloads will be
   instrumented by the Dash0 operator.
@@ -489,10 +497,11 @@ The Dash0 monitoring resource supports additional configuration settings:
   [Disabling Auto-Instrumentation for Specific Workloads](#disabling-auto-instrumentation-for-specific-workloads).
 
   The behavior when changing this setting for an existing Dash0 monitoring resource is as follows:
-    * When this setting is updated to `spec.instrumentWorkloads=all` (and it had a different value before): All existing
-      uninstrumented workloads will be instrumented. Their pods will be restarted to apply the instrumentation.
-    * When this setting is updated to `spec.instrumentWorkloads=none` (and it had a different value before): The
-      instrumentation will be removed from all instrumented workloads.
+    * When this setting is updated to `spec.instrumentWorkloads=all` (and it had a different value before):
+      All existing uninstrumented workloads will be instrumented.
+      Their pods will be restarted to apply the instrumentation.
+    * When this setting is updated to `spec.instrumentWorkloads=none` (and it had a different value before):
+      The instrumentation will be removed from all instrumented workloads.
       Their pods will be restarted to remove the instrumentation.
       (After this change, the operator will no longer instrument any workloads nor will it restart any pods.)
     * Updating this value to `spec.instrumentWorkloads=created-and-updated` has no immediate effect; existing
@@ -504,21 +513,21 @@ The Dash0 monitoring resource supports additional configuration settings:
   You can read more about what exactly this feature entails in the section
   [Automatic Workload Instrumentation](#automatic-workload-instrumentation).
 
-* <a href="#monitoringresource.spec.instrumentWorkloads.labelSelector"><span id="monitoringresource.spec.instrumentWorkloads.labelSelector">`spec.instrumentWorkloads.labelSelector`</span></a>:
+* <a href="#monitoringresource.spec.instrumentWorkloads.labelSelector"><span id="monitoringresource.spec.instrumentWorkloads.labelSelector">**`spec.instrumentWorkloads.labelSelector`**</span></a>:
   A custom Kubernetes [label selector](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors)
   for controlling the workload instrumentation on the level of individual workloads, see
   [Using a Custom Label Selector to Control Auto-Instrumentation](#using-a-custom-label-selector-to-control-auto-instrumentation).
 
-* <a href="#monitoringresource.spec.instrumentWorkloads.traceContext.propagators"><span id="monitoringresource.spec.instrumentWorkloads.traceContext.propagators">`spec.instrumentWorkloads.traceContext.propagators`</span></a>:
+* <a href="#monitoringresource.spec.instrumentWorkloads.traceContext.propagators"><span id="monitoringresource.spec.instrumentWorkloads.traceContext.propagators">**`spec.instrumentWorkloads.traceContext.propagators`**</span></a>:
   When set, the operator will add the environment variable `OTEL_PROPAGATORS` to all instrumented workloads in the
   target namespace.
   This environment variable determines which trace context propagation headers an OTel SDK uses.
-  Setting this can be useful if the workloads in this namespace interact with services do not use the W3C trace context
-  standard header `traceparent` for trace context propagation, but for example AWS X-Ray (`X-Amzn-Trace-Id`).
+  Setting this can be useful if the workloads in this namespace interact with services that do not use the W3C trace
+  context standard header `traceparent` for trace context propagation, but for example AWS X-Ray (`X-Amzn-Trace-Id`).
   The value of the setting will be validated, it needs to be a comma-separated list of valid propagators.
   See <https://opentelemetry.io/docs/languages/sdk-configuration/general/#otel_propagators> for more information.
 
-  When the option is no set, the operator will not set the environment variable `OTEL_PROPAGATORS`.
+  When the option is not set, the operator will not set the environment variable `OTEL_PROPAGATORS`.
   If the option is set in the monitoring resource at some point and then later removed again, the operator will remove
   the environment variable from instrumented workloads if and only if the value of the environment variable matches the
   previously used setting in the monitoring resource.
@@ -526,7 +535,7 @@ The Dash0 monitoring resource supports additional configuration settings:
   and not by the operator.
   (For that purpose, the previous setting is stored in the monitoring resource's status.)
 
-* <a href="#monitoringresource.spec.instrumentWorkloads.captureSqlQueryParameters"><span id="monitoringresource.spec.instrumentWorkloads.captureSqlQueryParameters">`spec.instrumentWorkloads.captureSqlQueryParameters`</span></a>:
+* <a href="#monitoringresource.spec.instrumentWorkloads.captureSqlQueryParameters"><span id="monitoringresource.spec.instrumentWorkloads.captureSqlQueryParameters">**`spec.instrumentWorkloads.captureSqlQueryParameters`**</span></a>:
   When set to `true`, the operator enables SQL query parameter capture in the language agents that support it.
   Currently this covers the OpenTelemetry Java agent's JDBC instrumentation and the OpenTelemetry .NET
   auto-instrumentation for Microsoft.Data.SqlClient and Entity Framework Core, by adding the following environment
@@ -549,35 +558,35 @@ The Dash0 monitoring resource supports additional configuration settings:
   would have set (the literal `true`); a user-set value that differs is preserved.
   (For that purpose, the previous setting is stored in the monitoring resource's status.)
 
-* <a href="#monitoringresource.spec.logCollection.enabled"><span id="monitoringresource.spec.logCollection.enabled">`spec.logCollection.enabled`</span></a>:
+* <a href="#monitoringresource.spec.logCollection.enabled"><span id="monitoringresource.spec.logCollection.enabled">**`spec.logCollection.enabled`**</span></a>:
   A namespace-wide opt-out for collecting pod logs via the `filelog` receiver.
   If enabled, the operator will configure its OpenTelemetry collector to watch the log output of all pods in the
   namespace and send the resulting log records to Dash0.
-  This setting is optional, it defaults to true; unless there is an operator configuration resource with
+  This setting is optional, it defaults to `true`; unless there is an operator configuration resource with
   `telemetryCollection.enabled=false`, then log collection is off by default.
   It is a validation error to set `telemetryCollection.enabled=false` in the operator configuration resource and
   `logCollection.enabled=true` in any monitoring resource at the same time.
 
-* <a href="#monitoringresource.spec.prometheusScraping.enabled"><span id="monitoringresource.spec.prometheusScraping.enabled">`spec.prometheusScraping.enabled`</span></a>:
+* <a href="#monitoringresource.spec.prometheusScraping.enabled"><span id="monitoringresource.spec.prometheusScraping.enabled">**`spec.prometheusScraping.enabled`**</span></a>:
   A namespace-wide opt-out for Prometheus scraping for the target namespace.
   If enabled, the operator will configure its OpenTelemetry collector to scrape metrics from pods in the namespace
-  of this Dash0Monitoring resource according to their prometheus.io/scrape annotations via the OpenTelemetry Prometheus
-  receiver.
+  of this Dash0Monitoring resource according to their `prometheus.io/scrape` annotations via the OpenTelemetry
+  Prometheus receiver.
   In addition, if the operator configuration resource has `prometheusCrdSupport.enabled=true`, the collectors will scrape metrics
   from endpoints defined in Prometheus CRs (`ServiceMonitor`, `PodMonitor`, `ScrapeConfig`) present in this namespace.
-  This setting is optional, it defaults to true; unless there is an operator configuration resource with
+  This setting is optional, it defaults to `true`; unless there is an operator configuration resource with
   `telemetryCollection.enabled=false`, then Prometheus scraping is off by default.
   It is a validation error to set `telemetryCollection.enabled=false` in the operator configuration resource and
   `prometheusScraping.enabled=true` in any monitoring resource at the same time.
-  Note that the collection of OpenTelemetry-native metrics is not
-  affected by setting `prometheusScraping.enabled=false` for a namespace.
+  Note that the collection of OpenTelemetry-native metrics is not affected by setting `prometheusScraping.enabled=false`
+  for a namespace.
 
-* <a href="#monitoringresource.spec.filter"><span id="monitoringresource.spec.filter">`spec.filter`</span></a>:
+* <a href="#monitoringresource.spec.filter"><span id="monitoringresource.spec.filter">**`spec.filter`**</span></a>:
   An optional custom filter configuration to drop some of the collected telemetry before sending it to the configured
   telemetry backend.
   Filters for a specific telemetry object type (e.g. spans) are lists of
   [OTTL](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/pkg/ottl/README.md) expressions.
-  If at least one of the one conditions of a list evaluates to true, the object will be dropped.
+  If at least one of the conditions of a list evaluates to true, the object will be dropped.
   (That is, conditions are implicitly connected by a logical OR.)
   The configuration structure is identical to the configuration of the OpenTelemetry collector's
   [filter processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/filterprocessor/README.md).
@@ -585,27 +594,27 @@ The Dash0 monitoring resource supports additional configuration settings:
   applied to the telemetry collected in the namespace the monitoring resource is installed in.
   Telemetry from other namespaces is not affected.
   Existing configurations for the filter processor can be copied and pasted without syntactical changes.
-    * `spec.filter.traces.span`:
-       A list of OTTL conditions for filtering spans.
-       All spans where at least one condition evaluates to true will be dropped.
-	   (That is, conditions are implicitly connected by a logical OR.)
-    * `spec.filter.traces.spanevent`:
-       A list of OTTL conditions for filtering span events.
-       All span events where at least one condition evaluates to true will be dropped.
-	   If all span events for a span are dropped, the span will be left intact.
-    * `spec.filter.metrics.metric`:
-       A list of OTTL conditions for filtering metrics.
-       All metrics where at least one condition evaluates to true will be dropped.
-    * `spec.filter.metrics.datapoint`:
-       A list of OTTL conditions for filtering individual data points of metrics.
-       All data points where at least one condition evaluates to true will be dropped.
-	   If all datapoints for a metric are dropped, the metric will also be dropped.
-    * `spec.filter.logs.log_records`:
-       A list of OTTL conditions for filtering log records.
-       All log records where at least one condition evaluates to true will be dropped.
-    * `spec.filter.profiles.profile`:
-       A list of OTTL conditions for filtering profiles.
-       All profiles where at least one condition evaluates to true will be dropped.
+    * **`spec.filter.traces.span`**:
+      A list of OTTL conditions for filtering spans.
+      All spans where at least one condition evaluates to true will be dropped.
+      (That is, conditions are implicitly connected by a logical OR.)
+    * **`spec.filter.traces.spanevent`**:
+      A list of OTTL conditions for filtering span events.
+      All span events where at least one condition evaluates to true will be dropped.
+      If all span events for a span are dropped, the span will be left intact.
+    * **`spec.filter.metrics.metric`**:
+      A list of OTTL conditions for filtering metrics.
+      All metrics where at least one condition evaluates to true will be dropped.
+    * **`spec.filter.metrics.datapoint`**:
+      A list of OTTL conditions for filtering individual data points of metrics.
+      All data points where at least one condition evaluates to true will be dropped.
+      If all datapoints for a metric are dropped, the metric will also be dropped.
+    * **`spec.filter.logs.log_records`**:
+      A list of OTTL conditions for filtering log records.
+      All log records where at least one condition evaluates to true will be dropped.
+    * **`spec.filter.profiles.profile`**:
+      A list of OTTL conditions for filtering profiles.
+      All profiles where at least one condition evaluates to true will be dropped.
   This setting is optional, by default, no filters are applied.
   It is a validation error to set `telemetryCollection.enabled=false` in the operator configuration resource and set
   filters in any monitoring resource at the same time.
@@ -614,7 +623,7 @@ The Dash0 monitoring resource supports additional configuration settings:
   single filter processor in the resulting OpenTelemetry collector configuration; if different error modes are
   specified in different namespaces, the "most severe" error mode will be used (propagate > ignore > silent).
 
-* <a href="#monitoringresource.spec.transform"><span id="monitoringresource.spec.transform">`spec.transform`</span></a>:
+* <a href="#monitoringresource.spec.transform"><span id="monitoringresource.spec.transform">**`spec.transform`**</span></a>:
   An optional custom transformation configuration that will be applied to the collected telemetry before sending it to
   the configured telemetry backend.
   Transformations for a specific telemetry signal (e.g. traces, metrics, logs, profiles) are lists of
@@ -632,16 +641,16 @@ The Dash0 monitoring resource supports additional configuration settings:
   only be applied to the telemetry collected in the namespace the monitoring resource is installed in.
   Telemetry from other namespaces is not affected.
   If both `spec.filter` and `spec.transform` are configured, the filtering for a given signal (traces, metrics, logs, profiles)
-  will be executed _before_ the transform processor.
+  will be executed before the transform processor.
   (That is, you cannot assume that transformations have already been applied when writing filter rules.)
   Existing configurations for the transform processor can be copied and pasted without syntactical changes.
-    * `spec.transform.trace_statements`:
+    * **`spec.transform.trace_statements`**:
       A list of OTTL statements (or a list of groups in the advanced config style) for transforming trace telemetry.
-    * `spec.transform.metric_statements`:
+    * **`spec.transform.metric_statements`**:
       A list of OTTL statements (or a list of groups in the advanced config style) for transforming metric telemetry.
-    * `spec.transform.log_statements`:
+    * **`spec.transform.log_statements`**:
       A list of OTTL statements (or a list of groups in the advanced config style) for transforming log telemetry.
-    * `spec.transform.profile_statements`:
+    * **`spec.transform.profile_statements`**:
       A list of OTTL statements (or a list of groups in the advanced config style) for transforming profile telemetry.
   This setting is optional, by default, no transformations are applied.
   It is a validation error to set `telemetryCollection.enabled=false` in the operator configuration resource and set
@@ -651,25 +660,28 @@ The Dash0 monitoring resource supports additional configuration settings:
   single transform processor in the resulting OpenTelemetry collector configuration; if different error modes are
   specified in different namespaces, the "most severe" error mode will be used (propagate > ignore > silent).
 
-* <a href="#monitoringresource.spec.synchronizePersesDashboards"><span id="monitoringresource.spec.synchronizePersesDashboards">`spec.synchronizePersesDashboards`</span></a>:
+* <a href="#monitoringresource.spec.synchronizePersesDashboards"><span id="monitoringresource.spec.synchronizePersesDashboards">**`spec.synchronizePersesDashboards`**</span></a>:
   A namespace-wide opt-out for synchronizing Perses dashboard resources found in the target namespace.
   If enabled, the operator will watch Perses dashboard resources in this namespace and create corresponding dashboards
   in Dash0 via the Dash0 API.
   More fine-grained per-resource control over synchronization is available by setting the label
   `dash0.com/enable=false` on individual Perses dashboard resources.
-  See [Managing Dash0 Dashboards](#managing-dash0-dashboards) for details. This setting is optional, it defaults to
-  true.
+  See [Managing Dash0 Dashboards](#managing-dash0-dashboards) for details.
+  This setting is optional, it defaults to `true`.
 
-* <a href="#monitoringresource.spec.synchronizePrometheusRules"><span id="monitoringresource.spec.synchronizePrometheusRules">`spec.synchronizePrometheusRules`</span></a>:
+* <a href="#monitoringresource.spec.synchronizePrometheusRules"><span id="monitoringresource.spec.synchronizePrometheusRules">**`spec.synchronizePrometheusRules`**</span></a>:
   A namespace-wide opt-out for synchronizing Prometheus rule resources found in the target namespace.
   If enabled, the operator will watch Prometheus rule resources in this namespace and create corresponding check rules
   in Dash0 via the Dash0 API.
   More fine-grained per-resource control over synchronization is available by setting the label
   `dash0.com/enable=false` on individual Prometheus rule resources.
   See [Managing Dash0 Check Rules](#managing-dash0-check-rules) for details.
-  This setting is optional, it defaults to true.
+  This setting is optional, it defaults to `true`.
 
-Here is comprehensive example for a monitoring resource which
+#### Example
+
+Here is a comprehensive example for a monitoring resource which:
+
 * sets the instrumentation mode to `created-and-updated`,
 * disables Prometheus scraping,
 * sets a couple of filters for all six telemetry object types,
@@ -1017,12 +1029,12 @@ example by using the OpenTelemetry Python [zero-code instrumentation](https://op
 ### Using a Kubernetes Secret for the Dash0 Authorization Token
 
 If you want to provide the Dash0 authorization token via a Kubernetes secret instead of providing the token as a string,
-create the secret in the namespace where the Dash0 operator is installed. This also applies when providing a
-per-namespace export and API-sync config via a monitoring resource, i.e. the operator will always try to look up the
-auth token secret in the operator namespace.
+create the secret in the namespace where the Dash0 operator is installed.
+This also applies when providing a per-namespace export and API-sync config via a monitoring resource, i.e. the operator
+will always try to look up the auth token secret in the operator namespace.
 If you followed the guide above, the name of that namespace is `dash0-system`.
-The authorization token for your Dash0 organization can be copied from https://app.dash0.com -> organization settings
--> "Auth Tokens".
+The authorization token for your Dash0 organization can be copied from https://app.dash0.com → organization settings →
+"Auth Tokens".
 You can freely choose the name of the secret and the key of the token within the secret.
 
 Create the secret by using the following command:
@@ -1059,9 +1071,8 @@ helm install \
   dash0-operator/dash0-operator
 ```
 
-If you do not want to install the operator configuration resource via `helm install` but instead deploy it manually,
-and use a secret reference for the auth token, the following example YAML file would work with the secret created
-above:
+If you do not want to install the operator configuration resource via `helm install` but instead deploy it manually, and
+use a secret reference for the auth token, the following example YAML file would work with the secret created above:
 
 ```yaml
 apiVersion: operator.dash0.com/v1alpha1
@@ -1103,11 +1114,11 @@ spec:
         apiEndpoint: https://api... # optional, see above
 ```
 
-Note: There are no defaults when using `--set operator.dash0Export.secretRef.name` and
-`--set operator.dash0Export.secretRef.key` with `helm install`, so for that approach the values must always be
-provided explicitly.
+> **Note:** There are no defaults when using `--set operator.dash0Export.secretRef.name` and
+> `--set operator.dash0Export.secretRef.key` with `helm install`, so for that approach the values must always be
+> provided explicitly.
 
-Note that by default, Kubernetes secrets are stored _unencrypted_, and anyone with API access to the Kubernetes cluster
+Note that by default, Kubernetes secrets are stored unencrypted, and anyone with API access to the Kubernetes cluster
 will be able to read the value.
 Additional steps are required to make sure secret values are encrypted, if that is desired.
 See https://kubernetes.io/docs/concepts/configuration/secret/ for more information on Kubernetes secrets.
@@ -1139,9 +1150,7 @@ spec:
 ### Configure Metrics Collection
 
 By default, the operator collects metrics as follows:
-* The operator collects node, pod, container, and volume metrics from the API server on
-  [kubelets](https://kubernetes.io/docs/concepts/architecture/#kubelet)
-  via the
+* The operator collects node, pod, container, and volume metrics from the API server on via the
   [Kubelet Stats Receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/kubeletstatsreceiver/README.md),
   cluster-level metrics from the Kubernetes API server via the
   [Kubernetes Cluster Receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/k8sclusterreceiver/README.md),
@@ -1155,17 +1164,17 @@ By default, the operator collects metrics as follows:
 * Namespace-scoped metrics (e.g. metrics related to a workload running in a specific namespace) will only be collected
   if the namespace is monitored, that is, there is a Dash0 monitoring resource in that namespace.
 * The Dash0 operator scrapes Prometheus endpoints on pods annotated with the `prometheus.io/*` annotations in monitored
-  namespaces, as described in the section [Scraping Prometheus endpoints](#scraping-prometheus-endpoints).
+  namespaces, as described in the section [Scraping Prometheus Endpoints](#scraping-prometheus-endpoints).
   This can be disabled per namespace by explicitly setting
   [`prometheusScraping.enabled: false`](#monitoringresource.spec.prometheusScraping.enabled) in the Dash0 monitoring
   resource.
 * Metrics which are not namespace-scoped (for example node metrics like `k8s.node.*` or host metrics like
   `system.cpu.utilization`) will always be collected, unless metrics collection is disabled globally for the cluster
   (`kubernetesInfrastructureMetricsCollection.enabled: false`, see above).
-  An operator configuration resource with [exports settings](#configuring-the-dash0-backend-connection) has to be present
-  in the cluster, otherwise no metrics collection takes place.
-
-Disabling or enabling individual metrics via configuration is not supported.
+  An operator configuration resource with [exports settings](#configuring-the-dash0-backend-connection) has to be
+  present in the cluster, otherwise no metrics collection takes place.
+* Disabling or enabling individual metrics via configuration is not supported.
+* Changing the frequency of metrics collection is not supported.
 
 #### Resource Attributes for Prometheus Scraping
 
@@ -1174,11 +1183,12 @@ available to the OpenTelemetry SDK in an instrumented application.
 For that reason, resource attributes including the service name might be different.
 The operator makes an effort to derive reasonable resource attributes.
 
-The _service name_ is derived as follows:
+The service name is derived as follows:
 
 1. If the scraped service provides the `target_info` metric with a `service_name` attribute, that service name will be
    used.
-   See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/compatibility/prometheus_and_openmetrics.md#resource-attributes
+   See
+   https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/compatibility/prometheus_and_openmetrics.md#resource-attributes
 2. If no service name was found via (1.), but the pod has the `app.kubernetes.io/name` label, the value of that label
    will be used as the service name.
    If the service name is derived from this pod label, the following pod labels (if present) will be mapped to resource
@@ -1194,14 +1204,15 @@ The _service name_ is derived as follows:
    telemetry into one service (to see everything in one place), with the service name taken from other signals than
    Prometheus metrics.
 
-Note that in contrast to [Resource Attributes for Workloads via Labels and Annotations](#specifying-additional-resource-attributes-for-workloads-via-labels-and-annotations),
-Prometheus scraping can only see pod labels, not workload level (deployment, daemonset, ...) labels.
+> **Note:** In contrast to
+> [Resource Attributes for Workloads via Labels and Annotations](#specifying-additional-resource-attributes-for-workloads-via-labels-and-annotations),
+> Prometheus scraping can only see pod labels, not workload level (deployment, daemonset, ...) labels.
 
 ### Providing a Filelog Offset Volume
 
 The operator's collector uses the filelog receiver to read pod log files for monitored workloads.
-When the collector is restarted (which can happen for various reasons, for example to apply configuration changes),
-it is important that the filelog receiver can continue reading the log files from where it left off.
+When the collector is restarted (which can happen for various reasons, for example to apply configuration changes), it
+is important that the filelog receiver can continue reading the log files from where it left off.
 If the filelog receiver started to read all log files from the beginning again after a restart, log records would be
 duplicated, that is, they would appear multiple times in Dash0.
 For that purpose, the filelog receiver stores the log file offsets in persistent storage.
@@ -1212,8 +1223,9 @@ offsets.
 
 Any persistent volume that is accessible from the collector pods can be used for this purpose.
 
-Here is an example with a `hostPath` volume (see also https://kubernetes.io/docs/concepts/storage/volumes/#hostpath
-for considerations around using `hostPath` volumes):
+Here is an example with a `hostPath` volume (see also https://kubernetes.io/docs/concepts/storage/volumes/#hostpath for
+considerations around using `hostPath` volumes):
+
 ```yaml
 operator:
   collectors:
@@ -1227,10 +1239,11 @@ operator:
 The directory in the hostPath volume will automatically be created with the correct permissions so that the
 OpenTelemetry collector container can write to it.
 
-Here is another example based on persistent volume claims. (This assumes that a PersistentVolumeClaim named
-`offset-storage-claim exists`.) See also
-https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims and
+Here is another example based on persistent volume claims.
+(This assumes that a PersistentVolumeClaim named `offset-storage-claim` exists.)
+See also https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims and
 https://kubernetes.io/docs/concepts/storage/persistent-volumes/#reclaiming.
+
 ```yaml
 operator:
   collectors:
@@ -1240,13 +1253,14 @@ operator:
         claimName: offset-storage-claim
 ```
 
-**Important:** Since this volume is needed by a Daemonset run by the Dash0 operator, the PersistentVolumeClaim needs
-to be set with the `ReadWriteMany` access mode.
+> **Important:** Since this volume is needed by a Daemonset run by the Dash0 operator, the PersistentVolumeClaim needs
+> to be set with the `ReadWriteMany` access mode.
 
 Using a volume instead of the default config map approach is also helpful if you have webhooks in your cluster which
 process every config map update.
 
 Known examples for this are:
+
 * The [Open Police Agent](https://www.openpolicyagent.org/), in particular the
   [OPA gatekeeeper](https://github.com/open-policy-agent/gatekeeper).
   When operating the OPA gatekeeper in the same cluster as the Dash0 operator, it is highly recommended to use a volume
@@ -1271,8 +1285,8 @@ Known examples for this are:
 
 ### Using cert-manager
 
-When installing the Helm chart, it generates TLS certificates on the fly for all components that need certificates
-(the operator's webhook service and its metrics service).
+When installing the Helm chart, it generates TLS certificates on the fly for all components that need certificates (the
+operator's webhook service and its metrics service).
 This also happens when updating the operator, e.g. via `helm upgrade`.
 This is the default behavior, and it works out of the box without the need to manage certificates with a third-party
 solution.
@@ -1323,10 +1337,10 @@ Explaining all configuration options of `cert-manager` is out of scope for this 
 Please refer to the [cert-manager documentation](https://cert-manager.io/docs/) for details on how to install and
 configure `cert-manager` in your cluster.
 
-The following annotated example is a minimal configuration that matches the Dash0 operator configuration snippet
-shown above.
-Both configuration snippets assume that the Dash0 operator is installed in the default `dash0-system` namespace,
-and the Certificate and Issuer resource are also deployed into that namespace.
+The following annotated example is a minimal configuration that matches the Dash0 operator configuration snippet shown
+above.
+Both configuration snippets assume that the Dash0 operator is installed in the default `dash0-system` namespace, and the
+Certificate and Issuer resource are also deployed into that namespace.
 
 ```yaml
 apiVersion: cert-manager.io/v1
@@ -1400,7 +1414,8 @@ Kubernetes will not schedule any pods there, preventing the daemonset collector 
 You can allow the daemonset collector pods to be scheduled there by configuring tolerations matching your taints for the
 collector pods.
 Tolerations can be configured as follows:
-```
+
+```yaml
 operator:
   collectors:
     daemonSetTolerations:
@@ -1426,11 +1441,11 @@ All the pods deployed by the operator have a default node anti-affinity for the 
 That is, if you add the `dash0.com/enable=false` label to a node, none of the pods owned by the operator will be
 scheduled on that node.
 
-**IMPORTANT:** This includes the daemonset that the operator will set up to receive telemetry from the pods, which might
-leads to situations in which instrumented pods cannot send telemetry because the local node does not have a daemonset
-collector pod.
-In other words, if you want to monitor workloads with the Dash0 operator and use the `dash0.com/enable=false` node
-anti-affinity, make sure that the workloads you want to monitor have the same anti-affinity:
+> **IMPORTANT:** This includes the daemonset that the operator will set up to receive telemetry from the pods, which
+> might lead to situations in which instrumented pods cannot send telemetry because the local node does not have a
+> daemonset collector pod.
+> In other words, if you want to monitor workloads with the Dash0 operator and use the `dash0.com/enable=false` node
+> anti-affinity, make sure that the workloads you want to monitor have the same anti-affinity:
 
 ```yaml
 # Add this to your workloads
@@ -1478,10 +1493,11 @@ The modifications are described in detail in the section
 You can disable these workload modifications for specific workloads by setting the label `dash0.com/enable: "false"` in
 the top level metadata section of the workload specification.
 
-Note: The actual label selector for enabling or disabling workload modification can be customized in the Dash0
-monitoring resource.
-The label `dash0.com/enable: "false"` can be used when no custom label selector has been configured in the Dash0
-monitoring resource, see [Using a Custom Label Selector to Control Auto-Instrumentation](#using-a-custom-label-selector-to-control-auto-instrumentation).
+> **Note:** The actual label selector for enabling or disabling workload modification can be customized in the Dash0
+> monitoring resource.
+> The label `dash0.com/enable: "false"` can be used when no custom label selector has been configured in the Dash0
+> monitoring resource, see
+> [Using a Custom Label Selector to Control Auto-Instrumentation](#using-a-custom-label-selector-to-control-auto-instrumentation).
 
 Here is an example for a deployment with this label:
 
@@ -1509,12 +1525,13 @@ spec:
 ```
 
 The label can also be applied by using `kubectl`:
-```
+
+```console
 kubectl label --namespace $YOUR_NAMESPACE --overwrite deployment $YOUR_DEPLOYMENT_NAME dash0.com/enable=false
 ```
 
-Note that setting `dash0.com/enable: "false"` will _not_ prevent log collection for pods of workloads with that label,
-in namespaces that have Dash0 [log collection](#monitoringresource.spec.logCollection.enabled) enabled.
+Note that setting `dash0.com/enable: "false"` will not prevent log collection for pods of workloads with that label, in
+namespaces that have Dash0 [log collection](#monitoringresource.spec.logCollection.enabled) enabled.
 Also, log collection is enabled by default for all monitored namespaces, unless `spec.logCollection.enabled` has been
 set to `false` explicitly in the respective Dash0 monitoring resource.
 Controlling log collection for individual workloads via Kubernetes labels is not supported.
@@ -1548,7 +1565,7 @@ monitoring resource, you can control which workloads in this namespace will be i
 - The setting `spec.instrumentWorkloads.labelSelector` setting is ignored if `spec.instrumentWorkloads.mode=none`.
 
 If not set explicitly, this label selector assumes the value `"dash0.com/enable!=false"` by default.
-That is, when no expicit label selector is provided via `spec.instrumentWorkloads.labelSelector`, workloads which
+That is, when no explicit label selector is provided via `spec.instrumentWorkloads.labelSelector`, workloads which:
 
 - do not have the label `dash0.com/enable` at all, or
 - have the label `dash0.com/enable` with a value other than `"false"`
@@ -1565,23 +1582,25 @@ others uninstrumented.
 Use a label selector with equals (`=`) instead of not-equals (`!=`) to achieve this, for example
 `auto-instrument-this-workload-with-dash0="true"`.
 
-Note that opting out of auto-instrumentation and workload modification via a label/label selector will _not_ prevent log
-collection for pods in namespaces that have Dash0 [log collection](#monitoringresource.spec.logCollection.enabled)
-enabled, see previous section for details.
+> **Note:** Opting out of auto-instrumentation and workload modification via a label/label selector will not prevent
+> log collection for pods in namespaces that have Dash0
+> [log collection](#monitoringresource.spec.logCollection.enabled) enabled, see previous section for details.
 
 ### Specifying Additional Resource Attributes via Labels and Annotations
 
-_Note:_ The labels and annotations listed in this section can be specified at the pod level, or at the workload level
-(i.e., the cronjob, deployment, daemonset, job, replicaset, or statefulset).
-Pod labels and annotations take precedence over workload labels and annotations.
+> **Note:** The labels and annotations listed in this section can be specified at the pod level, or at the workload
+> level (i.e., the cronjob, deployment, daemonset, job, replicaset, or statefulset).
+> Pod labels and annotations take precedence over workload labels and annotations.
 
 The following
 [standard Kubernetes labels](https://kubernetes.io/docs/reference/labels-annotations-taints/#labels-annotations-and-taints-used-on-api-objects)
 are mapped to resource attributes as follows:
 
-* the label `app.kubernetes.io/name` is mapped to `service.name`
-* if `app.kubernetes.io/name` is set, and the label `app.kubernetes.io/version` is also set, it is mapped to `service.version`
-* if `app.kubernetes.io/name` is set, and the label `app.kubernetes.io/part-of` is also set, it is mapped to `service.namespace`
+* The label `app.kubernetes.io/name` is mapped to `service.name`.
+* If `app.kubernetes.io/name` is set, and the label `app.kubernetes.io/version` is also set, it is mapped to
+  `service.version`.
+* If `app.kubernetes.io/name` is set, and the label `app.kubernetes.io/part-of` is also set, it is mapped to
+  `service.namespace`.
 
 The operator will not combine pod labels with workload labels for this mapping.
 The labels `app.kubernetes.io/version` and `app.kubernetes.io/part-of` are only read from the pod labels if
@@ -1592,13 +1611,13 @@ Workload labels are not considered at all if `app.kubernetes.io/name` is present
 This ensures that resource attributes are not partially based on pod and partially on workload labels, giving an
 inconsistent result.
 
-Note: The `OTEL_SERVICE_NAME` environment variable and `service.*` key-value pairs specified in the
-`OTEL_RESOURCE_ATTRIBUTES` environment variable have precedence over attributes derived from the `app.kubernetes.io/*`
-labels.
+> **Note:** The `OTEL_SERVICE_NAME` environment variable and `service.*` key-value pairs specified in the
+> `OTEL_RESOURCE_ATTRIBUTES` environment variable have precedence over attributes derived from the `app.kubernetes.io/*`
+> labels.
 
-Additionally, any _annotation_ in the form of `resource.opentelemetry.io/<key>: <value>` will be mapped to the
-resource attribute `<key>=<value>`.
-For example, the following will result in the `my.attribute=my-value` resource attribute:
+Any _annotation_ in the form of `resource.opentelemetry.io/<key>: <value>` is also mapped to the resource attribute
+`<key>=<value>`.
+For example, the following results in the `my.attribute=my-value` resource attribute:
 
 ```yaml
 apiVersion: v1
@@ -1610,16 +1629,16 @@ metadata:
 
 As with the `app.kubernetes.io/*` labels, the `resource.opentelemetry.io/*` annotations can be set on the pod as well as
 on the workload.
-In contrast to the `app.kubernetes.io/*` labels, mixing workload level and pod annotations is allowed, that is, you
-can set `resource.opentelemetry.io/attribute-one` on the workload and `resource.opentelemetry.io/attribute-two` on the
-pod, and both will be used.
+In contrast to the `app.kubernetes.io/*` labels, mixing workload level and pod annotations is allowed, that is, you can
+set `resource.opentelemetry.io/attribute-one` on the workload and `resource.opentelemetry.io/attribute-two` on the pod,
+and both will be used.
 In case the same `key` is listed both on the workload and on the pod, the pod annotation takes precedence.
 
 Key-value pairs with a specific `key` set via the `OTEL_RESOURCE_ATTRIBUTES` environment variable will override the
 value derived from a `resource.opentelemetry.io/<key>: <value>` annotation.
-Resource attributes set via the `resource.opentelemetry.io/<key>: <value>` annotations will override the
-resource attributes value set via `app.kubernetes.io/*` labels: for example, `resource.opentelemetry.io/service.name`
-has precendence over `app.kubernetes.io/name`.
+Resource attributes set via the `resource.opentelemetry.io/<key>: <value>` annotations will override the resource
+attributes value set via `app.kubernetes.io/*` labels: for example, `resource.opentelemetry.io/service.name` has
+precedence over `app.kubernetes.io/name`.
 
 ### Sending Data to the OpenTelemetry Collectors Managed by the Dash0 Operator
 
@@ -1636,22 +1655,22 @@ correct values when applying the [automatic workload instrumentation](#automatic
 
 If the workload is in a namespace that is not monitored by Dash0 (or if
 [`spec.instrumentWorkloads.mode`](#monitoringresource.spec.instrumentWorkloads.mode) is set to `none` in the respective
-Dash0 monitoring resource, or if the workload has opted out of auto-instrumentations via a
+Dash0 monitoring resource, or if the workload has opted out of auto-instrumentation via a
 [label](#disabling-auto-instrumentation-for-specific-workloads), you need to set the environment variable
 [`OTEL_EXPORTER_OTLP_ENDPOINT`](#https://opentelemetry.io/docs/languages/sdk-configuration/otlp-exporter/)
 (and optionally also
 [`OTEL_EXPORTER_OTLP_PROTOCOL`](https://opentelemetry.io/docs/specs/otel/protocol/exporter/#specify-protocol)) yourself.
 
 The DaemonSet OpenTelemetry collector managed by the Dash0 operator listens on host port 40318 for HTTP traffic and
-40317 for gRPC traffic
-(unless the Helm chart has been deployed with `operator.collectors.disableHostPorts=true`, which disables the host
-ports for the collector pods).
-Additionally, there is also a service for the DaemonSet collector, which listens on the standard ports, that is 4318 for
-HTTP and 4317 for gRPC.
+40317 for gRPC traffic (unless the Helm chart has been deployed with `operator.collectors.disableHostPorts=true`, which
+disables the host ports for the collector pods).
+A service for the DaemonSet collector which listens on the standard ports (4318 for HTTP and 4317 for gRPC) is also
+available.
 
-The preferred way of sending OTLP from your workoad to the Dash0-managed collector is to use node-local traffic via the
+The preferred way of sending OTLP from your workload to the Dash0-managed collector is to use node-local traffic via the
 host port.
 To do so, add the following environment variables to your workload:
+
 ```yaml
 env:
   - name: K8S_NODE_IP
@@ -1664,13 +1683,15 @@ env:
     value: "http/protobuf"
 ```
 
-* Note that listing the definition for `K8S_NODE_IP` _before_ `OTEL_EXPORTER_OTLP_ENDPOINT` is crucial.
-* Adding `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf` is optional when the OpenTelemetry SDK in question uses that
-  protocol as the default.
-* For gRCP, use `OTEL_EXPORTER_OTLP_ENDPOINT=http://$(K8S_NODE_IP):40317` together with
-  `OTEL_EXPORTER_OTLP_PROTOCOL=grpc` instead.
+> **Notes:**
+> * Listing the definition for `K8S_NODE_IP` _before_ `OTEL_EXPORTER_OTLP_ENDPOINT` is crucial.
+> * Adding `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf` is optional when the OpenTelemetry SDK in question uses that
+>   protocol as the default.
+> * For gRCP, use `OTEL_EXPORTER_OTLP_ENDPOINT=http://$(K8S_NODE_IP):40317` together with
+>   `OTEL_EXPORTER_OTLP_PROTOCOL=grpc` instead.
 
-To use the service endpoint instead of the host port, you need to know
+To use the service endpoint instead of the host port, you need to know:
+
 * the Helm release name of the Dash0 operator (for example `dash0-operator`), and
 * the namespace where the Dash0 operator is installed (for example `dash0-system`).
 
@@ -1934,8 +1955,8 @@ which can be useful when using self-signed certificates.
 
 ## Disable Self-Monitoring
 
-By default, self-monitoring is enabled for the Dash0 operator as soon as you deploy a Dash0 operator
-configuration resource with exports.
+By default, self-monitoring is enabled for the Dash0 operator as soon as you deploy a Dash0 operator configuration
+resource with exports.
 That means, the operator will send self-monitoring telemetry to the configured Dash0 backend.
 Disabling self-monitoring is available as a setting on the Dash0 operator configuration resource.
 Dash0 does not recommend to disable the operator's self-monitoring.
@@ -1972,7 +1993,7 @@ kubectl delete --namespace my-nodejs-applications -f dash0-monitoring.yaml
 
 ## Upgrading
 
-To upgrade the Dash0 Operator to a newer version, run the following commands:
+To upgrade the Dash0 operator to a newer version, run the following commands:
 
 ```console
 helm repo update dash0-operator
@@ -1986,21 +2007,22 @@ Dash0Monitoring) will be updated to new versions.
 Whenever possible, this will happen in a way that requires no manual intervention by users.
 This section contains details about CRD version updates and version migrations.
 
-### Operator Version 0.71.0: operator.dash0.com/v1alpha1/Dash0Monitoring -> operator.dash0.com/v1beta1/Dash0Monitoring
+### Operator Version 0.71.0: `operator.dash0.com/v1alpha1/Dash0Monitoring` -> `operator.dash0.com/v1beta1/Dash0Monitoring`
 
-With operator version 0.71.0, the Dash0 operator's `Dash0Monitoring` custom resource definition (CRD) is upgraded
-from version `v1alpha1` to `v1beta1`.
+With operator version 0.71.0, the Dash0 operator's `Dash0Monitoring` custom resource definition (CRD) is upgraded from
+version `v1alpha1` to `v1beta1`.
 The operator handles both versions correctly, that is version `v1alpha1` to `v1beta1` are both fully supported.
 Here is what you need to know about this version update for `Dash0Monitoring`:
-- If you have existing `Dash0Monitoring` resources in version `v1alpha1` in your cluster, they will be automatically
+
+* If you have existing `Dash0Monitoring` resources in version `v1alpha1` in your cluster, they will be automatically
   converted on the fly, for example when the Dash0 operator reads the `v1alpha1` resource version.
   At some point Kubernetes might also convert the resource permanently and store it in version `v1beta1`.
-- After the upgrade to version 0.71.0, you can still deploy new `Dash0Monitoring` resource in version `v1alpha1`
-  (for example via `kubectl apply`).
+* After the upgrade to version 0.71.0, you can still deploy new `Dash0Monitoring` resource in version `v1alpha1` (for
+  example via `kubectl apply`).
   They will be automatically converted and stored as `v1beta1` resources by Kubernetes.
-- If you want to migrate a `Dash0Monitoring` _template_ (e.g. a yaml file) from version `v1alpha1` to `v1beta1`, follow
+* If you want to migrate a `Dash0Monitoring` _template_ (e.g. a yaml file) from version `v1alpha1` to `v1beta1`, follow
   these steps:
-    - If the template specifies the workload instrumentation mode via `spec.instrumentWorkloads`, replace that with
+    * If the template specifies the workload instrumentation mode via `spec.instrumentWorkloads`, replace that with
       `spec.instrumentWorkloads.mode`.
       That is:
       ```yaml
@@ -2015,7 +2037,7 @@ Here is what you need to know about this version update for `Dash0Monitoring`:
       ```
       If the template does not specify the workload instrumentation mode explicitly (that is, it relies on using the
       default instrumentation mode), no change is necessary here.
-    - If the template contains the attribute `spec.prometheusScrapingEnabled`, replace that with
+    * If the template contains the attribute `spec.prometheusScrapingEnabled`, replace that with
       `spec.prometheusScraping.enabled`.
       That is:
       ```yaml
@@ -2032,23 +2054,23 @@ Here is what you need to know about this version update for `Dash0Monitoring`:
       can be applied independently of the CRD version change.
       If the template does not specify whether prometheusScraping is enabled or not (that is, it relies on using the
       default value), no change is necessary here.
-- We recommend to update your templates from `v1alpha1` to `v1beta1` at some point.
+* We recommend to update your templates from `v1alpha1` to `v1beta1` at some point.
   However, there are currently no plans to remove support for version `v1alpha1`.
-- If you want to use the new [trace context propagators](#monitoringresource.spec.instrumentWorkloads.traceContext.propagators)
+* If you want to use the new [trace context propagators](#monitoringresource.spec.instrumentWorkloads.traceContext.propagators)
   option that has been added in version 0.71.0, you need to use version `v1beta1` of the `Dash0Monitoring` resource.
   This includes updating your Yaml templates to that version, as described above.
-- After upgrading to operator version 0.71.0 or later, you can no longer easily downgrade to a version before 0.71.0.
+* After upgrading to operator version 0.71.0 or later, you can no longer easily downgrade to a version before 0.71.0.
   In particular, this downgrade would require to manually delete all `Dash0Monitoring` resources in the cluster.
-  The reason is that the Dash0Monitoring resource are now stored as version `v1beta1` by Kubernetes and there is no
+  The reason is that the Dash0Monitoring resources are now stored as version `v1beta1` by Kubernetes and there is no
   automatic downward conversion from `v1beta1` back to `v1alpha1`.
-- The only supported version for `Dash0OperatorConfiguration` is still `v1alpha1`, that is, trying to use
+* The only supported version for `Dash0OperatorConfiguration` is still `v1alpha1`, that is, trying to use
   `operator.dash0.com/v1beta1/Dash0OperatorConfiguration` will not work.
 
 ## Uninstallation
 
-To remove the Dash0 Operator from your cluster, run the following command:
+To remove the Dash0 operator from your cluster, run the following command:
 
-```
+```console
 helm uninstall dash0-operator --namespace dash0-system
 ```
 
@@ -2062,7 +2084,7 @@ This will restart the pods of all workloads that were previously instrumented by
 
 Optionally, after `helm uninstall` has finished, remove the namespace that has been created for the operator:
 
-```
+```console
 kubectl delete namespace dash0-system
 ```
 
@@ -2076,8 +2098,9 @@ kubectl delete secret --namespace dash0-system dash0-authorization-secret
 If you later decide to install the operator again, you will need to perform the [initial configuration](#configuration)
 steps again:
 
-1. set up a [Dash0 backend connection](#configuring-the-dash0-backend-connection) and
-2. enable Dash0 monitoring in each namespace you want to monitor, see [Enable Dash0 Monitoring For a Namespace](#enable-dash0-monitoring-for-a-namespace).
+1. Set up a [Dash0 backend connection](#configuring-the-dash0-backend-connection), and
+2. Enable Dash0 monitoring in each namespace you want to monitor, see
+   [Enable Dash0 Monitoring For a Namespace](#enable-dash0-monitoring-for-a-namespace).
 
 ### Unsupported Uninstallation Procedures
 
@@ -2095,17 +2118,18 @@ In turn, this will make it harder to delete namespaces with a Dash0 monitoring r
 the "Terminating" state, due to the finalizer in the monitoring resource no longer being handled correctly.
 
 To rectify this, follow these steps:
+
 1. Delete all Dash0 validating/mutating webhook configs manually (exact command depends on the Helm release name):
-   ```
+   ```console
    kubectl delete validatingwebhookconfiguration dash0-operator-monitoring-validator dash0-operator-operator-configuration-validator
    kubectl delete mutatingwebhookconfiguration dash0-operator-injector dash0-operator-monitoring-mutating dash0-operator-operator-configuration-mutating
    ```
 2. Remove the finalizer from all Dash0 monitoring resources:
-   ```
+   ```console
    kubectl patch dash0monitorings <name> -n <namespace> --type=json -p='[{"op":"remove","path":"/metadata/finalizers"}]'
    ```
 3. Delete the Dash0 monitoring resources:
-   ```
+   ```console
    kubectl delete dash0monitorings <name> -n <namespace>
    ```
 
@@ -2113,8 +2137,9 @@ To rectify this, follow these steps:
 
 In namespaces that are [enabled for Dash0 monitoring](#enable-dash0-monitoring-for-a-namespace), all supported workload
 types are automatically instrumented by the Dash0 operator, to achieve two goals:
-* Enable tracing for [supported runtimes](#supported-runtimes) out of the box, and
-* improve auto-detection of OpenTelemetry resource attributes.
+
+1. Enable tracing for [supported runtimes](#supported-runtimes) out of the box, and
+2. Improve auto-detection of OpenTelemetry resource attributes.
 
 This allows Dash0 users to avoid the hassle of manually adding the OpenTelemetry SDK to their applications, or to set
 Kubernetes-related resource attributes manually.
@@ -2124,9 +2149,8 @@ Automatic tracing only works for [supported runtimes](#supported-runtimes).
 For other runtimes, you can add an OpenTelemetry SDK to your workloads
 [by other means](#https://opentelemetry.io/docs/languages/).
 
-Auto-detecting OpenTelemetry resource attributes works for _all_ runtimes, that is, for runtimes that are
-supported by Dash0's auto-instrumentation as well as for workloads to which an OpenTelemetry SDK has been added
-otherwise.
+Auto-detecting OpenTelemetry resource attributes works for all runtimes, that is, for runtimes that are supported by
+Dash0's auto-instrumentation as well as for workloads to which an OpenTelemetry SDK has been added otherwise.
 There is currently one caveat: The resource attribute auto-detection relies on the process or runtime in question to
 use dynamic linking at startup (that is, binding to a flavor of libc), which is true for almost all runtimes.
 One notable exception are so called freestanding a.k.a. libc-free binaries, for example most binaries built with Go.
@@ -2141,7 +2165,7 @@ The Dash0 operator will instrument the following workload types:
 * [ReplicaSets](https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/)
 * [StatefulSets](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/)
 
-Note that Kubernetes jobs and Kubernetes pods are only instrumented at deploy time, _existing_ jobs and pods cannot be
+Note that Kubernetes jobs and Kubernetes pods are only instrumented at deploy time, existing jobs and pods cannot be
 instrumented since there is no way to restart them.
 For all other workload types, the operator can instrument existing workloads as well as new workloads at deploy time
 (depending on the setting of [`spec.instrumentWorkloads.mode`](#monitoringresource.spec.instrumentWorkloads.mode) in the
@@ -2153,23 +2177,23 @@ Jobs, ReplicaSets, and StatefulSets) or the Pod spec itself (for standalone Pods
 The modifications that are performed for workloads are the following, depending on the chosen
 [instrumentation delivery mechanism](#using-image-volumes-for-auto-instrumentation-files).
 With instrumentation delivery `image-volume`:
-* add an [`image` volume](https://kubernetes.io/docs/concepts/storage/volumes/#image) named
+* Add an [`image` volume](https://kubernetes.io/docs/concepts/storage/volumes/#image) named
   `dash0-instrumentation` to the pod spec, which contains the instrumentation files
 With instrumentation delivery `init-container`:
-* add an [`emptyDir` volume](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir) named
+* Add an [`emptyDir` volume](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir) named
   `dash0-instrumentation` to the pod spec
-* add an [init container](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/) named
+* Add an [init container](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/) named
   `dash0-instrumentation` that will copy the OpenTelemetry SDKs and distributions for supported runtimes to the
   `dash0-instrumentation` volume mount, so they are available in the target container's file system
-* add the `cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes=dash0-instrumentation` annotation to the pod
+* Add the `cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes=dash0-instrumentation` annotation to the pod
   spec
 Regardless of the instrumentation delivery:
-* add a volume mount `dash0-instrumentation` to all containers of the pod
-* add environment variables (`OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_PROTOCOL`, `LD_PRELOAD`, and several
+* Add a volume mount `dash0-instrumentation` to all containers of the pod
+* Add environment variables (`OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_PROTOCOL`, `LD_PRELOAD`, and several
   Dash0-specific variables prefixed with `DASH0_`) to all containers of the pod
-* add the [OpenTelemetry injector](https://github.com/open-telemetry/opentelemetry-injector) (see below for details) as
+* Add the [OpenTelemetry injector](https://github.com/open-telemetry/opentelemetry-injector) (see below for details) as
   a startup hook (via the `LD_PRELOAD` environment variable) to all containers of the pod
-* add the following labels to the workload metadata:
+* Add the following labels to the workload metadata:
     * `dash0.com/instrumented`: `true` or `false` depending on whether the workload has been successfully instrumented
       or not
     * `dash0.com/operator-image`: the fully qualified name of the Dash0 operator image that has instrumented this
@@ -2177,63 +2201,65 @@ Regardless of the instrumentation delivery:
     * `dash0.com/instrumentation-image`: the fully qualified name of the image that has been used to deliver
       instrumentation files to the workload
     * `dash0.com/instrumented-by`: either `controller` or `webhook`, depending on which component has instrumented this
-      workload. The controller is responsible for instrumenting existing workloads while the webhook is responsible for
+      workload.
+      The controller is responsible for instrumenting existing workloads while the webhook is responsible for
       instrumenting new workloads at deploy time.
-* add the following annotations to the workload metadata:
-  * `dash0.com/instrumented-by`: either `controller` or `webhook`, depending on which component has instrumented this
-    workload. The controller is responsible for instrumenting existing workloads while the webhook is responsible for
-    instrumenting new workloads at deploy time.
+* Add the following annotations to the workload metadata:
+    * `dash0.com/instrumented-by`: either `controller` or `webhook`, depending on which component has instrumented this
+      workload.
+      The controller is responsible for instrumenting existing workloads while the webhook is responsible for
+      instrumenting new workloads at deploy time.
 
-**Notes:**
-
-1. Automatic tracing will only happen for [supported runtimes](#supported-runtimes).
-   Nonetheless, the modifications outlined above are performed for _every_ workload.
-   One reason for that is that there is no way to tell which runtime a workload uses from the outside, e.g. on the
-   Kubernetes level.
-   The more important reason is that runtimes that are not (yet) supported for auto-instrumentation still benefit from
-   the improved OpenTelemetry resource attribute detection.
-2. The operator will add neither `OTEL_EXPORTER_OTLP_ENDPOINT` nor `OTEL_EXPORTER_OTLP_PROTOCOL` to containers that
-   already have at least one of those environment variables set.
-   A Kubernetes event of type `Warning` is created for workloads with affected containers.
-3. The operator operates sets `OTEL_EXPORTER_OTLP_ENDPOINT=http://$(NODE_IP):40318`, that is, it tells the workload to
-   send OTLP traffic to the HTTP port of the OpenTelemetry collector pod on the same host, which belongs to the
-   OpenTelemetry collector DaemonSet managed by the operator.
-   It also sets the protocol accordingly by setting `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf`.
-   The protocol `http/protobuf` is the recommended default according to the
-   [OpenTelemetry specification](https://opentelemetry.io/docs/specs/otel/protocol/exporter/#specify-protocol), and it
-   is widely supported.
-   It does so under the assumption that workloads _which have an OpenTelemetry SDK_ use an SDK that respects
-   `OTEL_EXPORTER_OTLP_PROTOCOL` and also has support for the `http/protobuf` protocol.
-   For workloads that have an OpenTelemetry SDK that either does not respect `OTEL_EXPORTER_OTLP_PROTOCOL` (and defaults
-   to `grpc`) or does not have support for `http/protobuf`, this will lead to the SDK trying to establish a gRPC
-   connection to the collector's HTTP endpoint, that is, the SDK will not be able to emit telemetry.
-   SDKs without support for `http/protobuf` are rather rare, but one prominent example is the Kubernetes
-   [ingress-nginx](https://kubernetes.github.io/ingress-nginx/user-guide/third-party-addons/opentelemetry/).
-   The recommended approach is to either set `OTEL_EXPORTER_OTLP_ENDPOINT` manually to the gRPC port or to disable
-   workload instrumentation by the Dash0 operator for these workloads.
-   To set `OTEL_EXPORTER_OTLP_ENDPOINT` manually, you can add the following entries to the container's `env` section:
-   ```
-   - name: MY_NODE_IP
-     valueFrom:
-       fieldRef:
-         fieldPath: status.hostIP
-   - name: OTEL_EXPORTER_OTLP_ENDPOINT
-     value: http://$(MY_NODE_IP):40317
-   ```
-   To disable workload instrumentation for a workload, you can opt out of auto-instrumentation via a workload label
-   (i.e. `dash0.com/enable: "false"`, see
-   [Disabling Auto-Instrumentation for Specific Workloads](#disabling-auto-instrumentation-for-specific-workloads)),
-   or by not installing a Dash0 monitoring resource in the namespace where these workloads are located.
-   The workloads can then be monitored by following the setup described in
-   [Sending Data to the OpenTelemetry Collectors Managed by the Dash0 Operator](#sending-data-to-the-opentelemetry-collectors-managed-by-the-dash0-operator)
-   to have the workload send telemetry to the collectors managed by the Dash0 operator, using gRPC.
-   Note that this is not relevant for workloads that do not have an OpenTelemetry SDK at all, since they will ignore
-   `OTEL_EXPORTER_OTLP_ENDPOINT`.
-   In case the Dash0 operator Helm chart has been deployed with `operator.collectors.forceUseServiceUrl=true` or
-   `operator.collectors.disableHostPorts=true`, `OTEL_EXPORTER_OTLP_ENDPOINT` is not set to `http://$(NODE_IP):40318`,
-   but to the HTTP port of the DaemonSet collector's service URL
-   `http://${helm-release-name}-opentelemetry-collector-service.${namespace-of-the-dash0-operator}.svc.cluster.local:4318`
-   instead.
+> **Notes:**
+>
+> * Automatic tracing will only happen for [supported runtimes](#supported-runtimes).
+>   Nonetheless, the modifications outlined above are performed for every workload.
+>   One reason for that is that there is no way to tell which runtime a workload uses from the outside, e.g. on the
+>   Kubernetes level.
+>   The more important reason is that runtimes that are not (yet) supported for auto-instrumentation still benefit from
+>   the improved OpenTelemetry resource attribute detection.
+> * The operator will add neither `OTEL_EXPORTER_OTLP_ENDPOINT` nor `OTEL_EXPORTER_OTLP_PROTOCOL` to containers that
+>   already have at least one of those environment variables set.
+>   A Kubernetes event of type `Warning` is created for workloads with affected containers.
+> * The operator sets `OTEL_EXPORTER_OTLP_ENDPOINT=http://$(NODE_IP):40318`, that is, it tells the workload to send OTLP
+>   traffic to the HTTP port of the OpenTelemetry collector pod on the same host, which belongs to the OpenTelemetry
+>   collector DaemonSet managed by the operator.
+>   It also sets the protocol accordingly by setting `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf`.
+>   The protocol `http/protobuf` is the recommended default according to the
+>   [OpenTelemetry specification](https://opentelemetry.io/docs/specs/otel/protocol/exporter/#specify-protocol), and it
+>   is widely supported.
+>   It does so under the assumption that workloads which have an OpenTelemetry SDK use an SDK that respects
+>   `OTEL_EXPORTER_OTLP_PROTOCOL` and also has support for the `http/protobuf` protocol.
+>   For workloads that have an OpenTelemetry SDK that either does not respect `OTEL_EXPORTER_OTLP_PROTOCOL` (and
+>   defaults to `grpc`) or does not have support for `http/protobuf`, this will lead to the SDK trying to establish a
+>   gRPC connection to the collector's HTTP endpoint, that is, the SDK will not be able to emit telemetry.
+>   SDKs without support for `http/protobuf` are rather rare, but one prominent example is the Kubernetes
+>   [ingress-nginx](https://kubernetes.github.io/ingress-nginx/user-guide/third-party-addons/opentelemetry/).
+>   The recommended approach is to either set `OTEL_EXPORTER_OTLP_ENDPOINT` manually to the gRPC port or to disable
+>   workload instrumentation by the Dash0 operator for these workloads.
+>   To set `OTEL_EXPORTER_OTLP_ENDPOINT` manually, you can add the following entries to the container's `env` section:
+>   ```
+>   - name: MY_NODE_IP
+>     valueFrom:
+>       fieldRef:
+>         fieldPath: status.hostIP
+>   - name: OTEL_EXPORTER_OTLP_ENDPOINT
+>     value: http://$(MY_NODE_IP):40317
+>   ```
+>   To disable workload instrumentation for a workload, you can opt out of auto-instrumentation via a workload label
+>   (i.e. `dash0.com/enable: "false"`, see
+>   [Disabling Auto-Instrumentation for Specific Workloads](#disabling-auto-instrumentation-for-specific-workloads)),
+>   or by not installing a Dash0 monitoring resource in the namespace where these workloads are located.
+>   The workloads can then be monitored by following the setup described in
+>   [Sending Data to the OpenTelemetry Collectors Managed by the Dash0 Operator](#sending-data-to-the-opentelemetry-collectors-managed-by-the-dash0-operator)
+>   to have the workload send telemetry to the collectors managed by the Dash0 operator, using gRPC.
+>   Note that this is not relevant for workloads that do not have an OpenTelemetry SDK at all, since they will ignore
+>   `OTEL_EXPORTER_OTLP_ENDPOINT`.
+>   In case the Dash0 operator Helm chart has been deployed with `operator.collectors.forceUseServiceUrl=true` or
+>   `operator.collectors.disableHostPorts=true`, `OTEL_EXPORTER_OTLP_ENDPOINT` is not set to `http://$(NODE_IP):40318`,
+>   but to the HTTP port of the DaemonSet collector's service URL
+>   `http://${helm-release-name}-opentelemetry-collector-service.${namespace-of-the-dash0-operator}.svc.cluster.local:4318`
+>   instead.
 
 The remainder of this section provides a more detailed step-by-step description of how the Dash0 operator's workload
 instrumentation for tracing works internally, intended for the technically curious reader.
@@ -2274,7 +2300,7 @@ You can safely skip this section if you are not interested in the technical deta
    instrumentation.
    For Python auto-instrumentation, the OpenTelemetry SDK is prepended to `PYTHONPATH`.
    (Python auto-instrumentation needs to be [enabled](https://github.com/dash0hq/dash0-operator/blob/0.100.0/helm-chart/dash0-operator/values.yaml#L408-L409) explicitly via Helm.)
-5. Additionally, the OpenTelemetry injector automatically improves Kubernetes-related resource attributes as follows:
+5. The OpenTelemetry injector also automatically improves Kubernetes-related resource attributes as follows:
    The operator sets the environment variables `OTEL_INJECTOR_K8S_NAMESPACE_NAME`, `OTEL_INJECTOR_K8S_POD_NAME`,
    `OTEL_INJECTOR_K8S_POD_UID` and `OTEL_INJECTOR_K8S_CONTAINER_NAME` on workloads.
    The OpenTelemetry injector binary picks these values up and uses them to populate the resource attributes
@@ -2292,19 +2318,21 @@ as defined by the
 [Prometheus Helm chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus#scraping-pod-metrics-via-annotations).
 
 The supported annotations are:
-* `prometheus.io/scrape`: Only scrape pods that have a value of `true`, except if `prometheus.io/scrape-slow` is set to
-  `true` as well. Endpoints on pods annotated with this annotation are scraped every minute, i.e., scrape interval is 1
-  minute, unless `prometheus.io/scrape-slow` is also set to `true`.
-* `prometheus.io/scrape-slow`: If set to `true`, enables scraping for the pod with scrape interval of 5 minutes. If both
-  `prometheus.io/scrape` and `prometheus.io/scrape-slow` are annotated on a pod with both values set to `true`, the pod
-  will be scraped every 5 minutes.
-* `prometheus.io/scheme`: If the metrics endpoint is secured then you will need to set this to `https`.
-* `prometheus.io/path`: Override the metrics endpoint path if it is not the default `/metrics`.
-* `prometheus.io/port`: Override the metrics endpoint port if it is not the default `9102`.
+
+* **`prometheus.io/scrape`**: Only scrape pods that have a value of `true`, except if `prometheus.io/scrape-slow` is set
+  to `true` as well.
+  Endpoints on pods annotated with this annotation are scraped every minute, i.e., scrape interval is 1 minute, unless
+  `prometheus.io/scrape-slow` is also set to `true`.
+* **`prometheus.io/scrape-slow`**: If set to `true`, enables scraping for the pod with scrape interval of 5 minutes.
+  If both `prometheus.io/scrape` and `prometheus.io/scrape-slow` are annotated on a pod with both values set to `true`,
+  the pod will be scraped every 5 minutes.
+* **`prometheus.io/scheme`**: If the metrics endpoint is secured then you will need to set this to `https`.
+* **`prometheus.io/path`**: Override the metrics endpoint path if it is not the default `/metrics`.
+* **`prometheus.io/port`**: Override the metrics endpoint port if it is not the default `9102`.
 
 To be scraped, a pod annotated with the `prometheus.io/scrape` or `prometheus.io/scrape-slow` annotations must belong to
-namespaces that are configured to be monitored by the Dash0 operator
-(see [Enable Dash0 Monitoring For a Namespace](#enable-dash0-monitoring-for-a-namespace) section).
+namespaces that are configured to be monitored by the Dash0 operator (see
+[Enable Dash0 Monitoring For a Namespace](#enable-dash0-monitoring-for-a-namespace)).
 
 The scraping of a pod is executed from the same Kubernetes node the pod resides on.
 
@@ -2312,10 +2340,10 @@ This feature can be disabled for a namespace by explicitly setting
 [`prometheusScraping.enabled: false`](#monitoringresource.spec.prometheusScraping.enabled) in the Dash0 monitoring
 resource.
 
-Note: To also have [Kube state metrics available](https://github.com/kubernetes/kube-state-metrics) (which are used
-extensively in [Awesome Prometheus alerts](#https://samber.github.io/awesome-prometheus-alerts/)) scraped and delivered
-to Dash0, you can annotate the kube-state-metrics pod with `prometheus.io/scrape: "true"` and add a Dash0 monitoring
-resource to the namespace it is running in.
+> **Note:** To also have [Kube state metrics](https://github.com/kubernetes/kube-state-metrics) (which are used
+> extensively in [Awesome Prometheus alerts](#https://samber.github.io/awesome-prometheus-alerts/)) scraped and
+> delivered to Dash0, you can annotate the kube-state-metrics pod with `prometheus.io/scrape: "true"` and add a Dash0
+> monitoring resource to the namespace it is running in.
 
 ## Managing Dash0 Configurations
 
@@ -2326,40 +2354,43 @@ them as Kubernetes resources to a cluster and letting the operator synchronize t
 
 You can manage your Dash0 dashboards via the Dash0 operator.
 
-Pre-requisites for this feature:
+**Pre-requisites for this feature:**
+
 * A Dash0 operator configuration resource has to be installed in the cluster.
 * The operator configuration resource must have the `apiEndpoint` property.
-* The operator configuration resource must have at least one Dash0 export configured with authorization
-  (either `token` or `secret-ref`).
+* The operator configuration resource must have at least one Dash0 export configured with authorization (either `token`
+  or `secret-ref`).
 * The operator will only pick up Perses dashboard resources in namespaces that have a Dash0 monitoring resource
   deployed.
-* The operator will not synchronize Perses dashboard resources in namespaces where the Dash0 monitoring resource
-  has the setting [`synchronizePersesDashboards`](#monitoringresource.spec.synchronizePersesDashboards) set to `false`.
+* The operator will not synchronize Perses dashboard resources in namespaces where the Dash0 monitoring resource has the
+  setting [`synchronizePersesDashboards`](#monitoringresource.spec.synchronizePersesDashboards) set to `false`.
   (This setting is optional and defaults to `true` when omitted.)
 * Optional: In addition to the global/default API endpoint and authorization described above, it is possible to define
   namespace-specific overrides by providing one or more Dash0 export(s) with an API endpoint and token in the Dash0
   monitoring resource.
 
-Furthermore, the custom resource definition for Perses dashboards needs to be installed in the cluster. There are two
-ways to achieve this:
-* Install the Perses dashboard custom resource definition with the following command:
-```console
-kubectl apply --server-side -f https://raw.githubusercontent.com/perses/perses-operator/refs/tags/v0.4.0/config/crd/bases/perses.dev_persesdashboards.yaml
-```
-* Alternatively, install the full Perses operator: Go to <https://github.com/perses/perses-operator> and follow the
-  installation instructions there.
+The custom resource definition for Perses dashboards needs to be installed in the cluster.
+There are two ways to achieve this:
+
+1. Install the Perses dashboard custom resource definition with the following command:
+   ```console
+   kubectl apply --server-side -f https://raw.githubusercontent.com/perses/perses-operator/refs/tags/v0.4.0/config/crd/bases/perses.dev_persesdashboards.yaml
+   ```
+2. Alternatively, install the full Perses operator: Go to <https://github.com/perses/perses-operator> and follow the
+   installation instructions there.
 
 With the prerequisites in place, you can manage Dash0 dashboards via the operator.
 The Dash0 operator will watch for Perses dashboard resources in all namespaces that have a Dash0 monitoring resource
 deployed, and synchronize the Perses dashboard resources with the Dash0 backend:
+
 * When a new Perses dashboard resource is created, the operator will create a corresponding dashboard via Dash0's API.
 * When a Perses dashboard resource is changed, the operator will update the corresponding dashboard via Dash0's API.
 * When a Perses dashboard resource is deleted, the operator will delete the corresponding dashboard via Dash0's API.
 
-The dashboards created by the operator will be in read-only mode in the Dash0 UI.
+The dashboards created by the operator will be in read-only mode in Dash0.
 
-If the Dash0 operator configuration resource has the `dataset` property set, the operator will create the dashboards
-in that dataset, otherwise they will be created in the `default` dataset.
+If the Dash0 operator configuration resource has the `dataset` property set, the operator will create the dashboards in
+that dataset, otherwise they will be created in the `default` dataset.
 
 You can opt out of synchronization for individual Perses dashboard resources by adding the Kubernetes label
 `dash0.com/enable: false` to the Perses dashboard resource.
@@ -2370,9 +2401,10 @@ Perses dashboards, the label to opt out of synchronization is always `dash0.com/
 label selector has been set in `spec.instrumentWorkloads.labelSelector`.
 
 When a Perses dashboard resource has been synchronized to Dash0, the operator will write a summary of that
-synchronization operation to the status of the Dash0 monitoring resource in the same namespace. This summary will also
-show whether the dashboard had any validation issues or an error occurred during synchronization:
-```
+synchronization operation to the status of the Dash0 monitoring resource in the same namespace.
+This summary will also show whether the dashboard had any validation issues or an error occurred during synchronization:
+
+```yaml
 Kind: Dash0Monitoring
 ...
 Status:
@@ -2382,11 +2414,11 @@ Status:
       Synchronized At:            2024-10-25T12:02:12Z
 ```
 
-Note: If you only want to manage dashboards, check rules, synthetic checks, views, notification channels, spam filters
-and signal-to-metrics rules via the Dash0 operator, and you do not want it to collect telemetry, you can set
-`telemetryCollection.enabled` to `false` in the Dash0 operator configuration resource.
-This will disable the telemetry collection by the operator, and it will also instruct the operator to not deploy the
-OpenTelemetry collector in your cluster.
+> **Note:** If you only want to manage dashboards, check rules, synthetic checks, views, notification channels, spam
+> filters and signal-to-metrics rules via the Dash0 operator, and you do not want it to collect telemetry, you can set
+> `telemetryCollection.enabled` to `false` in the Dash0 operator configuration resource.
+> This will disable the telemetry collection by the operator, and it will also instruct the operator to not deploy the
+> OpenTelemetry collector in your cluster.
 
 #### Conversion Webhook for the PersesDashboard CRD
 
@@ -2439,33 +2471,35 @@ back-and-forth patching between the Dash0 operator and the GitOps system is obse
 
 You can manage your Dash0 check rules via the Dash0 operator.
 
-Pre-requisites for this feature:
+**Pre-requisites for this feature:**
+
 * A Dash0 operator configuration resource has to be installed in the cluster.
 * The operator configuration resource must have the `apiEndpoint` property.
-* The operator configuration resource must have at least one Dash0 export configured with authorization
-  (either `token` or `secret-ref`).
-* The operator will only pick up Prometheus rule resources in namespaces that have a Dash0 monitoring resource
-  deployed.
-* The operator will not synchronize Prometheus rule resources in namespaces where the Dash0 monitoring resource
-  has the setting [`synchronizePrometheusRules`](#monitoringresource.spec.synchronizePrometheusRules) set to `false`.
+* The operator configuration resource must have at least one Dash0 export configured with authorization (either `token`
+  or `secret-ref`).
+* The operator will only pick up Prometheus rule resources in namespaces that have a Dash0 monitoring resource deployed.
+* The operator will not synchronize Prometheus rule resources in namespaces where the Dash0 monitoring resource has the
+  setting [`synchronizePrometheusRules`](#monitoringresource.spec.synchronizePrometheusRules) set to `false`.
   (This setting is optional and defaults to `true` when omitted.)
 * Optional: In addition to the global/default API endpoint and authorization described above, it is possible to define
   namespace-specific overrides by providing one or more Dash0 export(s) with an API endpoint and token in the Dash0
   monitoring resource.
 
-Furthermore, the custom resource definition for Prometheus rules needs to be installed in the cluster. There are two
-ways to achieve this:
-* Install the Prometheus rules custom resource definition with the following command:
-```console
-kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.91.0/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml
-```
-* Alternatively, install the full kube-prometheus stack Helm chart: Go to
-  <https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack> and follow the
-  installation instructions there.
+The custom resource definition for Prometheus rules also needs to be installed in the cluster.
+There are two ways to achieve this:
+
+1. Install the Prometheus rules custom resource definition with the following command:
+   ```console
+   kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.91.0/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml
+   ```
+2. Alternatively, install the full kube-prometheus stack Helm chart: Go to
+   <https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack> and follow the
+   installation instructions there.
 
 With the prerequisites in place, you can manage Dash0 check rules via the operator.
 The Dash0 operator will watch for Prometheus rule resources in all namespaces that have a Dash0 monitoring resource
 deployed, and synchronize the Prometheus rule resources with the Dash0 backend:
+
 * When a new Prometheus rule resource is created, the operator will create corresponding check rules via Dash0's API.
 * When a Prometheus rule resource is changed, the operator will update the corresponding check rules via Dash0's API.
 * When a Prometheus rule resource is deleted, the operator will delete the corresponding check rules via Dash0's API.
@@ -2473,10 +2507,13 @@ deployed, and synchronize the Prometheus rule resources with the Dash0 backend:
 Note that a Prometheus rule resource can contain multiple groups, and each of those groups can have multiple rules.
 The Dash0 operator will create individual check rules for each rule in each group.
 
-If the Dash0 operator configuration resource has the `dataset` property set, the operator will create the rules
-in that dataset, otherwise they will be created in the `default` dataset.
+If the Dash0 operator configuration resource has the `dataset` property set, the operator will create the rules in that
+dataset, otherwise they will be created in the `default` dataset.
+
+#### Prometheus Rule to Dash0 Check Rule Mapping
 
 Prometheus rules will be mapped to Dash0 check rules as follows:
+
 * Each `rules` list item with an `alert` attribute in all `groups` will be converted to an individual check rule in
   Dash0.
 * Rules that have the `record` attribute set instead of the `alert` attribute will be ignored.
@@ -2495,18 +2532,17 @@ Prometheus rules will be mapped to Dash0 check rules as follows:
   Prometheus rule resource.
 * If `expr` contains the token `$__threshold`, and neither annotation `dash0-threshold-degraded` nor
   `dash0-threshold-critical` is present, the rule will be considered invalid and will not be synchronized to Dash0.
-* If the rule has the annotation `dash0-enabled=false`, the check rule will be synchronized but disabled
-  in Dash0.
+* If the rule has the annotation `dash0-enabled=false`, the check rule will be synchronized but disabled in Dash0.
   This Prometheus annotation is not to be confused with the Kubernetes label `dash0.com/enable: false`, which disables
   synchronization of the entire Prometheus rules resource (and all its check rules) to Dash0 (see below).
 * The group attribute `limit` is not supported by Dash0 and will be ignored.
 * The group attribute `partial_response_strategy` is not supported by Dash0 and will be ignored.
-* All labels (except for the ones explicitly mentioned in the conversion table below) will be listed under
-  "Additional labels".
+* All labels (except for the ones explicitly mentioned in the conversion table below) will be listed under "Additional
+  labels".
 * All annotations (except for the ones explicitly mentioned in the conversion table below) will be listed under
   "Annotations".
 
-| Prometheus alert rule attribute        | Dash0 Check rule field                                                                                            | Notes                                                                                                                                                      |
+| Prometheus alerting rule attribute     | Dash0 Check rule field                                                                                            | Notes                                                                                                                                                      |
 |----------------------------------------|-------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `alert`                                | Name of check rule, prefixed by the group name                                                                    | must be a non-empty string                                                                                                                                 |
 | `expr`                                 | "Expression"                                                                                                      | must be a non-empty string                                                                                                                                 |
@@ -2516,10 +2552,10 @@ Prometheus rules will be mapped to Dash0 check rules as follows:
 | `annotations/summary`                  | "Summary"                                                                                                         |                                                                                                                                                            |
 | `annotations/description`              | "Description"                                                                                                     |                                                                                                                                                            |
 | `annotations/dash0-enabled`            | Denotes whether the check rule is enabled and should be evaluated.                                                | default: "true"; must be either "true" or "false"                                                                                                          |
-| `annotations/dash0-threshold-degraded` | Will be used in place of the token `$__threshold` in the expression, to determine whether the check is _degraded_ | If present, needs to a be string that can be parsed to a float value according to the syntax described in https://go.dev/ref/spec#Floating-point_literals. |
-| `annotations/dash0-threshold-critical` | Will be used in place of the token `$__threshold` in the expression, to determine whether the check is _critical_ | If present, needs to a be string that can be parsed to a float value according to the syntax described in https://go.dev/ref/spec#Floating-point_literals. |
-| `annotations/*`                        | "Annotations"                                                                                                     |
-| `labels/*`                             | "Additional labels"                                                                                               |
+| `annotations/dash0-threshold-degraded` | Will be used in place of the token `$__threshold` in the expression, to determine whether the check is degraded   | If present, needs to be string that can be parsed to a float value according to the syntax described in https://go.dev/ref/spec#Floating-point_literals.   |
+| `annotations/dash0-threshold-critical` | Will be used in place of the token `$__threshold` in the expression, to determine whether the check is critical   | If present, needs to be string that can be parsed to a float value according to the syntax described in https://go.dev/ref/spec#Floating-point_literals.   |
+| `annotations/*`                        | "Annotations"                                                                                                     | |
+| `labels/*`                             | "Additional labels"                                                                                               | |
 
 You can opt out of synchronization for individual Prometheus rules resources by adding the Kubernetes label
 `dash0.com/enable: false` to it.
@@ -2536,8 +2572,7 @@ synchronization of Prometheus rule resources, the label to opt out of synchroniz
 
 When a Prometheus rules resource has been synchronized to Dash0, the operator will write a summary of that
 synchronization operation to the status of the Dash0 monitoring resource in the same namespace.
-This summary will also
-show whether any of the rules had validation issues or errors occurred during synchronization:
+This summary will also show whether any of the rules had validation issues or errors occurred during synchronization:
 
 ```yaml
 Kind: Dash0Monitoring
@@ -2566,21 +2601,22 @@ Status:
         Synchronized Rules Total:  4
 ```
 
-Note: If you only want to manage dashboards, check rules, synthetic checks, views, notification channels, spam filters
-and signal-to-metrics rules via the Dash0 operator, and you do not want it to collect telemetry, you can set
-`telemetryCollection.enabled` to `false` in the Dash0 operator configuration resource.
-This will disable the telemetry collection by the operator, and it will also instruct the operator to not deploy the
-OpenTelemetry collector in your cluster.
+> **Note:** If you only want to manage dashboards, check rules, synthetic checks, views, notification channels, spam
+> filters and signal-to-metrics rules via the Dash0 operator, and you do not want it to collect telemetry, you can set
+> `telemetryCollection.enabled` to `false` in the Dash0 operator configuration resource.
+> This will disable the telemetry collection by the operator, and it will also instruct the operator to not deploy the
+> OpenTelemetry collector in your cluster.
 
 ### Managing Dash0 Synthetic Checks
 
 You can manage your Dash0 synthetic checks via the Dash0 operator.
 
-Pre-requisites for this feature:
+**Pre-requisites for this feature:**
+
 * A Dash0 operator configuration resource has to be installed in the cluster.
 * The operator configuration resource must have the `apiEndpoint` property.
-* The operator configuration resource must have at least one Dash0 export configured with authorization
-  (either `token` or `secret-ref`).
+* The operator configuration resource must have at least one Dash0 export configured with authorization (either `token`
+  or `secret-ref`).
 * The operator will only pick up synthetic check resources in namespaces that have a Dash0 monitoring resource
   deployed.
 * Optional: In addition to the global/default API endpoint and authorization described above, it is possible to define
@@ -2590,6 +2626,7 @@ Pre-requisites for this feature:
 With the prerequisites in place, you can manage Dash0 synthetic checks via the operator.
 The Dash0 operator will watch for synthetic check resources in all namespaces that have a Dash0 monitoring resource
 deployed, and synchronize the synthetic check resources with the Dash0 backend:
+
 * When a new synthetic check resource is created, the operator will create a corresponding synthetic check via Dash0's
   API.
 * When a synthetic check resource is changed, the operator will update the corresponding synthetic check via Dash0's
@@ -2597,7 +2634,7 @@ deployed, and synchronize the synthetic check resources with the Dash0 backend:
 * When a synthetic check resource is deleted, the operator will delete the corresponding synthetic check via Dash0's
   API.
 
-The synthetic checks created by the operator will be in read-only mode in the Dash0 UI.
+The synthetic checks created by the operator will be in read-only mode in Dash0.
 
 The custom resource definition for Dash0 synthetic checks can be found
 [here](https://github.com/dash0hq/dash0-operator/blob/main/helm-chart/dash0-operator/templates/operator/custom-resource-definition-synthetic-checks.yaml).
@@ -2613,8 +2650,8 @@ checks in that dataset, otherwise they will be created in the `default` dataset.
 
 You can opt out of synchronization for individual synthetic checks resources by adding the Kubernetes label
 `dash0.com/enable: false` to the synthetic check resource.
-If this label is added to a synthetic chec which has previously been synchronized to Dash0, the operator will delete the
-corresponding synthetic chec in Dash0.
+If this label is added to a synthetic check which has previously been synchronized to Dash0, the operator will delete
+the corresponding synthetic check in Dash0.
 Note that the `spec.instrumentWorkloads.labelSelector` in the monitoring resource does not affect the synchronization of
 synthetic checks, the label to opt out of synchronization is always `dash0.com/enable: false`, even if a non-default
 label selector has been set in `spec.instrumentWorkloads.labelSelector`.
@@ -2636,21 +2673,22 @@ Status:
   Synchronized At:        2025-09-05T11:47:56Z
 ```
 
-Note: If you only want to manage dashboards, check rules, synthetic checks, views, notification channels, spam filters
-and signal-to-metrics rules via the Dash0 operator, and you do not want it to collect telemetry, you can set
-`telemetryCollection.enabled` to `false` in the Dash0 operator configuration resource.
-This will disable the telemetry collection by the operator, and it will also instruct the operator to not deploy the
-OpenTelemetry collector in your cluster.
+> **Note:** If you only want to manage dashboards, check rules, synthetic checks, views, notification channels, spam
+> filters and signal-to-metrics rules via the Dash0 operator, and you do not want it to collect telemetry, you can set
+> `telemetryCollection.enabled` to `false` in the Dash0 operator configuration resource.
+> This will disable the telemetry collection by the operator, and it will also instruct the operator to not deploy the
+> OpenTelemetry collector in your cluster.
 
 ### Managing Dash0 Views
 
 You can manage your Dash0 views via the Dash0 operator.
 
-Pre-requisites for this feature:
+**Pre-requisites for this feature:**
+
 * A Dash0 operator configuration resource has to be installed in the cluster.
 * The operator configuration resource must have the `apiEndpoint` property.
-* The operator configuration resource must have at least one Dash0 export configured with authorization
-  (either `token` or `secret-ref`).
+* The operator configuration resource must have at least one Dash0 export configured with authorization (either `token`
+  or `secret-ref`).
 * The operator will only pick up Dash0 view resources in namespaces that have a Dash0 monitoring resource
   deployed.
 * Optional: In addition to the global/default API endpoint and authorization described above, it is possible to define
@@ -2660,16 +2698,17 @@ Pre-requisites for this feature:
 With the prerequisites in place, you can manage Dash0 views via the operator.
 The Dash0 operator will watch for view resources in all namespaces that have a Dash0 monitoring resource deployed, and
 synchronize the view resources with the Dash0 backend:
+
 * When a new view resource is created, the operator will create a corresponding view via Dash0's API.
 * When a view resource is changed, the operator will update the corresponding view via Dash0's API.
 * When a view resource is deleted, the operator will delete the corresponding view via Dash0's API.
 
-The views created by the operator will be in read-only mode in the Dash0 UI.
+The views created by the operator will be in read-only mode in Dash0.
 
 The custom resource definition for Dash0 views can be found
 [here](https://github.com/dash0hq/dash0-operator/blob/main/helm-chart/dash0-operator/templates/operator/custom-resource-definition-views.yaml).
 An easy way to get started is to create a view in the Dash0 UI and then download the YAML representation of that view by
-using the "Download -> YAML" action from the context menu of the view.
+using the "Download → YAML" action from the context menu of the view.
 The downloaded YAML can then be deployed as the manifest of a view in your Kubernetes cluster.
 Once the view is managed via the operator, you might want to delete the view that has been created in the Dash0 UI
 directly in the first step -- otherwise it would show up as a duplicate in the Dash0 UI, i.e. two views with the same
@@ -2680,8 +2719,8 @@ dataset, otherwise they will be created in the `default` dataset.
 
 You can opt out of synchronization for individual view resources by adding the Kubernetes label
 `dash0.com/enable: false` to the view resource.
-If this label is added to a synthetic chec which has previously been synchronized to Dash0, the operator will delete the
-corresponding synthetic chec in Dash0.
+If this label is added to a view which has previously been synchronized to Dash0, the operator will delete the
+corresponding view in Dash0.
 Note that the `spec.instrumentWorkloads.labelSelector` in the monitoring resource does not affect the synchronization of
 views, the label to opt out of synchronization is always `dash0.com/enable: false`, even if a non-default label selector
 has been set in `spec.instrumentWorkloads.labelSelector`.
@@ -2702,11 +2741,11 @@ Status:
   Synchronized At:        2025-09-05T11:47:56Z
 ```
 
-Note: If you only want to manage dashboards, check rules, synthetic checks, views, notification channels, spam filters
-and signal-to-metrics rules via the Dash0 operator, and you do not want it to collect telemetry, you can set
-`telemetryCollection.enabled` to `false` in the Dash0 operator configuration resource.
-This will disable the telemetry collection by the operator, and it will also instruct the operator to not deploy the
-OpenTelemetry collector in your cluster.
+> **Note:** If you only want to manage dashboards, check rules, synthetic checks, views, notification channels, spam
+> filters and signal-to-metrics rules via the Dash0 operator, and you do not want it to collect telemetry, you can set
+> `telemetryCollection.enabled` to `false` in the Dash0 operator configuration resource.
+> This will disable the telemetry collection by the operator, and it will also instruct the operator to not deploy the
+> OpenTelemetry collector in your cluster.
 
 ### Managing Dash0 Notification Channels
 
@@ -3355,12 +3394,12 @@ namespaces without a [Dash0 monitoring resource](#enable-dash0-monitoring-for-a-
 
 ## Notes on ArgoCD
 
-As many other Helm charts, the Dash0 operator Helm chart regenerates TLS certificates for in-cluster communication,
-that is, for its services and webhooks.
+As many other Helm charts, the Dash0 operator Helm chart regenerates TLS certificates for in-cluster communication, that
+is, for its services and webhooks.
 The certificate will be regenerated every time the Dash0 operator Helm chart is applied.
 For users deploying the Dash0 operator via ArgoCD, and in particular without using ArgoCD's auto-sync feature, the
 certificates and derived data (`ca.crt`, `tls.crt`, `tls.key`, `caBundle`) will show up as a diff in the ArgoCD UI.
-The certificate is also regenerated everytime the hard refresh option is used in ArgoCD, since this action will trigger
+The certificate is also regenerated every time the hard refresh option is used in ArgoCD, since this action will trigger
 rendering the Helm chart templates again, even if nothing has changed in the git repository.
 
 To avoid this, you can instruct ArgoCD to ignore these particular differences.
@@ -3422,26 +3461,29 @@ spec:
 ## Notes on Running The Operator on Apple Silicon
 
 When running the operator on an Apple Silicon host (M1, M3 etc.), for example via Docker Desktop, some attention needs
-to be paid to the CPU architecture of images. The architecture of the Kubernetes node for this scenario will be `arm64`.
+to be paid to the CPU architecture of images.
+The architecture of the Kubernetes node for this scenario will be `arm64`.
 When running a single-architecture `amd64` image (as opposed to a single-architecture `arm64` image or a
 [multi-platform build](https://docs.docker.com/build/building/multi-platform/) containing `amd64` as well as `arm64`)
 the operator will prevent the container from starting.
 
-The reason for this is the interaction between Rosetta emulation and how the operator works. The Dash0 instrumentation
-image (which is added as an init container and contains the OpenTelemetry injector) is a multi-platform image,
-supporting both `amd64` and `arm64`. When this image is pulled from an Apple Silicon machine, it automatically pulls the
-`arm64` variant. That is, the injector binary that is added via the init container is compiled for `arm64`. Now, when
-the application from your `amd64` application image is started, the injector and the application will be incompatible,
-as they have been built for two different CPU architectures.
+The reason for this is the interaction between Rosetta emulation and how the operator works.
+The Dash0 instrumentation image (which is added as an init container and contains the OpenTelemetry injector) is a
+multi-platform image, supporting both `amd64` and `arm64`.
+When this image is pulled from an Apple Silicon machine, it automatically pulls the `arm64` variant.
+That is, the injector binary that is added via the init container is compiled for `arm64`.
+Now, when the application from your `amd64` application image is started, the injector and the application will be
+incompatible, as they have been built for two different CPU architectures.
 
 Under normal circumstances, an `amd64` image would not work on an `arm64` Kubernetes node anyway, but in the case of
 Docker Desktop on MacOS, this combination is enabled due to Docker Desktop automatically running `amd64` images via
 Rosetta2 emulation.
 
 You can work around this issue by one of the following methods:
-* using an `amd64` Kubernetes node,
-* by building a multi-platform image for your application, or
-* by building the application as an `arm64` image (e.g. by using `--platform=linux/arm64` when building the image).
+
+* Using an `amd64` Kubernetes node,
+* By building a multi-platform image for your application, or
+* By building the application as an `arm64` image (e.g. by using `--platform=linux/arm64` when building the image).
 
 ## Notes on Running The Operator on Docker Desktop
 


### PR DESCRIPTION
This commit back-ports a large number of small/trivial formatting changes and typo fixes from the copy of the docs that is published on dash0.com/docs.

This is in preparation of using the Helm chart docs as the source of thruth for the dash0.com/docs version as well.

List of changes:
* various typo fixes
* use `*` more consistently for lists (instead of `-`)
* align capitalization style of lists with dash0.com/docs
* highligh config attributes at the start of sections that explain them
* consistent formatting for "Notes: " sections, as quotes (which is what dash0.com/docs uses)
* more consistent line breaks (line break after each sentence, and after 120 characters)
* reduce overusage of inline emphasis markers