### PR TITLE
chore: add spamfilter processor to daemonset metrics pipeline

### DIFF
--- a/api/operator/v1alpha1/dash0signalcontrol_types.go
+++ b/api/operator/v1alpha1/dash0signalcontrol_types.go
@@ -71,9 +71,10 @@ type Dash0SignalControlSpec struct {
 	// +kubebuilder:validation:Optional
 	SignalToMetrics SignalToMetricsConfig `json:"signalToMetrics,omitempty"`
 
-	// Configuration for the dash0filter processor in the collector pipeline. The processor drops spans and
-	// log records that match Dash0SpamFilter rules synced to the Dash0 control plane, allowing high-volume
-	// or low-value telemetry to be filtered out at the edge before it leaves the cluster.
+	// Configuration for the dash0filter processor in the collector pipeline. The processor drops spans,
+	// metric data points, and log records that match Dash0SpamFilter rules synced to the Dash0 control
+	// plane, allowing high-volume or low-value telemetry to be filtered out at the edge before it leaves
+	// the cluster.
 	//
 	// +kubebuilder:validation:Optional
 	SpamFilter SpamFilterConfig `json:"spamFilter,omitempty"`
@@ -253,8 +254,8 @@ type SignalToMetricsConfig struct {
 	FlushInterval *metav1.Duration `json:"flushInterval,omitempty"`
 }
 
-// SpamFilterConfig configures the dash0filter processor. The processor drops spans and log records
-// that match Dash0SpamFilter rules synced to the Dash0 control plane.
+// SpamFilterConfig configures the dash0filter processor. The processor drops spans, metric data points,
+// and log records that match Dash0SpamFilter rules synced to the Dash0 control plane.
 type SpamFilterConfig struct {
 	// Whether to wire the dash0filter processor into the daemonset collector pipeline. When disabled,
 	// Dash0SpamFilter rules synced to the Dash0 control plane are not evaluated at the edge and no

--- a/config/crd/bases/operator.dash0.com_dash0signalcontrols.yaml
+++ b/config/crd/bases/operator.dash0.com_dash0signalcontrols.yaml
@@ -309,9 +309,10 @@ spec:
                 type: object
               spamFilter:
                 description: |-
-                  Configuration for the dash0filter processor in the collector pipeline. The processor drops spans and
-                  log records that match Dash0SpamFilter rules synced to the Dash0 control plane, allowing high-volume
-                  or low-value telemetry to be filtered out at the edge before it leaves the cluster.
+                  Configuration for the dash0filter processor in the collector pipeline. The processor drops spans,
+                  metric data points, and log records that match Dash0SpamFilter rules synced to the Dash0 control
+                  plane, allowing high-volume or low-value telemetry to be filtered out at the edge before it leaves
+                  the cluster.
                 properties:
                   allowNoSettingsExt:
                     description: |-

--- a/helm-chart/dash0-operator/templates/operator/custom-resource-definition-signal-control.yaml
+++ b/helm-chart/dash0-operator/templates/operator/custom-resource-definition-signal-control.yaml
@@ -315,9 +315,10 @@ spec:
                 type: object
               spamFilter:
                 description: |-
-                  Configuration for the dash0filter processor in the collector pipeline. The processor drops spans and
-                  log records that match Dash0SpamFilter rules synced to the Dash0 control plane, allowing high-volume
-                  or low-value telemetry to be filtered out at the edge before it leaves the cluster.
+                  Configuration for the dash0filter processor in the collector pipeline. The processor drops spans,
+                  metric data points, and log records that match Dash0SpamFilter rules synced to the Dash0 control
+                  plane, allowing high-volume or low-value telemetry to be filtered out at the edge before it leaves
+                  the cluster.
                 properties:
                   allowNoSettingsExt:
                     description: |-

--- a/internal/collectors/otelcolresources/collector_config_maps_test.go
+++ b/internal/collectors/otelcolresources/collector_config_maps_test.go
@@ -2412,6 +2412,10 @@ var _ = Describe("The OpenTelemetry Collector ConfigMaps", func() {
 			Expect(logsCommonProcessors).To(ContainElement("dash0filter"))
 			Expect(logsCommonProcessors).To(ContainElements("resource/signal_control_attributes", "dash0resource", "dash0filter"),
 				"dash0filter must run after resource/signal_control_attributes, and dash0resource must run so dash0signaltometrics gets the resource hash")
+			metricsCommonProcessors := readPipelineProcessors(pipelines, "metrics/common-processors")
+			Expect(metricsCommonProcessors).To(ContainElement("dash0filter"))
+			Expect(metricsCommonProcessors).To(ContainElements("resource/signal_control_attributes", "dash0filter"),
+				"dash0filter must run after resource/signal_control_attributes sets Signal Control attributes")
 		})
 
 		It("should render dash0filter tunables when set on the Signal Control config [DaemonSet]", func() {
@@ -2463,6 +2467,7 @@ var _ = Describe("The OpenTelemetry Collector ConfigMaps", func() {
 
 			Expect(readPipelineProcessors(pipelines, "traces/common-processors")).To(ContainElement("dash0filter"))
 			Expect(readPipelineProcessors(pipelines, "logs/common-processors")).To(ContainElement("dash0filter"))
+			Expect(readPipelineProcessors(pipelines, "metrics/common-processors")).To(ContainElement("dash0filter"))
 		})
 
 		It("should still wire dash0filter when sampling is disabled [DaemonSet]", func() {
@@ -2489,6 +2494,7 @@ var _ = Describe("The OpenTelemetry Collector ConfigMaps", func() {
 			pipelines := readPipelines(collectorConfig)
 			Expect(readPipelineProcessors(pipelines, "traces/common-processors")).To(ContainElement("dash0filter"))
 			Expect(readPipelineProcessors(pipelines, "logs/common-processors")).To(ContainElement("dash0filter"))
+			Expect(readPipelineProcessors(pipelines, "metrics/common-processors")).To(ContainElement("dash0filter"))
 		})
 
 		It("should not wire the dash0filter processor when spamFilter is disabled [DaemonSet]", func() {
@@ -2516,6 +2522,8 @@ var _ = Describe("The OpenTelemetry Collector ConfigMaps", func() {
 			Expect(readPipelineProcessors(pipelines, "traces/common-processors")).
 				ToNot(ContainElement("dash0filter"))
 			Expect(readPipelineProcessors(pipelines, "logs/common-processors")).
+				ToNot(ContainElement("dash0filter"))
+			Expect(readPipelineProcessors(pipelines, "metrics/common-processors")).
 				ToNot(ContainElement("dash0filter"))
 		})
 

--- a/internal/collectors/otelcolresources/daemonset.config.yaml.template
+++ b/internal/collectors/otelcolresources/daemonset.config.yaml.template
@@ -1401,6 +1401,9 @@ service:
         - transform/resources
         {{- if .SignalControl.Enabled }}
         - resource/signal_control_attributes
+        {{- if .SignalControl.SpamFilterEnabled }}
+        - dash0filter
+        {{- end }}
         {{- end }}
       exporters:
         {{- if $hasNamespacedExporters }}


### PR DESCRIPTION
note: there will be a follow-up pr for the deployment collector (since that collector doesn't have signal control components at all right now).