### PR TITLE
fix: do not log warning for empty instrumentation delivery

### DIFF
--- a/internal/controller/operator_configuration_controller.go
+++ b/internal/controller/operator_configuration_controller.go
@@ -364,6 +364,7 @@ func (r *OperatorConfigurationReconciler) applyInstrumentationDelivery(
 		originalDeliverySetting,
 		r.clusterInstrumentationConfig.KubernetesVersion,
 		r.clusterInstrumentationConfig.KubernetesVersionDetected,
+		true,
 		logger,
 	)
 	previous := r.clusterInstrumentationConfig.SetInstrumentationDelivery(resolvedDelivery)

--- a/internal/startup/operator_manager_startup.go
+++ b/internal/startup/operator_manager_startup.go
@@ -346,7 +346,7 @@ func Start() {
 	}
 
 	var operatorConfigurationValues *OperatorConfigurationValues
-	if len(cliArgs.operatorConfigurationEndpoint) > 0 {
+	if operatorConfigurationIsManagedViaHelm(cliArgs) {
 		operatorConfigurationValues = &OperatorConfigurationValues{
 			Endpoint: cliArgs.operatorConfigurationEndpoint,
 			Token:    cliArgs.operatorConfigurationToken,
@@ -1044,6 +1044,7 @@ func startOperatorManager(
 		cliArgs.operatorConfigurationInstrumentationDelivery,
 		kubernetesVersionInfo,
 		kubernetesVersionDetected,
+		operatorConfigurationIsManagedViaHelm(cliArgs),
 		setupLog,
 	)
 
@@ -1726,6 +1727,11 @@ func findDeploymentReference(
 	}
 	logger.Debug(fmt.Sprintf("found deployment reference with UID: %s", deploymentReference.UID))
 	return deploymentReference, nil
+}
+
+func operatorConfigurationIsManagedViaHelm(cliArgs *commandLineArguments) bool {
+	// cliArgs.operatorConfigurationEndpoint is provided via Helm if and only if operator.dash0Export.enabled is true.
+	return len(cliArgs.operatorConfigurationEndpoint) > 0
 }
 
 func createOrUpdateAutoOperatorConfigurationResource(

--- a/internal/util/cluster/instrumentation_delivery.go
+++ b/internal/util/cluster/instrumentation_delivery.go
@@ -29,6 +29,7 @@ func ResolveInstrumentationDelivery(
 	delivery string,
 	versionInfo KubernetesVersionInfo,
 	versionDetected bool,
+	logWarningForEmptyValue bool,
 	logger logd.Logger,
 ) ResolvedInstrumentationDelivery {
 	// maintenance note: this switch statement needs to be updated once we move to the default being "auto"
@@ -81,12 +82,17 @@ func ResolveInstrumentationDelivery(
 		return ResolvedInstrumentationDeliveryInitContainer
 
 	default:
-		// Should not happen, there should always be a valid delivery mode set on the operator configuration CRD and also
-		// via Helm.
-		logger.WarnTelemetryCollectionIssue(fmt.Sprintf(
-			"unknown instrumentation delivery: \"%s\". Falling back to the init container approach for instrumenting workloads.",
-			delivery,
-		))
+		if delivery != "" || logWarningForEmptyValue {
+			logger.WarnTelemetryCollectionIssue(fmt.Sprintf(
+				"unknown instrumentation delivery: \"%s\". Falling back to the init container approach for instrumenting workloads.",
+				delivery,
+			))
+		} else {
+			logger.Debug(fmt.Sprintf(
+				"unknown instrumentation delivery: \"%s\". Falling back to the init container approach for instrumenting workloads.",
+				delivery,
+			))
+		}
 		return ResolvedInstrumentationDeliveryInitContainer
 	}
 }

--- a/internal/util/cluster/instrumentation_delivery_test.go
+++ b/internal/util/cluster/instrumentation_delivery_test.go
@@ -25,6 +25,7 @@ var _ = Describe("ResolveInstrumentationDelivery", func() {
 				testConfig.delivery,
 				testConfig.versionInfo,
 				testConfig.versionDetected,
+				true,
 				logd.Discard(),
 			)
 			Expect(result).To(Equal(testConfig.expectedDelivery))


### PR DESCRIPTION
We call cluster.ResolveInstrumentationDelivery early in the operator startup, and if the Dash0OperatorConfiguration resource is not managed via Helm, the instrumenation delivery value (read from the command line argument --operator-configuration-instrumentation-delivery) passed into cluster.ResolveInstrumentationDelivery can be legitimately empty.

We now suppress the warning for this case.