### PR TITLE
ci: update Go version in go.mod files automatically

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,9 +25,6 @@ updates:
         dependency-type: "production"
       development-dependencies:
         dependency-type: "development"
-    ignore:
-      - dependency-name: "golang"
-        update-types: ["version-update:semver-minor"]
 
   # Dash0 OpenTelemetry Distro for Node.js
   - package-ecosystem: "npm"

--- a/.github/workflows/scripts/sync-go-version-with-dockerfile.sh
+++ b/.github/workflows/scripts/sync-go-version-with-dockerfile.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright 2026 Dash0 Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Synchronizes the `go` directive in each go.mod file with the golang base image tag of its associated Dockerfile.
+# The Dockerfile's golang:<version> base image is treated as the source of truth; whenever the `go` directive in the
+# associated go.mod differs, it is rewritten to match. If anything changed, the result is committed and pushed to the
+# branch given via the HEAD_REF environment variable.
+#
+# This is invoked from the sync-go-version-with-dockerfile.yaml workflow. HEAD_REF must be set to the name of the
+# branch to push the synchronizing commit to (the pull request's head branch).
+
+set -euo pipefail
+
+if [[ -z "${HEAD_REF:-}" ]]; then
+  echo "Error: the HEAD_REF environment variable is not set." >&2
+  exit 1
+fi
+
+# Mapping of "Dockerfile:go.mod" pairs. Each Dockerfile's golang base image tag is the source of truth; the `go`
+# directive in the associated go.mod is updated to match it. The list intentionally only contains Dockerfiles that
+# build from a golang:* base image and have an associated go.mod file. images/collector has no tracked go.mod (the
+# collector is built via the OpenTelemetry collector builder), so it is not listed.
+mappings=(
+  "Dockerfile:go.mod"
+  "images/configreloader/Dockerfile:images/configreloader/src/go.mod"
+  "images/filelogoffsetsync/Dockerfile:images/filelogoffsetsync/src/go.mod"
+  "test/e2e/otlp-sink/telemetrymatcher/Dockerfile:test/e2e/otlp-sink/telemetrymatcher/go.mod"
+  "test/e2e/dash0-api-mock/Dockerfile:test/e2e/dash0-api-mock/go.mod"
+  "test/e2e/control-plane-mock/Dockerfile:test/e2e/control-plane-mock/go.mod"
+  "test/e2e/decision-maker-mock/Dockerfile:test/e2e/decision-maker-mock/go.mod"
+)
+
+changed=false
+
+for mapping in "${mappings[@]}"; do
+  dockerfile="${mapping%%:*}"
+  gomod="${mapping##*:}"
+
+  if [[ ! -f "$dockerfile" ]]; then
+    echo "skipping ${dockerfile}: file not found"
+    continue
+  fi
+  if [[ ! -f "$gomod" ]]; then
+    echo "skipping ${gomod}: file not found"
+    continue
+  fi
+
+  # Extract the version from the first golang:<version> reference in the Dockerfile, dropping any suffix such as
+  # -alpine3.23. Matches both "golang:1.26.4" and "golang:1.26.4-alpine3.23".
+  docker_go_version=$(grep -oE 'golang:[0-9]+\.[0-9]+(\.[0-9]+)?' "$dockerfile" | head -n 1 | sed 's/^golang://')
+  if [[ -z "$docker_go_version" ]]; then
+    echo "skipping ${dockerfile}: no golang base image version found"
+    continue
+  fi
+
+  # Extract the current value of the `go` directive (e.g. "1.26.4") from go.mod.
+  gomod_go_version=$(grep -oE '^go [0-9]+\.[0-9]+(\.[0-9]+)?' "$gomod" | head -n 1 | awk '{print $2}')
+  if [[ -z "$gomod_go_version" ]]; then
+    echo "skipping ${gomod}: no go directive found"
+    continue
+  fi
+
+  if [[ "$docker_go_version" == "$gomod_go_version" ]]; then
+    echo "${gomod}: go directive (${gomod_go_version}) already matches ${dockerfile} (golang:${docker_go_version}), nothing to do"
+    continue
+  fi
+
+  echo "${gomod}: updating go directive from ${gomod_go_version} to ${docker_go_version} to match ${dockerfile}"
+  # Replace only the `go` directive line, leaving the rest of go.mod untouched for a minimal diff.
+  sed -i.bak -E "s/^go [0-9]+\.[0-9]+(\.[0-9]+)?$/go ${docker_go_version}/" "$gomod"
+  rm -f "${gomod}.bak"
+  changed=true
+done
+
+if [[ "$changed" != "true" ]]; then
+  echo "All go.mod files are already in sync with their Dockerfiles, no commit needed."
+  exit 0
+fi
+
+git config user.name "github-actions[bot]"
+git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+if git diff --quiet; then
+  echo "No file changes detected after processing, no commit needed."
+  exit 0
+fi
+
+git add -- '*go.mod'
+git commit --message "chore(deps): sync go directive in go.mod with golang base image"
+git push origin "HEAD:${HEAD_REF}"

--- a/.github/workflows/sync-go-version-with-dockerfile.yaml
+++ b/.github/workflows/sync-go-version-with-dockerfile.yaml
@@ -1,0 +1,57 @@
+name: Sync go.mod Go version with Dockerfile golang base image
+
+# When a pull request changes the golang base image tag in one of the Dockerfiles below (for example a Dependabot
+# PR bumping golang:1.26.3-alpine3.23 to golang:1.26.4-alpine3.23), this workflow updates the `go` directive in the
+# associated go.mod file so that the two Go versions stay in sync. The change is added as a separate commit to the
+# same branch (the pull request's head branch).
+#
+# Dependabot's docker and gomod ecosystem updaters are independent and have no awareness of each other, so without
+# this workflow the golang base image and the `go` directive in go.mod drift apart over time.
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+    paths:
+      - "Dockerfile"
+      - "images/configreloader/Dockerfile"
+      - "images/filelogoffsetsync/Dockerfile"
+      - "test/e2e/otlp-sink/telemetrymatcher/Dockerfile"
+      - "test/e2e/dash0-api-mock/Dockerfile"
+      - "test/e2e/control-plane-mock/Dockerfile"
+      - "test/e2e/decision-maker-mock/Dockerfile"
+
+# contents: write is required to push the synchronizing commit back to the pull request branch. Workflows triggered
+# by Dependabot pull requests respect this permissions key (see
+# https://github.blog/changelog/2021-10-06-github-actions-workflows-triggered-by-dependabot-prs-will-respect-permissions-key-in-workflows/).
+permissions:
+  contents: write
+
+# Avoid races and redundant runs when Dependabot force-pushes updates to the same branch in quick succession.
+concurrency:
+  group: sync-go-version-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  sync-go-version:
+    name: sync go.mod Go version with Dockerfile golang base image
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # We can only push commits to branches that live in this repository. Pull requests from forks (head.repo differs
+    # from the base repository) cannot be updated with the default GITHUB_TOKEN, so we skip them. Dependabot pushes its
+    # branches to this repository, so its pull requests are always handled.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+        with:
+          # Check out the pull request's head branch (not the merge ref) so that we can commit and push back to it.
+          ref: ${{ github.head_ref }}
+
+      - name: sync go directive in go.mod with golang base image
+        shell: bash
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+        run: .github/workflows/scripts/sync-go-version-with-dockerfile.sh


### PR DESCRIPTION
Dependabot automatically updates the golang base image that we use in most Dockerfiles. The go version in the associated Dockerfile is currently not updated automatically in tandem, which leads to the two versions getting out of sync. Apparently this cannot be solved via Dependabot. This introduces a Github action that automatically updates the go.mod file when the respective Dockerfile is changed.