### PR TITLE
feat(agent0-connector): allow custom labels and annotations

### DIFF
--- a/helm-chart/dash0-operator/docs/advanced-configuration.md
+++ b/helm-chart/dash0-operator/docs/advanced-configuration.md
@@ -293,7 +293,7 @@ operator:
 
 ### Adding Custom Labels and Annotations to the Collector Resources
 
-Additional labels and annotations can be added to the collector resources and the target-allocator resource managed by the operator, both to the workload objects (the daemonset and the deployments) and to their pods.
+Additional labels and annotations can be added to the collector resources, the target-allocator resource, and the agent0-connector resource managed by the operator, both to the workload objects (the daemonset and the deployments) and to their pods.
 These are merged with the labels and annotations the operator sets itself; the operator-managed entries always take precedence, so they cannot be overridden.
 
 ```yaml
@@ -321,6 +321,18 @@ operator:
 
   targetAllocator:
     # labels/annotations for the target-allocator deployment
+    labels:
+      my-label: my-value
+    annotations:
+      my-annotation: my-value
+    podLabels:
+      my-pod-label: my-value
+    podAnnotations:
+      my-pod-annotation: my-value
+
+  agent0Connector:
+    enabled: true
+    # [... other settings like serverAddress etc.]
     labels:
       my-label: my-value
     annotations:

--- a/helm-chart/dash0-operator/templates/operator/extra-config-map.yaml
+++ b/helm-chart/dash0-operator/templates/operator/extra-config-map.yaml
@@ -157,6 +157,22 @@ data:
     barkerNodeAffinity:
       {{- toYaml .Values.operator.intelligentEdge.barker.nodeAffinity | nindent 6 }}
 {{- end }}
+{{- if .Values.operator.agent0Connector.labels }}
+    agent0ConnectorLabels:
+      {{- toYaml .Values.operator.agent0Connector.labels | nindent 6 }}
+{{- end }}
+{{- if .Values.operator.agent0Connector.annotations }}
+    agent0ConnectorAnnotations:
+      {{- toYaml .Values.operator.agent0Connector.annotations | nindent 6 }}
+{{- end }}
+{{- if .Values.operator.agent0Connector.podLabels }}
+    agent0ConnectorPodLabels:
+      {{- toYaml .Values.operator.agent0Connector.podLabels | nindent 6 }}
+{{- end }}
+{{- if .Values.operator.agent0Connector.podAnnotations }}
+    agent0ConnectorPodAnnotations:
+      {{- toYaml .Values.operator.agent0Connector.podAnnotations | nindent 6 }}
+{{- end }}
 
     {{- if .Values.operator.autoMonitorNamespaces.monitoringTemplate }}
     {{- fail "Error: operator.autoMonitorNamespaces.monitoringTemplate is not a valid setting. The monitoring template is a top-level operator setting; please use operator.monitoringTemplate instead." -}}

--- a/helm-chart/dash0-operator/tests/operator/extra-config-map_test.yaml
+++ b/helm-chart/dash0-operator/tests/operator/extra-config-map_test.yaml
@@ -686,6 +686,46 @@ tests:
           path: data['extra.yaml']
           pattern: targetAllocatorPodAnnotations
 
+  - it: should render agent0-connector labels and annotations when set
+    set:
+      operator:
+        agent0Connector:
+          labels:
+            a0c-label: a0c-label-value
+          annotations:
+            a0c-annotation: a0c-annotation-value
+          podLabels:
+            a0c-pod-label: a0c-pod-label-value
+          podAnnotations:
+            a0c-pod-annotation: a0c-pod-annotation-value
+    asserts:
+      - matchRegex:
+          path: data['extra.yaml']
+          pattern: |-
+            agent0ConnectorLabels:
+              a0c-label: a0c-label-value
+            agent0ConnectorAnnotations:
+              a0c-annotation: a0c-annotation-value
+            agent0ConnectorPodLabels:
+              a0c-pod-label: a0c-pod-label-value
+            agent0ConnectorPodAnnotations:
+              a0c-pod-annotation: a0c-pod-annotation-value
+
+  - it: should not render agent0-connector labels and annotations by default
+    asserts:
+      - notMatchRegex:
+          path: data['extra.yaml']
+          pattern: agent0ConnectorLabels
+      - notMatchRegex:
+          path: data['extra.yaml']
+          pattern: agent0ConnectorAnnotations
+      - notMatchRegex:
+          path: data['extra.yaml']
+          pattern: agent0ConnectorPodLabels
+      - notMatchRegex:
+          path: data['extra.yaml']
+          pattern: agent0ConnectorPodAnnotations
+
   # This test also verifies that the collectorFilelogOffsetStorageVolume is not rendered if
   # operator.collectors.filelogOffsetSyncStorageVolume isn't set as a value.
   - it: should render custom resource settings from legacy paths

--- a/helm-chart/dash0-operator/values.yaml
+++ b/helm-chart/dash0-operator/values.yaml
@@ -1145,3 +1145,15 @@ operator:
     # Disables TLS for the agent0-connector workload's connection to the Dash0 backend, connecting via plaintext
     # instead. This is only intended for local development.
     insecure: false
+
+    # Additional labels to be set on the agent0-connector deployment managed by the operator.
+    labels: {}
+
+    # Additional annotations to be set on the agent0-connector deployment managed by the operator.
+    annotations: {}
+
+    # Additional labels to be set on the agent0-connector deployment pods managed by the operator.
+    podLabels: {}
+
+    # Additional annotations to be set on the agent0-connector deployment pods managed by the operator.
+    podAnnotations: {}

--- a/internal/agent0connector/a0cresources/a0c_resources.go
+++ b/internal/agent0connector/a0cresources/a0c_resources.go
@@ -24,6 +24,7 @@ type Agent0ConnectorResourceManager struct {
 	scheme                    *runtime.Scheme
 	operatorManagerDeployment *appsv1.Deployment
 	agent0ConnectorConfig     util.Agent0ConnectorConfig
+	extraConfig               util.ExtraConfig
 }
 
 func NewAgent0ConnectorResourceManager(
@@ -31,12 +32,14 @@ func NewAgent0ConnectorResourceManager(
 	scheme *runtime.Scheme,
 	operatorManagerDeployment *appsv1.Deployment,
 	agent0ConnectorConfig util.Agent0ConnectorConfig,
+	extraConfig util.ExtraConfig,
 ) *Agent0ConnectorResourceManager {
 	return &Agent0ConnectorResourceManager{
 		Client:                    k8sClient,
 		scheme:                    scheme,
 		operatorManagerDeployment: operatorManagerDeployment,
 		agent0ConnectorConfig:     agent0ConnectorConfig,
+		extraConfig:               extraConfig,
 	}
 }
 
@@ -54,7 +57,7 @@ func (m *Agent0ConnectorResourceManager) CreateOrUpdateAgent0ConnectorResources(
 		return false, false, err
 	}
 
-	desiredState := assembleDesiredState(&m.agent0ConnectorConfig, &authTokenEnvVar)
+	desiredState := assembleDesiredState(&m.agent0ConnectorConfig, &authTokenEnvVar, m.extraConfig)
 
 	resourcesHaveBeenCreated := false
 	resourcesHaveBeenUpdated := false
@@ -181,7 +184,7 @@ func (m *Agent0ConnectorResourceManager) DeleteResources(
 			"Deleting the agent0-connector Kubernetes resources in the Dash0 operator namespace %s (if existing).",
 			m.agent0ConnectorConfig.OperatorNamespace,
 		))
-	desiredResources := assembleDesiredState(&m.agent0ConnectorConfig, nil)
+	desiredResources := assembleDesiredState(&m.agent0ConnectorConfig, nil, m.extraConfig)
 	var allErrors []error
 	resourcesHaveBeenDeleted := false
 	for _, wrapper := range desiredResources {

--- a/internal/agent0connector/a0cresources/a0c_resources_test.go
+++ b/internal/agent0connector/a0cresources/a0c_resources_test.go
@@ -273,6 +273,7 @@ func newAgent0ConnectorResourceManager(authorization dash0common.Authorization) 
 			Authorization:     authorization,
 			DevelopmentMode:   true,
 		},
+		util.ExtraConfig{},
 	)
 }
 

--- a/internal/agent0connector/a0cresources/desired_state.go
+++ b/internal/agent0connector/a0cresources/desired_state.go
@@ -46,12 +46,16 @@ type clientObject struct {
 	object client.Object
 }
 
-func assembleDesiredState(config *util.Agent0ConnectorConfig, authTokenEnvVar *corev1.EnvVar) []clientObject {
+func assembleDesiredState(
+	config *util.Agent0ConnectorConfig,
+	authTokenEnvVar *corev1.EnvVar,
+	extraConfig util.ExtraConfig,
+) []clientObject {
 	desiredState := make([]clientObject, 0, 4)
 	desiredState = append(desiredState, addCommonMetadata(assembleServiceAccount(config)))
 	desiredState = append(desiredState, addCommonMetadata(assembleClusterRole(config)))
 	desiredState = append(desiredState, addCommonMetadata(assembleClusterRoleBinding(config)))
-	desiredState = append(desiredState, addCommonMetadata(assembleDeployment(config, authTokenEnvVar)))
+	desiredState = append(desiredState, addCommonMetadata(assembleDeployment(config, authTokenEnvVar, extraConfig)))
 	return desiredState
 }
 
@@ -135,7 +139,11 @@ func assembleClusterRoleBinding(c *util.Agent0ConnectorConfig) *rbacv1.ClusterRo
 	}
 }
 
-func assembleDeployment(c *util.Agent0ConnectorConfig, authTokenEnvVar *corev1.EnvVar) *appsv1.Deployment {
+func assembleDeployment(
+	c *util.Agent0ConnectorConfig,
+	authTokenEnvVar *corev1.EnvVar,
+	extraConfig util.ExtraConfig,
+) *appsv1.Deployment {
 	replicas := int32(1)
 
 	container := corev1.Container{
@@ -235,9 +243,10 @@ func assembleDeployment(c *util.Agent0ConnectorConfig, authTokenEnvVar *corev1.E
 			Kind:       "Deployment",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      DeploymentName(c.NamePrefix),
-			Namespace: c.OperatorNamespace,
-			Labels:    labels(),
+			Name:        DeploymentName(c.NamePrefix),
+			Namespace:   c.OperatorNamespace,
+			Labels:      util.MergeMaps(labels(), extraConfig.Agent0ConnectorLabels),
+			Annotations: util.MergeMaps(nil, extraConfig.Agent0ConnectorAnnotations),
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &replicas,
@@ -246,7 +255,8 @@ func assembleDeployment(c *util.Agent0ConnectorConfig, authTokenEnvVar *corev1.E
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: labels(),
+					Labels:      util.MergeMaps(labels(), extraConfig.Agent0ConnectorPodLabels),
+					Annotations: util.MergeMaps(nil, extraConfig.Agent0ConnectorPodAnnotations),
 				},
 				Spec: podSpec,
 			},

--- a/internal/agent0connector/a0cresources/desired_state_test.go
+++ b/internal/agent0connector/a0cresources/desired_state_test.go
@@ -52,7 +52,7 @@ func testConfig() *util.Agent0ConnectorConfig {
 
 var _ = Describe("The desired state of the agent0-connector resources", func() {
 	It("renders exactly the expected set of resources with the expected names", func() {
-		desiredState := assembleDesiredState(testConfig(), authTokenEnvVar)
+		desiredState := assembleDesiredState(testConfig(), authTokenEnvVar, util.ExtraConfig{})
 
 		Expect(desiredState).To(HaveLen(4))
 		Expect(getServiceAccount(desiredState).Name).To(Equal(testNamePrefix + "-agent0-connector-sa"))
@@ -63,14 +63,14 @@ var _ = Describe("The desired state of the agent0-connector resources", func() {
 	})
 
 	It("deploys the namespaced resources into the operator namespace", func() {
-		desiredState := assembleDesiredState(testConfig(), authTokenEnvVar)
+		desiredState := assembleDesiredState(testConfig(), authTokenEnvVar, util.ExtraConfig{})
 
 		Expect(getServiceAccount(desiredState).Namespace).To(Equal(testOperatorNamespace))
 		Expect(getDeployment(desiredState).Namespace).To(Equal(testOperatorNamespace))
 	})
 
 	It("adds the ArgoCD prune/compare annotations to all resources", func() {
-		desiredState := assembleDesiredState(testConfig(), authTokenEnvVar)
+		desiredState := assembleDesiredState(testConfig(), authTokenEnvVar, util.ExtraConfig{})
 
 		for _, wrapper := range desiredState {
 			annotations := wrapper.object.GetAnnotations()
@@ -81,7 +81,7 @@ var _ = Describe("The desired state of the agent0-connector resources", func() {
 
 	Describe("the cluster role", func() {
 		It("grants cluster-wide read-only access and no write access", func() {
-			clusterRole := getClusterRole(assembleDesiredState(testConfig(), authTokenEnvVar))
+			clusterRole := getClusterRole(assembleDesiredState(testConfig(), authTokenEnvVar, util.ExtraConfig{}))
 
 			Expect(clusterRole.Rules).ToNot(BeEmpty())
 			for _, rule := range clusterRole.Rules {
@@ -99,7 +99,7 @@ var _ = Describe("The desired state of the agent0-connector resources", func() {
 		})
 
 		It("covers all resources in all API groups plus non-resource URLs", func() {
-			clusterRole := getClusterRole(assembleDesiredState(testConfig(), authTokenEnvVar))
+			clusterRole := getClusterRole(assembleDesiredState(testConfig(), authTokenEnvVar, util.ExtraConfig{}))
 
 			hasResourceWildcard := false
 			hasNonResourceURLs := false
@@ -120,7 +120,7 @@ var _ = Describe("The desired state of the agent0-connector resources", func() {
 	})
 
 	It("binds the cluster role to the agent0-connector service account", func() {
-		desiredState := assembleDesiredState(testConfig(), authTokenEnvVar)
+		desiredState := assembleDesiredState(testConfig(), authTokenEnvVar, util.ExtraConfig{})
 		clusterRoleBinding := getClusterRoleBinding(desiredState)
 
 		Expect(clusterRoleBinding.RoleRef.Kind).To(Equal("ClusterRole"))
@@ -133,7 +133,7 @@ var _ = Describe("The desired state of the agent0-connector resources", func() {
 
 	Describe("the deployment", func() {
 		It("uses the configured image, pull policy, and service account", func() {
-			desiredState := assembleDesiredState(testConfig(), authTokenEnvVar)
+			desiredState := assembleDesiredState(testConfig(), authTokenEnvVar, util.ExtraConfig{})
 			deployment := getDeployment(desiredState)
 
 			Expect(*deployment.Spec.Replicas).To(Equal(int32(1)))
@@ -145,18 +145,18 @@ var _ = Describe("The desired state of the agent0-connector resources", func() {
 		})
 
 		It("passes the pseudo cluster UID as the K8S_CLUSTER_UID environment variable", func() {
-			container := getDeployment(assembleDesiredState(testConfig(), authTokenEnvVar)).Spec.Template.Spec.Containers[0]
+			container := getDeployment(assembleDesiredState(testConfig(), authTokenEnvVar, util.ExtraConfig{})).Spec.Template.Spec.Containers[0]
 			Expect(container.Env).To(ContainElement(corev1.EnvVar{Name: "K8S_CLUSTER_UID", Value: testPseudoClusterUid}))
 		})
 
 		It("passes the server address as the DASH0_AGENT0_CONNECTOR_SERVER_ADDRESS environment variable", func() {
-			container := getDeployment(assembleDesiredState(testConfig(), authTokenEnvVar)).Spec.Template.Spec.Containers[0]
+			container := getDeployment(assembleDesiredState(testConfig(), authTokenEnvVar, util.ExtraConfig{})).Spec.Template.Spec.Containers[0]
 			Expect(container.Env).To(ContainElement(
 				corev1.EnvVar{Name: "DASH0_AGENT0_CONNECTOR_SERVER_ADDRESS", Value: Agent0ConnectorServerAddress}))
 		})
 
 		It("does not set the DASH0_AGENT0_CONNECTOR_INSECURE environment variable by default", func() {
-			container := getDeployment(assembleDesiredState(testConfig(), authTokenEnvVar)).Spec.Template.Spec.Containers[0]
+			container := getDeployment(assembleDesiredState(testConfig(), authTokenEnvVar, util.ExtraConfig{})).Spec.Template.Spec.Containers[0]
 			for _, envVar := range container.Env {
 				Expect(envVar.Name).ToNot(Equal("DASH0_AGENT0_CONNECTOR_INSECURE"))
 			}
@@ -165,20 +165,20 @@ var _ = Describe("The desired state of the agent0-connector resources", func() {
 		It("sets DASH0_AGENT0_CONNECTOR_INSECURE when TLS is disabled", func() {
 			config := testConfig()
 			config.Insecure = true
-			container := getDeployment(assembleDesiredState(config, authTokenEnvVar)).Spec.Template.Spec.Containers[0]
+			container := getDeployment(assembleDesiredState(config, authTokenEnvVar, util.ExtraConfig{})).Spec.Template.Spec.Containers[0]
 			Expect(container.Env).To(ContainElement(
 				corev1.EnvVar{Name: "DASH0_AGENT0_CONNECTOR_INSECURE", Value: "true"}))
 		})
 
 		It("does not set the DASH0_AGENT0_CONNECTOR_AUTH_TOKEN environment variable when no authorization is configured", func() {
-			container := getDeployment(assembleDesiredState(testConfig(), nil)).Spec.Template.Spec.Containers[0]
+			container := getDeployment(assembleDesiredState(testConfig(), nil, util.ExtraConfig{})).Spec.Template.Spec.Containers[0]
 			for _, envVar := range container.Env {
 				Expect(envVar.Name).ToNot(Equal("DASH0_AGENT0_CONNECTOR_AUTH_TOKEN"))
 			}
 		})
 
 		It("mounts a writable tmp volume for kubectl's cache", func() {
-			podSpec := getDeployment(assembleDesiredState(testConfig(), authTokenEnvVar)).Spec.Template.Spec
+			podSpec := getDeployment(assembleDesiredState(testConfig(), authTokenEnvVar, util.ExtraConfig{})).Spec.Template.Spec
 			container := podSpec.Containers[0]
 			Expect(container.Env).To(ContainElement(corev1.EnvVar{Name: "DASH0_KUBECTL_TMP", Value: "/tmp"}))
 			Expect(container.VolumeMounts).To(ContainElement(corev1.VolumeMount{Name: "tmp", MountPath: "/tmp"}))
@@ -189,7 +189,7 @@ var _ = Describe("The desired state of the agent0-connector resources", func() {
 		})
 
 		It("applies a restrictive container security context", func() {
-			container := getDeployment(assembleDesiredState(testConfig(), authTokenEnvVar)).Spec.Template.Spec.Containers[0]
+			container := getDeployment(assembleDesiredState(testConfig(), authTokenEnvVar, util.ExtraConfig{})).Spec.Template.Spec.Containers[0]
 			sc := container.SecurityContext
 			Expect(sc).ToNot(BeNil())
 			Expect(*sc.AllowPrivilegeEscalation).To(BeFalse())
@@ -200,13 +200,41 @@ var _ = Describe("The desired state of the agent0-connector resources", func() {
 		})
 
 		It("applies a restrictive pod security context", func() {
-			podSpec := getDeployment(assembleDesiredState(testConfig(), authTokenEnvVar)).Spec.Template.Spec
+			podSpec := getDeployment(assembleDesiredState(testConfig(), authTokenEnvVar, util.ExtraConfig{})).Spec.Template.Spec
 			sc := podSpec.SecurityContext
 			Expect(sc).ToNot(BeNil())
 			Expect(*sc.RunAsNonRoot).To(BeTrue())
 			Expect(*sc.RunAsUser).To(Equal(int64(65532)))
 			Expect(*sc.RunAsGroup).To(Equal(int64(0)))
 			Expect(sc.SeccompProfile.Type).To(Equal(corev1.SeccompProfileTypeRuntimeDefault))
+		})
+
+		It("renders additional labels and annotations on the workload and the pods", func() {
+			deployment := getDeployment(assembleDesiredState(testConfig(), authTokenEnvVar, util.ExtraConfig{
+				Agent0ConnectorLabels:         map[string]string{"a0c-label": "a0c-label-value"},
+				Agent0ConnectorAnnotations:    map[string]string{"a0c-annotation": "a0c-annotation-value"},
+				Agent0ConnectorPodLabels:      map[string]string{"a0c-pod-label": "a0c-pod-label-value"},
+				Agent0ConnectorPodAnnotations: map[string]string{"a0c-pod-annotation": "a0c-pod-annotation-value"},
+			}))
+
+			Expect(deployment.ObjectMeta.Labels).To(HaveKeyWithValue("a0c-label", "a0c-label-value"))
+			// operator-managed labels are still present
+			Expect(deployment.ObjectMeta.Labels).To(HaveKeyWithValue(util.AppKubernetesIoNameLabel, appKubernetesIoNameValue))
+			Expect(deployment.ObjectMeta.Annotations).To(HaveKeyWithValue("a0c-annotation", "a0c-annotation-value"))
+			Expect(deployment.Spec.Template.Labels).To(HaveKeyWithValue("a0c-pod-label", "a0c-pod-label-value"))
+			Expect(deployment.Spec.Template.Labels).To(HaveKeyWithValue(util.AppKubernetesIoNameLabel, appKubernetesIoNameValue))
+			Expect(deployment.Spec.Template.Annotations).To(HaveKeyWithValue("a0c-pod-annotation", "a0c-pod-annotation-value"))
+		})
+
+		It("does not let additional labels override operator-managed labels", func() {
+			deployment := getDeployment(assembleDesiredState(testConfig(), authTokenEnvVar, util.ExtraConfig{
+				Agent0ConnectorLabels:    map[string]string{util.AppKubernetesIoNameLabel: "custom-value"},
+				Agent0ConnectorPodLabels: map[string]string{util.AppKubernetesIoNameLabel: "custom-value"},
+			}))
+
+			// the operator-managed value wins over the additional label
+			Expect(deployment.ObjectMeta.Labels).To(HaveKeyWithValue(util.AppKubernetesIoNameLabel, appKubernetesIoNameValue))
+			Expect(deployment.Spec.Template.Labels).To(HaveKeyWithValue(util.AppKubernetesIoNameLabel, appKubernetesIoNameValue))
 		})
 	})
 })

--- a/internal/agent0connector/agent0connector_manager_test.go
+++ b/internal/agent0connector/agent0connector_manager_test.go
@@ -38,6 +38,7 @@ func newResourceManager() *a0cresources.Agent0ConnectorResourceManager {
 			ServerAddress:     "https://example.com:4317",
 			Authorization:     dash0common.Authorization{Token: &token},
 		},
+		util.ExtraConfig{},
 	)
 }
 

--- a/internal/startup/operator_manager_startup.go
+++ b/internal/startup/operator_manager_startup.go
@@ -2009,6 +2009,7 @@ func setupAgent0ConnectorManager(
 		mgr.GetScheme(),
 		operatorDeploymentSelfReference,
 		agent0ConnectorConfig,
+		extraConfig,
 	)
 	agent0ConnectorManager := agent0connector.NewAgent0ConnectorManager(
 		k8sClient,

--- a/internal/util/extra_config.go
+++ b/internal/util/extra_config.go
@@ -89,6 +89,11 @@ type ExtraConfig struct {
 	BarkerTolerations        []corev1.Toleration                `json:"barkerTolerations,omitempty"`
 	BarkerNodeAffinity       *corev1.NodeAffinity               `json:"barkerNodeAffinity,omitempty"`
 
+	Agent0ConnectorLabels         map[string]string `json:"agent0ConnectorLabels,omitempty"`
+	Agent0ConnectorAnnotations    map[string]string `json:"agent0ConnectorAnnotations,omitempty"`
+	Agent0ConnectorPodLabels      map[string]string `json:"agent0ConnectorPodLabels,omitempty"`
+	Agent0ConnectorPodAnnotations map[string]string `json:"agent0ConnectorPodAnnotations,omitempty"`
+
 	// Actually we would like to use the type *dash0v1alpha1.MonitoringTemplate here, but that leads to circular package
 	// dependencies. We should revisit how to untangle this.
 	MonitoringTemplateRaw *json.RawMessage `json:"monitoringTemplate,omitempty"`


### PR DESCRIPTION
 The Helm chart now allows adding additional custom labels and annotations on the agent0-connector. Custom labels and annotations are supported both on the agent0-connector deployment and on the pod level.