### PR TITLE
test: fix 1s wait on OTel SDK shutdown in unit tests

### DIFF
--- a/images/pkg/common/otel.go
+++ b/images/pkg/common/otel.go
@@ -183,10 +183,38 @@ func createLogExporterFromProtocolEnvVar(ctx context.Context, protocol string) s
 	return logExporter
 }
 
+// ExporterFactory creates the metric and log exporters used by InitOTelSdkWithConfig. The production code uses the
+// default OTLP-based implementation (see NewDefaultExporterFactory). Tests can inject an alternative factory (e.g. a
+// no-op exporter) to avoid network I/O and the blocking shutdown that happens when the actual OTLP gRPC exporters try
+// (and fail) to flush telemetry to an unreachable test endpoint.
+type ExporterFactory interface {
+	CreateMetricExporter(ctx context.Context, oTelSdkConfig *OTelSdkConfig) sdkmetric.Exporter
+	CreateLogExporter(ctx context.Context, oTelSdkConfig *OTelSdkConfig) sdklog.Exporter
+}
+
+type otlpExporterFactory struct{}
+
+func (otlpExporterFactory) CreateMetricExporter(ctx context.Context, oTelSdkConfig *OTelSdkConfig) sdkmetric.Exporter {
+	return createMetricExporterFromConfig(ctx, oTelSdkConfig)
+}
+
+func (otlpExporterFactory) CreateLogExporter(ctx context.Context, oTelSdkConfig *OTelSdkConfig) sdklog.Exporter {
+	return createLogExporterFromConfig(ctx, oTelSdkConfig)
+}
+
+var defaultExporterFactory ExporterFactory = otlpExporterFactory{}
+
+// NewDefaultExporterFactory returns the production ExporterFactory, which creates real OTLP gRPC/HTTP exporters from
+// the given configuration.
+func NewDefaultExporterFactory() ExporterFactory {
+	return defaultExporterFactory
+}
+
 func InitOTelSdkWithConfig(
 	ctx context.Context,
 	meterName string,
 	oTelSdkConfig *OTelSdkConfig,
+	exporterFactory ExporterFactory,
 ) (*otelzap.Core, otelmetric.Meter) {
 	// InitOTelSdkWithConfig is used in the operator manager process. Depending on changes to the operator configuration
 	// resource (in particular, spec.selfMonitoring.enabled and the export config), the OTel SDK might need to be
@@ -197,13 +225,17 @@ func InitOTelSdkWithConfig(
 		oTelSdkMutex.Unlock()
 	}()
 
+	if exporterFactory == nil {
+		exporterFactory = defaultExporterFactory
+	}
+
 	if oTelSdkConfig.Endpoint != "" {
 		// We currently ignore the log level from the config, setting a log level is cumbersome with OTel Go SDK.
 		// Would need to be a new logger with the correct level.
 		// otel.SetLogger(logger)
 
-		metricExporter := createMetricExporterFromConfig(ctx, oTelSdkConfig)
-		logExporter := createLogExporterFromConfig(ctx, oTelSdkConfig)
+		metricExporter := exporterFactory.CreateMetricExporter(ctx, oTelSdkConfig)
+		logExporter := exporterFactory.CreateLogExporter(ctx, oTelSdkConfig)
 
 		resourceAttributes := assembleResource(
 			ctx,

--- a/internal/controller/operator_configuration_controller_test.go
+++ b/internal/controller/operator_configuration_controller_test.go
@@ -1315,7 +1315,7 @@ func createReconciler(apiClient1 *DummyApiClient, apiClient2 *DummyApiClient) (*
 		k8sClient, clientset, util.ExtraConfigDefaults, false, targetallocatorResourceManager,
 	)
 	delegatingZapCoreWrapper := zaputil.NewDelegatingZapCoreWrapper()
-	otelSdkStarter := selfmonitoringapiaccess.NewOTelSdkStarter(delegatingZapCoreWrapper)
+	otelSdkStarter := selfmonitoringapiaccess.NewOTelSdkStarter(delegatingZapCoreWrapper, NewNoopExporterFactory())
 
 	operatorConfigurationReconciler := NewOperatorConfigurationReconciler(
 		k8sClient,

--- a/internal/selfmonitoringapiaccess/otel_init_wait.go
+++ b/internal/selfmonitoringapiaccess/otel_init_wait.go
@@ -40,6 +40,7 @@ type OTelSdkStarter struct {
 	oTelSdkConfigInput       atomic.Pointer[OTelSdkConfigInput]
 	activeOTelSdkConfig      atomic.Pointer[common.OTelSdkConfig]
 	delegatingZapCoreWrapper *zaputil.DelegatingZapCoreWrapper
+	exporterFactory          common.ExporterFactory
 
 	startOrRestartOTelSdkChannel chan *common.OTelSdkConfig
 	shutDownChannel              chan bool
@@ -57,12 +58,17 @@ var (
 
 func NewOTelSdkStarter(
 	delegatingZapCoreWrapper *zaputil.DelegatingZapCoreWrapper,
+	exporterFactory common.ExporterFactory,
 ) *OTelSdkStarter {
+	if exporterFactory == nil {
+		exporterFactory = common.NewDefaultExporterFactory()
+	}
 	starter := &OTelSdkStarter{
 		sdkIsActive:                  atomic.Bool{},
 		oTelSdkConfigInput:           atomic.Pointer[OTelSdkConfigInput]{},
 		activeOTelSdkConfig:          atomic.Pointer[common.OTelSdkConfig]{},
 		delegatingZapCoreWrapper:     delegatingZapCoreWrapper,
+		exporterFactory:              exporterFactory,
 		startOrRestartOTelSdkChannel: make(chan *common.OTelSdkConfig),
 		shutDownChannel:              make(chan bool),
 	}
@@ -119,7 +125,7 @@ func (s *OTelSdkStarter) waitForCompleteOTelSDKConfiguration(
 		case config := <-s.startOrRestartOTelSdkChannel:
 			s.UpdateOTelSdkState(true)
 			s.activeOTelSdkConfig.Store(config)
-			startOTelSDK(s.delegatingZapCoreWrapper, selfMonitoringMetricsClients, config)
+			startOTelSDK(s.delegatingZapCoreWrapper, selfMonitoringMetricsClients, config, s.exporterFactory)
 
 		case <-s.shutDownChannel:
 			return
@@ -255,6 +261,7 @@ func startOTelSDK(
 	delegatingZapCoreWrapper *zaputil.DelegatingZapCoreWrapper,
 	selfMonitoringMetricsClients []SelfMonitoringMetricsClient,
 	oTelSdkConfig *common.OTelSdkConfig,
+	exporterFactory common.ExporterFactory,
 ) {
 	ctx := context.Background()
 	logger := logd.FromContext(ctx)
@@ -264,6 +271,7 @@ func startOTelSDK(
 			ctx,
 			meterName,
 			oTelSdkConfig,
+			exporterFactory,
 		)
 
 	// Setting the zap OTel bridge as the delegate logger core will spool all messages that have been only logged to

--- a/internal/selfmonitoringapiaccess/otel_init_wait_test.go
+++ b/internal/selfmonitoringapiaccess/otel_init_wait_test.go
@@ -41,7 +41,7 @@ var _ = Describe(
 
 		It(
 			"should start with empty values", func() {
-				oTelSdkStarter := NewOTelSdkStarter(zaputil.NewDelegatingZapCoreWrapper())
+				oTelSdkStarter := NewOTelSdkStarter(zaputil.NewDelegatingZapCoreWrapper(), NewNoopExporterFactory())
 				Expect(oTelSdkStarter.sdkIsActive.Load()).To(BeFalse())
 				Expect(*oTelSdkStarter.oTelSdkConfigInput.Load()).To(Equal(OTelSdkConfigInput{}))
 				Expect(oTelSdkStarter.activeOTelSdkConfig.Load()).To(BeNil())
@@ -55,7 +55,7 @@ var _ = Describe(
 
 				BeforeEach(
 					func() {
-						oTelSdkStarter = NewOTelSdkStarter(zaputil.NewDelegatingZapCoreWrapper())
+						oTelSdkStarter = NewOTelSdkStarter(zaputil.NewDelegatingZapCoreWrapper(), NewNoopExporterFactory())
 						mockChannel = make(chan *common.OTelSdkConfig, 100)
 						oTelSdkStarter.startOrRestartOTelSdkChannel = mockChannel
 					},
@@ -301,7 +301,7 @@ var _ = Describe(
 				BeforeEach(
 					func() {
 						delegatingZapCoreWrapper = zaputil.NewDelegatingZapCoreWrapper()
-						oTelSdkStarter = NewOTelSdkStarter(delegatingZapCoreWrapper)
+						oTelSdkStarter = NewOTelSdkStarter(delegatingZapCoreWrapper, NewNoopExporterFactory())
 					},
 				)
 

--- a/internal/startup/operator_manager_startup.go
+++ b/internal/startup/operator_manager_startup.go
@@ -44,6 +44,7 @@ import (
 
 	dash0v1alpha1 "github.com/dash0hq/dash0-operator/api/operator/v1alpha1"
 	dash0v1beta1 "github.com/dash0hq/dash0-operator/api/operator/v1beta1"
+	"github.com/dash0hq/dash0-operator/images/pkg/common"
 	"github.com/dash0hq/dash0-operator/internal/allowlistreadycheck"
 	"github.com/dash0hq/dash0-operator/internal/collectors"
 	"github.com/dash0hq/dash0-operator/internal/collectors/otelcolresources"
@@ -1679,7 +1680,7 @@ func startDash0Controllers(
 	}
 
 	setupLog.Info("Creating the self-monitoring OTel SDK starter.")
-	oTelSdkStarter = selfmonitoringapiaccess.NewOTelSdkStarter(delegatingZapCoreWrapper)
+	oTelSdkStarter = selfmonitoringapiaccess.NewOTelSdkStarter(delegatingZapCoreWrapper, common.NewDefaultExporterFactory())
 
 	setupLog.Info("Creating the operator configuration resource reconciler.")
 	apiClients := []controller.ApiClient{

--- a/test/util/no_op_otel_exporter_factory.go
+++ b/test/util/no_op_otel_exporter_factory.go
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: Copyright 2026 Dash0 Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package util
+
+import (
+	"context"
+
+	sdklog "go.opentelemetry.io/otel/sdk/log"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	"github.com/dash0hq/dash0-operator/images/pkg/common"
+)
+
+// NoopExporterFactory is a common.ExporterFactory that creates no-op metric and log exporters. It is intended for unit
+// tests, where the real OTLP gRPC exporters would otherwise attempt to connect to (and flush telemetry to) an
+// unreachable endpoint. In particular, the real exporters block for up to one second on shutdown while their flush
+// attempts time out against the unreachable endpoint; the no-op exporters return immediately instead.
+type NoopExporterFactory struct{}
+
+func NewNoopExporterFactory() common.ExporterFactory {
+	return NoopExporterFactory{}
+}
+
+func (NoopExporterFactory) CreateMetricExporter(_ context.Context, _ *common.OTelSdkConfig) sdkmetric.Exporter {
+	return noopMetricExporter{}
+}
+
+func (NoopExporterFactory) CreateLogExporter(_ context.Context, _ *common.OTelSdkConfig) sdklog.Exporter {
+	return noopLogExporter{}
+}
+
+type noopMetricExporter struct{}
+
+func (noopMetricExporter) Temporality(kind sdkmetric.InstrumentKind) metricdata.Temporality {
+	return sdkmetric.DefaultTemporalitySelector(kind)
+}
+
+func (noopMetricExporter) Aggregation(kind sdkmetric.InstrumentKind) sdkmetric.Aggregation {
+	return sdkmetric.DefaultAggregationSelector(kind)
+}
+
+func (noopMetricExporter) Export(_ context.Context, _ *metricdata.ResourceMetrics) error { return nil }
+
+func (noopMetricExporter) ForceFlush(_ context.Context) error { return nil }
+
+func (noopMetricExporter) Shutdown(_ context.Context) error { return nil }
+
+type noopLogExporter struct{}
+
+func (noopLogExporter) Export(_ context.Context, _ []sdklog.Record) error { return nil }
+
+func (noopLogExporter) ForceFlush(_ context.Context) error { return nil }
+
+func (noopLogExporter) Shutdown(_ context.Context) error { return nil }


### PR DESCRIPTION
Some unit tests took longer then they should, because they initialize the self-monitoring OTel SDK with an unreachable mock endpoint. This blocked the test shutdown because the OTel SDK tries to flush its telemetry:
    Failed to shutdown self monitoring … context deadline exceeded

Now tests use a no-op exporter that avoids this.