### PR TITLE
feat(collectors, target-allocator): allow custom labels and annotations

### DIFF
--- a/helm-chart/dash0-operator/README.md
+++ b/helm-chart/dash0-operator/README.md
@@ -1502,6 +1502,48 @@ operator:
     nodeAffinity: <custom_node_affinity>
 ```
 
+### Adding Custom Labels and Annotations to the Collector Resources
+
+Additional labels and annotations can be added to the collector resources and the target-allocator resource managed by
+the operator, both to the workload objects (the daemonset and the deployments) and to their pods.
+These are merged with the labels and annotations the operator sets itself; the operator-managed entries always take
+precedence, so they cannot be overridden.
+
+```yaml
+operator:
+  collectors:
+    # labels/annotations for the daemonset collector
+    daemonSetLabels:
+      my-label: my-value
+    daemonSetAnnotations:
+      my-annotation: my-value
+    daemonSetPodLabels:
+      my-pod-label: my-value
+    daemonSetPodAnnotations:
+      my-pod-annotation: my-value
+
+    # labels/annotations for the cluster-metrics-collector deployment
+    deploymentLabels:
+      my-label: my-value
+    deploymentAnnotations:
+      my-annotation: my-value
+    deploymentPodLabels:
+      my-pod-label: my-value
+    deploymentPodAnnotations:
+      my-pod-annotation: my-value
+
+  targetAllocator:
+    # labels/annotations for the target-allocator deployment
+    labels:
+      my-label: my-value
+    annotations:
+      my-annotation: my-value
+    podLabels:
+      my-pod-label: my-value
+    podAnnotations:
+      my-pod-annotation: my-value
+```
+
 ### Configuring Pod-Level sysctls for the Collector Pods (TCP Keepalive)
 
 Pod-level [sysctls](https://kubernetes.io/docs/tasks/administer-cluster/sysctl-cluster/) can be applied to the

--- a/helm-chart/dash0-operator/templates/operator/extra-config-map.yaml
+++ b/helm-chart/dash0-operator/templates/operator/extra-config-map.yaml
@@ -51,6 +51,22 @@ data:
               .Values.operator.collectors.daemonSetFileLogOffsetSyncContainerResources
               .Values.operator.collectorDaemonSetFileLogOffsetSyncContainerResources
           ) | nindent 6 }}
+{{- if .Values.operator.collectors.daemonSetLabels }}
+    collectorDaemonSetLabels:
+      {{- toYaml .Values.operator.collectors.daemonSetLabels | nindent 6 }}
+{{- end }}
+{{- if .Values.operator.collectors.daemonSetAnnotations }}
+    collectorDaemonSetAnnotations:
+      {{- toYaml .Values.operator.collectors.daemonSetAnnotations | nindent 6 }}
+{{- end }}
+{{- if .Values.operator.collectors.daemonSetPodLabels }}
+    collectorDaemonSetPodLabels:
+      {{- toYaml .Values.operator.collectors.daemonSetPodLabels | nindent 6 }}
+{{- end }}
+{{- if .Values.operator.collectors.daemonSetPodAnnotations }}
+    collectorDaemonSetPodAnnotations:
+      {{- toYaml .Values.operator.collectors.daemonSetPodAnnotations | nindent 6 }}
+{{- end }}
     daemonSetTolerations:
       {{- toYaml .Values.operator.collectors.daemonSetTolerations | nindent 6 }}
     daemonSetNodeAffinity:
@@ -76,6 +92,22 @@ data:
               .Values.operator.collectors.deploymentConfigurationReloaderContainerResources
               .Values.operator.collectorDeploymentConfigurationReloaderContainerResources
           ) | nindent 6 }}
+{{- if .Values.operator.collectors.deploymentLabels }}
+    collectorDeploymentLabels:
+      {{- toYaml .Values.operator.collectors.deploymentLabels | nindent 6 }}
+{{- end }}
+{{- if .Values.operator.collectors.deploymentAnnotations }}
+    collectorDeploymentAnnotations:
+      {{- toYaml .Values.operator.collectors.deploymentAnnotations | nindent 6 }}
+{{- end }}
+{{- if .Values.operator.collectors.deploymentPodLabels }}
+    collectorDeploymentPodLabels:
+      {{- toYaml .Values.operator.collectors.deploymentPodLabels | nindent 6 }}
+{{- end }}
+{{- if .Values.operator.collectors.deploymentPodAnnotations }}
+    collectorDeploymentPodAnnotations:
+      {{- toYaml .Values.operator.collectors.deploymentPodAnnotations | nindent 6 }}
+{{- end }}
     deploymentTolerations:
       {{- toYaml .Values.operator.collectors.deploymentTolerations | nindent 6 }}
     deploymentNodeAffinity:
@@ -97,6 +129,22 @@ data:
     targetAllocatorMtlsClientCertSecretName: {{ .Values.operator.targetAllocator.mTls.clientCertSecretName | quote }}
     targetAllocatorContainerResources:
       {{- toYaml .Values.operator.targetAllocator.containerResources | nindent 6 }}
+{{- if .Values.operator.targetAllocator.labels }}
+    targetAllocatorLabels:
+      {{- toYaml .Values.operator.targetAllocator.labels | nindent 6 }}
+{{- end }}
+{{- if .Values.operator.targetAllocator.annotations }}
+    targetAllocatorAnnotations:
+      {{- toYaml .Values.operator.targetAllocator.annotations | nindent 6 }}
+{{- end }}
+{{- if .Values.operator.targetAllocator.podLabels }}
+    targetAllocatorPodLabels:
+      {{- toYaml .Values.operator.targetAllocator.podLabels | nindent 6 }}
+{{- end }}
+{{- if .Values.operator.targetAllocator.podAnnotations }}
+    targetAllocatorPodAnnotations:
+      {{- toYaml .Values.operator.targetAllocator.podAnnotations | nindent 6 }}
+{{- end }}
     targetAllocatorTolerations:
       {{- toYaml .Values.operator.targetAllocator.tolerations | nindent 6 }}
     targetAllocatorNodeAffinity:

--- a/helm-chart/dash0-operator/tests/operator/extra-config-map_test.yaml
+++ b/helm-chart/dash0-operator/tests/operator/extra-config-map_test.yaml
@@ -587,6 +587,105 @@ tests:
           path: data['extra.yaml']
           pattern: deploymentSysctls
 
+  - it: should render collector labels and annotations when set
+    set:
+      operator:
+        collectors:
+          daemonSetLabels:
+            ds-label: ds-label-value
+          daemonSetAnnotations:
+            ds-annotation: ds-annotation-value
+          daemonSetPodLabels:
+            ds-pod-label: ds-pod-label-value
+          daemonSetPodAnnotations:
+            ds-pod-annotation: ds-pod-annotation-value
+          deploymentLabels:
+            deploy-label: deploy-label-value
+          deploymentAnnotations:
+            deploy-annotation: deploy-annotation-value
+          deploymentPodLabels:
+            deploy-pod-label: deploy-pod-label-value
+          deploymentPodAnnotations:
+            deploy-pod-annotation: deploy-pod-annotation-value
+    asserts:
+      - matchRegex:
+          path: data['extra.yaml']
+          pattern: |-
+            collectorDaemonSetLabels:
+              ds-label: ds-label-value
+            collectorDaemonSetAnnotations:
+              ds-annotation: ds-annotation-value
+            collectorDaemonSetPodLabels:
+              ds-pod-label: ds-pod-label-value
+            collectorDaemonSetPodAnnotations:
+              ds-pod-annotation: ds-pod-annotation-value
+      - matchRegex:
+          path: data['extra.yaml']
+          pattern: |-
+            collectorDeploymentLabels:
+              deploy-label: deploy-label-value
+            collectorDeploymentAnnotations:
+              deploy-annotation: deploy-annotation-value
+            collectorDeploymentPodLabels:
+              deploy-pod-label: deploy-pod-label-value
+            collectorDeploymentPodAnnotations:
+              deploy-pod-annotation: deploy-pod-annotation-value
+
+  - it: should not render collector labels and annotations by default
+    asserts:
+      - notMatchRegex:
+          path: data['extra.yaml']
+          pattern: collectorDaemonSetLabels
+      - notMatchRegex:
+          path: data['extra.yaml']
+          pattern: collectorDaemonSetAnnotations
+      - notMatchRegex:
+          path: data['extra.yaml']
+          pattern: collectorDeploymentLabels
+      - notMatchRegex:
+          path: data['extra.yaml']
+          pattern: collectorDeploymentAnnotations
+
+  - it: should render target-allocator labels and annotations when set
+    set:
+      operator:
+        targetAllocator:
+          labels:
+            ta-label: ta-label-value
+          annotations:
+            ta-annotation: ta-annotation-value
+          podLabels:
+            ta-pod-label: ta-pod-label-value
+          podAnnotations:
+            ta-pod-annotation: ta-pod-annotation-value
+    asserts:
+      - matchRegex:
+          path: data['extra.yaml']
+          pattern: |-
+            targetAllocatorLabels:
+              ta-label: ta-label-value
+            targetAllocatorAnnotations:
+              ta-annotation: ta-annotation-value
+            targetAllocatorPodLabels:
+              ta-pod-label: ta-pod-label-value
+            targetAllocatorPodAnnotations:
+              ta-pod-annotation: ta-pod-annotation-value
+
+  - it: should not render target-allocator labels and annotations by default
+    asserts:
+      - notMatchRegex:
+          path: data['extra.yaml']
+          pattern: targetAllocatorLabels
+      - notMatchRegex:
+          path: data['extra.yaml']
+          pattern: targetAllocatorAnnotations
+      - notMatchRegex:
+          path: data['extra.yaml']
+          pattern: targetAllocatorPodLabels
+      - notMatchRegex:
+          path: data['extra.yaml']
+          pattern: targetAllocatorPodAnnotations
+
   # This test also verifies that the collectorFilelogOffsetStorageVolume is not rendered if
   # operator.collectors.filelogOffsetSyncStorageVolume isn't set as a value.
   - it: should render custom resource settings from legacy paths

--- a/helm-chart/dash0-operator/values.yaml
+++ b/helm-chart/dash0-operator/values.yaml
@@ -687,6 +687,18 @@ operator:
         memory: 32Mi
         # ephemeral-storage: (no ephemeral-storage request by default)
 
+    # Additional labels to be set on the collector DaemonSet managed by the operator.
+    daemonSetLabels: {}
+
+    # Additional annotations to be set on the collector DaemonSet managed by the operator.
+    daemonSetAnnotations: {}
+
+    # Additional labels to be set on the collector DaemonSet pods managed by the operator.
+    daemonSetPodLabels: {}
+
+    # Additional annotations to be set on the collector DaemonSet pods managed by the operator.
+    daemonSetPodAnnotations: {}
+
     # An array of tolerations for the collector DaemonSet pods managed by the operator. This can be used to make sure
     # that collector pods are scheduled on nodes where they would not be scheduled otherwise due to Kubernetes taints.
     # Example:
@@ -812,6 +824,20 @@ operator:
     # priority class. See https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/.
     # deploymentPriorityClassName:
 
+    # Additional labels to be set on the collector Deployment (cluster-metrics-collector) managed by the operator.
+    deploymentLabels: {}
+
+    # Additional annotations to be set on the collector Deployment (cluster-metrics-collector) managed by the
+    # operator.
+    deploymentAnnotations: {}
+
+    # Additional labels to be set on the collector Deployment pod (cluster-metrics-collector) managed by the operator.
+    deploymentPodLabels: {}
+
+    # Additional annotations to be set on the collector Deployment pod (cluster-metrics-collector) managed by the
+    # operator.
+    deploymentPodAnnotations: {}
+
     # An array of tolerations for the collector Deployment pod (cluster-metrics-collector) managed by the operator.
     # This can be used to make sure that collector pod can be scheduled on nodes where it would not be scheduled
     # otherwise due to Kubernetes taints.
@@ -912,6 +938,18 @@ operator:
       requests:
         cpu: 200m
         memory: 128Mi
+
+    # Additional labels to be set on the target-allocator deployment managed by the operator.
+    labels: {}
+
+    # Additional annotations to be set on the target-allocator deployment managed by the operator.
+    annotations: {}
+
+    # Additional labels to be set on the target-allocator deployment pods managed by the operator.
+    podLabels: {}
+
+    # Additional annotations to be set on the target-allocator deployment pods managed by the operator.
+    podAnnotations: {}
 
     # An array of tolerations for the target-allocator deployment pods managed by the operator.
     # This can be used to make sure the target-allocator pod can be scheduled on nodes where it would not be scheduled

--- a/internal/collectors/otelcolresources/desired_state.go
+++ b/internal/collectors/otelcolresources/desired_state.go
@@ -759,9 +759,10 @@ func assembleCollectorDaemonSet(config *oTelColConfig, extraConfig util.ExtraCon
 	collectorDaemonSet := &appsv1.DaemonSet{
 		TypeMeta: util.K8sTypeMetaDaemonSet,
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      daemonSetName,
-			Namespace: config.OperatorNamespace,
-			Labels:    labels(true),
+			Name:        daemonSetName,
+			Namespace:   config.OperatorNamespace,
+			Labels:      util.MergeMaps(labels(true), extraConfig.CollectorDaemonSetLabels),
+			Annotations: util.MergeMaps(nil, extraConfig.CollectorDaemonSetAnnotations),
 		},
 		Spec: appsv1.DaemonSetSpec{
 			Selector: &metav1.LabelSelector{
@@ -772,7 +773,8 @@ func assembleCollectorDaemonSet(config *oTelColConfig, extraConfig util.ExtraCon
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: templateLabels,
+					Labels:      util.MergeMaps(templateLabels, extraConfig.CollectorDaemonSetPodLabels),
+					Annotations: util.MergeMaps(nil, extraConfig.CollectorDaemonSetPodAnnotations),
 				},
 				Spec: podSpec,
 			},
@@ -1599,9 +1601,10 @@ func assembleCollectorDeployment(
 	collectorDeployment := &appsv1.Deployment{
 		TypeMeta: util.K8sTypeMetaDeployment,
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      deploymentName,
-			Namespace: config.OperatorNamespace,
-			Labels:    labels(true),
+			Name:        deploymentName,
+			Namespace:   config.OperatorNamespace,
+			Labels:      util.MergeMaps(labels(true), extraConfig.CollectorDeploymentLabels),
+			Annotations: util.MergeMaps(nil, extraConfig.CollectorDeploymentAnnotations),
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &deploymentReplicas,
@@ -1613,7 +1616,8 @@ func assembleCollectorDeployment(
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: templateLabels,
+					Labels:      util.MergeMaps(templateLabels, extraConfig.CollectorDeploymentPodLabels),
+					Annotations: util.MergeMaps(nil, extraConfig.CollectorDeploymentPodAnnotations),
 				},
 				Spec: podSpec,
 			},

--- a/internal/collectors/otelcolresources/desired_state_test.go
+++ b/internal/collectors/otelcolresources/desired_state_test.go
@@ -1429,6 +1429,59 @@ var _ = Describe("The desired state of the OpenTelemetry Collector resources", f
 		Expect(getDeployment(desiredState).Spec.Template.Spec.SecurityContext.Sysctls).To(BeNil())
 	})
 
+	It("should render additional collector labels and annotations", func() {
+		desiredState, err := assembleDesiredStateForUpsert(&oTelColConfig{
+			OperatorNamespace: OperatorNamespace,
+			NamePrefix:        namePrefix,
+			Exporters:         defaultDash0ExportersWithToken(),
+			KubernetesInfrastructureMetricsCollectionEnabled: true,
+			UseHostMetricsReceiver:                           true,
+			Images:                                           TestImages,
+		}, nil, util.ExtraConfig{
+			CollectorDaemonSetLabels:          map[string]string{"ds-label": "ds-label-value"},
+			CollectorDaemonSetAnnotations:     map[string]string{"ds-annotation": "ds-annotation-value"},
+			CollectorDaemonSetPodLabels:       map[string]string{"ds-pod-label": "ds-pod-label-value"},
+			CollectorDaemonSetPodAnnotations:  map[string]string{"ds-pod-annotation": "ds-pod-annotation-value"},
+			CollectorDeploymentLabels:         map[string]string{"deploy-label": "deploy-label-value"},
+			CollectorDeploymentAnnotations:    map[string]string{"deploy-annotation": "deploy-annotation-value"},
+			CollectorDeploymentPodLabels:      map[string]string{"deploy-pod-label": "deploy-pod-label-value"},
+			CollectorDeploymentPodAnnotations: map[string]string{"deploy-pod-annotation": "deploy-pod-annotation-value"},
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		daemonSet := getDaemonSet(desiredState)
+		Expect(daemonSet.ObjectMeta.Labels).To(HaveKeyWithValue("ds-label", "ds-label-value"))
+		// operator-managed labels are still present
+		Expect(daemonSet.ObjectMeta.Labels).To(HaveKeyWithValue("dash0.com/enable", "false"))
+		Expect(daemonSet.ObjectMeta.Annotations).To(HaveKeyWithValue("ds-annotation", "ds-annotation-value"))
+		Expect(daemonSet.Spec.Template.Labels).To(HaveKeyWithValue("ds-pod-label", "ds-pod-label-value"))
+		Expect(daemonSet.Spec.Template.Annotations).To(HaveKeyWithValue("ds-pod-annotation", "ds-pod-annotation-value"))
+
+		deployment := getDeployment(desiredState)
+		Expect(deployment.ObjectMeta.Labels).To(HaveKeyWithValue("deploy-label", "deploy-label-value"))
+		Expect(deployment.ObjectMeta.Labels).To(HaveKeyWithValue("dash0.com/enable", "false"))
+		Expect(deployment.ObjectMeta.Annotations).To(HaveKeyWithValue("deploy-annotation", "deploy-annotation-value"))
+		Expect(deployment.Spec.Template.Labels).To(HaveKeyWithValue("deploy-pod-label", "deploy-pod-label-value"))
+		Expect(deployment.Spec.Template.Annotations).To(HaveKeyWithValue("deploy-pod-annotation", "deploy-pod-annotation-value"))
+	})
+
+	It("should not override operator-managed collector labels with additional labels", func() {
+		desiredState, err := assembleDesiredStateForUpsert(&oTelColConfig{
+			OperatorNamespace: OperatorNamespace,
+			NamePrefix:        namePrefix,
+			Exporters:         defaultDash0ExportersWithToken(),
+			KubernetesInfrastructureMetricsCollectionEnabled: true,
+			UseHostMetricsReceiver:                           true,
+			Images:                                           TestImages,
+		}, nil, util.ExtraConfig{
+			CollectorDaemonSetLabels: map[string]string{"dash0.com/enable": "true"},
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		// the operator-managed value wins over the additional label
+		Expect(getDaemonSet(desiredState).ObjectMeta.Labels).To(HaveKeyWithValue("dash0.com/enable", "false"))
+	})
+
 	It("should render custom probe values", func() {
 		desiredState, err := assembleDesiredStateForUpsert(&oTelColConfig{
 			OperatorNamespace: OperatorNamespace,

--- a/internal/targetallocator/taresources/desired_state.go
+++ b/internal/targetallocator/taresources/desired_state.go
@@ -481,8 +481,10 @@ func assembleDeployment(c *targetAllocatorConfig, taConfigMap *corev1.ConfigMap,
 			Kind:       "Deployment",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      DeploymentName(c.NamePrefix),
-			Namespace: c.OperatorNamespace,
+			Name:        DeploymentName(c.NamePrefix),
+			Namespace:   c.OperatorNamespace,
+			Labels:      util.MergeMaps(labels(), extraConfig.TargetAllocatorLabels),
+			Annotations: util.MergeMaps(nil, extraConfig.TargetAllocatorAnnotations),
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &replicas,
@@ -491,8 +493,8 @@ func assembleDeployment(c *targetAllocatorConfig, taConfigMap *corev1.ConfigMap,
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels:      templateLabels,
-					Annotations: podTemplateAnnotations,
+					Labels:      util.MergeMaps(templateLabels, extraConfig.TargetAllocatorPodLabels),
+					Annotations: util.MergeMaps(podTemplateAnnotations, extraConfig.TargetAllocatorPodAnnotations),
 				},
 				Spec: taPodSpec,
 			},

--- a/internal/targetallocator/taresources/desired_state_test.go
+++ b/internal/targetallocator/taresources/desired_state_test.go
@@ -125,6 +125,46 @@ var _ = Describe("The desired state of the OpenTelemetry TargetAllocator resourc
 		Expect(deploymentAffinityPref[0].Preference.MatchExpressions[0].Values[1]).To(Equal("affinity-key2-value2"))
 	})
 
+	It("should render additional labels and annotations on the workload and the pods", func() {
+		desiredState, err := assembleDesiredStateForUpsert(&targetAllocatorConfig{
+			OperatorNamespace: OperatorNamespace,
+			NamePrefix:        TargetAllocatorPrefixTest,
+			Images:            TestImages,
+		}, nil, util.ExtraConfig{
+			TargetAllocatorLabels:         map[string]string{"ta-label": "ta-label-value"},
+			TargetAllocatorAnnotations:    map[string]string{"ta-annotation": "ta-annotation-value"},
+			TargetAllocatorPodLabels:      map[string]string{"ta-pod-label": "ta-pod-label-value"},
+			TargetAllocatorPodAnnotations: map[string]string{"ta-pod-annotation": "ta-pod-annotation-value"},
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		deployment := getDeployment(desiredState)
+		Expect(deployment.ObjectMeta.Labels).To(HaveKeyWithValue("ta-label", "ta-label-value"))
+		// operator-managed labels are still present
+		Expect(deployment.ObjectMeta.Labels).To(HaveKeyWithValue(util.AppKubernetesIoNameLabel, AppKubernetesIoNameValue))
+		Expect(deployment.ObjectMeta.Annotations).To(HaveKeyWithValue("ta-annotation", "ta-annotation-value"))
+		Expect(deployment.Spec.Template.Labels).To(HaveKeyWithValue("ta-pod-label", "ta-pod-label-value"))
+		Expect(deployment.Spec.Template.Labels).To(HaveKeyWithValue(util.AppKubernetesIoNameLabel, AppKubernetesIoNameValue))
+		Expect(deployment.Spec.Template.Annotations).To(HaveKeyWithValue("ta-pod-annotation", "ta-pod-annotation-value"))
+		// operator-managed pod annotations are still present
+		Expect(deployment.Spec.Template.Annotations).To(HaveKey("ta-config-sha"))
+	})
+
+	It("should not let additional labels override operator-managed labels", func() {
+		desiredState, err := assembleDesiredStateForUpsert(&targetAllocatorConfig{
+			OperatorNamespace: OperatorNamespace,
+			NamePrefix:        TargetAllocatorPrefixTest,
+			Images:            TestImages,
+		}, nil, util.ExtraConfig{
+			TargetAllocatorPodLabels: map[string]string{util.AppKubernetesIoNameLabel: "custom-value"},
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		// the operator-managed value wins over the additional label
+		Expect(getDeployment(desiredState).Spec.Template.Labels).
+			To(HaveKeyWithValue(util.AppKubernetesIoNameLabel, AppKubernetesIoNameValue))
+	})
+
 	It("should add GKE Autopilot allowlist match labels", func() {
 		desiredState, err := assembleDesiredStateForUpsert(&targetAllocatorConfig{
 			OperatorNamespace: OperatorNamespace,

--- a/internal/util/extra_config.go
+++ b/internal/util/extra_config.go
@@ -43,6 +43,11 @@ type ExtraConfig struct {
 	CollectorDaemonSetConfigurationReloaderContainerResources ResourceRequirementsWithGoMemLimit `json:"collectorDaemonSetConfigurationReloaderContainerResources"`
 	CollectorDaemonSetFileLogOffsetSyncContainerResources     ResourceRequirementsWithGoMemLimit `json:"collectorDaemonSetFileLogOffsetSyncContainerResources"`
 
+	CollectorDaemonSetLabels         map[string]string `json:"collectorDaemonSetLabels,omitempty"`
+	CollectorDaemonSetAnnotations    map[string]string `json:"collectorDaemonSetAnnotations,omitempty"`
+	CollectorDaemonSetPodLabels      map[string]string `json:"collectorDaemonSetPodLabels,omitempty"`
+	CollectorDaemonSetPodAnnotations map[string]string `json:"collectorDaemonSetPodAnnotations,omitempty"`
+
 	DaemonSetTolerations  []corev1.Toleration  `json:"daemonSetTolerations,omitempty"`
 	DaemonSetNodeAffinity *corev1.NodeAffinity `json:"daemonSetNodeAffinity,omitempty"`
 
@@ -54,6 +59,11 @@ type ExtraConfig struct {
 
 	CollectorDeploymentCollectorContainerResources             ResourceRequirementsWithGoMemLimit `json:"collectorDeploymentCollectorContainerResources"`
 	CollectorDeploymentConfigurationReloaderContainerResources ResourceRequirementsWithGoMemLimit `json:"collectorDeploymentConfigurationReloaderContainerResources"`
+
+	CollectorDeploymentLabels         map[string]string `json:"collectorDeploymentLabels,omitempty"`
+	CollectorDeploymentAnnotations    map[string]string `json:"collectorDeploymentAnnotations,omitempty"`
+	CollectorDeploymentPodLabels      map[string]string `json:"collectorDeploymentPodLabels,omitempty"`
+	CollectorDeploymentPodAnnotations map[string]string `json:"collectorDeploymentPodAnnotations,omitempty"`
 
 	DeploymentTolerations  []corev1.Toleration  `json:"deploymentTolerations,omitempty"`
 	DeploymentNodeAffinity *corev1.NodeAffinity `json:"deploymentNodeAffinity,omitempty"`
@@ -68,6 +78,10 @@ type ExtraConfig struct {
 	TargetAllocatorMtlsServerCertSecretName string                             `json:"targetAllocatorMtlsServerCertSecretName,omitempty"`
 	TargetAllocatorMtlsClientCertSecretName string                             `json:"targetAllocatorMtlsClientCertSecretName,omitempty"`
 	TargetAllocatorContainerResources       ResourceRequirementsWithGoMemLimit `json:"targetAllocatorContainerResources"`
+	TargetAllocatorLabels                   map[string]string                  `json:"targetAllocatorLabels,omitempty"`
+	TargetAllocatorAnnotations              map[string]string                  `json:"targetAllocatorAnnotations,omitempty"`
+	TargetAllocatorPodLabels                map[string]string                  `json:"targetAllocatorPodLabels,omitempty"`
+	TargetAllocatorPodAnnotations           map[string]string                  `json:"targetAllocatorPodAnnotations,omitempty"`
 	TargetAllocatorTolerations              []corev1.Toleration                `json:"targetAllocatorTolerations,omitempty"`
 	TargetAllocatorNodeAffinity             *corev1.NodeAffinity               `json:"targetAllocatorNodeAffinity,omitempty"`
 

--- a/internal/util/labels.go
+++ b/internal/util/labels.go
@@ -4,6 +4,7 @@
 package util
 
 import (
+	"maps"
 	"regexp"
 	"strings"
 
@@ -222,4 +223,19 @@ func readLabel(objectMeta *metav1.ObjectMeta, key string) (string, bool) {
 		return value, true
 	}
 	return "", false
+}
+
+// MergeMaps returns a new map combining the default labels/annotations managed by the operator with user-provided
+// additional custom labels or annotations. The defaults take precedence, so that custom labels/annotations cannot
+// override defaults (for example the labels used by selectors). The result is always a freshly allocated map (or nil
+// when both inputs are empty); so follow-up mutations in downstream code (for example addCommonMetadata) do not
+// leak back into one of the input maps.
+func MergeMaps(defaults map[string]string, additional map[string]string) map[string]string {
+	if len(additional) == 0 && len(defaults) == 0 {
+		return nil
+	}
+	merged := make(map[string]string, len(defaults)+len(additional))
+	maps.Copy(merged, additional)
+	maps.Copy(merged, defaults)
+	return merged
 }

--- a/internal/util/labels_test.go
+++ b/internal/util/labels_test.go
@@ -84,3 +84,61 @@ var _ = Describe("labels", func() {
 		})
 	})
 })
+
+var _ = Describe("MergeMaps", func() {
+	It("should return nil when both maps are empty", func() {
+		Expect(MergeMaps(nil, nil)).To(BeNil())
+		Expect(MergeMaps(map[string]string{}, map[string]string{})).To(BeNil())
+	})
+
+	It("should return the defaults map when there are no custom entries", func() {
+		defaults := map[string]string{"default-key": "default-value"}
+		Expect(MergeMaps(defaults, nil)).To(Equal(defaults))
+		Expect(MergeMaps(defaults, map[string]string{})).To(Equal(defaults))
+	})
+
+	It("should return the custom map when there are no default entries", func() {
+		custom := map[string]string{"custom-key": "custom-value"}
+		Expect(MergeMaps(nil, custom)).To(Equal(custom))
+		Expect(MergeMaps(map[string]string{}, custom)).To(Equal(custom))
+	})
+
+	It("should merge default and custom entries when there is no overlap", func() {
+		defaults := map[string]string{"default-key": "default-value"}
+		custom := map[string]string{"custom-key": "custom-value"}
+		Expect(MergeMaps(defaults, custom)).To(Equal(map[string]string{
+			"default-key": "default-value",
+			"custom-key":  "custom-value",
+		}))
+	})
+
+	It("should let default entries take precedence over custom entries on conflicting keys", func() {
+		defaults := map[string]string{"shared-key": "default-value", "default-key": "default-value"}
+		custom := map[string]string{"shared-key": "custom-value", "custom-key": "custom-value"}
+		Expect(MergeMaps(defaults, custom)).To(Equal(map[string]string{
+			"shared-key":  "default-value",
+			"default-key": "default-value",
+			"custom-key":  "custom-value",
+		}))
+	})
+
+	It("should not mutate the input maps", func() {
+		defaults := map[string]string{"default-key": "default-value"}
+		custom := map[string]string{"custom-key": "custom-value"}
+		MergeMaps(defaults, custom)
+		Expect(defaults).To(Equal(map[string]string{"default-key": "default-value"}))
+		Expect(custom).To(Equal(map[string]string{"custom-key": "custom-value"}))
+	})
+
+	It("should always return a copy that can be mutated without affecting the inputs", func() {
+		defaults := map[string]string{"default-key": "default-value"}
+		mergedDefaultsOnly := MergeMaps(defaults, nil)
+		mergedDefaultsOnly["injected-key"] = "injected-value"
+		Expect(defaults).To(Equal(map[string]string{"default-key": "default-value"}))
+
+		custom := map[string]string{"custom-key": "custom-value"}
+		mergedCustomOnly := MergeMaps(nil, custom)
+		mergedCustomOnly["injected-key"] = "injected-value"
+		Expect(custom).To(Equal(map[string]string{"custom-key": "custom-value"}))
+	})
+})


### PR DESCRIPTION
The Helm chart now allows adding additional custom labels and
annotations on the collectors and on the target allocator. Custom labels
and annotations are supported both on the workload level
(e.g. daemonset, deployment) and on the pod level.