### PR TITLE
fix(collectors): add resourcedetector to deployment collector

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,6 +11,7 @@ on:
   pull_request:
     paths-ignore:
       - '*.md'
+  merge_group:
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,6 @@ on:
   pull_request:
     paths-ignore:
       - '*.md'
-  merge_group:
   workflow_dispatch:
 
 concurrency:

--- a/internal/collectors/otelcolresources/collector_config_maps_test.go
+++ b/internal/collectors/otelcolresources/collector_config_maps_test.go
@@ -4376,6 +4376,25 @@ var _ = Describe("The OpenTelemetry Collector ConfigMaps", func() {
 			Expect(pipelines["metrics/common-processors"]).To(BeNil())
 		})
 
+		It("should not render the resourcedetection processor if neither cluster metrics nor event collection is enabled", func() {
+			configMap, err := assembleDeploymentCollectorConfigMap(
+				&oTelColConfig{
+					OperatorNamespace: OperatorNamespace,
+					NamePrefix:        namePrefix,
+					Exporters:         cmTestSingleDefaultOtlpExporter(),
+					KubernetesInfrastructureMetricsCollectionEnabled: false,
+				},
+				[]string{"namespace"},
+				[]string{},
+				nil,
+				nil,
+				false,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			collectorConfig := parseConfigMapContent(configMap)
+			Expect(ReadFromMap(collectorConfig, []string{"processors", "resourcedetection"})).To(BeNil())
+		})
+
 		DescribeTable("should render the k8s_cluster receiver and the associated pipeline if Kubernetes infrastructure metrics collection is enabled",
 			func(k8sEventCollectionEnabledForAtLeastOneNamespace bool) {
 				var namespacesWithEventCollection []string
@@ -4406,8 +4425,11 @@ var _ = Describe("The OpenTelemetry Collector ConfigMaps", func() {
 					"processors",
 					"filter/drop-replicaset-metrics-zero-value",
 				})).ToNot(BeNil())
+				Expect(ReadFromMap(collectorConfig, []string{"processors", "resourcedetection"})).ToNot(BeNil())
 				pipelines := readPipelines(collectorConfig)
 				Expect(pipelines["metrics/common-processors"]).NotTo(BeNil())
+				Expect(readPipelineProcessors(pipelines, "metrics/common-processors")).
+					To(ContainElement("resourcedetection"))
 			},
 			Entry("without K8s event collection", false),
 			Entry("together with K8s event collection", true),
@@ -4464,9 +4486,12 @@ var _ = Describe("The OpenTelemetry Collector ConfigMaps", func() {
 				Expect(namespaces).To(ContainElement("namespace-2"))
 
 				Expect(ReadFromMap(collectorConfig, []string{"processors", "transform/k8s_events"})).ToNot(BeNil())
+				Expect(ReadFromMap(collectorConfig, []string{"processors", "resourcedetection"})).ToNot(BeNil())
 
 				pipelines := readPipelines(collectorConfig)
 				Expect(pipelines["logs/k8sevents"]).NotTo(BeNil())
+				Expect(readPipelineProcessors(pipelines, "logs/k8sevents")).
+					To(ContainElement("resourcedetection"))
 			},
 			Entry("without Kubernetes infra metrics collection", false),
 			Entry("together with Kubernetes infra metrics collection", true),

--- a/internal/collectors/otelcolresources/deployment.config.yaml.template
+++ b/internal/collectors/otelcolresources/deployment.config.yaml.template
@@ -84,6 +84,72 @@ processors:
   batch: {}
 {{- end }}
 
+  {{- if or .KubernetesInfrastructureMetricsCollectionEnabled $hasEventCollectionEnabledForAtLeastOneNamespace }}
+  # Enrich cluster-scoped telemetry cloud/account resource attributes (cloud.provider, cloud.platform, cloud.account.id,
+  # cloud.region). Deliberately not adding node- or host-related attributes (k8s.node.*, host.*,
+  # cloud.availability_zone, GCE/Azure instance identifiers) here, since that would incorrectly include node attribtues
+  # from the collector deployment's node to the telemetry.
+  resourcedetection:
+    detectors:
+    # Note: Later detectors do *not* overwrite attributes provided by earlier detectors, hence more specific detectors
+    # must come first (e.g. eks before ec2 - both write to cloud.platform).
+    - eks
+    - ec2
+    - gcp
+    - azure
+    - aks
+    # Never overwrite resource attributes already set by the receivers (e.g. per-object k8s.* attributes from the
+    # k8s_cluster receiver); the detected node identity must not clobber cluster-scoped attributes.
+    override: false
+    timeout: 2s
+    eks:
+      node_from_env_var: K8S_NODE_NAME
+    ec2:
+      resource_attributes:
+        # Do not add the collector's availability zone, some of the actual telemetry might be from a different
+        # availability zone. cloud.account.id, cloud.region, cloud.platform and cloud.provider remain enabled.
+        cloud.availability_zone:
+          enabled: false
+        host.id:
+          enabled: false
+        host.image.id:
+          enabled: false
+        host.name:
+          enabled: false
+        host.type:
+          enabled: false
+    gcp:
+      resource_attributes:
+        cloud.availability_zone:
+          enabled: false
+        host.id:
+          enabled: false
+        host.name:
+          enabled: false
+        host.type:
+          enabled: false
+        gcp.gce.instance_group_manager.name:
+          enabled: false
+        gcp.gce.instance_group_manager.region:
+          enabled: false
+        gcp.gce.instance_group_manager.zone:
+          enabled: false
+    azure:
+      resource_attributes:
+        azure.resourcegroup.name:
+          enabled: false
+        azure.vm.name:
+          enabled: false
+        azure.vm.scaleset.name:
+          enabled: false
+        azure.vm.size:
+          enabled: false
+        host.id:
+          enabled: false
+        host.name:
+          enabled: false
+  {{- end }}
+
   k8s_attributes:
     extract:
       {{- if .K8sAttributesDisableReplicasetInformer }}
@@ -525,6 +591,7 @@ service:
         - k8s_cluster
       processors:
         - memory_limiter
+        - resourcedetection
         - k8s_attributes
         {{- if .ClusterName }}
         - resource/clustername
@@ -591,6 +658,7 @@ service:
         - k8s_events
       processors:
         - memory_limiter
+        - resourcedetection
         - transform/k8s_events
         - k8s_attributes
         {{- if .ClusterName }}

--- a/internal/collectors/otelcolresources/desired_state.go
+++ b/internal/collectors/otelcolresources/desired_state.go
@@ -1773,7 +1773,10 @@ func assembleDeploymentCollectorContainer(
 
 	collectorContainer := corev1.Container{
 		Name: openTelemetryCollector,
-		Args: []string{"--config=file:" + collectorConfigurationFilePath},
+		Args: []string{
+			"--config=file:" + collectorConfigurationFilePath,
+			"--feature-gates=-processor.resourcedetection.propagateerrors",
+		},
 		SecurityContext: &corev1.SecurityContext{
 			AllowPrivilegeEscalation: new(false),
 			ReadOnlyRootFilesystem:   new(false),

--- a/internal/collectors/otelcolresources/desired_state_test.go
+++ b/internal/collectors/otelcolresources/desired_state_test.go
@@ -610,8 +610,9 @@ var _ = Describe("The desired state of the OpenTelemetry Collector resources", f
 		Expect(deploymentCollectorContainer.Resources.Limits.Memory().String()).To(Equal("500Mi"))
 		Expect(deploymentCollectorContainer.Resources.Requests.Memory().String()).To(Equal("500Mi"))
 		deploymentCollectorContainerArgs := deploymentCollectorContainer.Args
-		Expect(deploymentCollectorContainerArgs).To(HaveLen(1))
+		Expect(deploymentCollectorContainerArgs).To(HaveLen(2))
 		Expect(deploymentCollectorContainerArgs[0]).To(Equal("--config=file:/etc/otelcol/conf/config.yaml"))
+		Expect(deploymentCollectorContainerArgs[1]).To(Equal("--feature-gates=-processor.resourcedetection.propagateerrors"))
 		Expect(deploymentCollectorContainer.VolumeMounts).To(HaveLen(2))
 		Expect(deploymentCollectorContainer.VolumeMounts).To(
 			ContainElement(MatchVolumeMount("opentelemetry-collector-configmap", "/etc/otelcol/conf")))


### PR DESCRIPTION
This adds cloud.provider, cloud.platform, cloud.account.id, and cloud.region to telemetry collected by the deployment collector.