### PR TITLE
fix(perses): preserve panel-spec unknown fields in PersesDashboard CRD

### DIFF
--- a/helm-chart/dash0-operator/docs/managing-dash0-resources.md
+++ b/helm-chart/dash0-operator/docs/managing-dash0-resources.md
@@ -124,6 +124,22 @@ If you leave `operator.iac.persesDashboard.autoPatchConversionWebhook` enabled a
 `spec.conversion` on every sync, the operator will re-apply the patch on each CRD update event and log a warning, so the
 back-and-forth patching between the Dash0 operator and the GitOps system is observable.
 
+#### Preserving Dash0 Panel Extensions in the PersesDashboard CRD
+
+The upstream `persesdashboards.perses.dev` CRD models the per-panel `spec` as a closed schema (only `display`, `links`,
+`plugin` and `queries`) without `x-kubernetes-preserve-unknown-fields`. Dash0-specific panel extensions - most notably the
+per-panel `annotations` block (a sibling of `plugin`/`queries`, for example a `LogsAnnotation` placing log-based markers on a
+GeoMap) - are therefore pruned by the Kubernetes API server at admission, before the Dash0 operator ever reads the resource.
+The dashboard is stored without the extension and, for example, the map shows no markers.
+
+To prevent this, the Dash0 operator patches the PersesDashboard CRD schema to set `x-kubernetes-preserve-unknown-fields: true`
+at the panel `spec` level (for every CRD version), so these extensions survive admission.
+This can be disabled by setting the Helm value `operator.iac.persesDashboard.autoPreservePanelSpecFields` to `false` (the
+default is `true`).
+As with the conversion webhook patch, the operator leaves the CRD untouched when it detects a foreign conversion webhook (i.e.
+when the Perses operator manages the CRD).
+In that case the durable fix is an upstream Perses schema change, or managing the affected dashboard via the Dash0 API/UI.
+
 ### Managing Dash0 Check Rules
 
 You can manage your Dash0 check rules via the Dash0 operator.

--- a/helm-chart/dash0-operator/templates/operator/deployment-and-webhooks.yaml
+++ b/helm-chart/dash0-operator/templates/operator/deployment-and-webhooks.yaml
@@ -367,6 +367,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: DASH0_PERSES_DASHBOARD_AUTO_PRESERVE_PANEL_SPEC_FIELDS
+          value: {{ .Values.operator.iac.persesDashboard.autoPreservePanelSpecFields | toString | quote }}
         ports:
         - containerPort: 9443
           name: webhook-server

--- a/helm-chart/dash0-operator/tests/operator/__snapshot__/deployment-and-webhooks_test.yaml.snap
+++ b/helm-chart/dash0-operator/tests/operator/__snapshot__/deployment-and-webhooks_test.yaml.snap
@@ -114,6 +114,8 @@ deployment should match snapshot (default values):
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.name
+                - name: DASH0_PERSES_DASHBOARD_AUTO_PRESERVE_PANEL_SPEC_FIELDS
+                  value: "true"
               image: ghcr.io/dash0hq/operator-controller:0.0.0
               livenessProbe:
                 httpGet:
@@ -286,6 +288,8 @@ deployment should match snapshot when using cert-manager:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.name
+                - name: DASH0_PERSES_DASHBOARD_AUTO_PRESERVE_PANEL_SPEC_FIELDS
+                  value: "true"
               image: ghcr.io/dash0hq/operator-controller:0.0.0
               livenessProbe:
                 httpGet:

--- a/helm-chart/dash0-operator/tests/operator/deployment-and-webhooks_test.yaml
+++ b/helm-chart/dash0-operator/tests/operator/deployment-and-webhooks_test.yaml
@@ -92,8 +92,14 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].env[22].valueFrom.fieldRef.fieldPath
           value: metadata.name
-      - notExists:
+      - equal:
           path: spec.template.spec.containers[0].env[23].name
+          value: DASH0_PERSES_DASHBOARD_AUTO_PRESERVE_PANEL_SPEC_FIELDS
+      - equal:
+          path: spec.template.spec.containers[0].env[23].value
+          value: "true"
+      - notExists:
+          path: spec.template.spec.containers[0].env[24].name
 
   - it: secret should contain ca and cert
     documentSelector:
@@ -652,8 +658,14 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].env[41].valueFrom.fieldRef.fieldPath
           value: metadata.name
-      - notExists:
+      - equal:
           path: spec.template.spec.containers[0].env[42].name
+          value: DASH0_PERSES_DASHBOARD_AUTO_PRESERVE_PANEL_SPEC_FIELDS
+      - equal:
+          path: spec.template.spec.containers[0].env[42].value
+          value: "true"
+      - notExists:
+          path: spec.template.spec.containers[0].env[43].name
       - equal:
           path: spec.template.spec.containers[0].resources.limits.cpu
           value: 123m
@@ -1319,8 +1331,14 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].env[22].valueFrom.fieldRef.fieldPath
           value: metadata.name
-      - notExists:
+      - equal:
           path: spec.template.spec.containers[0].env[23].name
+          value: DASH0_PERSES_DASHBOARD_AUTO_PRESERVE_PANEL_SPEC_FIELDS
+      - equal:
+          path: spec.template.spec.containers[0].env[23].value
+          value: "true"
+      - notExists:
+          path: spec.template.spec.containers[0].env[24].name
 
   - it: deployment should support changing repositories for images
     chart:
@@ -1430,8 +1448,14 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].env[22].valueFrom.fieldRef.fieldPath
           value: metadata.name
-      - notExists:
+      - equal:
           path: spec.template.spec.containers[0].env[23].name
+          value: DASH0_PERSES_DASHBOARD_AUTO_PRESERVE_PANEL_SPEC_FIELDS
+      - equal:
+          path: spec.template.spec.containers[0].env[23].value
+          value: "true"
+      - notExists:
+          path: spec.template.spec.containers[0].env[24].name
 
   - it: mutating webhook should have caBundle set
     documentSelector:

--- a/helm-chart/dash0-operator/values.yaml
+++ b/helm-chart/dash0-operator/values.yaml
@@ -316,6 +316,19 @@ operator:
       # resources will lose fields when stored.
       autoPatchConversionWebhook: true
 
+      # The upstream Perses PersesDashboard CRD models the per-panel spec as a closed schema (only display/links/plugin/
+      # queries) with no x-kubernetes-preserve-unknown-fields. As a result, Dash0-specific panel extensions - most notably
+      # the per-panel `annotations` block (a sibling of plugin/queries, e.g. a LogsAnnotation on a GeoMap) - are pruned by
+      # the Kubernetes API server at admission, before the Dash0 operator ever reads the resource. When this setting is true
+      # (the default) and the Dash0 operator detects the PersesDashboard CRD with no foreign conversion webhook, it patches
+      # the CRD schema to set x-kubernetes-preserve-unknown-fields: true at the panel spec, so these extensions survive.
+      #
+      # If the Perses operator is installed and manages the CRD (detected via a foreign conversion webhook), the Dash0
+      # operator leaves the CRD untouched; in that case the durable fix is an upstream Perses schema change or managing the
+      # affected dashboard via the Dash0 API/UI. If you manage the PersesDashboard CRD via GitOps and do not want the Dash0
+      # operator to patch its schema, set this to false.
+      autoPreservePanelSpecFields: true
+
   # settings for the service account to be used
   serviceAccount:
     # whether to create a dedicated service account, set this to false if you want to provide a separately

--- a/internal/controller/perses_dashboards_controller.go
+++ b/internal/controller/perses_dashboards_controller.go
@@ -54,13 +54,18 @@ type PersesDashboardCrdReconciler struct {
 	conversionWebhookSettings PersesDashboardConversionWebhookSettings
 }
 
-// PersesDashboardConversionWebhookSettings are the settings for auto-patching the PersesDashboard CRD's conversion webhook stanza
-// when the Perses operator (which would normally own the conversion webhook) is not installed.
+// PersesDashboardConversionWebhookSettings are the settings for auto-patching the PersesDashboard CRD when the Perses operator
+// (which would normally own the CRD) is not installed. Two independent behaviors are gated here: patching the CRD's conversion
+// webhook stanza (AutoPatchConversionWebhook) and preserving unknown fields at the panel-spec level (AutoPreservePanelSpecFields).
 type PersesDashboardConversionWebhookSettings struct {
 	AutoPatchConversionWebhook bool
-	OperatorNamespace          string
-	WebhookServiceName         string
-	WebhookServicePort         int32
+	// AutoPreservePanelSpecFields, when true, makes the operator patch the PersesDashboard CRD schema so panel-spec-level
+	// Dash0 extensions (e.g. the `annotations` block, a sibling of plugin/queries) are not pruned by the API server at
+	// admission. See ensurePanelSpecPreservesUnknownFields.
+	AutoPreservePanelSpecFields bool
+	OperatorNamespace           string
+	WebhookServiceName          string
+	WebhookServicePort          int32
 	// CaBundlePath is optional; defaults to the standard controller-runtime serving-certs mount.
 	CaBundlePath string
 }
@@ -936,12 +941,20 @@ func (r *PersesDashboardReconciler) synchronizeNamespacedResources(
 	}()
 }
 
-// ensurePersesConversionWebhookConfigured patches the perses.dev PersesDashboard CRD to point its conversion stanza at the
-// operator manager's webhook endpoint, but only if no conversion webhook is already configured. The CRD has two versions
-// (v1alpha1, v1alpha2) with v1alpha2 as the storage version, and without a working conversion webhook the API server falls back
-// to strategy "None", which prunes v1alpha1 fields at write time (since v1alpha2 wraps them under spec.config). Some users
-// install only a stand-alone Perses CRD without the Perses operator (which would normally ship the conversion webhook), so this
-// patch is the only thing keeping v1alpha1 dashboards from silently losing data.
+// ensurePersesConversionWebhookConfigured patches the perses.dev PersesDashboard CRD so Dash0 does not silently lose dashboard
+// data on the GitOps path. It performs up to two independent patches in a single API call:
+//
+//  1. Conversion webhook stanza (gated by AutoPatchConversionWebhook): points the CRD's conversion stanza at the operator
+//     manager's webhook endpoint, but only if no conversion webhook is already configured. The CRD has two versions
+//     (v1alpha1, v1alpha2) with v1alpha2 as the storage version, and without a working conversion webhook the API server falls
+//     back to strategy "None", which prunes v1alpha1 fields at write time (since v1alpha2 wraps them under spec.config).
+//  2. Panel-spec unknown-field preservation (gated by AutoPreservePanelSpecFields): adds
+//     x-kubernetes-preserve-unknown-fields at the panel spec so Dash0 extensions such as `annotations` are not pruned at
+//     admission (see ensurePanelSpecPreservesUnknownFields).
+//
+// Both patches back off when a foreign conversion webhook is present, because that indicates the Perses operator owns the CRD
+// and we must not fight it. Some users install only a stand-alone Perses CRD without the Perses operator, and for them these
+// patches are the only thing keeping dashboards from silently losing data.
 //
 // onUpdate distinguishes "first observation" (CRD created event) from "subsequent update" (CRD reconciled by GitOps or kubectl
 // apply). Re-patching during an update is logged as a warning so a patch-war between us and an external reconciler is observable.
@@ -951,14 +964,12 @@ func (r *PersesDashboardCrdReconciler) ensurePersesConversionWebhookConfigured(
 	onUpdate bool,
 	logger logd.Logger,
 ) {
-	if !r.conversionWebhookSettings.AutoPatchConversionWebhook {
+	if !r.conversionWebhookSettings.AutoPatchConversionWebhook && !r.conversionWebhookSettings.AutoPreservePanelSpecFields {
 		return
 	}
 
-	if r.conversionStanzaMatchesOurs(crd) {
-		return
-	}
-
+	// A foreign conversion webhook means another controller (typically the Perses operator) owns this CRD. We do not fight it,
+	// neither for the conversion stanza nor for the schema.
 	if hasForeignConversionWebhook(crd) {
 		if !onUpdate {
 			logger.Info(
@@ -969,15 +980,78 @@ func (r *PersesDashboardCrdReconciler) ensurePersesConversionWebhookConfigured(
 		return
 	}
 
+	patched := crd.DeepCopy()
+	conversionPatched := false
+	schemaPatched := false
+
+	if r.conversionWebhookSettings.AutoPatchConversionWebhook && !r.conversionStanzaMatchesOurs(crd) {
+		if caBundle, ok := r.readConversionWebhookCaBundle(logger); ok {
+			patched.Spec.Conversion = r.buildConversionStanza(caBundle)
+			conversionPatched = true
+		}
+	}
+
+	if r.conversionWebhookSettings.AutoPreservePanelSpecFields {
+		schemaPatched = ensurePanelSpecPreservesUnknownFields(patched)
+	}
+
+	if !conversionPatched && !schemaPatched {
+		return
+	}
+
+	if err := r.Patch(ctx, patched, client.MergeFrom(crd)); err != nil {
+		logger.Error(
+			err,
+			"Failed to patch the perses.dev PersesDashboard CRD (conversion webhook and/or panel-spec preservation). "+
+				"PersesDashboard resources may lose fields when stored.",
+		)
+		return
+	}
+
+	if conversionPatched {
+		if onUpdate {
+			logger.Warn(
+				"The conversion stanza on the perses.dev PersesDashboard CRD was missing or pointing elsewhere on a CRD update; " +
+					"re-applied the Dash0-operator conversion webhook configuration. If this happens repeatedly, a GitOps reconciler " +
+					"(Argo CD, Flux, etc.) is likely overwriting the CRD. Configure your GitOps tooling to leave spec.conversion " +
+					"alone (preferred), install the Perses operator to let it handle the conversion, or set the Helm value " +
+					"operator.persesDashboard.autoPatchConversionWebhook=false.",
+			)
+		} else {
+			logger.Info(
+				"Patched the perses.dev PersesDashboard CRD to route conversions through the Dash0 operator's conversion webhook.",
+			)
+		}
+	}
+	if schemaPatched {
+		if onUpdate {
+			logger.Warn(
+				"Re-applied x-kubernetes-preserve-unknown-fields at the panel spec of the perses.dev PersesDashboard CRD on a " +
+					"CRD update (a GitOps reconciler or the Perses operator likely overwrote it). If this happens repeatedly, " +
+					"configure your tooling to leave the CRD schema alone, or set the Helm value " +
+					"operator.persesDashboard.autoPreservePanelSpecFields=false.",
+			)
+		} else {
+			logger.Info(
+				"Patched the perses.dev PersesDashboard CRD to preserve unknown fields at the panel spec so Dash0 panel " +
+					"extensions (e.g. annotations) are not pruned at admission.",
+			)
+		}
+	}
+}
+
+// readConversionWebhookCaBundle reads the CA bundle used for the conversion webhook stanza. It returns ok=false (and logs) when
+// the bundle cannot be read or is empty, in which case the conversion patch must be skipped.
+func (r *PersesDashboardCrdReconciler) readConversionWebhookCaBundle(logger logd.Logger) ([]byte, bool) {
 	caBundle, err := os.ReadFile(r.conversionWebhookSettings.CaBundlePath)
 	if err != nil {
 		logger.Error(
 			err,
 			"Cannot read CA bundle for patching the perses.dev PersesDashboard CRD conversion webhook; "+
-				"skipping the patch. v1alpha1 PersesDashboard resources may lose fields when stored.",
+				"skipping the conversion patch. v1alpha1 PersesDashboard resources may lose fields when stored.",
 			"caBundlePath", r.conversionWebhookSettings.CaBundlePath,
 		)
-		return
+		return nil, false
 	}
 	// Skip the patch on an empty bundle: this happens transiently while cert-manager (or whatever provisions the serving cert)
 	// has not yet materialized the file. Patching with an empty caBundle would make the API server reject every conversion
@@ -985,39 +1059,79 @@ func (r *PersesDashboardCrdReconciler) ensurePersesConversionWebhookConfigured(
 	if len(bytes.TrimSpace(caBundle)) == 0 {
 		logger.Error(
 			fmt.Errorf("CA bundle file is empty"),
-			"CA bundle for patching the perses.dev PersesDashboard CRD conversion webhook is empty; skipping the patch. "+
-				"This is expected briefly while the serving cert is being provisioned; the next CRD reconciliation will "+
+			"CA bundle for patching the perses.dev PersesDashboard CRD conversion webhook is empty; skipping the conversion "+
+				"patch. This is expected briefly while the serving cert is being provisioned; the next CRD reconciliation will "+
 				"retry. If it persists, v1alpha1 PersesDashboard resources may lose fields when stored.",
 			"caBundlePath", r.conversionWebhookSettings.CaBundlePath,
 		)
-		return
+		return nil, false
 	}
+	return caBundle, true
+}
 
-	patched := crd.DeepCopy()
-	patched.Spec.Conversion = r.buildConversionStanza(caBundle)
-
-	if err := r.Patch(ctx, patched, client.MergeFrom(crd)); err != nil {
-		logger.Error(
-			err,
-			"Failed to patch the perses.dev PersesDashboard CRD with the Dash0-operator conversion webhook configuration. "+
-				"v1alpha1 PersesDashboard resources will lose fields when stored.",
-		)
-		return
+// ensurePanelSpecPreservesUnknownFields sets x-kubernetes-preserve-unknown-fields: true on the panel spec object of every
+// version of the PersesDashboard CRD, so Dash0-specific extensions that live at panel-spec level (e.g. `annotations`, a sibling
+// of plugin/queries) are not pruned by the API server at admission. The upstream Perses CRD models the panel spec as a closed
+// schema (only display/links/plugin/queries), which is why these fields are silently dropped on the GitOps path.
+// v1alpha2 nests the dashboard body under spec.config, while v1alpha1 keeps it directly under spec; both are handled. Returns
+// true if it changed anything (so the caller only issues a patch when needed and does not churn on every reconcile).
+//
+// Caveat: if the Perses operator is installed, it owns this CRD and may re-assert its own schema, undoing this patch. The caller
+// already backs off entirely when a foreign conversion webhook is present; where the Perses operator manages the CRD without
+// such a webhook, the durable fix is an upstream Perses schema change (or managing the dashboard via the Dash0 API/UI).
+func ensurePanelSpecPreservesUnknownFields(crd *apiextensionsv1.CustomResourceDefinition) bool {
+	changed := false
+	for i := range crd.Spec.Versions {
+		version := &crd.Spec.Versions[i]
+		if version.Schema == nil || version.Schema.OpenAPIV3Schema == nil {
+			continue
+		}
+		specSchema, ok := version.Schema.OpenAPIV3Schema.Properties["spec"]
+		if !ok {
+			continue
+		}
+		panelsHolder := specSchema.Properties
+		if config, ok := specSchema.Properties["config"]; ok {
+			// v1alpha2: the dashboard body (incl. panels) is nested under spec.config.
+			panelsHolder = config.Properties
+		}
+		if setPanelSpecPreservesUnknownFields(panelsHolder) {
+			changed = true
+		}
 	}
+	return changed
+}
 
-	if onUpdate {
-		logger.Warn(
-			"The conversion stanza on the perses.dev PersesDashboard CRD was missing or pointing elsewhere on a CRD update; " +
-				"re-applied the Dash0-operator conversion webhook configuration. If this happens repeatedly, a GitOps reconciler " +
-				"(Argo CD, Flux, etc.) is likely overwriting the CRD. Configure your GitOps tooling to leave spec.conversion " +
-				"alone (preferred), install the Perses operator to let it handle the conversion, or set the Helm value " +
-				"operator.persesDashboard.autoPatchConversionWebhook=false.",
-		)
-	} else {
-		logger.Info(
-			"Patched the perses.dev PersesDashboard CRD to route conversions through the Dash0 operator's conversion webhook.",
-		)
+// setPanelSpecPreservesUnknownFields flips x-kubernetes-preserve-unknown-fields to true on panels.<any>.spec, reached via the
+// panels object's additionalProperties schema. panelsHolder is the map that directly contains the "panels" key (spec.properties
+// for v1alpha1, spec.config.properties for v1alpha2). Returns true if a change was made.
+//
+// Go note: apiextensionsv1.JSONSchemaProps is stored by value in map[string]JSONSchemaProps, so we read the panel spec struct,
+// mutate it, and write it back into panelSchema.Properties. That map lives under panels.AdditionalProperties.Schema, which is a
+// pointer shared with the CRD we hand to Patch, so the write-back persists.
+func setPanelSpecPreservesUnknownFields(panelsHolder map[string]apiextensionsv1.JSONSchemaProps) bool {
+	if panelsHolder == nil {
+		return false
 	}
+	panels, ok := panelsHolder["panels"]
+	if !ok || panels.AdditionalProperties == nil || panels.AdditionalProperties.Schema == nil {
+		return false
+	}
+	panelSchema := panels.AdditionalProperties.Schema
+	if panelSchema.Properties == nil {
+		return false
+	}
+	panelSpec, ok := panelSchema.Properties["spec"]
+	if !ok {
+		return false
+	}
+	if panelSpec.XPreserveUnknownFields != nil && *panelSpec.XPreserveUnknownFields {
+		return false
+	}
+	preserve := true
+	panelSpec.XPreserveUnknownFields = &preserve
+	panelSchema.Properties["spec"] = panelSpec
+	return true
 }
 
 // conversionStanzaMatchesOurs reports whether the CRD's conversion stanza is already pointing

--- a/internal/controller/perses_dashboards_controller.go
+++ b/internal/controller/perses_dashboards_controller.go
@@ -968,9 +968,12 @@ func (r *PersesDashboardCrdReconciler) ensurePersesConversionWebhookConfigured(
 		return
 	}
 
-	// A foreign conversion webhook means another controller (typically the Perses operator) owns this CRD. We do not fight it,
-	// neither for the conversion stanza nor for the schema.
-	if hasForeignConversionWebhook(crd) {
+	// A foreign conversion webhook means another controller (typically the Perses operator) owns this CRD; we do not fight it,
+	// neither for the conversion stanza nor for the schema. Our own stanza is not foreign: hasForeignConversionWebhook alone
+	// returns true for any webhook (including ours), so we must exclude the case where the stanza already matches ours -
+	// otherwise, in the default steady state (autoPatchConversionWebhook=true, our stanza already applied), this would skip
+	// the panel-spec patch entirely.
+	if hasForeignConversionWebhook(crd) && !r.conversionStanzaMatchesOurs(crd) {
 		if !onUpdate {
 			logger.Info(
 				"Detected pre-existing conversion webhook on the perses.dev PersesDashboard CRD " +
@@ -1015,7 +1018,7 @@ func (r *PersesDashboardCrdReconciler) ensurePersesConversionWebhookConfigured(
 					"re-applied the Dash0-operator conversion webhook configuration. If this happens repeatedly, a GitOps reconciler " +
 					"(Argo CD, Flux, etc.) is likely overwriting the CRD. Configure your GitOps tooling to leave spec.conversion " +
 					"alone (preferred), install the Perses operator to let it handle the conversion, or set the Helm value " +
-					"operator.persesDashboard.autoPatchConversionWebhook=false.",
+					"operator.iac.persesDashboard.autoPatchConversionWebhook=false.",
 			)
 		} else {
 			logger.Info(
@@ -1029,7 +1032,7 @@ func (r *PersesDashboardCrdReconciler) ensurePersesConversionWebhookConfigured(
 				"Re-applied x-kubernetes-preserve-unknown-fields at the panel spec of the perses.dev PersesDashboard CRD on a " +
 					"CRD update (a GitOps reconciler or the Perses operator likely overwrote it). If this happens repeatedly, " +
 					"configure your tooling to leave the CRD schema alone, or set the Helm value " +
-					"operator.persesDashboard.autoPreservePanelSpecFields=false.",
+					"operator.iac.persesDashboard.autoPreservePanelSpecFields=false.",
 			)
 		} else {
 			logger.Info(
@@ -1082,56 +1085,57 @@ func (r *PersesDashboardCrdReconciler) readConversionWebhookCaBundle(logger logd
 func ensurePanelSpecPreservesUnknownFields(crd *apiextensionsv1.CustomResourceDefinition) bool {
 	changed := false
 	for i := range crd.Spec.Versions {
-		version := &crd.Spec.Versions[i]
-		if version.Schema == nil || version.Schema.OpenAPIV3Schema == nil {
+		panelSchema := panelSchemaForVersion(&crd.Spec.Versions[i])
+		if panelSchema == nil {
 			continue
 		}
-		specSchema, ok := version.Schema.OpenAPIV3Schema.Properties["spec"]
+		panelSpec, ok := panelSchema.Properties["spec"]
 		if !ok {
 			continue
 		}
-		panelsHolder := specSchema.Properties
-		if config, ok := specSchema.Properties["config"]; ok {
-			// v1alpha2: the dashboard body (incl. panels) is nested under spec.config.
-			panelsHolder = config.Properties
+		if panelSpec.XPreserveUnknownFields != nil && *panelSpec.XPreserveUnknownFields {
+			continue
 		}
-		if setPanelSpecPreservesUnknownFields(panelsHolder) {
-			changed = true
-		}
+		// Go note: apiextensionsv1.JSONSchemaProps is stored by value in map[string]JSONSchemaProps, so we read the panel
+		// spec struct, mutate it, and write it back. panelSchema.Properties lives under panels.AdditionalProperties.Schema,
+		// which is a pointer shared with the CRD we hand to Patch, so the write-back persists.
+		preserve := true
+		panelSpec.XPreserveUnknownFields = &preserve
+		panelSchema.Properties["spec"] = panelSpec
+		changed = true
 	}
 	return changed
 }
 
-// setPanelSpecPreservesUnknownFields flips x-kubernetes-preserve-unknown-fields to true on panels.<any>.spec, reached via the
-// panels object's additionalProperties schema. panelsHolder is the map that directly contains the "panels" key (spec.properties
-// for v1alpha1, spec.config.properties for v1alpha2). Returns true if a change was made.
-//
-// Go note: apiextensionsv1.JSONSchemaProps is stored by value in map[string]JSONSchemaProps, so we read the panel spec struct,
-// mutate it, and write it back into panelSchema.Properties. That map lives under panels.AdditionalProperties.Schema, which is a
-// pointer shared with the CRD we hand to Patch, so the write-back persists.
-func setPanelSpecPreservesUnknownFields(panelsHolder map[string]apiextensionsv1.JSONSchemaProps) bool {
+// panelSchemaForVersion returns the per-panel schema node (panels.<any>, whose Properties holds "spec") for a single CRD
+// version, or nil if the version's schema does not have the expected shape. v1alpha2 nests the dashboard body under
+// spec.config while v1alpha1 keeps it directly under spec; both are handled. The returned pointer aliases into the CRD, so
+// callers can mutate the schema in place. This is the single traversal shared by the production patch and the tests.
+func panelSchemaForVersion(version *apiextensionsv1.CustomResourceDefinitionVersion) *apiextensionsv1.JSONSchemaProps {
+	if version.Schema == nil || version.Schema.OpenAPIV3Schema == nil {
+		return nil
+	}
+	specSchema, ok := version.Schema.OpenAPIV3Schema.Properties["spec"]
+	if !ok {
+		return nil
+	}
+	panelsHolder := specSchema.Properties
+	if config, ok := specSchema.Properties["config"]; ok {
+		// v1alpha2: the dashboard body (incl. panels) is nested under spec.config.
+		panelsHolder = config.Properties
+	}
 	if panelsHolder == nil {
-		return false
+		return nil
 	}
 	panels, ok := panelsHolder["panels"]
 	if !ok || panels.AdditionalProperties == nil || panels.AdditionalProperties.Schema == nil {
-		return false
+		return nil
 	}
 	panelSchema := panels.AdditionalProperties.Schema
 	if panelSchema.Properties == nil {
-		return false
+		return nil
 	}
-	panelSpec, ok := panelSchema.Properties["spec"]
-	if !ok {
-		return false
-	}
-	if panelSpec.XPreserveUnknownFields != nil && *panelSpec.XPreserveUnknownFields {
-		return false
-	}
-	preserve := true
-	panelSpec.XPreserveUnknownFields = &preserve
-	panelSchema.Properties["spec"] = panelSpec
-	return true
+	return panelSchema
 }
 
 // conversionStanzaMatchesOurs reports whether the CRD's conversion stanza is already pointing

--- a/internal/controller/perses_dashboards_controller_test.go
+++ b/internal/controller/perses_dashboards_controller_test.go
@@ -779,6 +779,75 @@ var _ = Describe("The Perses dashboard controller", Ordered, func() {
 					BeFalse(), "expected panel spec to be left untouched while the Perses operator owns the CRD")
 			})
 
+			It("does not patch the schema when autoPreservePanelSpecFields is disabled", func() {
+				ensurePersesDashboardCrdExists(ctx)
+
+				r := createPersesDashboardCrdReconcilerWithSettings(false, false, caBundlePath)
+				r.ensurePersesConversionWebhookConfigured(ctx, persesDashboardCrd, false, logger)
+
+				after := &apiextensionsv1.CustomResourceDefinition{}
+				Expect(k8sClient.Get(ctx, PersesDashboardCrdQualifiedName, after)).To(Succeed())
+				Expect(panelSpecPreservesUnknownFields(after, persesDashboardV1Alpha2)).To(BeFalse())
+			})
+
+			It("still patches the schema when the operator's own conversion webhook is already present", func() {
+				// Regression test: hasForeignConversionWebhook returns true for our own stanza too, so in the default steady
+				// state (autoPatchConversionWebhook=true, our stanza already applied) the schema patch must not be skipped.
+				ensurePersesDashboardCrdExists(ctx)
+
+				// Steady state: the operator has already applied its own conversion stanza, schema not yet preserved.
+				conv := createPersesDashboardCrdReconcilerWithSettings(false, true, caBundlePath)
+				conv.ensurePersesConversionWebhookConfigured(ctx, persesDashboardCrd, false, logger)
+				withOurStanza := &apiextensionsv1.CustomResourceDefinition{}
+				Expect(k8sClient.Get(ctx, PersesDashboardCrdQualifiedName, withOurStanza)).To(Succeed())
+				Expect(withOurStanza.Spec.Conversion).NotTo(BeNil())
+				Expect(withOurStanza.Spec.Conversion.Strategy).To(Equal(apiextensionsv1.WebhookConverter))
+				Expect(panelSpecPreservesUnknownFields(withOurStanza, persesDashboardV1Alpha2)).To(BeFalse())
+
+				// A preservation-enabled reconcile must NOT be blocked by our own conversion stanza.
+				r := createPersesDashboardCrdReconcilerWithSettings(true, true, caBundlePath)
+				r.ensurePersesConversionWebhookConfigured(ctx, withOurStanza, false, logger)
+
+				after := &apiextensionsv1.CustomResourceDefinition{}
+				Expect(k8sClient.Get(ctx, PersesDashboardCrdQualifiedName, after)).To(Succeed())
+				for _, versionName := range []string{persesDashboardV1Alpha1, persesDashboardV1Alpha2} {
+					Expect(panelSpecPreservesUnknownFields(after, versionName)).To(
+						BeTrue(), "expected panel spec of %s to be preserved despite our own conversion stanza", versionName)
+				}
+			})
+
+			It("re-applies the schema preservation on update if it was removed", func() {
+				ensurePersesDashboardCrdExists(ctx)
+				r := createPersesDashboardCrdReconcilerWithSettings(true, false, caBundlePath)
+				r.ensurePersesConversionWebhookConfigured(ctx, persesDashboardCrd, false, logger)
+
+				preserved := &apiextensionsv1.CustomResourceDefinition{}
+				Expect(k8sClient.Get(ctx, PersesDashboardCrdQualifiedName, preserved)).To(Succeed())
+				Expect(panelSpecPreservesUnknownFields(preserved, persesDashboardV1Alpha2)).To(BeTrue())
+
+				// Simulate a GitOps reconciler wiping the preserve flag back off.
+				wiped := preserved.DeepCopy()
+				for i := range wiped.Spec.Versions {
+					if panelSchema := panelSchemaForVersion(&wiped.Spec.Versions[i]); panelSchema != nil {
+						if panelSpec, ok := panelSchema.Properties["spec"]; ok {
+							panelSpec.XPreserveUnknownFields = nil
+							panelSchema.Properties["spec"] = panelSpec
+						}
+					}
+				}
+				Expect(k8sClient.Patch(ctx, wiped, client.MergeFrom(preserved))).To(Succeed())
+
+				updated := &apiextensionsv1.CustomResourceDefinition{}
+				Expect(k8sClient.Get(ctx, PersesDashboardCrdQualifiedName, updated)).To(Succeed())
+				Expect(panelSpecPreservesUnknownFields(updated, persesDashboardV1Alpha2)).To(BeFalse())
+
+				r.ensurePersesConversionWebhookConfigured(ctx, updated, true, logger)
+
+				after := &apiextensionsv1.CustomResourceDefinition{}
+				Expect(k8sClient.Get(ctx, PersesDashboardCrdQualifiedName, after)).To(Succeed())
+				Expect(panelSpecPreservesUnknownFields(after, persesDashboardV1Alpha2)).To(BeTrue())
+			})
+
 			It("ensurePanelSpecPreservesUnknownFields is idempotent and covers both versions (unit)", func() {
 				crd := &apiextensionsv1.CustomResourceDefinition{}
 				Expect(yaml.Unmarshal(embeddedPersesDashboardCrdYaml(), crd)).To(Succeed())
@@ -1629,26 +1698,18 @@ func buildV1Alpha2DashboardWithPanelAnnotations() *unstructured.Unstructured {
 }
 
 // panelSpecPreservesUnknownFields reports whether the panel spec object of the given CRD version has
-// x-kubernetes-preserve-unknown-fields set to true.
+// x-kubernetes-preserve-unknown-fields set to true. It reuses the production traversal (panelSchemaForVersion) so the test
+// cannot drift from the code it verifies.
 func panelSpecPreservesUnknownFields(crd *apiextensionsv1.CustomResourceDefinition, versionName string) bool {
 	for i := range crd.Spec.Versions {
-		v := &crd.Spec.Versions[i]
-		if v.Name != versionName || v.Schema == nil || v.Schema.OpenAPIV3Schema == nil {
+		if crd.Spec.Versions[i].Name != versionName {
 			continue
 		}
-		specSchema, ok := v.Schema.OpenAPIV3Schema.Properties["spec"]
-		if !ok {
+		panelSchema := panelSchemaForVersion(&crd.Spec.Versions[i])
+		if panelSchema == nil {
 			return false
 		}
-		holder := specSchema.Properties
-		if config, ok := specSchema.Properties["config"]; ok {
-			holder = config.Properties
-		}
-		panels, ok := holder["panels"]
-		if !ok || panels.AdditionalProperties == nil || panels.AdditionalProperties.Schema == nil {
-			return false
-		}
-		panelSpec, ok := panels.AdditionalProperties.Schema.Properties["spec"]
+		panelSpec, ok := panelSchema.Properties["spec"]
 		if !ok {
 			return false
 		}

--- a/internal/controller/perses_dashboards_controller_test.go
+++ b/internal/controller/perses_dashboards_controller_test.go
@@ -16,6 +16,7 @@ import (
 	"math/big"
 	"net/http"
 	"os"
+	"path/filepath"
 	"time"
 
 	persesv1alpha1 "github.com/perses/perses-operator/api/v1alpha1"
@@ -23,6 +24,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllertest"
@@ -673,6 +675,124 @@ var _ = Describe("The Perses dashboard controller", Ordered, func() {
 	)
 
 	Describe(
+		"panel-spec unknown-field preservation", func() {
+
+			AfterEach(func() {
+				deletePersesDashboardCrdIfItExists(ctx)
+			})
+
+			// readStoredPanelAnnotations creates the given dashboard via the real (envtest) API server, reads it back, and
+			// returns whatever survived at spec.config.panels.<panelId>.spec.annotations. A nil return means the field was
+			// pruned by CRD field-pruning at admission.
+			readStoredPanelAnnotations := func(dashboard *unstructured.Unstructured) (any, bool) {
+				// The CRD may need a moment to become served after being (re-)created; retry the create until it succeeds.
+				Eventually(func(g Gomega) {
+					err := k8sClient.Create(ctx, dashboard.DeepCopy())
+					g.Expect(err).NotTo(HaveOccurred())
+				}, timeout, pollingInterval).Should(Succeed())
+
+				stored := &unstructured.Unstructured{}
+				stored.SetGroupVersionKind(dashboard.GroupVersionKind())
+				Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(dashboard), stored)).To(Succeed())
+				annotations, found, err := unstructured.NestedFieldNoCopy(
+					stored.Object,
+					"spec", "config", "panels", examplePanelId, "spec", "annotations",
+				)
+				Expect(err).NotTo(HaveOccurred())
+				return annotations, found
+			}
+
+			It("prunes panel-spec annotations with the unpatched upstream CRD (reproduces the bug)", func() {
+				ensurePersesDashboardCrdExists(ctx)
+
+				annotations, found := readStoredPanelAnnotations(buildV1Alpha2DashboardWithPanelAnnotations())
+
+				// GATE: the whole CRD-pruning diagnosis hinges on this. If the annotation survives here, the theory is wrong
+				// for this setup and the fix below would be speculative.
+				Expect(found).To(BeFalse(), "expected the upstream CRD to prune spec.config.panels[].spec.annotations")
+				Expect(annotations).To(BeNil())
+			})
+
+			It("preserves panel-spec annotations after the operator patches the CRD (proves the fix)", func() {
+				ensurePersesDashboardCrdExists(ctx)
+
+				// Patch the live CRD via the operator's reconcile path (schema preservation only, no conversion patch).
+				r := createPersesDashboardCrdReconcilerWithSettings(true, false, caBundlePath)
+				r.ensurePersesConversionWebhookConfigured(ctx, persesDashboardCrd, false, logger)
+
+				// The stored CRD now carries x-kubernetes-preserve-unknown-fields at both versions' panel spec.
+				patchedCrd := &apiextensionsv1.CustomResourceDefinition{}
+				Expect(k8sClient.Get(ctx, PersesDashboardCrdQualifiedName, patchedCrd)).To(Succeed())
+				for _, versionName := range []string{persesDashboardV1Alpha1, persesDashboardV1Alpha2} {
+					Expect(panelSpecPreservesUnknownFields(patchedCrd, versionName)).To(
+						BeTrue(), "expected panel spec of %s to preserve unknown fields", versionName)
+				}
+
+				// End to end: the annotation now survives admission pruning. Retry create/get because the API server may take
+				// a moment to serve the updated schema.
+				dashboard := buildV1Alpha2DashboardWithPanelAnnotations()
+				Eventually(func(g Gomega) {
+					_ = k8sClient.Delete(ctx, dashboard.DeepCopy())
+					g.Expect(k8sClient.Create(ctx, dashboard.DeepCopy())).To(Succeed())
+
+					stored := &unstructured.Unstructured{}
+					stored.SetGroupVersionKind(dashboard.GroupVersionKind())
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(dashboard), stored)).To(Succeed())
+					annotations, found, err := unstructured.NestedSlice(
+						stored.Object, "spec", "config", "panels", examplePanelId, "spec", "annotations")
+					g.Expect(err).NotTo(HaveOccurred())
+					g.Expect(found).To(BeTrue(), "expected spec.config.panels[].spec.annotations to survive")
+					g.Expect(annotations).To(HaveLen(1))
+				}, timeout, pollingInterval).Should(Succeed())
+			})
+
+			It("leaves the CRD schema untouched when a foreign conversion webhook is present", func() {
+				ensurePersesDashboardCrdExists(ctx)
+				fresh := &apiextensionsv1.CustomResourceDefinition{}
+				Expect(k8sClient.Get(ctx, PersesDashboardCrdQualifiedName, fresh)).To(Succeed())
+				patched := fresh.DeepCopy()
+				foreignPath := "/foreign-convert"
+				foreignPort := int32(8443)
+				patched.Spec.Conversion = &apiextensionsv1.CustomResourceConversion{
+					Strategy: apiextensionsv1.WebhookConverter,
+					Webhook: &apiextensionsv1.WebhookConversion{
+						ConversionReviewVersions: []string{"v1"},
+						ClientConfig: &apiextensionsv1.WebhookClientConfig{
+							CABundle: caPEM,
+							Service: &apiextensionsv1.ServiceReference{
+								Name:      "perses-operator-webhook-service",
+								Namespace: "perses-system",
+								Path:      &foreignPath,
+								Port:      &foreignPort,
+							},
+						},
+					},
+				}
+				Expect(k8sClient.Patch(ctx, patched, client.MergeFrom(fresh))).To(Succeed())
+
+				r := createPersesDashboardCrdReconcilerWithSettings(true, false, caBundlePath)
+				r.ensurePersesConversionWebhookConfigured(ctx, patched, false, logger)
+
+				after := &apiextensionsv1.CustomResourceDefinition{}
+				Expect(k8sClient.Get(ctx, PersesDashboardCrdQualifiedName, after)).To(Succeed())
+				Expect(panelSpecPreservesUnknownFields(after, persesDashboardV1Alpha2)).To(
+					BeFalse(), "expected panel spec to be left untouched while the Perses operator owns the CRD")
+			})
+
+			It("ensurePanelSpecPreservesUnknownFields is idempotent and covers both versions (unit)", func() {
+				crd := &apiextensionsv1.CustomResourceDefinition{}
+				Expect(yaml.Unmarshal(embeddedPersesDashboardCrdYaml(), crd)).To(Succeed())
+
+				Expect(ensurePanelSpecPreservesUnknownFields(crd)).To(BeTrue(), "expected the first pass to change the schema")
+				for _, versionName := range []string{persesDashboardV1Alpha1, persesDashboardV1Alpha2} {
+					Expect(panelSpecPreservesUnknownFields(crd, versionName)).To(BeTrue())
+				}
+				Expect(ensurePanelSpecPreservesUnknownFields(crd)).To(BeFalse(), "expected a second pass to be a no-op")
+			})
+		},
+	)
+
+	Describe(
 		"the Perses dashboard resource reconciler", func() {
 			var persesDashboardCrdReconciler *PersesDashboardCrdReconciler
 			var persesDashboardReconciler *PersesDashboardReconciler
@@ -1314,18 +1434,29 @@ spec:
 )
 
 func createPersesDashboardCrdReconciler(autoPatch bool, caBundlePath string) *PersesDashboardCrdReconciler {
+	// AutoPreservePanelSpecFields defaults to disabled here so the conversion-webhook tests remain isolated; the panel-spec
+	// preservation tests opt in via createPersesDashboardCrdReconcilerWithSettings.
+	return createPersesDashboardCrdReconcilerWithSettings(false, autoPatch, caBundlePath)
+}
+
+func createPersesDashboardCrdReconcilerWithSettings(
+	autoPreservePanelSpecFields bool,
+	autoPatch bool,
+	caBundlePath string,
+) *PersesDashboardCrdReconciler {
 	crdReconciler := NewPersesDashboardCrdReconciler(
 		k8sClient,
 		testQueuePersesDashboards,
 		&DummyLeaderElectionAware{Leader: true},
 		TestHTTPClient(),
 		PersesDashboardConversionWebhookSettings{
-			// Default to disabled in tests; individual tests that exercise the patch logic set this back to true.
-			AutoPatchConversionWebhook: autoPatch,
-			OperatorNamespace:          OperatorNamespace,
-			WebhookServiceName:         OperatorWebhookServiceName,
-			WebhookServicePort:         OperatorWebhookServicePort,
-			CaBundlePath:               caBundlePath,
+			// Default to disabled in tests; individual tests that exercise the patch logic set these back to true.
+			AutoPatchConversionWebhook:  autoPatch,
+			AutoPreservePanelSpecFields: autoPreservePanelSpecFields,
+			OperatorNamespace:           OperatorNamespace,
+			WebhookServiceName:          OperatorWebhookServiceName,
+			WebhookServicePort:          OperatorWebhookServicePort,
+			CaBundlePath:                caBundlePath,
 		},
 	)
 
@@ -1439,6 +1570,98 @@ func createDashboardResourceWithEnableLabel(dash0EnableLabelValue string) unstru
 	err = json.Unmarshal(marshalled, &unstructuredObject)
 	Expect(err).NotTo(HaveOccurred())
 	return unstructuredObject
+}
+
+// examplePanelId is the id of the example GeoMap panel used by the panel-spec preservation tests.
+const examplePanelId = "example-geomap-panel"
+
+// buildV1Alpha2DashboardWithPanelAnnotations returns a minimal but schema-valid perses.dev/v1alpha2 PersesDashboard
+// whose single panel carries a Dash0 `annotations` block at panel-spec level (sibling of plugin/queries). v1alpha2 is the
+// storage version, so creating it needs no conversion webhook; the only thing that can drop `annotations` is CRD field
+// pruning at admission.
+func buildV1Alpha2DashboardWithPanelAnnotations() *unstructured.Unstructured {
+	dashboard := &unstructured.Unstructured{}
+	dashboard.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "perses.dev",
+		Version: "v1alpha2",
+		Kind:    "PersesDashboard",
+	})
+	dashboard.SetName("test-dashboard")
+	dashboard.SetNamespace(TestNamespaceName)
+	dashboard.Object["spec"] = map[string]any{
+		"config": map[string]any{
+			"display":  map[string]any{"name": "Example Dashboard"},
+			"duration": "5m",
+			"layouts":  []any{},
+			"panels": map[string]any{
+				examplePanelId: map[string]any{
+					"kind": "Panel",
+					"spec": map[string]any{
+						"display": map[string]any{"name": "Example Panel"},
+						"plugin": map[string]any{
+							"kind": "GeoMap",
+							"spec": map[string]any{},
+						},
+						"annotations": []any{
+							map[string]any{
+								"kind": "LogsAnnotation",
+								"spec": map[string]any{
+									"id":   "example-annotation-id",
+									"name": "Example Annotation",
+									"query": map[string]any{
+										"filter": []any{
+											map[string]any{
+												"key":      "otel.log.body",
+												"operator": "contains",
+												"value":    "example log message",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	return dashboard
+}
+
+// panelSpecPreservesUnknownFields reports whether the panel spec object of the given CRD version has
+// x-kubernetes-preserve-unknown-fields set to true.
+func panelSpecPreservesUnknownFields(crd *apiextensionsv1.CustomResourceDefinition, versionName string) bool {
+	for i := range crd.Spec.Versions {
+		v := &crd.Spec.Versions[i]
+		if v.Name != versionName || v.Schema == nil || v.Schema.OpenAPIV3Schema == nil {
+			continue
+		}
+		specSchema, ok := v.Schema.OpenAPIV3Schema.Properties["spec"]
+		if !ok {
+			return false
+		}
+		holder := specSchema.Properties
+		if config, ok := specSchema.Properties["config"]; ok {
+			holder = config.Properties
+		}
+		panels, ok := holder["panels"]
+		if !ok || panels.AdditionalProperties == nil || panels.AdditionalProperties.Schema == nil {
+			return false
+		}
+		panelSpec, ok := panels.AdditionalProperties.Schema.Properties["spec"]
+		if !ok {
+			return false
+		}
+		return panelSpec.XPreserveUnknownFields != nil && *panelSpec.XPreserveUnknownFields
+	}
+	return false
+}
+
+// embeddedPersesDashboardCrdYaml reads the checked-in upstream Perses CRD used to seed envtest, for pure-function unit tests.
+func embeddedPersesDashboardCrdYaml() []byte {
+	data, err := os.ReadFile(filepath.Join("..", "..", "test", "util", "crds", "perses.dev_persesdashboards.yaml"))
+	Expect(err).NotTo(HaveOccurred())
+	return data
 }
 
 func ensurePersesDashboardCrdExists(ctx context.Context) {

--- a/internal/startup/operator_manager_startup.go
+++ b/internal/startup/operator_manager_startup.go
@@ -76,6 +76,7 @@ type environmentVariables struct {
 	iacPeriodicRetryEnabled                     bool
 	iacPeriodicRetryInterval                    time.Duration
 	autoPatchPersesDashboardConversionWebhook   bool
+	autoPreservePersesDashboardPanelSpecFields  bool
 	oTelCollectorNamePrefix                     string
 	targetAllocatorNamePrefix                   string
 	operatorImage                               string
@@ -166,6 +167,7 @@ const (
 	webhookServiceNameEnvVarName                          = "DASH0_WEBHOOK_SERVICE_NAME"
 	webhookServicePortEnvVarName                          = "DASH0_WEBHOOK_SERVICE_PORT"
 	persesDashboardAutoPatchConversionWebhookEnvVarName   = "DASH0_PERSES_DASHBOARD_AUTO_PATCH_CONVERSION_WEBHOOK"
+	persesDashboardAutoPreservePanelSpecFieldsEnvVarName  = "DASH0_PERSES_DASHBOARD_AUTO_PRESERVE_PANEL_SPEC_FIELDS"
 	periodicRetryEnabledEnvVarName                        = "DASH0_IAC_PERIODIC_RETRY_ENABLED"
 	periodicRetryIntervalEnvVarName                       = "DASH0_IAC_PERIODIC_RETRY_INTERVAL"
 	oTelCollectorNamePrefixEnvVarName                     = "OTEL_COLLECTOR_NAME_PREFIX"
@@ -797,6 +799,8 @@ func readEnvironmentVariables(logger logd.Logger) error {
 
 	autoPatchPersesDashboardConversionWebhook :=
 		readOptionalBoolFromEnvironmentVariable(persesDashboardAutoPatchConversionWebhookEnvVarName, true)
+	autoPreservePersesDashboardPanelSpecFields :=
+		readOptionalBoolFromEnvironmentVariable(persesDashboardAutoPreservePanelSpecFieldsEnvVarName, true)
 
 	iacPeriodicRetryEnabled := readOptionalBoolFromEnvironmentVariable(periodicRetryEnabledEnvVarName, true)
 	iacPeriodicRetryInterval :=
@@ -945,6 +949,7 @@ func readEnvironmentVariables(logger logd.Logger) error {
 		iacPeriodicRetryEnabled:                     iacPeriodicRetryEnabled,
 		iacPeriodicRetryInterval:                    iacPeriodicRetryInterval,
 		autoPatchPersesDashboardConversionWebhook:   autoPatchPersesDashboardConversionWebhook,
+		autoPreservePersesDashboardPanelSpecFields:  autoPreservePersesDashboardPanelSpecFields,
 		oTelCollectorNamePrefix:                     oTelCollectorNamePrefix,
 		targetAllocatorNamePrefix:                   targetAllocatorNamePrefix,
 		operatorImage:                               operatorImage,
@@ -1722,10 +1727,11 @@ func startDash0Controllers(
 		leaderElectionAwareRunnable,
 		httpClient,
 		controller.PersesDashboardConversionWebhookSettings{
-			AutoPatchConversionWebhook: envVars.autoPatchPersesDashboardConversionWebhook,
-			OperatorNamespace:          envVars.operatorNamespace,
-			WebhookServiceName:         envVars.webhookServiceName,
-			WebhookServicePort:         envVars.webhookServicePort,
+			AutoPatchConversionWebhook:  envVars.autoPatchPersesDashboardConversionWebhook,
+			AutoPreservePanelSpecFields: envVars.autoPreservePersesDashboardPanelSpecFields,
+			OperatorNamespace:           envVars.operatorNamespace,
+			WebhookServiceName:          envVars.webhookServiceName,
+			WebhookServicePort:          envVars.webhookServicePort,
 		},
 	)
 	if err := persesDashboardCrdReconciler.SetupWithManager(ctx, mgr, startupTasksK8sClient, setupLog); err != nil {


### PR DESCRIPTION
The upstream PersesDashboard CRD models the per-panel `spec` as a closed schema (only `display`/`links`/`plugin`/`queries`) with no `x-kubernetes-preserve-unknown-fields`. Dash0 panel extensions at panel-spec level (e.g. the per-panel `annotations` block) are pruned by the API server at admission, before the operator reads the resource, so they never reach Dash0.

The operator now patches the CRD to set `x-kubernetes-preserve-unknown-fields: true` at the panel spec for every version, so these extensions survive. Behavior:

- Gated by the new Helm value `operator.iac.persesDashboard.autoPreservePanelSpecFields` (default `true`).
- Skipped when a foreign conversion webhook is present (the Perses operator owns the CRD); in that case the durable fix is upstream Perses or managing the dashboard via the Dash0 API/UI.
- Reuses the existing CRD reconcile path alongside the conversion-webhook patch.

Tests: envtest reproduces the pruning against the unpatched CRD and proves the field survives after the patch; plus foreign-webhook backoff and an idempotent unit test for the schema helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)