### PR TITLE
fix(chart): grant RBAC permissions to manage the agent0-connector

### DIFF
--- a/helm-chart/dash0-operator/docs/MANAGING-DASH0-RESOURCES.md
+++ b/helm-chart/dash0-operator/docs/MANAGING-DASH0-RESOURCES.md
@@ -930,3 +930,10 @@ permissions have not been granted.
 To enable telemetry collection later on, it is required to change this Helm value to `true` and perform a
 `helm upgrade --install` with the updated setting.
 
+If the operator is installed with `telemetryCollectionEnabled=true`, and the flag is later flipped to false via
+`helm upgrade`, the operator will not remove its managed OpenTelemetry collectors, nor the associated resources
+(config maps, cluster roles, roles & bindings, services etc.) from the cluster.
+It cannot, because `telemetryCollectionEnabled=false` implies that the necessary RBAC permissions for managing these
+resources (including the permission to delete these resources) are not granted to the operator manger.
+The recommended resolution is to uninstall the operator from the cluster entirely, then re-install with
+`telemetryCollectionEnabled=false`.

--- a/helm-chart/dash0-operator/templates/operator/cluster-role-bindings.yaml
+++ b/helm-chart/dash0-operator/templates/operator/cluster-role-bindings.yaml
@@ -82,6 +82,25 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  name: {{ template "dash0-operator.chartName" . }}-manager-agent0-connector-ro
+  labels:
+    app.kubernetes.io/name: dash0-operator
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: cluster-role-binding-agent0-connector
+    {{- include "dash0-operator.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "dash0-operator.chartName" . }}-manager-agent0-connector-ro
+subjects:
+- kind: ServiceAccount
+  name: {{ template "dash0-operator.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
   name: {{ template "dash0-operator.chartName" . }}-manager-agent0-connector
   labels:
     app.kubernetes.io/name: dash0-operator

--- a/helm-chart/dash0-operator/templates/operator/cluster-roles.yaml
+++ b/helm-chart/dash0-operator/templates/operator/cluster-roles.yaml
@@ -623,16 +623,17 @@ rules:
 ---
 {{ if .Values.operator.agent0Connector.enabled }}
 {{/*
-The -manager-agent0-connector cluster role holds the permissions that the operator delegates to the agent0-connector
-deployment. The operator creates a dedicated cluster role/cluster role binding granting the agent0-connector service
-account get & list on all resources plus get on all non-resource URLs. Kubernetes' privilege-escalation prevention only
-allows the operator to grant permissions it holds itself, so it must hold these read permissions as well. This cluster
-role (and its binding) only exist when the agent0-connector feature is enabled (operator.agent0Connector.enabled).
+The -manager-agent0-connector-ro cluster role holds the read-only permissions that the operator delegates to the
+agent0-connector deployment. The operator creates a dedicated cluster role/cluster role binding granting the
+agent0-connector service account "get" & "list" on all resources plus get on all non-resource URLs. Kubernetes'
+privilege-escalation prevention only allows the operator to grant permissions it holds itself, so it must hold these
+read permissions as well. This cluster role (and its binding) only exist when the agent0-connector feature is enabled
+(operator.agent0Connector.enabled).
 */}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ template "dash0-operator.chartName" . }}-manager-agent0-connector
+  name: {{ template "dash0-operator.chartName" . }}-manager-agent0-connector-ro
   labels:
     app.kubernetes.io/name: dash0-operator
     app.kubernetes.io/component: controller
@@ -657,5 +658,67 @@ rules:
   - '*'
   verbs:
   - get
+
+---
+{{/*
+The -manager-agent0-connector cluster role holds the permissions the operator needs to manage the agent0-connector
+resources (service account, cluster role, cluster role binding and deployment). These permissions will *not* be granted
+to the agent0-connector deployment itself. This cluster role (and its binding) only exist when the agent0-connector
+feature is enabled.
+*/}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "dash0-operator.chartName" . }}-manager-agent0-connector
+  labels:
+    app.kubernetes.io/name: dash0-operator
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: cluster-role-agent0-connector
+    {{- include "dash0-operator.labels" . | nindent 4 }}
+
+rules:
+
+# Permissions required to manage the agent0-connector service account:
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+
+# Permissions required to manage the agent0-connector cluster role and cluster role binding:
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
+  - clusterrolebindings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+
+# Permissions required to manage the agent0-connector deployment:
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 
 {{ end }}

--- a/helm-chart/dash0-operator/tests/operator/cluster-role-bindings_test.yaml
+++ b/helm-chart/dash0-operator/tests/operator/cluster-role-bindings_test.yaml
@@ -54,6 +54,11 @@ tests:
       - containsDocument:
           kind: ClusterRoleBinding
           apiVersion: rbac.authorization.k8s.io/v1
+          name: dash0-operator-manager-agent0-connector-ro
+        not: true
+      - containsDocument:
+          kind: ClusterRoleBinding
+          apiVersion: rbac.authorization.k8s.io/v1
           name: dash0-operator-manager-agent0-connector
         not: true
 
@@ -66,5 +71,35 @@ tests:
       - containsDocument:
           kind: ClusterRoleBinding
           apiVersion: rbac.authorization.k8s.io/v1
-          name: dash0-operator-manager-agent0-connector
+          name: dash0-operator-manager-agent0-connector-ro
         documentIndex: 4
+      - containsDocument:
+          kind: ClusterRoleBinding
+          apiVersion: rbac.authorization.k8s.io/v1
+          name: dash0-operator-manager-agent0-connector
+        documentIndex: 5
+
+  - it: should bind agent0-connector management permissions independently of telemetry collection
+    set:
+      operator:
+        telemetryCollectionEnabled: false
+        agent0Connector:
+          enabled: true
+    asserts:
+      - hasDocuments:
+          count: 4
+      - containsDocument:
+          kind: ClusterRoleBinding
+          apiVersion: rbac.authorization.k8s.io/v1
+          name: dash0-operator-manager-collector
+        not: true
+      - containsDocument:
+          kind: ClusterRoleBinding
+          apiVersion: rbac.authorization.k8s.io/v1
+          name: dash0-operator-manager-agent0-connector-ro
+        documentIndex: 2
+      - containsDocument:
+          kind: ClusterRoleBinding
+          apiVersion: rbac.authorization.k8s.io/v1
+          name: dash0-operator-manager-agent0-connector
+        documentIndex: 3

--- a/helm-chart/dash0-operator/tests/operator/cluster-roles_test.yaml
+++ b/helm-chart/dash0-operator/tests/operator/cluster-roles_test.yaml
@@ -54,6 +54,11 @@ tests:
       - containsDocument:
           kind: ClusterRole
           apiVersion: rbac.authorization.k8s.io/v1
+          name: dash0-operator-manager-agent0-connector-ro
+        not: true
+      - containsDocument:
+          kind: ClusterRole
+          apiVersion: rbac.authorization.k8s.io/v1
           name: dash0-operator-manager-agent0-connector
         not: true
 
@@ -66,7 +71,7 @@ tests:
       - containsDocument:
           kind: ClusterRole
           apiVersion: rbac.authorization.k8s.io/v1
-          name: dash0-operator-manager-agent0-connector
+          name: dash0-operator-manager-agent0-connector-ro
         documentIndex: 4
       - contains:
           path: rules
@@ -87,3 +92,82 @@ tests:
             verbs:
               - get
         documentIndex: 4
+      - containsDocument:
+          kind: ClusterRole
+          apiVersion: rbac.authorization.k8s.io/v1
+          name: dash0-operator-manager-agent0-connector
+        documentIndex: 5
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - ""
+            resources:
+              - serviceaccounts
+            verbs:
+              - create
+              - delete
+              - get
+              - list
+              - patch
+              - update
+              - watch
+        documentIndex: 5
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - rbac.authorization.k8s.io
+            resources:
+              - clusterroles
+              - clusterrolebindings
+            verbs:
+              - create
+              - delete
+              - get
+              - list
+              - patch
+              - update
+              - watch
+        documentIndex: 5
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - apps
+            resources:
+              - deployments
+            verbs:
+              - create
+              - delete
+              - get
+              - list
+              - patch
+              - update
+              - watch
+        documentIndex: 5
+
+  - it: should grant agent0-connector management permissions independently of telemetry collection
+    set:
+      operator:
+        telemetryCollectionEnabled: false
+        agent0Connector:
+          enabled: true
+    asserts:
+      - hasDocuments:
+          count: 4
+      - containsDocument:
+          kind: ClusterRole
+          apiVersion: rbac.authorization.k8s.io/v1
+          name: dash0-operator-manager-collector
+        not: true
+      - containsDocument:
+          kind: ClusterRole
+          apiVersion: rbac.authorization.k8s.io/v1
+          name: dash0-operator-manager-agent0-connector-ro
+        documentIndex: 2
+      - containsDocument:
+          kind: ClusterRole
+          apiVersion: rbac.authorization.k8s.io/v1
+          name: dash0-operator-manager-agent0-connector
+        documentIndex: 3

--- a/helm-chart/dash0-operator/values.yaml
+++ b/helm-chart/dash0-operator/values.yaml
@@ -159,6 +159,13 @@ operator:
   # Dash0OperatorConfiguration, since the required RBAC permissions have not been granted. To enable telemetry
   # collection later, it is required to change this Helm value to true and perform a "helm upgrade --install" with the
   # updated setting.
+  #
+  # If the operator is installed with telemetryCollectionEnabled=true, and the flag is later flipped to false via
+  # helm upgrade, the operator will not remove its managed OpenTelemetry collectors, nor the associated resources
+  # (config maps, cluster roles, roles & bindings, services etc.) from the cluster. It cannot, because
+  # telemetryCollectionEnabled=false implies that the necessary RBAC permissions for managing these resources (including
+  # the permission to delete these resources) are not granted to the operator manger. The recommended resolution is to
+  # uninstall the operator from the cluster entirely, then re-install with telemetryCollectionEnabled=false.
   telemetryCollectionEnabled: true
 
   # If set, the value will be added as the resource attribute k8s.cluster.name to all telemetry. This setting is

--- a/internal/startup/operator_manager_startup.go
+++ b/internal/startup/operator_manager_startup.go
@@ -1969,6 +1969,11 @@ func setupAgent0ConnectorManager(
 	pseudoClusterUid types.UID,
 	developmentMode bool,
 ) (*agent0connector.Agent0ConnectorManager, error) {
+	if !envVars.agent0ConnectorEnabled {
+		// We might not have the permissions to manage the agent0 connector resources (in particular when telemetry
+		// collection is also disabled), e.g. no permission to manage cluster roles, config maps etc.
+		return nil, nil
+	}
 	agent0ConnectorConfig := util.Agent0ConnectorConfig{
 		Images:            images,
 		OperatorNamespace: envVars.operatorNamespace,

--- a/internal/startup/operator_manager_startup_test.go
+++ b/internal/startup/operator_manager_startup_test.go
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: Copyright 2026 Dash0 Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package startup
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/dash0hq/dash0-operator/internal/util"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	. "github.com/dash0hq/dash0-operator/test/util"
+)
+
+var _ = Describe("operator manager startup", func() {
+	var mgr ctrl.Manager
+
+	BeforeEach(func() {
+		var err error
+		mgr, err = ctrl.NewManager(cfg, ctrl.Options{Scheme: scheme.Scheme})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(mgr).NotTo(BeNil())
+	})
+
+	Context("agent0 connector", func() {
+		It("does not create the manager or register the controller when the agent0-connector feature is disabled", func() {
+			envVars := environmentVariables{
+				operatorNamespace:       OperatorNamespace,
+				oTelCollectorNamePrefix: "dash0-operator-test",
+				agent0ConnectorEnabled:  false,
+			}
+			agent0ConnectorManager, err := setupAgent0ConnectorManager(
+				mgr,
+				k8sClient,
+				envVars,
+				util.Images{},
+				&appsv1.Deployment{},
+				"cluster-uid",
+				false,
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(agent0ConnectorManager).To(BeNil())
+		})
+
+		It("creates the manager and registers the controller when the agent0-connector feature is enabled", func() {
+			envVars := environmentVariables{
+				operatorNamespace:            OperatorNamespace,
+				oTelCollectorNamePrefix:      "dash0-operator-test",
+				agent0ConnectorEnabled:       true,
+				agent0ConnectorServerAddress: "example.com:4317",
+			}
+			agent0ConnectorManager, err := setupAgent0ConnectorManager(
+				mgr,
+				k8sClient,
+				envVars,
+				util.Images{},
+				&appsv1.Deployment{},
+				types.UID("cluster-uid"),
+				false,
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(agent0ConnectorManager).NotTo(BeNil())
+		})
+	})
+})


### PR DESCRIPTION
This previously implicitly piggy-backed on the RBAC permissions to manage the collectors, hence the combination
agent0Connector.enabled=true and telemetryCollectionEnabled=false would not work.

Also: Only start the agent0-connector controller/manager if agent0-connector is enabled.