### PR TITLE
chore(sc): rename signal-control auth token

### DIFF
--- a/internal/collectors/otelcolresources/daemonset.config.yaml.template
+++ b/internal/collectors/otelcolresources/daemonset.config.yaml.template
@@ -34,7 +34,7 @@ extensions:
 {{- if .SignalControl.Enabled }}
   dash0settingsonedgeextension:
     endpoint: {{ .SignalControl.ApiEndpoint }}
-    auth_token: ${env:DASH0_SAMPLING_AUTH_TOKEN}
+    auth_token: ${env:DASH0_SIGNAL_CONTROL_AUTH_TOKEN}
 {{- end }}
 
 connectors:
@@ -1120,7 +1120,7 @@ processors:
   dash0sampling:
     decision_maker_endpoint: {{ .SignalControl.Endpoint }}
     decision_maker_headers:
-      Authorization: Bearer ${env:DASH0_SAMPLING_AUTH_TOKEN}
+      Authorization: Bearer ${env:DASH0_SIGNAL_CONTROL_AUTH_TOKEN}
       Dash0-Dataset: {{ .SignalControl.Dataset }}
     decision_maker_insecure: {{ .SignalControl.Insecure }}
     default_dataset: {{ .SignalControl.Dataset }}

--- a/internal/collectors/otelcolresources/desired_state.go
+++ b/internal/collectors/otelcolresources/desired_state.go
@@ -1157,13 +1157,15 @@ func assembleCollectorEnvVars(
 		}
 	}
 
-	if config.SignalControl.Enabled && config.SignalControl.SamplingEnabled {
+	if config.SignalControl.Enabled {
+		// The Signal Control settings extension authenticates against the control plane API and is used by both the
+		// sampling processor and the spam filter, so the token is emitted whenever Signal Control is enabled.
 		// Uses Kubernetes dependent variable expansion: $(VAR_NAME) references the exporter auth token env var
 		// defined earlier in this container's env list. The referenced env var (e.g., DASH0_AUTHORIZATION_DEFAULT_0)
 		// must appear before this one.
 		collectorEnv = append(collectorEnv,
 			corev1.EnvVar{
-				Name:  "DASH0_SAMPLING_AUTH_TOKEN",
+				Name:  "DASH0_SIGNAL_CONTROL_AUTH_TOKEN",
 				Value: fmt.Sprintf("$(%s)", config.SignalControl.AuthEnvVar),
 			},
 		)


### PR DESCRIPTION
The token is not only used for sampling, but also in the `dash0settingsonedgeextension`, which syncs spam filters and s2m rules, so the initial name `DASH0_SAMPLING_AUTH_TOKEN` was no longer accurate.

The env var is now named `DASH0_SIGNAL_CONTROL_AUTH_TOKEN`.