### PR TITLE
fix(chart): wait until webhook endpoint is ready

### DIFF
--- a/helm-chart/dash0-operator/templates/operator/post-install-hook-operator-configuration-available-check.yaml
+++ b/helm-chart/dash0-operator/templates/operator/post-install-hook-operator-configuration-available-check.yaml
@@ -1,7 +1,13 @@
-{{- if .Values.operator.dash0Export.enabled }}
-# If the Helm chart values have requested the automatic installation of a Dash0 operator configuration resource,
-# we run a post-install hook to check whether that resource has been successfully created
-# Thereby, helm install --wait ... will only terminate once that condition is reached.
+{{- /*
+We run a post-install/post-upgrade hook so that "helm install --wait" and "helm upgrade --wait" only terminate once the
+operator's admission webhooks are actually reachable.
+* If the Helm chart values have requested the automatic installation of a Dash0 operator configuration resource
+  (operator.dash0Export.enabled=true), the hook waits until that resource has been successfully created and has become
+  available (the operator itself only creates it after the webhook endpoint is ready).
+* Otherwise, the hook waits until the operator's webhook service endpoint is ready, so that a Dash0 operator
+  configuration resource created right after helm returns (for example via "kubectl apply") does not fail with a
+  "connection refused" error because the webhook service is not routable yet.
+*/}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -13,8 +19,8 @@ metadata:
     {{- include "dash0-operator.labels" . | nindent 4 }}
     dash0.com/enable: "false"
   annotations:
-    helm.sh/hook: post-install
-    helm.sh/hook-delete-policy: hook-succeeded
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 spec:
   template:
     metadata:
@@ -55,7 +61,11 @@ spec:
           command:
             - /manager
           args:
+            {{- if .Values.operator.dash0Export.enabled }}
             - "--auto-operator-configuration-resource-available-check"
+            {{- else }}
+            - "--dash0-webhook-endpoint-ready-check"
+            {{- end }}
           {{- /*
           Maintenance note: When adding new args or env entries, make sure they are covered by the Google GKE workload
           allowlist. In particular, adding args with the prefix "--dash0-" is always covered, as well as environment
@@ -65,6 +75,12 @@ spec:
           env:
             - name: GOMEMLIMIT
               value: {{ .Values.operator.managerContainerResources.gomemlimit }}
+            - name: DASH0_OPERATOR_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: DASH0_WEBHOOK_SERVICE_NAME
+              value: {{ include "dash0-operator.webhookServiceName" . }}
           resources:
             {{- unset (.Values.operator.managerContainerResources | mustDeepCopy) "gomemlimit" | toYaml | nindent 12 }}
       {{- with .Values.operator.imagePullSecrets }}
@@ -76,4 +92,3 @@ spec:
       serviceAccountName: {{ template "dash0-operator.serviceAccountName" . }}
       automountServiceAccountToken: true
   backoffLimit: 2
-  {{- end }}

--- a/helm-chart/dash0-operator/tests/operator/__snapshot__/post-install-hook-operator-configuration-available-check_test.yaml.snap
+++ b/helm-chart/dash0-operator/tests/operator/__snapshot__/post-install-hook-operator-configuration-available-check_test.yaml.snap
@@ -4,8 +4,8 @@ post-install hook job should match snapshot:
     kind: Job
     metadata:
       annotations:
-        helm.sh/hook: post-install
-        helm.sh/hook-delete-policy: hook-succeeded
+        helm.sh/hook: post-install,post-upgrade
+        helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
       labels:
         app.kubernetes.io/component: installation-process
         app.kubernetes.io/managed-by: Helm
@@ -50,6 +50,12 @@ post-install hook job should match snapshot:
               env:
                 - name: GOMEMLIMIT
                   value: 205MiB
+                - name: DASH0_OPERATOR_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: DASH0_WEBHOOK_SERVICE_NAME
+                  value: dash0-operator-webhook-service
               image: ghcr.io/dash0hq/operator-controller:0.0.0
               imagePullPolicy: null
               name: post-install-job

--- a/helm-chart/dash0-operator/tests/operator/post-install-hook-operator-configuration-available-check_test.yaml
+++ b/helm-chart/dash0-operator/tests/operator/post-install-hook-operator-configuration-available-check_test.yaml
@@ -13,6 +13,26 @@ tests:
     asserts:
       - matchSnapshot: {}
 
+  - it: hook should wait for the operator configuration resource if an auto resource is requested
+    set:
+      operator:
+        dash0Export:
+          enabled: true
+          endpoint: https://ingress.dash0.com
+          token: "very-secret-dash0-auth-token"
+          apiEndpoint: https://api.dash0.com
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].args
+          value:
+            - "--auto-operator-configuration-resource-available-check"
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: post-install,post-upgrade
+      - equal:
+          path: metadata.annotations["helm.sh/hook-delete-policy"]
+          value: before-hook-creation,hook-succeeded
+
   - it: image tag should default to appVersion
     chart:
       version: 4.5.6
@@ -29,14 +49,26 @@ tests:
           path: spec.template.spec.containers[0].image
           value: ghcr.io/dash0hq/operator-controller:99.100.101
 
-  - it: post-install hook job should not be deployed if no operator configuration auto resource is requested
+  - it: the post-install hook should wait for the webhook endpoint to become ready if no operator configuration auto resource is requested
     set:
       operator:
         dash0Export:
           enabled: false
     asserts:
       - hasDocuments:
-          count: 0
+          count: 1
+      - equal:
+          path: spec.template.spec.containers[0].args
+          value:
+            - "--dash0-webhook-endpoint-ready-check"
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: post-install,post-upgrade
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DASH0_WEBHOOK_SERVICE_NAME
+            value: dash0-operator-webhook-service
 
   - it: should render tolerations and priority class
     set:

--- a/internal/startup/operator_manager_startup.go
+++ b/internal/startup/operator_manager_startup.go
@@ -122,6 +122,7 @@ type environmentVariables struct {
 type commandLineArguments struct {
 	isUninstrumentAll                                                     bool
 	autoOperatorConfigurationResourceAvailableCheck                       bool
+	webhookEndpointReadyCheck                                             bool
 	allowlistSynchronizerReadyCheck                                       bool
 	allowlistVersion                                                      string
 	deleteAllowlistSynchronizer                                           bool
@@ -301,6 +302,13 @@ func Start() {
 		}
 		os.Exit(0)
 	}
+	if cliArgs.webhookEndpointReadyCheck {
+		if err := waitForWebhookEndpointReadiness(ctx, setupLog); err != nil {
+			setupLog.Error(err, "waiting for the Dash0 operator webhook service endpoint to become ready has failed")
+			os.Exit(1)
+		}
+		os.Exit(0)
+	}
 	if cliArgs.allowlistSynchronizerReadyCheck {
 		if cliArgs.allowlistVersion == "" {
 			setupLog.Error(
@@ -448,6 +456,13 @@ func defineCommandLineArguments() *commandLineArguments {
 		false,
 		"If set, the process will only wait until the Dash0 operator configuration resource has been created and "+
 			"becomes available, then exit.",
+	)
+	flag.BoolVar(
+		&cliArgs.webhookEndpointReadyCheck,
+		"dash0-webhook-endpoint-ready-check",
+		false,
+		"If set, the process will only wait until the Dash0 operator's webhook service endpoint has a port assigned "+
+			"and is marked as ready (that is, until the API server is actually able to reach the webhook), then exit.",
 	)
 	flag.BoolVar(
 		&cliArgs.allowlistSynchronizerReadyCheck,
@@ -2140,6 +2155,47 @@ func waitForOperatorConfigurationResourceAvailability(logger logd.Logger) error 
 	if err = handler.WaitForOperatorConfigurationResourceToBecomeAvailable(); err != nil {
 		logger.Error(err, "Failed to wait for the operator monitoring resource.")
 		return err
+	}
+	return nil
+}
+
+// waitForWebhookEndpointReadiness runs as a standalone process (invoked via the --dash0-webhook-endpoint-ready-check
+// flag from a Helm post-install/post-upgrade hook). It waits until the operator's webhook service endpoint has a port
+// assigned and is marked as ready, so that helm install/upgrade --wait only terminates once the API server is actually
+// able to reach the webhook. This closes the race in which an operator configuration resource is created (e.g. via
+// kubectl apply) immediately after helm returns, but before the webhook service is routable.
+func waitForWebhookEndpointReadiness(ctx context.Context, logger logd.Logger) error {
+	// Note: waiting on the EndpointSlice Ready condition reduces the probability of returning from
+	// helm install --wait before the webhook endpoint can be reached, but there is still a very small chance of being too
+	// early. kube-proxy manages service DNAT rules per-node. If the check here observes the endpoint slice as ready,
+	// it is not strictly guaranteed that kube-proxy on the API server's node has also reprogrammed iptables.
+	//
+	// If this turns out to be a problem in practice, we could make the "--wait" guarantee stronger by actually waiting
+	// until a TLS dial to the webhook Service ClusterIP connects successful, e.g. call
+	// https://dash0-operator-webhook-service.operator-namespace.svc:443/operator-configuration/mutate.
+	operatorNamespace := os.Getenv(operatorNamespaceEnvVarName)
+	if operatorNamespace == "" {
+		return fmt.Errorf("the environment variable %s is not set", operatorNamespaceEnvVarName)
+	}
+	webhookServiceName := os.Getenv(webhookServiceNameEnvVarName)
+	if webhookServiceName == "" {
+		return fmt.Errorf("the environment variable %s is not set", webhookServiceNameEnvVarName)
+	}
+
+	cfg := ctrl.GetConfigOrDie()
+	k8sClient, err := client.New(cfg, client.Options{Scheme: runtimeScheme})
+	if err != nil {
+		logger.Error(err, "failed to create Kubernetes API client for the webhook endpoint ready check")
+		return err
+	}
+
+	readyCheckExecuter := NewReadyCheckExecuter(k8sClient, operatorNamespace, webhookServiceName)
+	webhookServiceIsAvailable, err := readyCheckExecuter.waitForWebhookServiceEndpointToBecomeReady(ctx, logger)
+	if err != nil {
+		return err
+	}
+	if !webhookServiceIsAvailable {
+		return fmt.Errorf("the Dash0 operator webhook service endpoint did not become ready")
 	}
 	return nil
 }

--- a/test/e2e/dash0_operator_configuration_resource.go
+++ b/test/e2e/dash0_operator_configuration_resource.go
@@ -12,14 +12,9 @@ import (
 	"text/template"
 	"time"
 
-	"k8s.io/apimachinery/pkg/util/wait"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-
 	dash0common "github.com/dash0hq/dash0-operator/api/operator/common"
 	dash0v1alpha1 "github.com/dash0hq/dash0-operator/api/operator/v1alpha1"
 	"github.com/dash0hq/dash0-operator/internal/util"
-	"github.com/dash0hq/dash0-operator/internal/util/logd"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -70,13 +65,13 @@ func renderDash0OperatorConfigurationResourceTemplate(
 	)
 }
 
-func deployDash0OperatorConfigurationResourceWithRetry(
+func deployDash0OperatorConfigurationResource(
 	dash0OperatorConfigurationValues dash0OperatorConfigurationValues,
 	operatorNamespace string,
 	operatorHelmChart string,
 ) {
 	renderedResourceFileName := renderDash0OperatorConfigurationResourceTemplate(dash0OperatorConfigurationValues)
-	deployRenderedOperatorConfigurationResourceWithRetry(
+	deployRenderedOperatorConfigurationResource(
 		dash0OperatorConfigurationValues,
 		operatorNamespace,
 		operatorHelmChart,
@@ -84,7 +79,7 @@ func deployDash0OperatorConfigurationResourceWithRetry(
 	)
 }
 
-func deployRenderedOperatorConfigurationResourceWithRetry(
+func deployRenderedOperatorConfigurationResource(
 	dash0OperatorConfigurationValues dash0OperatorConfigurationValues,
 	operatorNamespace string,
 	operatorHelmChart string,
@@ -95,24 +90,13 @@ func deployRenderedOperatorConfigurationResourceWithRetry(
 	}()
 	By(fmt.Sprintf(
 		"deploying the Dash0 operator configuration resource with values %v", dash0OperatorConfigurationValues))
-	retryLogger := logd.NewLogger(zap.New())
-	err := util.RetryWithCustomBackoff("deploying the Dash0 operator configuration resource", func() error {
-		return runAndIgnoreOutput(exec.Command(
+	Expect(
+		runAndIgnoreOutput(exec.Command(
 			"kubectl",
 			"apply",
 			"-f",
 			renderedResourceFileName,
-		))
-	},
-		wait.Backoff{
-			Duration: 10 * time.Second,
-			Steps:    3,
-		},
-		true,
-		true,
-		retryLogger,
-	)
-	Expect(err).ToNot(HaveOccurred())
+		))).To(Succeed())
 
 	waitForOperatorConfigurationResourceToBecomeAvailable()
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -2035,7 +2035,7 @@ trace_statements:
 					nil,
 				)
 				By("create an operator configuration resource with telemetryCollection.enabled=false")
-				deployDash0OperatorConfigurationResourceWithRetry(dash0OperatorConfigurationValues{
+				deployDash0OperatorConfigurationResource(dash0OperatorConfigurationValues{
 					SelfMonitoringEnabled:      false,
 					Endpoint:                   defaultEndpoint,
 					Token:                      defaultToken,
@@ -2657,7 +2657,7 @@ trace_statements:
 
 			//nolint:lll
 			It("should update and reload the collector configuration when updating the Dash0 endpoint in the operator configuration resource", func() {
-				deployDash0OperatorConfigurationResourceWithRetry(dash0OperatorConfigurationValues{
+				deployDash0OperatorConfigurationResource(dash0OperatorConfigurationValues{
 					SelfMonitoringEnabled:      false,
 					Endpoint:                   defaultEndpoint,
 					Token:                      defaultToken,
@@ -2763,7 +2763,7 @@ trace_statements:
 
 			//nolint:lll
 			It("should remove the OpenTelemetry collector", func() {
-				deployDash0OperatorConfigurationResourceWithRetry(dash0OperatorConfigurationValues{
+				deployDash0OperatorConfigurationResource(dash0OperatorConfigurationValues{
 					SelfMonitoringEnabled:      false,
 					Endpoint:                   defaultEndpoint,
 					Token:                      defaultToken,
@@ -3038,7 +3038,7 @@ trace_statements:
 						"dash0.com/custom-auto-opt-in": "\"true\"",
 					})
 
-				deployDash0OperatorConfigurationResourceWithRetry(dash0OperatorConfigurationValues{
+				deployDash0OperatorConfigurationResource(dash0OperatorConfigurationValues{
 					SelfMonitoringEnabled:          false,
 					Endpoint:                       defaultEndpoint,
 					Token:                          defaultToken,


### PR DESCRIPTION
When installing the Helm chart with operator.dash0Export.enabled=false and with --wait, and then trying to kubectl apply a Dash0OperatorConfiguration resource directly after helm install --wait terminated, applying the operator configuration resource would sometimes fail with

  failed calling webhook "mutate-operator-configuration.dash0.com":
  failed to call webhook:
  Post "https://dash0-operator-webhook-service.operator-namespace.svc:443/operator-configuration/mutate?timeout=5s":
  dial tcp 10.96.32.156:443: connect: connection refused

This is because the webhook endpoint might not be ready yet when helm install --wait returned. This cannot be checked from inside the operator manager pod's ready check, since the endpoint will not become ready before its serving pod is marked ready.

To solve this, the existing post-install hook is now also used when the chart does not create the operator configuration resource. In that scenario, the post-install hook waits for the webhook endpoint readiness.

Setups that manage the operator configuration via the chart are not affected by this change, they always wait until the operator configuration resource has been created and is marked as ready.

Additional changes:
* add the waiting hook also as post-upgrade, i.e. also execute the readiness check when doing helm upgrade --wait
* add the hook-delete-policy before-hook-creation in addition to the existing hook-succeeded, that is, clean up leftovers from earlier invocations before installing a new hook
* remove the retry from the e2e test's method to install an operator configuration resource, to expose the new waiting hook to regular test coverage.