### PR TITLE
feat(sc): restructure pipelines to support namespaced/multiple datasets

### DIFF
--- a/internal/collectors/otelcolresources/collector_config_maps_test.go
+++ b/internal/collectors/otelcolresources/collector_config_maps_test.go
@@ -440,8 +440,7 @@ func cmTestMixedDefaultOtlpExporters() otlpExporters {
 }
 
 // cmTestMixedDefaultNoNamespacedExporters is the same mixed (Dash0 + non-Dash0) default as
-// cmTestMixedDefaultOtlpExporters but with NO namespaced exporters. Used to verify that a config without namespaced
-// exporters renders no routing connectors (which would otherwise have an empty, invalid table) and keeps SC inline.
+// cmTestMixedDefaultOtlpExporters but with NO namespaced exporters, to exercise the non-namespaced default split.
 func cmTestMixedDefaultNoNamespacedExporters() otlpExporters {
 	export := Dash0ExportWithEndpointAndToken()
 	auth, _ := dash0ExporterAuthorizationForExport(*export, 0, true, nil)
@@ -451,6 +450,55 @@ func cmTestMixedDefaultNoNamespacedExporters() otlpExporters {
 	Expect(err).ToNot(HaveOccurred())
 	return otlpExporters{
 		Default: []otlpExporter{*dash0ExporterDefault, *grpcExporterDefault},
+	}
+}
+
+// cmTestPassthroughOnlyDefaultExporters has a default export list with ONLY a non-Dash0 exporter (no Dash0), to
+// exercise the "SC enabled but nothing to apply it to" case (all default telemetry must be passthrough, no SC).
+func cmTestPassthroughOnlyDefaultExporters() otlpExporters {
+	grpcExporterDefault, err := convertGrpcExporterToOtlpExporter(GrpcExportTest().Grpc, "default")
+	Expect(err).ToNot(HaveOccurred())
+	return otlpExporters{
+		Default: []otlpExporter{*grpcExporterDefault},
+	}
+}
+
+// assertCollectorConfigStructurallyValid checks invariants the OpenTelemetry collector enforces at load that the
+// per-field unit assertions do not: (1) no routing connector with an empty table, (2) no pipeline with an empty
+// receivers or exporters list, and (3) no "one-sided" connector (a connector used only as a receiver or only as an
+// exporter; it must be used on both sides, or not at all). This catches the classes of template bug that slipped
+// through structural map assertions (empty routing tables, dangling forks). desc labels the config under test.
+func assertCollectorConfigStructurallyValid(collectorConfig map[string]interface{}, desc string) {
+	connectorsRaw, _ := collectorConfig["connectors"].(map[string]interface{})
+	pipelines := readPipelines(collectorConfig)
+
+	for name, c := range connectorsRaw {
+		if strings.HasPrefix(name, "routing/") {
+			cm, _ := c.(map[string]interface{})
+			table, _ := cm["table"].([]interface{})
+			Expect(table).ToNot(BeEmpty(), "%s: routing connector %q has an empty table", desc, name)
+		}
+	}
+
+	usedAsReceiver := map[string]bool{}
+	usedAsExporter := map[string]bool{}
+	for name := range pipelines {
+		recv := readPipelineReceivers(pipelines, name)
+		exp := readPipelineExporters(pipelines, name)
+		Expect(recv).ToNot(BeEmpty(), "%s: pipeline %q has no receivers", desc, name)
+		Expect(exp).ToNot(BeEmpty(), "%s: pipeline %q has no exporters", desc, name)
+		for _, r := range recv {
+			usedAsReceiver[fmt.Sprintf("%v", r)] = true
+		}
+		for _, e := range exp {
+			usedAsExporter[fmt.Sprintf("%v", e)] = true
+		}
+	}
+
+	for name := range connectorsRaw {
+		r := usedAsReceiver[name]
+		e := usedAsExporter[name]
+		Expect(r).To(Equal(e), "%s: connector %q is one-sided (usedAsReceiver=%t usedAsExporter=%t)", desc, name, r, e)
 	}
 }
 
@@ -2018,6 +2066,56 @@ var _ = Describe("The OpenTelemetry Collector ConfigMaps", func() {
 			Expect(logsExportDefaultReceivers).ToNot(ContainElement("routing/logs"))
 		})
 
+		It("should render structurally valid collector configs across exporter/SC combinations [DaemonSet+Deployment]", func() {
+			exporterCases := map[string]otlpExporters{
+				"single-default-dash0":          cmTestSingleDefaultOtlpExporter(),
+				"mixed-default-no-namespaced":   cmTestMixedDefaultNoNamespacedExporters(),
+				"mixed-default-with-namespaced": cmTestMixedDefaultOtlpExporters(),
+				"namespaced-multi-dataset":      cmTestNamespacedMultiDatasetExporters(),
+				"namespaced-passthrough-only":   cmTestNamespacedOtlpExporters(),
+				"passthrough-only-default":      cmTestPassthroughOnlyDefaultExporters(),
+			}
+			scVariants := map[string]SignalControlConfig{
+				"sc-off": {Enabled: false},
+				"sc-full": {
+					Enabled: true, SamplingEnabled: true, SpamFilterEnabled: true, SignalToMetricsEnabled: true,
+					Endpoint: "decision-maker.example.com:443", ApiEndpoint: "https://control-plane-api.dash0.com",
+					Dataset: "default", SamplingReservoirType: "serialized_memory", SamplingReservoirMetricLevel: "basic",
+				},
+				"sc-no-sampling": {
+					Enabled: true, SamplingEnabled: false, SpamFilterEnabled: true, SignalToMetricsEnabled: true,
+					Endpoint: "decision-maker.example.com:443", ApiEndpoint: "https://control-plane-api.dash0.com",
+					Dataset: "default",
+				},
+			}
+
+			for exName, exporters := range exporterCases {
+				for scName, sc := range scVariants {
+					desc := exName + "/" + scName
+
+					dsCM, err := assembleDaemonSetCollectorConfigMap(&oTelColConfig{
+						OperatorNamespace: OperatorNamespace,
+						NamePrefix:        namePrefix,
+						Exporters:         exporters,
+						SignalControl:     sc,
+						KubernetesInfrastructureMetricsCollectionEnabled: true,
+					}, monitoredNamespaces, nil, nil, nil, nil, emptyTargetAllocatorMtlsConfig, false)
+					Expect(err).ToNot(HaveOccurred(), "daemonset/"+desc)
+					assertCollectorConfigStructurallyValid(parseConfigMapContent(dsCM), "daemonset/"+desc)
+
+					depCM, err := assembleDeploymentCollectorConfigMapForTest(&oTelColConfig{
+						OperatorNamespace: OperatorNamespace,
+						NamePrefix:        namePrefix,
+						Exporters:         exporters,
+						SignalControl:     sc,
+						KubernetesInfrastructureMetricsCollectionEnabled: true,
+					}, monitoredNamespaces, nil, nil, false)
+					Expect(err).ToNot(HaveOccurred(), "deployment/"+desc)
+					assertCollectorConfigStructurallyValid(parseConfigMapContent(depCM), "deployment/"+desc)
+				}
+			}
+		})
+
 		It("should create per-dataset SC branches and sample only the first dataset for a multi-dataset namespace [DaemonSet]", func() {
 			configMap, err := assembleDaemonSetCollectorConfigMap(&oTelColConfig{
 				OperatorNamespace: OperatorNamespace,
@@ -2126,7 +2224,7 @@ var _ = Describe("The OpenTelemetry Collector ConfigMaps", func() {
 			Expect(readPipelineProcessors(pipelines, "traces/export/default/passthrough")).ToNot(ContainElement("resource/signal_control_attributes"))
 		})
 
-		It("should not render routing connectors or split the default without namespaced exporters [DaemonSet]", func() {
+		It("should fork the non-namespaced mixed default: SC to the Dash0 default, passthrough raw [DaemonSet]", func() {
 			configMap, err := assembleDaemonSetCollectorConfigMap(&oTelColConfig{
 				OperatorNamespace: OperatorNamespace,
 				NamePrefix:        namePrefix,
@@ -2148,20 +2246,43 @@ var _ = Describe("The OpenTelemetry Collector ConfigMaps", func() {
 			pipelines := readPipelines(collectorConfig)
 
 			// Without namespaced exporters there is no routing (an empty routing table would be rejected by the
-			// collector), so SC stays inline in common-processors and the whole default is exported as-is.
+			// collector). Instead, common-processors forks via forward/traces-to-sc so SC reaches only the Dash0
+			// default exporter, while the non-Dash0 (passthrough) default exporter is attached to common-processors
+			// directly and receives raw telemetry.
 			Expect(connectors).ToNot(HaveKey("routing/traces"))
 			Expect(connectors).ToNot(HaveKey("routing/traces-sampled"))
 			Expect(connectors).ToNot(HaveKey("routing/metrics"))
-			Expect(readPipelineProcessors(pipelines, "traces/common-processors")).To(ContainElement("resource/signal_control_attributes"))
-			Expect(readPipelineExporters(pipelines, "traces/export/default")).
-				To(ContainElements("otlp_grpc/dash0/default", "otlp_grpc/default_1"))
+			Expect(connectors).To(HaveKey("forward/traces-to-sc"))
+
+			// SC is no longer inline in common-processors; common-processors forks to the SC branch plus the raw
+			// passthrough exporter.
+			Expect(readPipelineProcessors(pipelines, "traces/common-processors")).ToNot(ContainElement("resource/signal_control_attributes"))
+			tracesCommonExporters := readPipelineExporters(pipelines, "traces/common-processors")
+			Expect(tracesCommonExporters).To(ContainElement("forward/traces-to-sc"))
+			Expect(tracesCommonExporters).To(ContainElement("otlp_grpc/default_1"))
+
+			// The SC branch applies Signal Control and feeds sampling + RED metrics.
+			Expect(readPipelineReceivers(pipelines, "traces/signal-control-pre-sampling")).To(ContainElement("forward/traces-to-sc"))
+			scProcessors := readPipelineProcessors(pipelines, "traces/signal-control-pre-sampling")
+			Expect(scProcessors).To(ContainElement("resource/signal_control_attributes"))
+			Expect(scProcessors).To(ContainElement("dash0filter"))
+
+			// The SC'd default sink exports ONLY the Dash0 default exporter, never the passthrough one.
+			Expect(readPipelineExporters(pipelines, "traces/export/default")).To(ContainElement("otlp_grpc/dash0/default"))
+			Expect(readPipelineExporters(pipelines, "traces/export/default")).ToNot(ContainElement("otlp_grpc/default_1"))
+
+			// Same fork for metrics (deployment-style k8s metrics run here too) and logs.
+			Expect(connectors).To(HaveKey("forward/metrics-to-sc"))
+			Expect(connectors).To(HaveKey("forward/logs-to-sc"))
+			Expect(readPipelineProcessors(pipelines, "metrics/common-processors")).ToNot(ContainElement("resource/signal_control_attributes"))
+			Expect(readPipelineProcessors(pipelines, "logs/common-processors")).ToNot(ContainElement("resource/signal_control_attributes"))
 		})
 
 		It("should route namespaced traces before sampling when Signal Control is enabled [DaemonSet]", func() {
 			configMap, err := assembleDaemonSetCollectorConfigMap(&oTelColConfig{
 				OperatorNamespace: OperatorNamespace,
 				NamePrefix:        namePrefix,
-				Exporters:         cmTestNamespacedOtlpExporters(),
+				Exporters:         cmTestMultipleNamespacedOtlpExporters(),
 				SignalControl: SignalControlConfig{
 					Enabled:         true,
 					SamplingEnabled: true,
@@ -2207,12 +2328,17 @@ var _ = Describe("The OpenTelemetry Collector ConfigMaps", func() {
 			Expect(tracesExportDefaultReceivers).To(ContainElement("routing/traces-sampled"))
 			Expect(tracesExportDefaultReceivers).ToNot(ContainElement("forward/traces-default-exporter"))
 
-			// non-Dash0 namespaced exporters route to passthrough pipelines (no Signal Control, no sampling)
+			// namespace1's non-Dash0 exporters route to a passthrough pipeline (no Signal Control, no sampling).
 			tracesPassthroughNs1Receivers := readPipelineReceivers(pipelines, "traces/export/ns/"+namespace1+"/passthrough")
 			Expect(tracesPassthroughNs1Receivers).To(ContainElement("routing/traces"))
 			Expect(readPipelineProcessors(pipelines, "traces/export/ns/"+namespace1+"/passthrough")).ToNot(ContainElement("resource/signal_control_attributes"))
-			tracesPassthroughNs2Receivers := readPipelineReceivers(pipelines, "traces/export/ns/"+namespace2+"/passthrough")
-			Expect(tracesPassthroughNs2Receivers).To(ContainElement("routing/traces"))
+
+			// namespace2's Dash0 exporter gets its own SC branch (branch 0), which feeds the shared sampler, and its
+			// kept traces are routed to a per-namespace sampled export.
+			ns2ScProcessors := readPipelineProcessors(pipelines, "traces/sc/ns/"+namespace2+"/0")
+			Expect(ns2ScProcessors).To(ContainElement("resource/signal_control_attributes/ns/" + namespace2 + "/0"))
+			Expect(readPipelineExporters(pipelines, "traces/sc/ns/"+namespace2+"/0")).To(ContainElement("forward/traces-to-sampling"))
+			Expect(readPipelineReceivers(pipelines, "traces/export/sampled/ns/"+namespace2)).To(ContainElement("routing/traces-sampled"))
 
 			// dash0settingsonedgeextension extension should be configured and listed in service extensions
 			extensions := collectorConfig["extensions"].(map[string]interface{})
@@ -2432,21 +2558,23 @@ var _ = Describe("The OpenTelemetry Collector ConfigMaps", func() {
 			s2m := connectors["dash0signaltometrics"].(map[string]interface{})
 			Expect(s2m).To(BeEmpty(), "dash0signaltometrics should render as `{}` when no tunables set")
 
-			// Spans flow into the connector pre-sampling, alongside dash0redmetrics
+			// Spans flow into the connectors from the traces SC branch (common-processors forks to it), alongside
+			// dash0redmetrics.
 			pipelines := readPipelines(collectorConfig)
-			tracesCommonExporters := readPipelineExporters(pipelines, "traces/common-processors")
-			Expect(tracesCommonExporters).To(ContainElement("dash0redmetrics"))
-			Expect(tracesCommonExporters).To(ContainElement("dash0signaltometrics"))
+			Expect(readPipelineExporters(pipelines, "traces/common-processors")).To(ContainElement("forward/traces-to-sc"))
+			scPreSamplingExporters := readPipelineExporters(pipelines, "traces/signal-control-pre-sampling")
+			Expect(scPreSamplingExporters).To(ContainElement("dash0redmetrics"))
+			Expect(scPreSamplingExporters).To(ContainElement("dash0signaltometrics"))
 
-			// Logs fan out to the connector alongside the default forward
-			logsCommonExporters := readPipelineExporters(pipelines, "logs/common-processors")
-			Expect(logsCommonExporters).To(ContainElement("forward/logs-default-exporter"))
-			Expect(logsCommonExporters).To(ContainElement("dash0signaltometrics"))
+			// Logs derive s2m in the logs SC branch, not in common-processors.
+			Expect(readPipelineExporters(pipelines, "logs/common-processors")).To(ContainElement("forward/logs-to-sc"))
+			Expect(readPipelineExporters(pipelines, "logs/sc/default")).To(ContainElement("dash0signaltometrics"))
 
-			// Emitted metrics enter the standard metrics path via metrics/otlp-to-forwarder
-			metricsForwarderReceivers := readPipelineReceivers(pipelines, "metrics/otlp-to-forwarder")
-			Expect(metricsForwarderReceivers).To(ContainElement("dash0redmetrics"))
-			Expect(metricsForwarderReceivers).To(ContainElement("dash0signaltometrics"))
+			// Emitted metrics enter the metrics path via metrics/derived/default (not re-ingested through the
+			// otlp forwarder).
+			derivedReceivers := readPipelineReceivers(pipelines, "metrics/derived/default")
+			Expect(derivedReceivers).To(ContainElement("dash0redmetrics"))
+			Expect(derivedReceivers).To(ContainElement("dash0signaltometrics"))
 		})
 
 		It("should also wire the dash0signaltometrics connector in traces/signal-control-pre-sampling when namespaced exporters are configured [DaemonSet]", func() {
@@ -2557,12 +2685,14 @@ var _ = Describe("The OpenTelemetry Collector ConfigMaps", func() {
 			Expect(connectors).To(HaveKey("dash0signaltometrics"))
 			Expect(connectors).ToNot(HaveKey("dash0sampling"), "sampling processor is in processors map, not connectors")
 
+			// No sampling: the SC branch exports the derived-metric connectors plus the default forward directly.
 			pipelines := readPipelines(collectorConfig)
-			tracesCommonExporters := readPipelineExporters(pipelines, "traces/common-processors")
-			Expect(tracesCommonExporters).To(ContainElement("dash0signaltometrics"))
-			Expect(tracesCommonExporters).To(ContainElement("dash0redmetrics"))
-			Expect(tracesCommonExporters).To(ContainElement("forward/traces-default-exporter"))
-			Expect(tracesCommonExporters).ToNot(ContainElement("forward/traces-to-sampling"))
+			Expect(readPipelineExporters(pipelines, "traces/common-processors")).To(ContainElement("forward/traces-to-sc"))
+			scPreSamplingExporters := readPipelineExporters(pipelines, "traces/signal-control-pre-sampling")
+			Expect(scPreSamplingExporters).To(ContainElement("dash0signaltometrics"))
+			Expect(scPreSamplingExporters).To(ContainElement("dash0redmetrics"))
+			Expect(scPreSamplingExporters).To(ContainElement("forward/traces-default-exporter"))
+			Expect(scPreSamplingExporters).ToNot(ContainElement("forward/traces-to-sampling"))
 		})
 
 		It("should not wire the dash0signaltometrics connector when signalToMetrics is disabled [DaemonSet]", func() {
@@ -2619,18 +2749,18 @@ var _ = Describe("The OpenTelemetry Collector ConfigMaps", func() {
 			webFilter := processors["dash0filter"].(map[string]interface{})
 			Expect(webFilter).To(BeEmpty(), "dash0filter should render as `{}` when no tunables set")
 
+			// SC always runs in the dedicated SC branch (never inline in common-processors), even without
+			// namespaced exporters (the branch is fed via forward/{signal}-to-sc).
 			pipelines := readPipelines(collectorConfig)
-			tracesCommonProcessors := readPipelineProcessors(pipelines, "traces/common-processors")
-			Expect(tracesCommonProcessors).To(ContainElement("dash0filter"))
-			Expect(tracesCommonProcessors).To(ContainElements("dash0resource", "dash0operation", "dash0filter"),
+			Expect(readPipelineProcessors(pipelines, "traces/common-processors")).ToNot(ContainElement("dash0filter"))
+			tracesScProcessors := readPipelineProcessors(pipelines, "traces/signal-control-pre-sampling")
+			Expect(tracesScProcessors).To(ContainElements("dash0resource", "dash0operation", "dash0filter"),
 				"dash0filter must run after dash0resource and dash0operation set Signal Control attributes")
-			logsCommonProcessors := readPipelineProcessors(pipelines, "logs/common-processors")
-			Expect(logsCommonProcessors).To(ContainElement("dash0filter"))
-			Expect(logsCommonProcessors).To(ContainElements("resource/signal_control_attributes", "dash0resource", "dash0filter"),
+			logsScProcessors := readPipelineProcessors(pipelines, "logs/sc/default")
+			Expect(logsScProcessors).To(ContainElements("resource/signal_control_attributes", "dash0resource", "dash0filter"),
 				"dash0filter must run after resource/signal_control_attributes, and dash0resource must run so dash0signaltometrics gets the resource hash")
-			metricsCommonProcessors := readPipelineProcessors(pipelines, "metrics/common-processors")
-			Expect(metricsCommonProcessors).To(ContainElement("dash0filter"))
-			Expect(metricsCommonProcessors).To(ContainElements("resource/signal_control_attributes", "dash0filter"),
+			metricsScProcessors := readPipelineProcessors(pipelines, "metrics/sc/default")
+			Expect(metricsScProcessors).To(ContainElements("resource/signal_control_attributes", "dash0filter"),
 				"dash0filter must run after resource/signal_control_attributes sets Signal Control attributes")
 		})
 
@@ -2715,9 +2845,10 @@ var _ = Describe("The OpenTelemetry Collector ConfigMaps", func() {
 			Expect(processors).To(HaveKey("dash0filter"))
 
 			pipelines := readPipelines(collectorConfig)
-			Expect(readPipelineProcessors(pipelines, "traces/common-processors")).To(ContainElement("dash0filter"))
-			Expect(readPipelineProcessors(pipelines, "logs/common-processors")).To(ContainElement("dash0filter"))
-			Expect(readPipelineProcessors(pipelines, "metrics/common-processors")).To(ContainElement("dash0filter"))
+			Expect(readPipelineProcessors(pipelines, "traces/common-processors")).ToNot(ContainElement("dash0filter"))
+			Expect(readPipelineProcessors(pipelines, "traces/signal-control-pre-sampling")).To(ContainElement("dash0filter"))
+			Expect(readPipelineProcessors(pipelines, "logs/sc/default")).To(ContainElement("dash0filter"))
+			Expect(readPipelineProcessors(pipelines, "metrics/sc/default")).To(ContainElement("dash0filter"))
 		})
 
 		It("should not wire the dash0filter processor when spamFilter is disabled [DaemonSet]", func() {
@@ -2781,10 +2912,12 @@ var _ = Describe("The OpenTelemetry Collector ConfigMaps", func() {
 			serviceExtensions := (collectorConfig["service"].(map[string]interface{}))["extensions"].([]interface{})
 			Expect(serviceExtensions).To(ContainElement("dash0settingsonedgeextension"))
 
+			// SC always runs in the dedicated SC branch (fed via forward/metrics-to-sc without namespaced exporters),
+			// never inline in common-processors.
 			pipelines := readPipelines(collectorConfig)
-			metricsCommonProcessors := readPipelineProcessors(pipelines, "metrics/common-processors")
-			Expect(metricsCommonProcessors).To(ContainElement("dash0filter"))
-			Expect(metricsCommonProcessors).To(ContainElements("resource/signal_control_attributes", "dash0filter"),
+			Expect(readPipelineProcessors(pipelines, "metrics/common-processors")).ToNot(ContainElement("dash0filter"))
+			metricsScProcessors := readPipelineProcessors(pipelines, "metrics/sc/default")
+			Expect(metricsScProcessors).To(ContainElements("resource/signal_control_attributes", "dash0filter"),
 				"dash0filter must run after resource/signal_control_attributes sets Signal Control attributes")
 		})
 
@@ -2863,7 +2996,8 @@ var _ = Describe("The OpenTelemetry Collector ConfigMaps", func() {
 			grpcName := "otlp_grpc/default_1"
 			dash0Name := "otlp_grpc/dash0/default"
 
-			// Routing is used to split the default Dash0 vs non-Dash0 metrics even without namespaced exporters.
+			// Routing is used (namespaced exporters present) and its default_pipelines split the default Dash0 vs
+			// non-Dash0 metrics.
 			Expect(connectors).To(HaveKey("routing/metrics"))
 			// SC is not inline in common-processors; it runs in the default SC branch.
 			Expect(readPipelineProcessors(pipelines, "metrics/common-processors")).ToNot(ContainElement("resource/signal_control_attributes"))
@@ -2901,7 +3035,8 @@ var _ = Describe("The OpenTelemetry Collector ConfigMaps", func() {
 			Expect(extensions).To(HaveKey("dash0settingsonedgeextension"))
 
 			pipelines := readPipelines(collectorConfig)
-			Expect(readPipelineProcessors(pipelines, "metrics/common-processors")).To(ContainElement("dash0filter"))
+			Expect(readPipelineProcessors(pipelines, "metrics/common-processors")).ToNot(ContainElement("dash0filter"))
+			Expect(readPipelineProcessors(pipelines, "metrics/sc/default")).To(ContainElement("dash0filter"))
 		})
 
 		It("should not wire the dash0filter processor when spamFilter is disabled [Deployment]", func() {

--- a/internal/collectors/otelcolresources/collector_config_maps_test.go
+++ b/internal/collectors/otelcolresources/collector_config_maps_test.go
@@ -419,9 +419,30 @@ func cmTestNamespacedMultiDatasetExporters() otlpExporters {
 }
 
 // cmTestMixedDefaultOtlpExporters models a default export list with both a Dash0 exporter and a non-Dash0
-// (passthrough) exporter, and no namespaced exporters, to exercise the default-path Dash0/passthrough split (SC
-// must not be applied to the non-Dash0 default exporter).
+// (passthrough) exporter, to exercise the default-path Dash0/passthrough split (SC must not be applied to the
+// non-Dash0 default exporter). A namespaced exporter is included because the default split is only performed for
+// configs that use routing, i.e. that have namespaced exporters.
 func cmTestMixedDefaultOtlpExporters() otlpExporters {
+	export := Dash0ExportWithEndpointAndToken()
+	auth, _ := dash0ExporterAuthorizationForExport(*export, 0, true, nil)
+	dash0ExporterDefault, err := convertDash0ExporterToOtlpExporter(export.Dash0, "default", auth)
+	Expect(err).ToNot(HaveOccurred())
+	grpcExporterDefault, err := convertGrpcExporterToOtlpExporter(GrpcExportTest().Grpc, "default_1")
+	Expect(err).ToNot(HaveOccurred())
+	dash0ExporterNs1, err := convertDash0ExporterToOtlpExporter(export.Dash0, "ns/"+namespace1, auth)
+	Expect(err).ToNot(HaveOccurred())
+	return otlpExporters{
+		Default: []otlpExporter{*dash0ExporterDefault, *grpcExporterDefault},
+		Namespaced: map[string][]otlpExporter{
+			namespace1: {*dash0ExporterNs1},
+		},
+	}
+}
+
+// cmTestMixedDefaultNoNamespacedExporters is the same mixed (Dash0 + non-Dash0) default as
+// cmTestMixedDefaultOtlpExporters but with NO namespaced exporters. Used to verify that a config without namespaced
+// exporters renders no routing connectors (which would otherwise have an empty, invalid table) and keeps SC inline.
+func cmTestMixedDefaultNoNamespacedExporters() otlpExporters {
 	export := Dash0ExportWithEndpointAndToken()
 	auth, _ := dash0ExporterAuthorizationForExport(*export, 0, true, nil)
 	dash0ExporterDefault, err := convertDash0ExporterToOtlpExporter(export.Dash0, "default", auth)
@@ -2103,6 +2124,37 @@ var _ = Describe("The OpenTelemetry Collector ConfigMaps", func() {
 			Expect(pipelines).To(HaveKey("traces/export/default/passthrough"))
 			Expect(readPipelineExporters(pipelines, "traces/export/default/passthrough")).To(ConsistOf(grpcName))
 			Expect(readPipelineProcessors(pipelines, "traces/export/default/passthrough")).ToNot(ContainElement("resource/signal_control_attributes"))
+		})
+
+		It("should not render routing connectors or split the default without namespaced exporters [DaemonSet]", func() {
+			configMap, err := assembleDaemonSetCollectorConfigMap(&oTelColConfig{
+				OperatorNamespace: OperatorNamespace,
+				NamePrefix:        namePrefix,
+				Exporters:         cmTestMixedDefaultNoNamespacedExporters(),
+				SignalControl: SignalControlConfig{
+					Enabled:           true,
+					SamplingEnabled:   true,
+					SpamFilterEnabled: true,
+					Endpoint:          "decision-maker.example.com:443",
+					ApiEndpoint:       "https://control-plane-api.dash0.com",
+					Dataset:           "default",
+				},
+				KubernetesInfrastructureMetricsCollectionEnabled: true,
+			}, monitoredNamespaces, nil, nil, nil, nil, emptyTargetAllocatorMtlsConfig, false)
+
+			Expect(err).ToNot(HaveOccurred())
+			collectorConfig := parseConfigMapContent(configMap)
+			connectors := collectorConfig["connectors"].(map[string]interface{})
+			pipelines := readPipelines(collectorConfig)
+
+			// Without namespaced exporters there is no routing (an empty routing table would be rejected by the
+			// collector), so SC stays inline in common-processors and the whole default is exported as-is.
+			Expect(connectors).ToNot(HaveKey("routing/traces"))
+			Expect(connectors).ToNot(HaveKey("routing/traces-sampled"))
+			Expect(connectors).ToNot(HaveKey("routing/metrics"))
+			Expect(readPipelineProcessors(pipelines, "traces/common-processors")).To(ContainElement("resource/signal_control_attributes"))
+			Expect(readPipelineExporters(pipelines, "traces/export/default")).
+				To(ContainElements("otlp_grpc/dash0/default", "otlp_grpc/default_1"))
 		})
 
 		It("should route namespaced traces before sampling when Signal Control is enabled [DaemonSet]", func() {

--- a/internal/collectors/otelcolresources/collector_config_maps_test.go
+++ b/internal/collectors/otelcolresources/collector_config_maps_test.go
@@ -386,6 +386,38 @@ func cmTestMultipleNamespacedOtlpExporters() otlpExporters {
 	}
 }
 
+// cmTestNamespacedMultiDatasetExporters models a namespace (namespace1) that fans out to two Dash0 datasets
+// (ds-a first, then ds-b) plus a non-Dash0 (passthrough) exporter, to exercise the per-dataset SC branches and the
+// "sample only the first dataset" behaviour.
+func cmTestNamespacedMultiDatasetExporters() otlpExporters {
+	defaultExport := Dash0ExportWithEndpointAndToken()
+	defaultAuth, _ := dash0ExporterAuthorizationForExport(*defaultExport, 0, true, nil)
+	dash0ExporterDefault, err := convertDash0ExporterToOtlpExporter(defaultExport.Dash0, "default", defaultAuth)
+	Expect(err).ToNot(HaveOccurred())
+
+	exportA := Dash0ExportWithEndpointAndToken()
+	exportA.Dash0.Dataset = "ds-a"
+	authA, _ := dash0ExporterAuthorizationForExport(*exportA, 0, true, nil)
+	dash0ExporterNs1A, err := convertDash0ExporterToOtlpExporter(exportA.Dash0, "ns/"+namespace1+"/0", authA)
+	Expect(err).ToNot(HaveOccurred())
+
+	exportB := Dash0ExportWithEndpointAndToken()
+	exportB.Dash0.Dataset = "ds-b"
+	authB, _ := dash0ExporterAuthorizationForExport(*exportB, 1, true, nil)
+	dash0ExporterNs1B, err := convertDash0ExporterToOtlpExporter(exportB.Dash0, "ns/"+namespace1+"/1", authB)
+	Expect(err).ToNot(HaveOccurred())
+
+	grpcExporterNs1, err := convertGrpcExporterToOtlpExporter(GrpcExportTest().Grpc, "ns/"+namespace1+"/2")
+	Expect(err).ToNot(HaveOccurred())
+
+	return otlpExporters{
+		Default: []otlpExporter{*dash0ExporterDefault},
+		Namespaced: map[string][]otlpExporter{
+			namespace1: {*dash0ExporterNs1A, *dash0ExporterNs1B, *grpcExporterNs1},
+		},
+	}
+}
+
 // cmTestMultipleDefaultDash0Exporters creates two Dash0 default exporters (simulating two Exports entries
 // each with a Dash0 config), which is only possible with multiple Exports array elements.
 func cmTestMultipleDefaultDash0Exporters() otlpExporters {
@@ -1950,6 +1982,64 @@ var _ = Describe("The OpenTelemetry Collector ConfigMaps", func() {
 			Expect(logsExportDefaultReceivers).ToNot(ContainElement("routing/logs"))
 		})
 
+		It("should create per-dataset SC branches and sample only the first dataset for a multi-dataset namespace [DaemonSet]", func() {
+			configMap, err := assembleDaemonSetCollectorConfigMap(&oTelColConfig{
+				OperatorNamespace: OperatorNamespace,
+				NamePrefix:        namePrefix,
+				Exporters:         cmTestNamespacedMultiDatasetExporters(),
+				SignalControl: SignalControlConfig{
+					Enabled:                true,
+					SamplingEnabled:        true,
+					SpamFilterEnabled:      true,
+					SignalToMetricsEnabled: true,
+					Endpoint:               "decision-maker.example.com:443",
+					ApiEndpoint:            "https://control-plane-api.dash0.com",
+					Dataset:                "default",
+				},
+				KubernetesInfrastructureMetricsCollectionEnabled: true,
+			}, monitoredNamespaces, nil, nil, nil, nil, emptyTargetAllocatorMtlsConfig, false)
+
+			Expect(err).ToNot(HaveOccurred())
+			collectorConfig := parseConfigMapContent(configMap)
+			processors := collectorConfig["processors"].(map[string]interface{})
+			connectors := collectorConfig["connectors"].(map[string]interface{})
+			pipelines := readPipelines(collectorConfig)
+
+			// One SC dataset branch per distinct dataset, each with its own attribute-stamping processor.
+			Expect(processors).To(HaveKey("resource/signal_control_attributes/ns/" + namespace1 + "/0"))
+			Expect(processors).To(HaveKey("resource/signal_control_attributes/ns/" + namespace1 + "/1"))
+
+			// Non-sampling SC (spam filter) runs on BOTH branches.
+			Expect(readPipelineProcessors(pipelines, "traces/sc/ns/"+namespace1+"/0")).To(ContainElement("dash0filter"))
+			Expect(readPipelineProcessors(pipelines, "traces/sc/ns/"+namespace1+"/1")).To(ContainElement("dash0filter"))
+
+			// Sampling ONLY on the first branch: branch 0 forwards to the per-namespace sampling pipeline; branch 1
+			// exports directly (unsampled).
+			Expect(readPipelineExporters(pipelines, "traces/sc/ns/"+namespace1+"/0")).
+				To(ContainElement("forward/traces-to-sampling/ns/" + namespace1))
+			Expect(readPipelineExporters(pipelines, "traces/sc/ns/"+namespace1+"/1")).
+				ToNot(ContainElement("forward/traces-to-sampling/ns/" + namespace1))
+			Expect(pipelines).To(HaveKey("traces/sampled/ns/" + namespace1))
+			Expect(readPipelineProcessors(pipelines, "traces/sampled/ns/"+namespace1)).
+				To(ContainElement("dash0sampling/ns/" + namespace1))
+			Expect(pipelines).ToNot(HaveKey("traces/sampled/ns/" + namespace1 + "/1"))
+
+			// The per-namespace sampler samples against the FIRST dataset (ds-a).
+			samplingCfg := processors["dash0sampling/ns/"+namespace1].(map[string]interface{})
+			Expect(samplingCfg["default_dataset"]).To(Equal("ds-a"))
+
+			// Per-branch RED/s2m connectors and local derived-metrics export.
+			Expect(connectors).To(HaveKey("dash0redmetrics/ns/" + namespace1 + "/0"))
+			Expect(connectors).To(HaveKey("dash0redmetrics/ns/" + namespace1 + "/1"))
+			Expect(readPipelineReceivers(pipelines, "metrics/derived/ns/"+namespace1+"/0")).
+				To(ContainElement("dash0redmetrics/ns/" + namespace1 + "/0"))
+
+			// The non-Dash0 exporter is passthrough (no Signal Control).
+			Expect(pipelines).To(HaveKey("traces/export/ns/" + namespace1 + "/passthrough"))
+			Expect(readPipelineProcessors(pipelines, "traces/export/ns/"+namespace1+"/passthrough")).
+				ToNot(ContainElement("resource/signal_control_attributes/ns/" + namespace1 + "/0"))
+		})
+
 		It("should route namespaced traces before sampling when Signal Control is enabled [DaemonSet]", func() {
 			configMap, err := assembleDaemonSetCollectorConfigMap(&oTelColConfig{
 				OperatorNamespace: OperatorNamespace,
@@ -2000,11 +2090,12 @@ var _ = Describe("The OpenTelemetry Collector ConfigMaps", func() {
 			Expect(tracesExportDefaultReceivers).To(ContainElement("forward/traces-default-exporter"))
 			Expect(tracesExportDefaultReceivers).ToNot(ContainElement("routing/traces"))
 
-			// namespace-specific export pipelines still receive from routing/traces
-			tracesExportNs1Receivers := readPipelineReceivers(pipelines, "traces/export/ns/"+namespace1)
-			Expect(tracesExportNs1Receivers).To(ContainElement("routing/traces"))
-			tracesExportNs2Receivers := readPipelineReceivers(pipelines, "traces/export/ns/"+namespace2)
-			Expect(tracesExportNs2Receivers).To(ContainElement("routing/traces"))
+			// non-Dash0 namespaced exporters route to passthrough pipelines (no Signal Control, no sampling)
+			tracesPassthroughNs1Receivers := readPipelineReceivers(pipelines, "traces/export/ns/"+namespace1+"/passthrough")
+			Expect(tracesPassthroughNs1Receivers).To(ContainElement("routing/traces"))
+			Expect(readPipelineProcessors(pipelines, "traces/export/ns/"+namespace1+"/passthrough")).ToNot(ContainElement("resource/signal_control_attributes"))
+			tracesPassthroughNs2Receivers := readPipelineReceivers(pipelines, "traces/export/ns/"+namespace2+"/passthrough")
+			Expect(tracesPassthroughNs2Receivers).To(ContainElement("routing/traces"))
 
 			// dash0settingsonedgeextension extension should be configured and listed in service extensions
 			extensions := collectorConfig["extensions"].(map[string]interface{})
@@ -2295,7 +2386,7 @@ var _ = Describe("The OpenTelemetry Collector ConfigMaps", func() {
 			Expect(s2m["cache_expiration"]).To(Equal("45s"))
 		})
 
-		It("should wire dash0signaltometrics into logs/common-processors even with namespaced exporters [DaemonSet]", func() {
+		It("should not leak dash0signaltometrics into logs/common-processors with namespaced exporters, wiring it into the logs SC branch instead [DaemonSet]", func() {
 			configMap, err := assembleDaemonSetCollectorConfigMap(&oTelColConfig{
 				OperatorNamespace: OperatorNamespace,
 				NamePrefix:        namePrefix,
@@ -2315,9 +2406,15 @@ var _ = Describe("The OpenTelemetry Collector ConfigMaps", func() {
 			collectorConfig := parseConfigMapContent(configMap)
 			pipelines := readPipelines(collectorConfig)
 
+			// With namespaced exporters, SC (including the s2m exporter) is moved out of common-processors,
+			// so it no longer derives metrics from namespaced-bound logs.
 			logsCommonExporters := readPipelineExporters(pipelines, "logs/common-processors")
 			Expect(logsCommonExporters).To(ContainElement("routing/logs"))
-			Expect(logsCommonExporters).To(ContainElement("dash0signaltometrics"))
+			Expect(logsCommonExporters).ToNot(ContainElement("dash0signaltometrics"))
+
+			// s2m is wired into the default logs SC branch instead.
+			logsScDefaultExporters := readPipelineExporters(pipelines, "logs/sc/default")
+			Expect(logsScDefaultExporters).To(ContainElement("dash0signaltometrics"))
 		})
 
 		It("should still wire dash0signaltometrics when sampling is disabled [DaemonSet]", func() {
@@ -2447,7 +2544,7 @@ var _ = Describe("The OpenTelemetry Collector ConfigMaps", func() {
 			Expect(webFilter["allow_no_settings_ext"]).To(BeTrue())
 		})
 
-		It("should wire dash0filter into common-processors even with namespaced exporters [DaemonSet]", func() {
+		It("should move dash0filter out of common-processors into the SC branches with namespaced exporters [DaemonSet]", func() {
 			configMap, err := assembleDaemonSetCollectorConfigMap(&oTelColConfig{
 				OperatorNamespace: OperatorNamespace,
 				NamePrefix:        namePrefix,
@@ -2467,9 +2564,16 @@ var _ = Describe("The OpenTelemetry Collector ConfigMaps", func() {
 			collectorConfig := parseConfigMapContent(configMap)
 			pipelines := readPipelines(collectorConfig)
 
-			Expect(readPipelineProcessors(pipelines, "traces/common-processors")).To(ContainElement("dash0filter"))
-			Expect(readPipelineProcessors(pipelines, "logs/common-processors")).To(ContainElement("dash0filter"))
-			Expect(readPipelineProcessors(pipelines, "metrics/common-processors")).To(ContainElement("dash0filter"))
+			// With namespaced exporters, SC must not run in common-processors (it would leak onto the copies
+			// routed to per-namespace exporters).
+			Expect(readPipelineProcessors(pipelines, "traces/common-processors")).ToNot(ContainElement("dash0filter"))
+			Expect(readPipelineProcessors(pipelines, "logs/common-processors")).ToNot(ContainElement("dash0filter"))
+			Expect(readPipelineProcessors(pipelines, "metrics/common-processors")).ToNot(ContainElement("dash0filter"))
+
+			// It runs in the default SC branches (downstream of routing) instead.
+			Expect(readPipelineProcessors(pipelines, "traces/signal-control-pre-sampling")).To(ContainElement("dash0filter"))
+			Expect(readPipelineProcessors(pipelines, "logs/sc/default")).To(ContainElement("dash0filter"))
+			Expect(readPipelineProcessors(pipelines, "metrics/sc/default")).To(ContainElement("dash0filter"))
 		})
 
 		It("should still wire dash0filter when sampling is disabled [DaemonSet]", func() {
@@ -2594,7 +2698,7 @@ var _ = Describe("The OpenTelemetry Collector ConfigMaps", func() {
 			Expect(webFilter["allow_no_settings_ext"]).To(BeTrue())
 		})
 
-		It("should wire dash0filter into the metrics pipeline even with namespaced exporters [Deployment]", func() {
+		It("should move dash0filter out of metrics/common-processors into the SC branch with namespaced exporters [Deployment]", func() {
 			configMap, err := assembleDeploymentCollectorConfigMapForTest(&oTelColConfig{
 				OperatorNamespace: OperatorNamespace,
 				NamePrefix:        namePrefix,
@@ -2613,7 +2717,10 @@ var _ = Describe("The OpenTelemetry Collector ConfigMaps", func() {
 			Expect(err).ToNot(HaveOccurred())
 			collectorConfig := parseConfigMapContent(configMap)
 			pipelines := readPipelines(collectorConfig)
-			Expect(readPipelineProcessors(pipelines, "metrics/common-processors")).To(ContainElement("dash0filter"))
+			// With namespaced exporters, SC must not run in common-processors (it would leak onto namespaced metrics).
+			Expect(readPipelineProcessors(pipelines, "metrics/common-processors")).ToNot(ContainElement("dash0filter"))
+			// It runs in the default metrics SC branch (downstream of routing) instead.
+			Expect(readPipelineProcessors(pipelines, "metrics/sc/default")).To(ContainElement("dash0filter"))
 		})
 
 		It("should still wire dash0filter into the metrics pipeline when sampling is disabled [Deployment]", func() {

--- a/internal/collectors/otelcolresources/collector_config_maps_test.go
+++ b/internal/collectors/otelcolresources/collector_config_maps_test.go
@@ -418,6 +418,21 @@ func cmTestNamespacedMultiDatasetExporters() otlpExporters {
 	}
 }
 
+// cmTestMixedDefaultOtlpExporters models a default export list with both a Dash0 exporter and a non-Dash0
+// (passthrough) exporter, and no namespaced exporters, to exercise the default-path Dash0/passthrough split (SC
+// must not be applied to the non-Dash0 default exporter).
+func cmTestMixedDefaultOtlpExporters() otlpExporters {
+	export := Dash0ExportWithEndpointAndToken()
+	auth, _ := dash0ExporterAuthorizationForExport(*export, 0, true, nil)
+	dash0ExporterDefault, err := convertDash0ExporterToOtlpExporter(export.Dash0, "default", auth)
+	Expect(err).ToNot(HaveOccurred())
+	grpcExporterDefault, err := convertGrpcExporterToOtlpExporter(GrpcExportTest().Grpc, "default_1")
+	Expect(err).ToNot(HaveOccurred())
+	return otlpExporters{
+		Default: []otlpExporter{*dash0ExporterDefault, *grpcExporterDefault},
+	}
+}
+
 // cmTestMultipleDefaultDash0Exporters creates two Dash0 default exporters (simulating two Exports entries
 // each with a Dash0 config), which is only possible with multiple Exports array elements.
 func cmTestMultipleDefaultDash0Exporters() otlpExporters {
@@ -2013,20 +2028,25 @@ var _ = Describe("The OpenTelemetry Collector ConfigMaps", func() {
 			Expect(readPipelineProcessors(pipelines, "traces/sc/ns/"+namespace1+"/0")).To(ContainElement("dash0filter"))
 			Expect(readPipelineProcessors(pipelines, "traces/sc/ns/"+namespace1+"/1")).To(ContainElement("dash0filter"))
 
-			// Sampling ONLY on the first branch: branch 0 forwards to the per-namespace sampling pipeline; branch 1
-			// exports directly (unsampled).
+			// Sampling ONLY on the first branch: branch 0 forwards to the SHARED sampler; branch 1 exports directly.
 			Expect(readPipelineExporters(pipelines, "traces/sc/ns/"+namespace1+"/0")).
-				To(ContainElement("forward/traces-to-sampling/ns/" + namespace1))
+				To(ContainElement("forward/traces-to-sampling"))
 			Expect(readPipelineExporters(pipelines, "traces/sc/ns/"+namespace1+"/1")).
-				ToNot(ContainElement("forward/traces-to-sampling/ns/" + namespace1))
-			Expect(pipelines).To(HaveKey("traces/sampled/ns/" + namespace1))
-			Expect(readPipelineProcessors(pipelines, "traces/sampled/ns/"+namespace1)).
-				To(ContainElement("dash0sampling/ns/" + namespace1))
-			Expect(pipelines).ToNot(HaveKey("traces/sampled/ns/" + namespace1 + "/1"))
+				ToNot(ContainElement("forward/traces-to-sampling"))
 
-			// The per-namespace sampler samples against the FIRST dataset (ds-a).
-			samplingCfg := processors["dash0sampling/ns/"+namespace1].(map[string]interface{})
-			Expect(samplingCfg["default_dataset"]).To(Equal("ds-a"))
+			// A single shared sampling processor/reservoir handles all branches (no per-namespace sampler).
+			Expect(processors).To(HaveKey("dash0sampling"))
+			Expect(processors).ToNot(HaveKey("dash0sampling/ns/" + namespace1))
+			Expect(pipelines).To(HaveKey("traces/sampled"))
+			Expect(pipelines).ToNot(HaveKey("traces/sampled/ns/" + namespace1))
+			Expect(readPipelineProcessors(pipelines, "traces/sampled")).To(ContainElement("dash0sampling"))
+
+			// Kept traces are routed back to the namespace's first-dataset (ds-a) exporters via routing/traces-sampled.
+			Expect(connectors).To(HaveKey("routing/traces-sampled"))
+			Expect(readPipelineExporters(pipelines, "traces/sampled")).To(ContainElement("routing/traces-sampled"))
+			Expect(pipelines).To(HaveKey("traces/export/sampled/ns/" + namespace1))
+			Expect(readPipelineReceivers(pipelines, "traces/export/sampled/ns/"+namespace1)).
+				To(ContainElement("routing/traces-sampled"))
 
 			// Per-branch RED/s2m connectors and local derived-metrics export.
 			Expect(connectors).To(HaveKey("dash0redmetrics/ns/" + namespace1 + "/0"))
@@ -2038,6 +2058,51 @@ var _ = Describe("The OpenTelemetry Collector ConfigMaps", func() {
 			Expect(pipelines).To(HaveKey("traces/export/ns/" + namespace1 + "/passthrough"))
 			Expect(readPipelineProcessors(pipelines, "traces/export/ns/"+namespace1+"/passthrough")).
 				ToNot(ContainElement("resource/signal_control_attributes/ns/" + namespace1 + "/0"))
+		})
+
+		It("should keep Signal Control off a non-Dash0 default exporter via a default passthrough [DaemonSet]", func() {
+			configMap, err := assembleDaemonSetCollectorConfigMap(&oTelColConfig{
+				OperatorNamespace: OperatorNamespace,
+				NamePrefix:        namePrefix,
+				Exporters:         cmTestMixedDefaultOtlpExporters(),
+				SignalControl: SignalControlConfig{
+					Enabled:           true,
+					SamplingEnabled:   true,
+					SpamFilterEnabled: true,
+					Endpoint:          "decision-maker.example.com:443",
+					ApiEndpoint:       "https://control-plane-api.dash0.com",
+					Dataset:           "default",
+				},
+				KubernetesInfrastructureMetricsCollectionEnabled: true,
+			}, monitoredNamespaces, nil, nil, nil, nil, emptyTargetAllocatorMtlsConfig, false)
+
+			Expect(err).ToNot(HaveOccurred())
+			collectorConfig := parseConfigMapContent(configMap)
+			connectors := collectorConfig["connectors"].(map[string]interface{})
+			pipelines := readPipelines(collectorConfig)
+
+			dash0Name := "otlp_grpc/dash0/default"
+			grpcName := "otlp_grpc/default_1"
+
+			// Routing is used even without namespaced exporters, to split the default Dash0 vs non-Dash0 telemetry.
+			Expect(connectors).To(HaveKey("routing/traces"))
+			routingTraces := connectors["routing/traces"].(map[string]interface{})
+			defaultPipelines := routingTraces["default_pipelines"].([]interface{})
+			Expect(defaultPipelines).To(ContainElement("traces/signal-control-pre-sampling"))
+			Expect(defaultPipelines).To(ContainElement("traces/export/default/passthrough"))
+
+			// SC is no longer inline in common-processors; it exports to routing/traces.
+			Expect(readPipelineProcessors(pipelines, "traces/common-processors")).ToNot(ContainElement("resource/signal_control_attributes"))
+			Expect(readPipelineExporters(pipelines, "traces/common-processors")).To(ContainElement("routing/traces"))
+
+			// The SC'd default sink exports ONLY the Dash0 default exporter.
+			Expect(readPipelineExporters(pipelines, "traces/export/default")).To(ContainElement(dash0Name))
+			Expect(readPipelineExporters(pipelines, "traces/export/default")).ToNot(ContainElement(grpcName))
+
+			// The passthrough carries the non-Dash0 default exporter with no Signal Control.
+			Expect(pipelines).To(HaveKey("traces/export/default/passthrough"))
+			Expect(readPipelineExporters(pipelines, "traces/export/default/passthrough")).To(ConsistOf(grpcName))
+			Expect(readPipelineProcessors(pipelines, "traces/export/default/passthrough")).ToNot(ContainElement("resource/signal_control_attributes"))
 		})
 
 		It("should route namespaced traces before sampling when Signal Control is enabled [DaemonSet]", func() {
@@ -2080,15 +2145,15 @@ var _ = Describe("The OpenTelemetry Collector ConfigMaps", func() {
 			Expect(scPreSamplingExporters).To(ContainElement("forward/traces-to-sampling"))
 			Expect(scPreSamplingExporters).To(ContainElement("dash0redmetrics"))
 
-			// traces/sampled should export to forward/traces-default-exporter (not routing)
+			// traces/sampled feeds the shared post-sampling router (kept traces are routed back per destination).
 			sampledExporters := readPipelineExporters(pipelines, "traces/sampled")
-			Expect(sampledExporters).To(ContainElement("forward/traces-default-exporter"))
-			Expect(sampledExporters).ToNot(ContainElement("routing/traces"))
+			Expect(sampledExporters).To(ContainElement("routing/traces-sampled"))
+			Expect(sampledExporters).ToNot(ContainElement("forward/traces-default-exporter"))
 
-			// traces/export/default should receive from forward/traces-default-exporter
+			// The default (unmatched) sampled traces land in traces/export/default via routing/traces-sampled.
 			tracesExportDefaultReceivers := readPipelineReceivers(pipelines, "traces/export/default")
-			Expect(tracesExportDefaultReceivers).To(ContainElement("forward/traces-default-exporter"))
-			Expect(tracesExportDefaultReceivers).ToNot(ContainElement("routing/traces"))
+			Expect(tracesExportDefaultReceivers).To(ContainElement("routing/traces-sampled"))
+			Expect(tracesExportDefaultReceivers).ToNot(ContainElement("forward/traces-default-exporter"))
 
 			// non-Dash0 namespaced exporters route to passthrough pipelines (no Signal Control, no sampling)
 			tracesPassthroughNs1Receivers := readPipelineReceivers(pipelines, "traces/export/ns/"+namespace1+"/passthrough")
@@ -2721,6 +2786,42 @@ var _ = Describe("The OpenTelemetry Collector ConfigMaps", func() {
 			Expect(readPipelineProcessors(pipelines, "metrics/common-processors")).ToNot(ContainElement("dash0filter"))
 			// It runs in the default metrics SC branch (downstream of routing) instead.
 			Expect(readPipelineProcessors(pipelines, "metrics/sc/default")).To(ContainElement("dash0filter"))
+		})
+
+		It("should keep Signal Control off a non-Dash0 default exporter via a default passthrough [Deployment]", func() {
+			configMap, err := assembleDeploymentCollectorConfigMapForTest(&oTelColConfig{
+				OperatorNamespace: OperatorNamespace,
+				NamePrefix:        namePrefix,
+				Exporters:         cmTestMixedDefaultOtlpExporters(),
+				SignalControl: SignalControlConfig{
+					Enabled:           true,
+					SpamFilterEnabled: true,
+					Endpoint:          "decision-maker.example.com:443",
+					ApiEndpoint:       "https://control-plane-api.dash0.com",
+					Dataset:           "default",
+				},
+				KubernetesInfrastructureMetricsCollectionEnabled: true,
+			}, monitoredNamespaces, nil, nil, false)
+
+			Expect(err).ToNot(HaveOccurred())
+			collectorConfig := parseConfigMapContent(configMap)
+			connectors := collectorConfig["connectors"].(map[string]interface{})
+			pipelines := readPipelines(collectorConfig)
+
+			grpcName := "otlp_grpc/default_1"
+			dash0Name := "otlp_grpc/dash0/default"
+
+			// Routing is used to split the default Dash0 vs non-Dash0 metrics even without namespaced exporters.
+			Expect(connectors).To(HaveKey("routing/metrics"))
+			// SC is not inline in common-processors; it runs in the default SC branch.
+			Expect(readPipelineProcessors(pipelines, "metrics/common-processors")).ToNot(ContainElement("resource/signal_control_attributes"))
+			Expect(readPipelineProcessors(pipelines, "metrics/sc/default")).To(ContainElement("resource/signal_control_attributes"))
+			// The SC'd default sink exports only the Dash0 exporter; the passthrough carries the non-Dash0 one with no SC.
+			Expect(readPipelineExporters(pipelines, "metrics/export/default")).To(ContainElement(dash0Name))
+			Expect(readPipelineExporters(pipelines, "metrics/export/default")).ToNot(ContainElement(grpcName))
+			Expect(pipelines).To(HaveKey("metrics/export/default/passthrough"))
+			Expect(readPipelineExporters(pipelines, "metrics/export/default/passthrough")).To(ConsistOf(grpcName))
+			Expect(readPipelineProcessors(pipelines, "metrics/export/default/passthrough")).To(BeEmpty())
 		})
 
 		It("should still wire dash0filter into the metrics pipeline when sampling is disabled [Deployment]", func() {

--- a/internal/collectors/otelcolresources/daemonset.config.yaml.template
+++ b/internal/collectors/otelcolresources/daemonset.config.yaml.template
@@ -21,14 +21,26 @@ use option 2.
 */}}
 
 {{- $hasNamespacedExporters := gt (len .Exporters.Namespaced) 0 -}}
-{{- /* Routing (splitting telemetry per destination) is only used when there are namespaced exporters: the routing
-connector requires a non-empty table, keyed on k8s.namespace.name. $useRouting is an alias for that condition.
-$splitDefault: when a (namespaced) config's DEFAULT export list mixes Dash0 + non-Dash0 exporters with SC enabled,
-the default telemetry is also split — SC'd -> default Dash0 exporters, raw -> default passthrough. Non-namespaced
-configs do not split the default (SC stays inline in common-processors, applied to all default exporters, as before
-this feature); splitting the non-namespaced default would need a fork rather than routing (see note). */}}
+{{- /* Signal Control (SC) is only ever applied to Dash0 exporters; non-Dash0 (passthrough) exporters always receive
+raw telemetry. SC always runs in a dedicated branch pipeline ({signal}/sc/... , or traces/signal-control-pre-sampling)
+downstream of {signal}/common-processors — never inline in common-processors. That branch is fed by the routing
+connector when there are namespaced exporters, and by a forward/{signal}-to-sc connector otherwise (routing cannot
+express a Dash0-vs-passthrough split, because the destination is not a record attribute). Variables:
+- $useRouting: routing is used (only with namespaced exporters; the routing connector requires a non-empty table).
+- $scDefault: the default path applies SC (SC enabled AND the default list has >=1 Dash0 exporter). When false the
+  whole default is passthrough (no SC branch).
+- $splitDefault: the default mixes Dash0 + non-Dash0 under SC, so it fans out — SC'd -> default Dash0 exporters, raw ->
+  default passthrough exporters (a per-namespace routing case) or the passthrough exporters attached to
+  common-processors directly (the non-namespaced case).
+- $hasNamespacedDash0: a namespace has a Dash0 exporter, so the post-sampling router + per-namespace sampled export
+  are needed.
+- $samplingActive: tail sampling is enabled AND something feeds it (the default is SC'd or a namespace has a Dash0
+  branch), so the shared sampling pipeline is exercised. */}}
 {{- $useRouting := $hasNamespacedExporters -}}
-{{- $splitDefault := and $hasNamespacedExporters .SignalControl.Enabled (gt (len .Exporters.DefaultDash0Exporters) 0) (gt (len .Exporters.DefaultPassthrough) 0) -}}
+{{- $scDefault := and .SignalControl.Enabled (gt (len .Exporters.DefaultDash0Exporters) 0) -}}
+{{- $splitDefault := and $scDefault (gt (len .Exporters.DefaultPassthrough) 0) -}}
+{{- $hasNamespacedDash0 := .Exporters.HasNamespacedDash0Exporters -}}
+{{- $samplingActive := and .SignalControl.SamplingEnabled (or $scDefault $hasNamespacedDash0) -}}
 
 extensions:
   health_check:
@@ -55,6 +67,11 @@ connectors:
   forward/traces-default-exporter: {}
   forward/metrics-default-exporter: {}
   forward/logs-default-exporter: {}
+{{- if and (not $useRouting) $scDefault }}
+  forward/traces-to-sc: {}
+  forward/metrics-to-sc: {}
+  forward/logs-to-sc: {}
+{{- end }}
 {{- if .SignalControl.Enabled }}
 {{- if .SignalControl.SamplingEnabled }}
   forward/traces-to-sampling: {}
@@ -132,7 +149,7 @@ connectors:
 
   {{- if $useRouting }}
   routing/traces:
-{{- if .SignalControl.Enabled }}
+{{- if $scDefault }}
     default_pipelines: [traces/signal-control-pre-sampling{{- if $splitDefault }}, traces/export/default/passthrough{{- end }}]
 {{- else }}
     default_pipelines: [traces/export/default]
@@ -159,7 +176,7 @@ connectors:
           - traces/export/ns/{{ $ns }}
     {{- end }}
 {{- end }}
-{{- if .SignalControl.SamplingEnabled }}
+{{- if and .SignalControl.SamplingEnabled $hasNamespacedDash0 }}
   routing/traces-sampled:
     default_pipelines: [traces/export/default]
     error_mode: ignore
@@ -174,7 +191,7 @@ connectors:
     {{- end }}
 {{- end }}
   routing/metrics:
-{{- if .SignalControl.Enabled }}
+{{- if $scDefault }}
     default_pipelines: [metrics/sc/default{{- if $splitDefault }}, metrics/export/default/passthrough{{- end }}]
 {{- else }}
     default_pipelines: [metrics/export/default]
@@ -202,7 +219,7 @@ connectors:
     {{- end }}
 {{- end }}
   routing/logs:
-{{- if .SignalControl.Enabled }}
+{{- if $scDefault }}
     default_pipelines: [logs/sc/default{{- if $splitDefault }}, logs/export/default/passthrough{{- end }}]
 {{- else }}
     default_pipelines: [logs/export/default]
@@ -1382,37 +1399,27 @@ service:
         - transform/traces/custom_telemetry_transform
         {{- end }}
         - transform/resources
-        {{- if and .SignalControl.Enabled (not $useRouting) }}
-        - resource/signal_control_attributes
-        - dash0resource
-        - dash0operation
-        {{- if .SignalControl.SpamFilterEnabled }}
-        - dash0filter
-        {{- end }}
-        {{- end }}
       exporters:
         {{- if $useRouting }}
         - routing/traces
-        {{- else if .SignalControl.Enabled }}
-        {{- if .SignalControl.SamplingEnabled }}
-        - forward/traces-to-sampling
-        {{- end }}
-        - dash0redmetrics
-        {{- if .SignalControl.SignalToMetricsEnabled }}
-        - dash0signaltometrics
-        {{- end }}
-        {{- if not .SignalControl.SamplingEnabled }}
-        - forward/traces-default-exporter
+        {{- else if $scDefault }}
+        - forward/traces-to-sc
+        {{- range $exporter := .Exporters.DefaultPassthrough }}
+        - {{ $exporter.Name }}
         {{- end }}
         {{- else }}
         - forward/traces-default-exporter
         {{- end }}
 {{- if .SignalControl.Enabled }}
-{{- if $useRouting }}
+{{- if $scDefault }}
 
     traces/signal-control-pre-sampling:
       receivers:
+        {{- if $useRouting }}
         - routing/traces
+        {{- else }}
+        - forward/traces-to-sc
+        {{- end }}
       processors:
         - resource/signal_control_attributes
         - dash0resource
@@ -1455,14 +1462,14 @@ service:
       {{- end }}
 {{- end }}
 
-{{- if .SignalControl.SamplingEnabled }}
+{{- if $samplingActive }}
     traces/sampled:
       receivers:
         - forward/traces-to-sampling
       processors:
         - dash0sampling
       exporters:
-        {{- if $useRouting }}
+        {{- if $hasNamespacedDash0 }}
         - routing/traces-sampled
         {{- else }}
         - forward/traces-default-exporter
@@ -1472,13 +1479,15 @@ service:
 
     traces/export/default:
       receivers:
-        {{- if and .SignalControl.SamplingEnabled $useRouting }}
+        {{- if and $samplingActive $hasNamespacedDash0 }}
         - routing/traces-sampled
-        {{- else if and $useRouting (not .SignalControl.Enabled) }}
+        {{- end }}
+        {{- if and $useRouting (not $scDefault) }}
         - routing/traces
-        {{- else }}
+        {{- end }}
+        {{- if or (not $hasNamespacedExporters) (and $scDefault (or (not .SignalControl.SamplingEnabled) (not $hasNamespacedDash0))) }}
         - forward/traces-default-exporter
-        {{- end}}
+        {{- end }}
       exporters:
       {{- if (or .DevelopmentMode .DebugVerbosityDetailed) }}
         - debug
@@ -1493,7 +1502,7 @@ service:
       {{- end }}
       {{- end }}
 
-{{- if $splitDefault }}
+{{- if and $hasNamespacedExporters $splitDefault }}
     traces/export/default/passthrough:
       receivers:
         - routing/traces
@@ -1601,12 +1610,6 @@ service:
         {{- if .UseHostMetricsReceiver }}
         - hostmetrics
         {{- end }}
-        {{- if and .SignalControl.Enabled (not $useRouting) }}
-        - dash0redmetrics
-        {{- if .SignalControl.SignalToMetricsEnabled }}
-        - dash0signaltometrics
-        {{- end }}
-        {{- end }}
       processors:
         - memory_limiter
       exporters:
@@ -1644,23 +1647,26 @@ service:
         - transform/metrics/custom_telemetry_transform
         {{- end }}
         - transform/resources
-        {{- if and .SignalControl.Enabled (not $useRouting) }}
-        - resource/signal_control_attributes
-        {{- if .SignalControl.SpamFilterEnabled }}
-        - dash0filter
-        {{- end }}
-        {{- end }}
       exporters:
         {{- if $useRouting }}
         - routing/metrics
+        {{- else if $scDefault }}
+        - forward/metrics-to-sc
+        {{- range $exporter := .Exporters.DefaultPassthrough }}
+        - {{ $exporter.Name }}
+        {{- end }}
         {{- else }}
         - forward/metrics-default-exporter
         {{- end }}
 
-{{- if and .SignalControl.Enabled $useRouting }}
+{{- if $scDefault }}
     metrics/sc/default:
       receivers:
+        {{- if $useRouting }}
         - routing/metrics
+        {{- else }}
+        - forward/metrics-to-sc
+        {{- end }}
       processors:
         - resource/signal_control_attributes
         {{- if .SignalControl.SpamFilterEnabled }}
@@ -1672,11 +1678,12 @@ service:
 
     metrics/export/default:
       receivers:
-        {{- if and $useRouting (not .SignalControl.Enabled) }}
+        {{- if and $useRouting (not $scDefault) }}
         - routing/metrics
-        {{- else }}
+        {{- end }}
+        {{- if or (not $hasNamespacedExporters) $scDefault }}
         - forward/metrics-default-exporter
-        {{- end}}
+        {{- end }}
       exporters:
         {{- if (or .DevelopmentMode .DebugVerbosityDetailed) }}
         - debug
@@ -1691,7 +1698,7 @@ service:
         {{- end }}
         {{- end }}
 
-{{- if $splitDefault }}
+{{- if and $hasNamespacedExporters $splitDefault }}
     metrics/export/default/passthrough:
       receivers:
         - routing/metrics
@@ -1804,27 +1811,26 @@ service:
         - transform/logs/custom_telemetry_transform
         {{- end }}
         - transform/resources
-        {{- if and .SignalControl.Enabled (not $useRouting) }}
-        - resource/signal_control_attributes
-        - dash0resource
-        {{- if .SignalControl.SpamFilterEnabled }}
-        - dash0filter
-        {{- end }}
-        {{- end }}
       exporters:
         {{- if $useRouting }}
         - routing/logs
+        {{- else if $scDefault }}
+        - forward/logs-to-sc
+        {{- range $exporter := .Exporters.DefaultPassthrough }}
+        - {{ $exporter.Name }}
+        {{- end }}
         {{- else }}
         - forward/logs-default-exporter
         {{- end }}
-        {{- if and .SignalControl.Enabled .SignalControl.SignalToMetricsEnabled (not $useRouting) }}
-        - dash0signaltometrics
-        {{- end }}
 
-{{- if and .SignalControl.Enabled $useRouting }}
+{{- if $scDefault }}
     logs/sc/default:
       receivers:
+        {{- if $useRouting }}
         - routing/logs
+        {{- else }}
+        - forward/logs-to-sc
+        {{- end }}
       processors:
         - resource/signal_control_attributes
         - dash0resource
@@ -1840,11 +1846,12 @@ service:
 
     logs/export/default:
       receivers:
-        {{- if and $useRouting (not .SignalControl.Enabled) }}
+        {{- if and $useRouting (not $scDefault) }}
         - routing/logs
-        {{- else }}
+        {{- end }}
+        {{- if or (not $hasNamespacedExporters) $scDefault }}
         - forward/logs-default-exporter
-        {{- end}}
+        {{- end }}
       exporters:
         {{- if (or .DevelopmentMode .DebugVerbosityDetailed) }}
         - debug
@@ -1859,7 +1866,7 @@ service:
         {{- end }}
         {{- end }}
 
-{{- if $splitDefault }}
+{{- if and $hasNamespacedExporters $splitDefault }}
     logs/export/default/passthrough:
       receivers:
         - routing/logs

--- a/internal/collectors/otelcolresources/daemonset.config.yaml.template
+++ b/internal/collectors/otelcolresources/daemonset.config.yaml.template
@@ -21,6 +21,11 @@ use option 2.
 */}}
 
 {{- $hasNamespacedExporters := gt (len .Exporters.Namespaced) 0 -}}
+{{- /* A non-Dash0 default exporter must not receive Signal Control, so when one is present (with SC enabled) the
+default telemetry has to be split (Dash0 -> SC, non-Dash0 -> passthrough) via the routing connector, just like the
+namespaced case. $useRouting is true whenever routing is needed for either reason. */}}
+{{- $hasDefaultPassthrough := and .SignalControl.Enabled (gt (len .Exporters.DefaultPassthrough) 0) -}}
+{{- $useRouting := or $hasNamespacedExporters $hasDefaultPassthrough -}}
 
 extensions:
   health_check:
@@ -83,9 +88,6 @@ connectors:
 {{- end }}
 {{- if $hasNamespacedExporters }}
 {{- range $ns, $sc := .Exporters.NamespaceSC }}
-{{- if and $.SignalControl.SamplingEnabled (gt (len $sc.DatasetBranches) 0) }}
-  forward/traces-to-sampling/ns/{{ $ns }}: {}
-{{- end }}
 {{- range $b := $sc.DatasetBranches }}
 {{- if or $.SignalControl.RedMetricsMaxTimeSeries $.SignalControl.RedMetricsAdditionalSpanAttributes }}
   dash0redmetrics/ns/{{ $ns }}/{{ $b.DatasetIndex }}:
@@ -125,10 +127,10 @@ connectors:
   forward/profiles-default-exporter: {}
   {{- end }}
 
-  {{- if $hasNamespacedExporters }}
+  {{- if $useRouting }}
   routing/traces:
 {{- if .SignalControl.Enabled }}
-    default_pipelines: [traces/signal-control-pre-sampling]
+    default_pipelines: [traces/signal-control-pre-sampling{{- if $hasDefaultPassthrough }}, traces/export/default/passthrough{{- end }}]
 {{- else }}
     default_pipelines: [traces/export/default]
 {{- end }}
@@ -154,9 +156,23 @@ connectors:
           - traces/export/ns/{{ $ns }}
     {{- end }}
 {{- end }}
+{{- if .SignalControl.SamplingEnabled }}
+  routing/traces-sampled:
+    default_pipelines: [traces/export/default]
+    error_mode: ignore
+    table:
+    {{- range $ns, $sc := $.Exporters.NamespaceSC }}
+    {{- if $sc.DatasetBranches }}
+      - context: resource
+        condition: attributes["k8s.namespace.name"] == "{{ $ns }}"
+        pipelines:
+          - traces/export/sampled/ns/{{ $ns }}
+    {{- end }}
+    {{- end }}
+{{- end }}
   routing/metrics:
 {{- if .SignalControl.Enabled }}
-    default_pipelines: [metrics/sc/default]
+    default_pipelines: [metrics/sc/default{{- if $hasDefaultPassthrough }}, metrics/export/default/passthrough{{- end }}]
 {{- else }}
     default_pipelines: [metrics/export/default]
 {{- end }}
@@ -184,7 +200,7 @@ connectors:
 {{- end }}
   routing/logs:
 {{- if .SignalControl.Enabled }}
-    default_pipelines: [logs/sc/default]
+    default_pipelines: [logs/sc/default{{- if $hasDefaultPassthrough }}, logs/export/default/passthrough{{- end }}]
 {{- else }}
     default_pipelines: [logs/export/default]
 {{- end }}
@@ -1159,33 +1175,6 @@ processors:
       value: {{ $b.Dataset }}
       action: upsert
 {{- end }}
-{{- if and $.SignalControl.SamplingEnabled (gt (len $sc.DatasetBranches) 0) }}
-  dash0sampling/ns/{{ $ns }}:
-    decision_maker_endpoint: {{ $.SignalControl.Endpoint }}
-    decision_maker_headers:
-      Authorization: Bearer ${env:DASH0_SIGNAL_CONTROL_AUTH_TOKEN}
-      Dash0-Dataset: {{ (index $sc.DatasetBranches 0).Dataset }}
-    decision_maker_insecure: {{ $.SignalControl.Insecure }}
-    default_dataset: {{ (index $sc.DatasetBranches 0).Dataset }}
-{{- if $.SignalControl.SamplingFallbackSampleRatio }}
-    fallback_sample_ratio: {{ $.SignalControl.SamplingFallbackSampleRatio }}
-{{- end }}
-{{- if $.SignalControl.SamplingDebug }}
-    debug: true
-{{- end }}
-{{- if $.SignalControl.SamplingEnableBatching }}
-    enable_batching: true
-{{- end }}
-    reservoir:
-      type: {{ $.SignalControl.SamplingReservoirType }}
-      metric_level: {{ $.SignalControl.SamplingReservoirMetricLevel }}
-{{- if eq $.SignalControl.SamplingReservoirType "disk" }}
-      data_dir: /var/lib/dash0/trace-reservoir/ns/{{ $ns }}
-      max_disk_bytes: {{ $.SignalControl.SamplingReservoirMaxDiskBytes }}
-{{- else if $.SignalControl.SamplingReservoirMaxMemoryBytes }}
-      max_memory_bytes: {{ $.SignalControl.SamplingReservoirMaxMemoryBytes }}
-{{- end }}
-{{- end }}
 {{- end }}
 {{- end }}
   dash0resource: {}
@@ -1390,7 +1379,7 @@ service:
         - transform/traces/custom_telemetry_transform
         {{- end }}
         - transform/resources
-        {{- if and .SignalControl.Enabled (not $hasNamespacedExporters) }}
+        {{- if and .SignalControl.Enabled (not $useRouting) }}
         - resource/signal_control_attributes
         - dash0resource
         - dash0operation
@@ -1399,7 +1388,7 @@ service:
         {{- end }}
         {{- end }}
       exporters:
-        {{- if $hasNamespacedExporters }}
+        {{- if $useRouting }}
         - routing/traces
         {{- else if .SignalControl.Enabled }}
         {{- if .SignalControl.SamplingEnabled }}
@@ -1416,7 +1405,7 @@ service:
         - forward/traces-default-exporter
         {{- end }}
 {{- if .SignalControl.Enabled }}
-{{- if $hasNamespacedExporters }}
+{{- if $useRouting }}
 
     traces/signal-control-pre-sampling:
       receivers:
@@ -1452,7 +1441,7 @@ service:
       {{- if (or .DevelopmentMode .DebugVerbosityDetailed) }}
         - debug
       {{- end }}
-      {{- range $i, $exporter := .Exporters.Default }}
+      {{- range $i, $exporter := .Exporters.DefaultDash0Exporters }}
         - {{ $exporter.Name }}
       {{- end }}
 {{- end }}
@@ -1464,13 +1453,19 @@ service:
       processors:
         - dash0sampling
       exporters:
+        {{- if $useRouting }}
+        - routing/traces-sampled
+        {{- else }}
         - forward/traces-default-exporter
+        {{- end }}
 {{- end }}
 {{- end }}
 
     traces/export/default:
       receivers:
-        {{- if and $hasNamespacedExporters (not .SignalControl.Enabled) }}
+        {{- if and .SignalControl.SamplingEnabled $useRouting }}
+        - routing/traces-sampled
+        {{- else if and $useRouting (not .SignalControl.Enabled) }}
         - routing/traces
         {{- else }}
         - forward/traces-default-exporter
@@ -1479,9 +1474,28 @@ service:
       {{- if (or .DevelopmentMode .DebugVerbosityDetailed) }}
         - debug
       {{- end }}
+      {{- if .SignalControl.Enabled }}
+      {{- range $i, $exporter := .Exporters.DefaultDash0Exporters }}
+        - {{ $exporter.Name }}
+      {{- end }}
+      {{- else }}
       {{- range $i, $exporter := .Exporters.Default }}
         - {{ $exporter.Name }}
       {{- end }}
+      {{- end }}
+
+{{- if $hasDefaultPassthrough }}
+    traces/export/default/passthrough:
+      receivers:
+        - routing/traces
+      exporters:
+      {{- if (or .DevelopmentMode .DebugVerbosityDetailed) }}
+        - debug
+      {{- end }}
+      {{- range $i, $exporter := .Exporters.DefaultPassthrough }}
+        - {{ $exporter.Name }}
+      {{- end }}
+{{- end }}
 
 {{- if .SignalControl.Enabled }}
     {{- range $ns, $sc := $.Exporters.NamespaceSC }}
@@ -1501,7 +1515,7 @@ service:
         - debug
       {{- end }}
         {{- if and $.SignalControl.SamplingEnabled (eq $b.DatasetIndex 0) }}
-        - forward/traces-to-sampling/ns/{{ $ns }}
+        - forward/traces-to-sampling
         {{- else }}
         {{- range $exporter := $b.Exporters }}
         - {{ $exporter.Name }}
@@ -1511,21 +1525,6 @@ service:
         {{- if $.SignalControl.SignalToMetricsEnabled }}
         - dash0signaltometrics/ns/{{ $ns }}/{{ $b.DatasetIndex }}
         {{- end }}
-
-    {{- if and $.SignalControl.SamplingEnabled (eq $b.DatasetIndex 0) }}
-    traces/sampled/ns/{{ $ns }}:
-      receivers:
-        - forward/traces-to-sampling/ns/{{ $ns }}
-      processors:
-        - dash0sampling/ns/{{ $ns }}
-      exporters:
-      {{- if (or $.DevelopmentMode $.DebugVerbosityDetailed) }}
-        - debug
-      {{- end }}
-        {{- range $exporter := $b.Exporters }}
-        - {{ $exporter.Name }}
-        {{- end }}
-    {{- end }}
 
     metrics/derived/ns/{{ $ns }}/{{ $b.DatasetIndex }}:
       receivers:
@@ -1540,6 +1539,18 @@ service:
         - debug
       {{- end }}
         {{- range $exporter := $b.Exporters }}
+        - {{ $exporter.Name }}
+        {{- end }}
+    {{- end }}
+    {{- if and $.SignalControl.SamplingEnabled (gt (len $sc.DatasetBranches) 0) }}
+    traces/export/sampled/ns/{{ $ns }}:
+      receivers:
+        - routing/traces-sampled
+      exporters:
+      {{- if (or $.DevelopmentMode $.DebugVerbosityDetailed) }}
+        - debug
+      {{- end }}
+        {{- range $exporter := (index $sc.DatasetBranches 0).Exporters }}
         - {{ $exporter.Name }}
         {{- end }}
     {{- end }}
@@ -1581,7 +1592,7 @@ service:
         {{- if .UseHostMetricsReceiver }}
         - hostmetrics
         {{- end }}
-        {{- if and .SignalControl.Enabled (not $hasNamespacedExporters) }}
+        {{- if and .SignalControl.Enabled (not $useRouting) }}
         - dash0redmetrics
         {{- if .SignalControl.SignalToMetricsEnabled }}
         - dash0signaltometrics
@@ -1624,20 +1635,20 @@ service:
         - transform/metrics/custom_telemetry_transform
         {{- end }}
         - transform/resources
-        {{- if and .SignalControl.Enabled (not $hasNamespacedExporters) }}
+        {{- if and .SignalControl.Enabled (not $useRouting) }}
         - resource/signal_control_attributes
         {{- if .SignalControl.SpamFilterEnabled }}
         - dash0filter
         {{- end }}
         {{- end }}
       exporters:
-        {{- if $hasNamespacedExporters }}
+        {{- if $useRouting }}
         - routing/metrics
         {{- else }}
         - forward/metrics-default-exporter
         {{- end }}
 
-{{- if and .SignalControl.Enabled $hasNamespacedExporters }}
+{{- if and .SignalControl.Enabled $useRouting }}
     metrics/sc/default:
       receivers:
         - routing/metrics
@@ -1652,7 +1663,7 @@ service:
 
     metrics/export/default:
       receivers:
-        {{- if and $hasNamespacedExporters (not .SignalControl.Enabled) }}
+        {{- if and $useRouting (not .SignalControl.Enabled) }}
         - routing/metrics
         {{- else }}
         - forward/metrics-default-exporter
@@ -1661,9 +1672,28 @@ service:
         {{- if (or .DevelopmentMode .DebugVerbosityDetailed) }}
         - debug
         {{- end }}
+        {{- if .SignalControl.Enabled }}
+        {{- range $i, $exporter := .Exporters.DefaultDash0Exporters }}
+        - {{ $exporter.Name }}
+        {{- end }}
+        {{- else }}
         {{- range $i, $exporter := .Exporters.Default }}
         - {{ $exporter.Name }}
         {{- end }}
+        {{- end }}
+
+{{- if $hasDefaultPassthrough }}
+    metrics/export/default/passthrough:
+      receivers:
+        - routing/metrics
+      exporters:
+        {{- if (or .DevelopmentMode .DebugVerbosityDetailed) }}
+        - debug
+        {{- end }}
+        {{- range $i, $exporter := .Exporters.DefaultPassthrough }}
+        - {{ $exporter.Name }}
+        {{- end }}
+{{- end }}
 
 {{- if .SignalControl.Enabled }}
     {{- range $ns, $sc := $.Exporters.NamespaceSC }}
@@ -1765,7 +1795,7 @@ service:
         - transform/logs/custom_telemetry_transform
         {{- end }}
         - transform/resources
-        {{- if and .SignalControl.Enabled (not $hasNamespacedExporters) }}
+        {{- if and .SignalControl.Enabled (not $useRouting) }}
         - resource/signal_control_attributes
         - dash0resource
         {{- if .SignalControl.SpamFilterEnabled }}
@@ -1773,16 +1803,16 @@ service:
         {{- end }}
         {{- end }}
       exporters:
-        {{- if $hasNamespacedExporters }}
+        {{- if $useRouting }}
         - routing/logs
         {{- else }}
         - forward/logs-default-exporter
         {{- end }}
-        {{- if and .SignalControl.Enabled .SignalControl.SignalToMetricsEnabled (not $hasNamespacedExporters) }}
+        {{- if and .SignalControl.Enabled .SignalControl.SignalToMetricsEnabled (not $useRouting) }}
         - dash0signaltometrics
         {{- end }}
 
-{{- if and .SignalControl.Enabled $hasNamespacedExporters }}
+{{- if and .SignalControl.Enabled $useRouting }}
     logs/sc/default:
       receivers:
         - routing/logs
@@ -1801,7 +1831,7 @@ service:
 
     logs/export/default:
       receivers:
-        {{- if and $hasNamespacedExporters (not .SignalControl.Enabled) }}
+        {{- if and $useRouting (not .SignalControl.Enabled) }}
         - routing/logs
         {{- else }}
         - forward/logs-default-exporter
@@ -1810,9 +1840,28 @@ service:
         {{- if (or .DevelopmentMode .DebugVerbosityDetailed) }}
         - debug
         {{- end }}
+        {{- if .SignalControl.Enabled }}
+        {{- range $i, $exporter := .Exporters.DefaultDash0Exporters }}
+        - {{ $exporter.Name }}
+        {{- end }}
+        {{- else }}
         {{- range $i, $exporter := .Exporters.Default }}
         - {{ $exporter.Name }}
         {{- end }}
+        {{- end }}
+
+{{- if $hasDefaultPassthrough }}
+    logs/export/default/passthrough:
+      receivers:
+        - routing/logs
+      exporters:
+        {{- if (or .DevelopmentMode .DebugVerbosityDetailed) }}
+        - debug
+        {{- end }}
+        {{- range $i, $exporter := .Exporters.DefaultPassthrough }}
+        - {{ $exporter.Name }}
+        {{- end }}
+{{- end }}
 
 {{- if .SignalControl.Enabled }}
     {{- range $ns, $sc := $.Exporters.NamespaceSC }}

--- a/internal/collectors/otelcolresources/daemonset.config.yaml.template
+++ b/internal/collectors/otelcolresources/daemonset.config.yaml.template
@@ -21,11 +21,14 @@ use option 2.
 */}}
 
 {{- $hasNamespacedExporters := gt (len .Exporters.Namespaced) 0 -}}
-{{- /* A non-Dash0 default exporter must not receive Signal Control, so when one is present (with SC enabled) the
-default telemetry has to be split (Dash0 -> SC, non-Dash0 -> passthrough) via the routing connector, just like the
-namespaced case. $useRouting is true whenever routing is needed for either reason. */}}
-{{- $hasDefaultPassthrough := and .SignalControl.Enabled (gt (len .Exporters.DefaultPassthrough) 0) -}}
-{{- $useRouting := or $hasNamespacedExporters $hasDefaultPassthrough -}}
+{{- /* Routing (splitting telemetry per destination) is only used when there are namespaced exporters: the routing
+connector requires a non-empty table, keyed on k8s.namespace.name. $useRouting is an alias for that condition.
+$splitDefault: when a (namespaced) config's DEFAULT export list mixes Dash0 + non-Dash0 exporters with SC enabled,
+the default telemetry is also split — SC'd -> default Dash0 exporters, raw -> default passthrough. Non-namespaced
+configs do not split the default (SC stays inline in common-processors, applied to all default exporters, as before
+this feature); splitting the non-namespaced default would need a fork rather than routing (see note). */}}
+{{- $useRouting := $hasNamespacedExporters -}}
+{{- $splitDefault := and $hasNamespacedExporters .SignalControl.Enabled (gt (len .Exporters.DefaultDash0Exporters) 0) (gt (len .Exporters.DefaultPassthrough) 0) -}}
 
 extensions:
   health_check:
@@ -130,7 +133,7 @@ connectors:
   {{- if $useRouting }}
   routing/traces:
 {{- if .SignalControl.Enabled }}
-    default_pipelines: [traces/signal-control-pre-sampling{{- if $hasDefaultPassthrough }}, traces/export/default/passthrough{{- end }}]
+    default_pipelines: [traces/signal-control-pre-sampling{{- if $splitDefault }}, traces/export/default/passthrough{{- end }}]
 {{- else }}
     default_pipelines: [traces/export/default]
 {{- end }}
@@ -172,7 +175,7 @@ connectors:
 {{- end }}
   routing/metrics:
 {{- if .SignalControl.Enabled }}
-    default_pipelines: [metrics/sc/default{{- if $hasDefaultPassthrough }}, metrics/export/default/passthrough{{- end }}]
+    default_pipelines: [metrics/sc/default{{- if $splitDefault }}, metrics/export/default/passthrough{{- end }}]
 {{- else }}
     default_pipelines: [metrics/export/default]
 {{- end }}
@@ -200,7 +203,7 @@ connectors:
 {{- end }}
   routing/logs:
 {{- if .SignalControl.Enabled }}
-    default_pipelines: [logs/sc/default{{- if $hasDefaultPassthrough }}, logs/export/default/passthrough{{- end }}]
+    default_pipelines: [logs/sc/default{{- if $splitDefault }}, logs/export/default/passthrough{{- end }}]
 {{- else }}
     default_pipelines: [logs/export/default]
 {{- end }}
@@ -1441,8 +1444,14 @@ service:
       {{- if (or .DevelopmentMode .DebugVerbosityDetailed) }}
         - debug
       {{- end }}
+      {{- if $splitDefault }}
       {{- range $i, $exporter := .Exporters.DefaultDash0Exporters }}
         - {{ $exporter.Name }}
+      {{- end }}
+      {{- else }}
+      {{- range $i, $exporter := .Exporters.Default }}
+        - {{ $exporter.Name }}
+      {{- end }}
       {{- end }}
 {{- end }}
 
@@ -1474,7 +1483,7 @@ service:
       {{- if (or .DevelopmentMode .DebugVerbosityDetailed) }}
         - debug
       {{- end }}
-      {{- if .SignalControl.Enabled }}
+      {{- if $splitDefault }}
       {{- range $i, $exporter := .Exporters.DefaultDash0Exporters }}
         - {{ $exporter.Name }}
       {{- end }}
@@ -1484,7 +1493,7 @@ service:
       {{- end }}
       {{- end }}
 
-{{- if $hasDefaultPassthrough }}
+{{- if $splitDefault }}
     traces/export/default/passthrough:
       receivers:
         - routing/traces
@@ -1672,7 +1681,7 @@ service:
         {{- if (or .DevelopmentMode .DebugVerbosityDetailed) }}
         - debug
         {{- end }}
-        {{- if .SignalControl.Enabled }}
+        {{- if $splitDefault }}
         {{- range $i, $exporter := .Exporters.DefaultDash0Exporters }}
         - {{ $exporter.Name }}
         {{- end }}
@@ -1682,7 +1691,7 @@ service:
         {{- end }}
         {{- end }}
 
-{{- if $hasDefaultPassthrough }}
+{{- if $splitDefault }}
     metrics/export/default/passthrough:
       receivers:
         - routing/metrics
@@ -1840,7 +1849,7 @@ service:
         {{- if (or .DevelopmentMode .DebugVerbosityDetailed) }}
         - debug
         {{- end }}
-        {{- if .SignalControl.Enabled }}
+        {{- if $splitDefault }}
         {{- range $i, $exporter := .Exporters.DefaultDash0Exporters }}
         - {{ $exporter.Name }}
         {{- end }}
@@ -1850,7 +1859,7 @@ service:
         {{- end }}
         {{- end }}
 
-{{- if $hasDefaultPassthrough }}
+{{- if $splitDefault }}
     logs/export/default/passthrough:
       receivers:
         - routing/logs

--- a/internal/collectors/otelcolresources/daemonset.config.yaml.template
+++ b/internal/collectors/otelcolresources/daemonset.config.yaml.template
@@ -81,6 +81,45 @@ connectors:
   dash0signaltometrics: {}
 {{- end }}
 {{- end }}
+{{- if $hasNamespacedExporters }}
+{{- range $ns, $sc := .Exporters.NamespaceSC }}
+{{- if and $.SignalControl.SamplingEnabled (gt (len $sc.DatasetBranches) 0) }}
+  forward/traces-to-sampling/ns/{{ $ns }}: {}
+{{- end }}
+{{- range $b := $sc.DatasetBranches }}
+{{- if or $.SignalControl.RedMetricsMaxTimeSeries $.SignalControl.RedMetricsAdditionalSpanAttributes }}
+  dash0redmetrics/ns/{{ $ns }}/{{ $b.DatasetIndex }}:
+{{- if $.SignalControl.RedMetricsMaxTimeSeries }}
+    max_time_series: {{ $.SignalControl.RedMetricsMaxTimeSeries }}
+{{- end }}
+{{- if $.SignalControl.RedMetricsAdditionalSpanAttributes }}
+    additional_span_attributes:
+    {{- range $attr := $.SignalControl.RedMetricsAdditionalSpanAttributes }}
+    - '{{ $attr }}'
+    {{- end }}
+{{- end }}
+{{- else }}
+  dash0redmetrics/ns/{{ $ns }}/{{ $b.DatasetIndex }}: {}
+{{- end }}
+{{- if $.SignalControl.SignalToMetricsEnabled }}
+{{- if or $.SignalControl.SignalToMetricsMaxTimeSeries $.SignalControl.SignalToMetricsFlushInterval $.SignalControl.SignalToMetricsCacheExpiration }}
+  dash0signaltometrics/ns/{{ $ns }}/{{ $b.DatasetIndex }}:
+{{- if $.SignalControl.SignalToMetricsMaxTimeSeries }}
+    max_time_series: {{ $.SignalControl.SignalToMetricsMaxTimeSeries }}
+{{- end }}
+{{- if $.SignalControl.SignalToMetricsCacheExpiration }}
+    cache_expiration: {{ $.SignalControl.SignalToMetricsCacheExpiration }}
+{{- end }}
+{{- if $.SignalControl.SignalToMetricsFlushInterval }}
+    metrics_flush_interval: {{ $.SignalControl.SignalToMetricsFlushInterval }}
+{{- end }}
+{{- else }}
+  dash0signaltometrics/ns/{{ $ns }}/{{ $b.DatasetIndex }}: {}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
 {{- end }}
   {{- if .ProfilingEnabled }}
   forward/profiles-default-exporter: {}
@@ -95,42 +134,82 @@ connectors:
 {{- end }}
     error_mode: ignore
     table:
-    {{- range $ns := .Exporters.AllNamespaceKeys }}
-    {{- $exporters := index $.Exporters.Namespaced $ns }}
+{{- if .SignalControl.Enabled }}
+    {{- range $ns, $sc := $.Exporters.NamespaceSC }}
       - context: resource
         condition: attributes["k8s.namespace.name"] == "{{ $ns }}"
         pipelines:
-        {{- range $i, $exporter := $exporters }}
+        {{- range $b := $sc.DatasetBranches }}
+          - traces/sc/ns/{{ $ns }}/{{ $b.DatasetIndex }}
+        {{- end }}
+        {{- if $sc.Passthrough }}
+          - traces/export/ns/{{ $ns }}/passthrough
+        {{- end }}
+    {{- end }}
+{{- else }}
+    {{- range $ns := .Exporters.AllNamespaceKeys }}
+      - context: resource
+        condition: attributes["k8s.namespace.name"] == "{{ $ns }}"
+        pipelines:
           - traces/export/ns/{{ $ns }}
-        {{- end }}
     {{- end }}
+{{- end }}
   routing/metrics:
+{{- if .SignalControl.Enabled }}
+    default_pipelines: [metrics/sc/default]
+{{- else }}
     default_pipelines: [metrics/export/default]
+{{- end }}
     error_mode: ignore
     table:
-    {{- range $ns := .Exporters.AllNamespaceKeys }}
-    {{- $exporters := index $.Exporters.Namespaced $ns }}
+{{- if .SignalControl.Enabled }}
+    {{- range $ns, $sc := $.Exporters.NamespaceSC }}
       - context: resource
         condition: attributes["k8s.namespace.name"] == "{{ $ns }}"
         pipelines:
-        {{- range $i, $exporter := $exporters }}
+        {{- range $b := $sc.DatasetBranches }}
+          - metrics/sc/ns/{{ $ns }}/{{ $b.DatasetIndex }}
+        {{- end }}
+        {{- if $sc.Passthrough }}
+          - metrics/export/ns/{{ $ns }}/passthrough
+        {{- end }}
+    {{- end }}
+{{- else }}
+    {{- range $ns := .Exporters.AllNamespaceKeys }}
+      - context: resource
+        condition: attributes["k8s.namespace.name"] == "{{ $ns }}"
+        pipelines:
           - metrics/export/ns/{{ $ns }}
-        {{- end }}
     {{- end }}
+{{- end }}
   routing/logs:
+{{- if .SignalControl.Enabled }}
+    default_pipelines: [logs/sc/default]
+{{- else }}
     default_pipelines: [logs/export/default]
+{{- end }}
     error_mode: ignore
     table:
-    {{- range $ns := .Exporters.AllNamespaceKeys }}
-    {{- $exporters := index $.Exporters.Namespaced $ns }}
+{{- if .SignalControl.Enabled }}
+    {{- range $ns, $sc := $.Exporters.NamespaceSC }}
       - context: resource
         condition: attributes["k8s.namespace.name"] == "{{ $ns }}"
-
         pipelines:
-        {{- range $i, $exporter := $exporters }}
-          - logs/export/ns/{{ $ns }}
+        {{- range $b := $sc.DatasetBranches }}
+          - logs/sc/ns/{{ $ns }}/{{ $b.DatasetIndex }}
+        {{- end }}
+        {{- if $sc.Passthrough }}
+          - logs/export/ns/{{ $ns }}/passthrough
         {{- end }}
     {{- end }}
+{{- else }}
+    {{- range $ns := .Exporters.AllNamespaceKeys }}
+      - context: resource
+        condition: attributes["k8s.namespace.name"] == "{{ $ns }}"
+        pipelines:
+          - logs/export/ns/{{ $ns }}
+    {{- end }}
+{{- end }}
   {{- end }}
   {{- if and .ProfilingEnabled $hasNamespacedExporters }}
   routing/profiles:
@@ -138,13 +217,10 @@ connectors:
     error_mode: ignore
     table:
     {{- range $ns := .Exporters.AllNamespaceKeys }}
-    {{- $exporters := index $.Exporters.Namespaced $ns }}
       - context: resource
         condition: attributes["k8s.namespace.name"] == "{{ $ns }}"
         pipelines:
-        {{- range $i, $exporter := $exporters }}
           - profiles/export/ns/{{ $ns }}
-        {{- end }}
     {{- end }}
   {{- end }}
 
@@ -1071,6 +1147,47 @@ processors:
     - key: dash0.dataset
       value: {{ .SignalControl.Dataset }}
       action: upsert
+{{- if $hasNamespacedExporters }}
+{{- range $ns, $sc := .Exporters.NamespaceSC }}
+{{- range $b := $sc.DatasetBranches }}
+  resource/signal_control_attributes/ns/{{ $ns }}/{{ $b.DatasetIndex }}:
+    attributes:
+    - key: dash0.org.technical.id
+      value: edge
+      action: upsert
+    - key: dash0.dataset
+      value: {{ $b.Dataset }}
+      action: upsert
+{{- end }}
+{{- if and $.SignalControl.SamplingEnabled (gt (len $sc.DatasetBranches) 0) }}
+  dash0sampling/ns/{{ $ns }}:
+    decision_maker_endpoint: {{ $.SignalControl.Endpoint }}
+    decision_maker_headers:
+      Authorization: Bearer ${env:DASH0_SIGNAL_CONTROL_AUTH_TOKEN}
+      Dash0-Dataset: {{ (index $sc.DatasetBranches 0).Dataset }}
+    decision_maker_insecure: {{ $.SignalControl.Insecure }}
+    default_dataset: {{ (index $sc.DatasetBranches 0).Dataset }}
+{{- if $.SignalControl.SamplingFallbackSampleRatio }}
+    fallback_sample_ratio: {{ $.SignalControl.SamplingFallbackSampleRatio }}
+{{- end }}
+{{- if $.SignalControl.SamplingDebug }}
+    debug: true
+{{- end }}
+{{- if $.SignalControl.SamplingEnableBatching }}
+    enable_batching: true
+{{- end }}
+    reservoir:
+      type: {{ $.SignalControl.SamplingReservoirType }}
+      metric_level: {{ $.SignalControl.SamplingReservoirMetricLevel }}
+{{- if eq $.SignalControl.SamplingReservoirType "disk" }}
+      data_dir: /var/lib/dash0/trace-reservoir/ns/{{ $ns }}
+      max_disk_bytes: {{ $.SignalControl.SamplingReservoirMaxDiskBytes }}
+{{- else if $.SignalControl.SamplingReservoirMaxMemoryBytes }}
+      max_memory_bytes: {{ $.SignalControl.SamplingReservoirMaxMemoryBytes }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
   dash0resource: {}
 {{- if or .SignalControl.OperationPreferSpanName .SignalControl.OperationCardinalityRules }}
   dash0operation:
@@ -1273,7 +1390,7 @@ service:
         - transform/traces/custom_telemetry_transform
         {{- end }}
         - transform/resources
-        {{- if .SignalControl.Enabled }}
+        {{- if and .SignalControl.Enabled (not $hasNamespacedExporters) }}
         - resource/signal_control_attributes
         - dash0resource
         - dash0operation
@@ -1304,6 +1421,13 @@ service:
     traces/signal-control-pre-sampling:
       receivers:
         - routing/traces
+      processors:
+        - resource/signal_control_attributes
+        - dash0resource
+        - dash0operation
+        {{- if .SignalControl.SpamFilterEnabled }}
+        - dash0filter
+        {{- end }}
       exporters:
         {{- if .SignalControl.SamplingEnabled }}
         - forward/traces-to-sampling
@@ -1315,6 +1439,22 @@ service:
         {{- if not .SignalControl.SamplingEnabled }}
         - forward/traces-default-exporter
         {{- end }}
+
+    metrics/derived/default:
+      receivers:
+        - dash0redmetrics
+        {{- if .SignalControl.SignalToMetricsEnabled }}
+        - dash0signaltometrics
+        {{- end }}
+      processors:
+        - batch
+      exporters:
+      {{- if (or .DevelopmentMode .DebugVerbosityDetailed) }}
+        - debug
+      {{- end }}
+      {{- range $i, $exporter := .Exporters.Default }}
+        - {{ $exporter.Name }}
+      {{- end }}
 {{- end }}
 
 {{- if .SignalControl.SamplingEnabled }}
@@ -1343,6 +1483,80 @@ service:
         - {{ $exporter.Name }}
       {{- end }}
 
+{{- if .SignalControl.Enabled }}
+    {{- range $ns, $sc := $.Exporters.NamespaceSC }}
+    {{- range $b := $sc.DatasetBranches }}
+    traces/sc/ns/{{ $ns }}/{{ $b.DatasetIndex }}:
+      receivers:
+        - routing/traces
+      processors:
+        - resource/signal_control_attributes/ns/{{ $ns }}/{{ $b.DatasetIndex }}
+        - dash0resource
+        - dash0operation
+        {{- if $.SignalControl.SpamFilterEnabled }}
+        - dash0filter
+        {{- end }}
+      exporters:
+      {{- if (or $.DevelopmentMode $.DebugVerbosityDetailed) }}
+        - debug
+      {{- end }}
+        {{- if and $.SignalControl.SamplingEnabled (eq $b.DatasetIndex 0) }}
+        - forward/traces-to-sampling/ns/{{ $ns }}
+        {{- else }}
+        {{- range $exporter := $b.Exporters }}
+        - {{ $exporter.Name }}
+        {{- end }}
+        {{- end }}
+        - dash0redmetrics/ns/{{ $ns }}/{{ $b.DatasetIndex }}
+        {{- if $.SignalControl.SignalToMetricsEnabled }}
+        - dash0signaltometrics/ns/{{ $ns }}/{{ $b.DatasetIndex }}
+        {{- end }}
+
+    {{- if and $.SignalControl.SamplingEnabled (eq $b.DatasetIndex 0) }}
+    traces/sampled/ns/{{ $ns }}:
+      receivers:
+        - forward/traces-to-sampling/ns/{{ $ns }}
+      processors:
+        - dash0sampling/ns/{{ $ns }}
+      exporters:
+      {{- if (or $.DevelopmentMode $.DebugVerbosityDetailed) }}
+        - debug
+      {{- end }}
+        {{- range $exporter := $b.Exporters }}
+        - {{ $exporter.Name }}
+        {{- end }}
+    {{- end }}
+
+    metrics/derived/ns/{{ $ns }}/{{ $b.DatasetIndex }}:
+      receivers:
+        - dash0redmetrics/ns/{{ $ns }}/{{ $b.DatasetIndex }}
+        {{- if $.SignalControl.SignalToMetricsEnabled }}
+        - dash0signaltometrics/ns/{{ $ns }}/{{ $b.DatasetIndex }}
+        {{- end }}
+      processors:
+        - batch
+      exporters:
+      {{- if (or $.DevelopmentMode $.DebugVerbosityDetailed) }}
+        - debug
+      {{- end }}
+        {{- range $exporter := $b.Exporters }}
+        - {{ $exporter.Name }}
+        {{- end }}
+    {{- end }}
+    {{- if $sc.Passthrough }}
+    traces/export/ns/{{ $ns }}/passthrough:
+      receivers:
+        - routing/traces
+      exporters:
+      {{- if (or $.DevelopmentMode $.DebugVerbosityDetailed) }}
+        - debug
+      {{- end }}
+        {{- range $exporter := $sc.Passthrough }}
+        - {{ $exporter.Name }}
+        {{- end }}
+    {{- end }}
+    {{- end }}
+{{- else }}
     {{- range $ns := .Exporters.AllNamespaceKeys }}
     {{- $exporters := index $.Exporters.Namespaced $ns }}
     traces/export/ns/{{- $ns -}}:
@@ -1356,6 +1570,7 @@ service:
         - {{ $exporter.Name }}
       {{- end }}
     {{- end }}
+{{- end }}
 
     metrics/otlp-to-forwarder:
       receivers:
@@ -1366,7 +1581,7 @@ service:
         {{- if .UseHostMetricsReceiver }}
         - hostmetrics
         {{- end }}
-        {{- if .SignalControl.Enabled }}
+        {{- if and .SignalControl.Enabled (not $hasNamespacedExporters) }}
         - dash0redmetrics
         {{- if .SignalControl.SignalToMetricsEnabled }}
         - dash0signaltometrics
@@ -1409,7 +1624,7 @@ service:
         - transform/metrics/custom_telemetry_transform
         {{- end }}
         - transform/resources
-        {{- if .SignalControl.Enabled }}
+        {{- if and .SignalControl.Enabled (not $hasNamespacedExporters) }}
         - resource/signal_control_attributes
         {{- if .SignalControl.SpamFilterEnabled }}
         - dash0filter
@@ -1422,9 +1637,22 @@ service:
         - forward/metrics-default-exporter
         {{- end }}
 
+{{- if and .SignalControl.Enabled $hasNamespacedExporters }}
+    metrics/sc/default:
+      receivers:
+        - routing/metrics
+      processors:
+        - resource/signal_control_attributes
+        {{- if .SignalControl.SpamFilterEnabled }}
+        - dash0filter
+        {{- end }}
+      exporters:
+        - forward/metrics-default-exporter
+{{- end }}
+
     metrics/export/default:
       receivers:
-        {{- if $hasNamespacedExporters }}
+        {{- if and $hasNamespacedExporters (not .SignalControl.Enabled) }}
         - routing/metrics
         {{- else }}
         - forward/metrics-default-exporter
@@ -1437,6 +1665,39 @@ service:
         - {{ $exporter.Name }}
         {{- end }}
 
+{{- if .SignalControl.Enabled }}
+    {{- range $ns, $sc := $.Exporters.NamespaceSC }}
+    {{- range $b := $sc.DatasetBranches }}
+    metrics/sc/ns/{{ $ns }}/{{ $b.DatasetIndex }}:
+      receivers:
+        - routing/metrics
+      processors:
+        - resource/signal_control_attributes/ns/{{ $ns }}/{{ $b.DatasetIndex }}
+        {{- if $.SignalControl.SpamFilterEnabled }}
+        - dash0filter
+        {{- end }}
+      exporters:
+        {{- if (or $.DevelopmentMode $.DebugVerbosityDetailed) }}
+        - debug
+        {{- end }}
+        {{- range $exporter := $b.Exporters }}
+        - {{ $exporter.Name }}
+        {{- end }}
+    {{- end }}
+    {{- if $sc.Passthrough }}
+    metrics/export/ns/{{ $ns }}/passthrough:
+      receivers:
+        - routing/metrics
+      exporters:
+        {{- if (or $.DevelopmentMode $.DebugVerbosityDetailed) }}
+        - debug
+        {{- end }}
+        {{- range $exporter := $sc.Passthrough }}
+        - {{ $exporter.Name }}
+        {{- end }}
+    {{- end }}
+    {{- end }}
+{{- else }}
     {{- range $ns := .Exporters.AllNamespaceKeys }}
     {{- $exporters := index $.Exporters.Namespaced $ns }}
     metrics/export/ns/{{- $ns -}}:
@@ -1450,6 +1711,7 @@ service:
         - {{ $exporter.Name }}
       {{- end }}
     {{- end }}
+{{- end }}
 
     logs/otlp-to-forwarder:
       receivers:
@@ -1503,7 +1765,7 @@ service:
         - transform/logs/custom_telemetry_transform
         {{- end }}
         - transform/resources
-        {{- if .SignalControl.Enabled }}
+        {{- if and .SignalControl.Enabled (not $hasNamespacedExporters) }}
         - resource/signal_control_attributes
         - dash0resource
         {{- if .SignalControl.SpamFilterEnabled }}
@@ -1516,13 +1778,30 @@ service:
         {{- else }}
         - forward/logs-default-exporter
         {{- end }}
-        {{- if and .SignalControl.Enabled .SignalControl.SignalToMetricsEnabled }}
+        {{- if and .SignalControl.Enabled .SignalControl.SignalToMetricsEnabled (not $hasNamespacedExporters) }}
         - dash0signaltometrics
         {{- end }}
 
+{{- if and .SignalControl.Enabled $hasNamespacedExporters }}
+    logs/sc/default:
+      receivers:
+        - routing/logs
+      processors:
+        - resource/signal_control_attributes
+        - dash0resource
+        {{- if .SignalControl.SpamFilterEnabled }}
+        - dash0filter
+        {{- end }}
+      exporters:
+        - forward/logs-default-exporter
+        {{- if .SignalControl.SignalToMetricsEnabled }}
+        - dash0signaltometrics
+        {{- end }}
+{{- end }}
+
     logs/export/default:
       receivers:
-        {{- if $hasNamespacedExporters }}
+        {{- if and $hasNamespacedExporters (not .SignalControl.Enabled) }}
         - routing/logs
         {{- else }}
         - forward/logs-default-exporter
@@ -1535,6 +1814,43 @@ service:
         - {{ $exporter.Name }}
         {{- end }}
 
+{{- if .SignalControl.Enabled }}
+    {{- range $ns, $sc := $.Exporters.NamespaceSC }}
+    {{- range $b := $sc.DatasetBranches }}
+    logs/sc/ns/{{ $ns }}/{{ $b.DatasetIndex }}:
+      receivers:
+        - routing/logs
+      processors:
+        - resource/signal_control_attributes/ns/{{ $ns }}/{{ $b.DatasetIndex }}
+        - dash0resource
+        {{- if $.SignalControl.SpamFilterEnabled }}
+        - dash0filter
+        {{- end }}
+      exporters:
+        {{- if (or $.DevelopmentMode $.DebugVerbosityDetailed) }}
+        - debug
+        {{- end }}
+        {{- range $exporter := $b.Exporters }}
+        - {{ $exporter.Name }}
+        {{- end }}
+        {{- if $.SignalControl.SignalToMetricsEnabled }}
+        - dash0signaltometrics/ns/{{ $ns }}/{{ $b.DatasetIndex }}
+        {{- end }}
+    {{- end }}
+    {{- if $sc.Passthrough }}
+    logs/export/ns/{{ $ns }}/passthrough:
+      receivers:
+        - routing/logs
+      exporters:
+        {{- if (or $.DevelopmentMode $.DebugVerbosityDetailed) }}
+        - debug
+        {{- end }}
+        {{- range $exporter := $sc.Passthrough }}
+        - {{ $exporter.Name }}
+        {{- end }}
+    {{- end }}
+    {{- end }}
+{{- else }}
     {{- range $ns := .Exporters.AllNamespaceKeys }}
     {{- $exporters := index $.Exporters.Namespaced $ns }}
     logs/export/ns/{{- $ns -}}:
@@ -1548,6 +1864,7 @@ service:
         - {{ $exporter.Name }}
         {{- end }}
     {{- end }}
+{{- end }}
 
     {{- if .ProfilingEnabled }}
     profiles:

--- a/internal/collectors/otelcolresources/deployment.config.yaml.template
+++ b/internal/collectors/otelcolresources/deployment.config.yaml.template
@@ -1,11 +1,11 @@
 {{- $hasEventCollectionEnabledForAtLeastOneNamespace := gt (len .NamespacesWithEventCollection) 0 -}}
 {{- $hasNamespacedExporters := gt (len .Exporters.Namespaced) 0 -}}
-{{- /* Signal Control is only applied to Dash0 exporters. When the default export list has a non-Dash0 exporter (with
-SC enabled), the default metrics have to be split (Dash0 -> SC, non-Dash0 -> passthrough) via routing, like the
-namespaced case. $useRouting drives the metrics routing; the k8s-events logs pipeline carries no SC and keeps using
-$hasNamespacedExporters. */}}
-{{- $hasDefaultPassthrough := and .SignalControl.Enabled (gt (len .Exporters.DefaultPassthrough) 0) -}}
-{{- $useRouting := or $hasNamespacedExporters $hasDefaultPassthrough -}}
+{{- /* Routing is only used with namespaced exporters (the routing connector requires a non-empty table). $useRouting
+is an alias for that. $splitDefault: when a namespaced config's DEFAULT export list mixes Dash0 + non-Dash0 exporters
+with SC enabled, the default metrics are split too (SC'd -> default Dash0 exporters, raw -> default passthrough).
+Non-namespaced configs do not split the default. The k8s-events logs pipeline carries no SC (keeps $hasNamespacedExporters). */}}
+{{- $useRouting := $hasNamespacedExporters -}}
+{{- $splitDefault := and $hasNamespacedExporters .SignalControl.Enabled (gt (len .Exporters.DefaultDash0Exporters) 0) (gt (len .Exporters.DefaultPassthrough) 0) -}}
 
 extensions:
   health_check:
@@ -26,7 +26,7 @@ connectors:
   {{- if and $useRouting .KubernetesInfrastructureMetricsCollectionEnabled }}
   routing/metrics:
 {{- if .SignalControl.Enabled }}
-    default_pipelines: [metrics/sc/default{{- if $hasDefaultPassthrough }}, metrics/export/default/passthrough{{- end }}]
+    default_pipelines: [metrics/sc/default{{- if $splitDefault }}, metrics/export/default/passthrough{{- end }}]
 {{- else }}
     default_pipelines: [metrics/export/default]
 {{- end }}
@@ -676,7 +676,7 @@ service:
         {{- if (or .DevelopmentMode .DebugVerbosityDetailed) }}
         - debug
         {{- end }}
-        {{- if .SignalControl.Enabled }}
+        {{- if $splitDefault }}
         {{- range $i, $exporter := .Exporters.DefaultDash0Exporters }}
         - {{ $exporter.Name }}
         {{- end }}
@@ -686,7 +686,7 @@ service:
         {{- end }}
         {{- end }}
 
-{{- if $hasDefaultPassthrough }}
+{{- if $splitDefault }}
     metrics/export/default/passthrough:
       receivers:
         - routing/metrics

--- a/internal/collectors/otelcolresources/deployment.config.yaml.template
+++ b/internal/collectors/otelcolresources/deployment.config.yaml.template
@@ -1,5 +1,11 @@
 {{- $hasEventCollectionEnabledForAtLeastOneNamespace := gt (len .NamespacesWithEventCollection) 0 -}}
 {{- $hasNamespacedExporters := gt (len .Exporters.Namespaced) 0 -}}
+{{- /* Signal Control is only applied to Dash0 exporters. When the default export list has a non-Dash0 exporter (with
+SC enabled), the default metrics have to be split (Dash0 -> SC, non-Dash0 -> passthrough) via routing, like the
+namespaced case. $useRouting drives the metrics routing; the k8s-events logs pipeline carries no SC and keeps using
+$hasNamespacedExporters. */}}
+{{- $hasDefaultPassthrough := and .SignalControl.Enabled (gt (len .Exporters.DefaultPassthrough) 0) -}}
+{{- $useRouting := or $hasNamespacedExporters $hasDefaultPassthrough -}}
 
 extensions:
   health_check:
@@ -17,11 +23,10 @@ connectors:
   forward/metrics-default-exporter: {}
   forward/logs-default-exporter: {}
 
-  {{- if $hasNamespacedExporters }}
-  {{- if .KubernetesInfrastructureMetricsCollectionEnabled }}
+  {{- if and $useRouting .KubernetesInfrastructureMetricsCollectionEnabled }}
   routing/metrics:
 {{- if .SignalControl.Enabled }}
-    default_pipelines: [metrics/sc/default]
+    default_pipelines: [metrics/sc/default{{- if $hasDefaultPassthrough }}, metrics/export/default/passthrough{{- end }}]
 {{- else }}
     default_pipelines: [metrics/export/default]
 {{- end }}
@@ -48,7 +53,7 @@ connectors:
     {{- end }}
 {{- end }}
   {{- end }}
-  {{- if $hasEventCollectionEnabledForAtLeastOneNamespace }}
+  {{- if and $hasNamespacedExporters $hasEventCollectionEnabledForAtLeastOneNamespace }}
   routing/logs:
     default_pipelines: [logs/export/default]
     error_mode: ignore
@@ -59,7 +64,6 @@ connectors:
         pipelines:
           - logs/export/ns/{{ $ns }}
     {{- end }}
-  {{- end }}
   {{- end }}
 
 receivers:
@@ -635,20 +639,20 @@ service:
         - transform/metrics/custom_telemetry_transform
         {{- end }}
         - transform/resources
-        {{- if and .SignalControl.Enabled (not $hasNamespacedExporters) }}
+        {{- if and .SignalControl.Enabled (not $useRouting) }}
         - resource/signal_control_attributes
         {{- if .SignalControl.SpamFilterEnabled }}
         - dash0filter
         {{- end }}
         {{- end }}
       exporters:
-        {{- if $hasNamespacedExporters }}
+        {{- if $useRouting }}
         - routing/metrics
         {{- else }}
         - forward/metrics-default-exporter
         {{- end }}
 
-{{- if and .SignalControl.Enabled $hasNamespacedExporters }}
+{{- if and .SignalControl.Enabled $useRouting }}
     metrics/sc/default:
       receivers:
         - routing/metrics
@@ -663,7 +667,7 @@ service:
 
     metrics/export/default:
       receivers:
-        {{- if and $hasNamespacedExporters (not .SignalControl.Enabled) }}
+        {{- if and $useRouting (not .SignalControl.Enabled) }}
         - routing/metrics
         {{- else }}
         - forward/metrics-default-exporter
@@ -672,9 +676,28 @@ service:
         {{- if (or .DevelopmentMode .DebugVerbosityDetailed) }}
         - debug
         {{- end }}
+        {{- if .SignalControl.Enabled }}
+        {{- range $i, $exporter := .Exporters.DefaultDash0Exporters }}
+        - {{ $exporter.Name }}
+        {{- end }}
+        {{- else }}
         {{- range $i, $exporter := .Exporters.Default }}
         - {{ $exporter.Name }}
         {{- end }}
+        {{- end }}
+
+{{- if $hasDefaultPassthrough }}
+    metrics/export/default/passthrough:
+      receivers:
+        - routing/metrics
+      exporters:
+        {{- if (or .DevelopmentMode .DebugVerbosityDetailed) }}
+        - debug
+        {{- end }}
+        {{- range $i, $exporter := .Exporters.DefaultPassthrough }}
+        - {{ $exporter.Name }}
+        {{- end }}
+{{- end }}
 
 {{- if .SignalControl.Enabled }}
     {{- range $ns, $sc := $.Exporters.NamespaceSC }}

--- a/internal/collectors/otelcolresources/deployment.config.yaml.template
+++ b/internal/collectors/otelcolresources/deployment.config.yaml.template
@@ -20,18 +20,33 @@ connectors:
   {{- if $hasNamespacedExporters }}
   {{- if .KubernetesInfrastructureMetricsCollectionEnabled }}
   routing/metrics:
+{{- if .SignalControl.Enabled }}
+    default_pipelines: [metrics/sc/default]
+{{- else }}
     default_pipelines: [metrics/export/default]
+{{- end }}
     error_mode: ignore
     table:
-    {{- range $ns := .Exporters.AllNamespaceKeys }}
-    {{- $exporters := index $.Exporters.Namespaced $ns }}
+{{- if .SignalControl.Enabled }}
+    {{- range $ns, $sc := $.Exporters.NamespaceSC }}
       - context: resource
         condition: attributes["k8s.namespace.name"] == "{{ $ns }}"
         pipelines:
-        {{- range $i, $exporter := $exporters }}
-          - metrics/export/ns/{{ $ns }}
+        {{- range $b := $sc.DatasetBranches }}
+          - metrics/sc/ns/{{ $ns }}/{{ $b.DatasetIndex }}
+        {{- end }}
+        {{- if $sc.Passthrough }}
+          - metrics/export/ns/{{ $ns }}/passthrough
         {{- end }}
     {{- end }}
+{{- else }}
+    {{- range $ns := .Exporters.AllNamespaceKeys }}
+      - context: resource
+        condition: attributes["k8s.namespace.name"] == "{{ $ns }}"
+        pipelines:
+          - metrics/export/ns/{{ $ns }}
+    {{- end }}
+{{- end }}
   {{- end }}
   {{- if $hasEventCollectionEnabledForAtLeastOneNamespace }}
   routing/logs:
@@ -39,13 +54,10 @@ connectors:
     error_mode: ignore
     table:
     {{- range $ns := .Exporters.AllNamespaceKeys }}
-    {{- $exporters := index $.Exporters.Namespaced $ns }}
       - context: resource
         condition: attributes["k8s.namespace.name"] == "{{ $ns }}"
         pipelines:
-        {{- range $i, $exporter := $exporters }}
           - logs/export/ns/{{ $ns }}
-        {{- end }}
     {{- end }}
   {{- end }}
   {{- end }}
@@ -474,6 +486,20 @@ processors:
     - key: dash0.dataset
       value: {{ .SignalControl.Dataset }}
       action: upsert
+{{- if $hasNamespacedExporters }}
+{{- range $ns, $sc := .Exporters.NamespaceSC }}
+{{- range $b := $sc.DatasetBranches }}
+  resource/signal_control_attributes/ns/{{ $ns }}/{{ $b.DatasetIndex }}:
+    attributes:
+    - key: dash0.org.technical.id
+      value: edge
+      action: upsert
+    - key: dash0.dataset
+      value: {{ $b.Dataset }}
+      action: upsert
+{{- end }}
+{{- end }}
+{{- end }}
 {{- if .SignalControl.SpamFilterEnabled }}
 {{- if or .SignalControl.SpamFilterCacheExpiration .SignalControl.SpamFilterAllowNoSettingsExt }}
   dash0filter:
@@ -609,7 +635,7 @@ service:
         - transform/metrics/custom_telemetry_transform
         {{- end }}
         - transform/resources
-        {{- if .SignalControl.Enabled }}
+        {{- if and .SignalControl.Enabled (not $hasNamespacedExporters) }}
         - resource/signal_control_attributes
         {{- if .SignalControl.SpamFilterEnabled }}
         - dash0filter
@@ -622,9 +648,22 @@ service:
         - forward/metrics-default-exporter
         {{- end }}
 
+{{- if and .SignalControl.Enabled $hasNamespacedExporters }}
+    metrics/sc/default:
+      receivers:
+        - routing/metrics
+      processors:
+        - resource/signal_control_attributes
+        {{- if .SignalControl.SpamFilterEnabled }}
+        - dash0filter
+        {{- end }}
+      exporters:
+        - forward/metrics-default-exporter
+{{- end }}
+
     metrics/export/default:
       receivers:
-        {{- if $hasNamespacedExporters }}
+        {{- if and $hasNamespacedExporters (not .SignalControl.Enabled) }}
         - routing/metrics
         {{- else }}
         - forward/metrics-default-exporter
@@ -637,6 +676,39 @@ service:
         - {{ $exporter.Name }}
         {{- end }}
 
+{{- if .SignalControl.Enabled }}
+    {{- range $ns, $sc := $.Exporters.NamespaceSC }}
+    {{- range $b := $sc.DatasetBranches }}
+    metrics/sc/ns/{{ $ns }}/{{ $b.DatasetIndex }}:
+      receivers:
+        - routing/metrics
+      processors:
+        - resource/signal_control_attributes/ns/{{ $ns }}/{{ $b.DatasetIndex }}
+        {{- if $.SignalControl.SpamFilterEnabled }}
+        - dash0filter
+        {{- end }}
+      exporters:
+        {{- if (or $.DevelopmentMode $.DebugVerbosityDetailed) }}
+        - debug
+        {{- end }}
+        {{- range $exporter := $b.Exporters }}
+        - {{ $exporter.Name }}
+        {{- end }}
+    {{- end }}
+    {{- if $sc.Passthrough }}
+    metrics/export/ns/{{ $ns }}/passthrough:
+      receivers:
+        - routing/metrics
+      exporters:
+        {{- if (or $.DevelopmentMode $.DebugVerbosityDetailed) }}
+        - debug
+        {{- end }}
+        {{- range $exporter := $sc.Passthrough }}
+        - {{ $exporter.Name }}
+        {{- end }}
+    {{- end }}
+    {{- end }}
+{{- else }}
     {{- range $ns := .Exporters.AllNamespaceKeys }}
     {{- $exporters := index $.Exporters.Namespaced $ns }}
     metrics/export/ns/{{- $ns -}}:
@@ -650,6 +722,7 @@ service:
         - {{ $exporter.Name }}
       {{- end }}
     {{- end }}
+{{- end }}
     {{- end}}
 
     {{- if $hasEventCollectionEnabledForAtLeastOneNamespace }}

--- a/internal/collectors/otelcolresources/deployment.config.yaml.template
+++ b/internal/collectors/otelcolresources/deployment.config.yaml.template
@@ -1,11 +1,16 @@
 {{- $hasEventCollectionEnabledForAtLeastOneNamespace := gt (len .NamespacesWithEventCollection) 0 -}}
 {{- $hasNamespacedExporters := gt (len .Exporters.Namespaced) 0 -}}
-{{- /* Routing is only used with namespaced exporters (the routing connector requires a non-empty table). $useRouting
-is an alias for that. $splitDefault: when a namespaced config's DEFAULT export list mixes Dash0 + non-Dash0 exporters
-with SC enabled, the default metrics are split too (SC'd -> default Dash0 exporters, raw -> default passthrough).
-Non-namespaced configs do not split the default. The k8s-events logs pipeline carries no SC (keeps $hasNamespacedExporters). */}}
+{{- /* Signal Control (SC) is only applied to Dash0 exporters; non-Dash0 (passthrough) exporters always receive raw
+telemetry. SC always runs in a dedicated branch pipeline (metrics/sc/default) downstream of common-processors, fed by
+the routing connector when there are namespaced exporters and by forward/metrics-to-sc otherwise. See the daemonset
+template for the full explanation. Variables:
+- $useRouting: routing is used (only with namespaced exporters; the routing connector requires a non-empty table).
+- $scDefault: the default path applies SC (SC enabled AND the default list has >=1 Dash0 exporter).
+- $splitDefault: the default mixes Dash0 + non-Dash0 under SC, so it fans out (SC'd -> Dash0, raw -> passthrough).
+The k8s-events logs pipeline carries no SC. */}}
 {{- $useRouting := $hasNamespacedExporters -}}
-{{- $splitDefault := and $hasNamespacedExporters .SignalControl.Enabled (gt (len .Exporters.DefaultDash0Exporters) 0) (gt (len .Exporters.DefaultPassthrough) 0) -}}
+{{- $scDefault := and .SignalControl.Enabled (gt (len .Exporters.DefaultDash0Exporters) 0) -}}
+{{- $splitDefault := and $scDefault (gt (len .Exporters.DefaultPassthrough) 0) -}}
 
 extensions:
   health_check:
@@ -22,10 +27,13 @@ extensions:
 connectors:
   forward/metrics-default-exporter: {}
   forward/logs-default-exporter: {}
+{{- if and (not $useRouting) $scDefault .KubernetesInfrastructureMetricsCollectionEnabled }}
+  forward/metrics-to-sc: {}
+{{- end }}
 
   {{- if and $useRouting .KubernetesInfrastructureMetricsCollectionEnabled }}
   routing/metrics:
-{{- if .SignalControl.Enabled }}
+{{- if $scDefault }}
     default_pipelines: [metrics/sc/default{{- if $splitDefault }}, metrics/export/default/passthrough{{- end }}]
 {{- else }}
     default_pipelines: [metrics/export/default]
@@ -639,23 +647,26 @@ service:
         - transform/metrics/custom_telemetry_transform
         {{- end }}
         - transform/resources
-        {{- if and .SignalControl.Enabled (not $useRouting) }}
-        - resource/signal_control_attributes
-        {{- if .SignalControl.SpamFilterEnabled }}
-        - dash0filter
-        {{- end }}
-        {{- end }}
       exporters:
         {{- if $useRouting }}
         - routing/metrics
+        {{- else if $scDefault }}
+        - forward/metrics-to-sc
+        {{- range $exporter := .Exporters.DefaultPassthrough }}
+        - {{ $exporter.Name }}
+        {{- end }}
         {{- else }}
         - forward/metrics-default-exporter
         {{- end }}
 
-{{- if and .SignalControl.Enabled $useRouting }}
+{{- if $scDefault }}
     metrics/sc/default:
       receivers:
+        {{- if $useRouting }}
         - routing/metrics
+        {{- else }}
+        - forward/metrics-to-sc
+        {{- end }}
       processors:
         - resource/signal_control_attributes
         {{- if .SignalControl.SpamFilterEnabled }}
@@ -667,11 +678,12 @@ service:
 
     metrics/export/default:
       receivers:
-        {{- if and $useRouting (not .SignalControl.Enabled) }}
+        {{- if and $useRouting (not $scDefault) }}
         - routing/metrics
-        {{- else }}
+        {{- end }}
+        {{- if or (not $hasNamespacedExporters) $scDefault }}
         - forward/metrics-default-exporter
-        {{- end}}
+        {{- end }}
       exporters:
         {{- if (or .DevelopmentMode .DebugVerbosityDetailed) }}
         - debug
@@ -686,7 +698,7 @@ service:
         {{- end }}
         {{- end }}
 
-{{- if $splitDefault }}
+{{- if and $hasNamespacedExporters $splitDefault }}
     metrics/export/default/passthrough:
       receivers:
         - routing/metrics

--- a/internal/collectors/otelcolresources/desired_state.go
+++ b/internal/collectors/otelcolresources/desired_state.go
@@ -1016,7 +1016,7 @@ func assembleCollectorDaemonSetVolumes(
 	}
 
 	if config.SignalControl.UsesDiskReservoir() {
-		traceReservoirSizeLimit := reservoirDerivedStorage(config.SignalControl.SamplingReservoirMaxDiskBytes, diskReservoirCount(config))
+		traceReservoirSizeLimit := reservoirDerivedStorage(config.SignalControl.SamplingReservoirMaxDiskBytes)
 		volumes = append(volumes, corev1.Volume{
 			Name: "trace-reservoir",
 			VolumeSource: corev1.VolumeSource{
@@ -1044,27 +1044,12 @@ const reservoirDefaultMaxDiskBytes int64 = 1024 * 1024 * 1024 // 1Gi
 // this floor to keep the reservoir functional.
 const reservoirMaxDiskBytesFloor int64 = 64 * 1024 * 1024 // 64Mi
 
-// reservoirDerivedStorage returns the Kubernetes storage quantity derived from the reservoir's max_disk_bytes by
-// applying reservoirStorageMargin, multiplied by reservoirCount. The daemonset renders one disk reservoir for the
-// default sampling path plus one per namespace that has a Dash0 dataset branch; they all share the single
-// trace-reservoir volume, so it must be sized for their combined on-disk usage.
-func reservoirDerivedStorage(maxDiskBytes int64, reservoirCount int) resource.Quantity {
-	derived := int64(math.Ceil(float64(maxDiskBytes)*reservoirStorageMargin)) * int64(reservoirCount)
+// reservoirDerivedStorage returns the Kubernetes storage quantity derived from the reservoir's
+// max_disk_bytes by applying reservoirStorageMargin. All sampling paths share a single dash0sampling
+// processor (one reservoir), so no per-namespace scaling is applied.
+func reservoirDerivedStorage(maxDiskBytes int64) resource.Quantity {
+	derived := int64(math.Ceil(float64(maxDiskBytes) * reservoirStorageMargin))
 	return *resource.NewQuantity(derived, resource.BinarySI)
-}
-
-// diskReservoirCount returns the number of disk-backed trace reservoirs the daemonset collector renders when the
-// disk reservoir is active: one for the default sampling path plus one for each namespace that has at least one
-// Dash0 dataset branch (each such namespace gets its own dash0sampling instance — see the collector config
-// templates). All of them share the single trace-reservoir EmptyDir volume.
-func diskReservoirCount(config *oTelColConfig) int {
-	count := 1
-	for _, sc := range config.Exporters.NamespaceSC() {
-		if len(sc.DatasetBranches) > 0 {
-			count++
-		}
-	}
-	return count
 }
 
 func assembleCollectorDaemonSetVolumeMounts(
@@ -1237,7 +1222,7 @@ func assembleDaemonSetCollectorContainer(
 			requests = corev1.ResourceList{}
 		}
 		requests[corev1.ResourceEphemeralStorage] =
-			reservoirDerivedStorage(config.SignalControl.SamplingReservoirMaxDiskBytes, diskReservoirCount(config))
+			reservoirDerivedStorage(config.SignalControl.SamplingReservoirMaxDiskBytes)
 		collectorResources.Requests = requests
 	}
 

--- a/internal/collectors/otelcolresources/desired_state.go
+++ b/internal/collectors/otelcolresources/desired_state.go
@@ -1016,7 +1016,7 @@ func assembleCollectorDaemonSetVolumes(
 	}
 
 	if config.SignalControl.UsesDiskReservoir() {
-		traceReservoirSizeLimit := reservoirDerivedStorage(config.SignalControl.SamplingReservoirMaxDiskBytes)
+		traceReservoirSizeLimit := reservoirDerivedStorage(config.SignalControl.SamplingReservoirMaxDiskBytes, diskReservoirCount(config))
 		volumes = append(volumes, corev1.Volume{
 			Name: "trace-reservoir",
 			VolumeSource: corev1.VolumeSource{
@@ -1044,11 +1044,27 @@ const reservoirDefaultMaxDiskBytes int64 = 1024 * 1024 * 1024 // 1Gi
 // this floor to keep the reservoir functional.
 const reservoirMaxDiskBytesFloor int64 = 64 * 1024 * 1024 // 64Mi
 
-// reservoirDerivedStorage returns the Kubernetes storage quantity derived from the reservoir's
-// max_disk_bytes by applying reservoirStorageMargin.
-func reservoirDerivedStorage(maxDiskBytes int64) resource.Quantity {
-	derived := int64(math.Ceil(float64(maxDiskBytes) * reservoirStorageMargin))
+// reservoirDerivedStorage returns the Kubernetes storage quantity derived from the reservoir's max_disk_bytes by
+// applying reservoirStorageMargin, multiplied by reservoirCount. The daemonset renders one disk reservoir for the
+// default sampling path plus one per namespace that has a Dash0 dataset branch; they all share the single
+// trace-reservoir volume, so it must be sized for their combined on-disk usage.
+func reservoirDerivedStorage(maxDiskBytes int64, reservoirCount int) resource.Quantity {
+	derived := int64(math.Ceil(float64(maxDiskBytes)*reservoirStorageMargin)) * int64(reservoirCount)
 	return *resource.NewQuantity(derived, resource.BinarySI)
+}
+
+// diskReservoirCount returns the number of disk-backed trace reservoirs the daemonset collector renders when the
+// disk reservoir is active: one for the default sampling path plus one for each namespace that has at least one
+// Dash0 dataset branch (each such namespace gets its own dash0sampling instance — see the collector config
+// templates). All of them share the single trace-reservoir EmptyDir volume.
+func diskReservoirCount(config *oTelColConfig) int {
+	count := 1
+	for _, sc := range config.Exporters.NamespaceSC() {
+		if len(sc.DatasetBranches) > 0 {
+			count++
+		}
+	}
+	return count
 }
 
 func assembleCollectorDaemonSetVolumeMounts(
@@ -1221,7 +1237,7 @@ func assembleDaemonSetCollectorContainer(
 			requests = corev1.ResourceList{}
 		}
 		requests[corev1.ResourceEphemeralStorage] =
-			reservoirDerivedStorage(config.SignalControl.SamplingReservoirMaxDiskBytes)
+			reservoirDerivedStorage(config.SignalControl.SamplingReservoirMaxDiskBytes, diskReservoirCount(config))
 		collectorResources.Requests = requests
 	}
 

--- a/internal/collectors/otelcolresources/desired_state_test.go
+++ b/internal/collectors/otelcolresources/desired_state_test.go
@@ -418,42 +418,6 @@ var _ = Describe("The desired state of the OpenTelemetry Collector resources", f
 		Expect(collectorContainer.Resources.Requests.StorageEphemeral().String()).To(Equal("1280Mi"))
 	})
 
-	It("should scale the trace reservoir storage by the number of per-namespace samplers", func() {
-		desiredState, err := assembleDesiredStateForUpsert(&oTelColConfig{
-			OperatorNamespace: OperatorNamespace,
-			NamePrefix:        namePrefix,
-			// default path + namespace1 (which has Dash0 dataset branches -> one per-namespace sampler) = 2 disk
-			// reservoirs sharing the single trace-reservoir volume.
-			Exporters: cmTestNamespacedMultiDatasetExporters(),
-			Images:    TestImages,
-			SignalControl: SignalControlConfig{
-				Enabled:                       true,
-				SamplingEnabled:               true,
-				SamplingReservoirType:         "disk",
-				SamplingReservoirMaxDiskBytes: 1024 * 1024 * 1024, // 1Gi -> 1280Mi per reservoir (x1.25)
-				SamplingReservoirMetricLevel:  "basic",
-				Endpoint:                      "decision-maker.example.com:443",
-				ApiEndpoint:                   "https://control-plane-api.dash0.com",
-				Dataset:                       "default",
-			},
-			KubernetesInfrastructureMetricsCollectionEnabled: true,
-		}, nil, util.ExtraConfigDefaults)
-		Expect(err).ToNot(HaveOccurred())
-
-		daemonSet := getDaemonSet(desiredState)
-		Expect(daemonSet).NotTo(BeNil())
-		daemonSetPodSpec := daemonSet.Spec.Template.Spec
-
-		// One default reservoir + one per-namespace reservoir = 2 x 1280Mi = 2560Mi.
-		reservoirVolume := FindVolumeByName(daemonSetPodSpec.Volumes, "trace-reservoir")
-		Expect(reservoirVolume).NotTo(BeNil())
-		Expect(reservoirVolume.VolumeSource.EmptyDir.SizeLimit).NotTo(BeNil())
-		Expect(reservoirVolume.VolumeSource.EmptyDir.SizeLimit.String()).To(Equal("2560Mi"))
-
-		collectorContainer := daemonSetPodSpec.Containers[0]
-		Expect(collectorContainer.Resources.Requests.StorageEphemeral().String()).To(Equal("2560Mi"))
-	})
-
 	It("should not override an explicit ephemeral-storage request", func() {
 		extraConfig := util.ExtraConfigDefaults
 		extraConfig.CollectorDaemonSetCollectorContainerResources = util.ResourceRequirementsWithGoMemLimit{

--- a/internal/collectors/otelcolresources/desired_state_test.go
+++ b/internal/collectors/otelcolresources/desired_state_test.go
@@ -418,6 +418,42 @@ var _ = Describe("The desired state of the OpenTelemetry Collector resources", f
 		Expect(collectorContainer.Resources.Requests.StorageEphemeral().String()).To(Equal("1280Mi"))
 	})
 
+	It("should scale the trace reservoir storage by the number of per-namespace samplers", func() {
+		desiredState, err := assembleDesiredStateForUpsert(&oTelColConfig{
+			OperatorNamespace: OperatorNamespace,
+			NamePrefix:        namePrefix,
+			// default path + namespace1 (which has Dash0 dataset branches -> one per-namespace sampler) = 2 disk
+			// reservoirs sharing the single trace-reservoir volume.
+			Exporters: cmTestNamespacedMultiDatasetExporters(),
+			Images:    TestImages,
+			SignalControl: SignalControlConfig{
+				Enabled:                       true,
+				SamplingEnabled:               true,
+				SamplingReservoirType:         "disk",
+				SamplingReservoirMaxDiskBytes: 1024 * 1024 * 1024, // 1Gi -> 1280Mi per reservoir (x1.25)
+				SamplingReservoirMetricLevel:  "basic",
+				Endpoint:                      "decision-maker.example.com:443",
+				ApiEndpoint:                   "https://control-plane-api.dash0.com",
+				Dataset:                       "default",
+			},
+			KubernetesInfrastructureMetricsCollectionEnabled: true,
+		}, nil, util.ExtraConfigDefaults)
+		Expect(err).ToNot(HaveOccurred())
+
+		daemonSet := getDaemonSet(desiredState)
+		Expect(daemonSet).NotTo(BeNil())
+		daemonSetPodSpec := daemonSet.Spec.Template.Spec
+
+		// One default reservoir + one per-namespace reservoir = 2 x 1280Mi = 2560Mi.
+		reservoirVolume := FindVolumeByName(daemonSetPodSpec.Volumes, "trace-reservoir")
+		Expect(reservoirVolume).NotTo(BeNil())
+		Expect(reservoirVolume.VolumeSource.EmptyDir.SizeLimit).NotTo(BeNil())
+		Expect(reservoirVolume.VolumeSource.EmptyDir.SizeLimit.String()).To(Equal("2560Mi"))
+
+		collectorContainer := daemonSetPodSpec.Containers[0]
+		Expect(collectorContainer.Resources.Requests.StorageEphemeral().String()).To(Equal("2560Mi"))
+	})
+
 	It("should not override an explicit ephemeral-storage request", func() {
 		extraConfig := util.ExtraConfigDefaults
 		extraConfig.CollectorDaemonSetCollectorContainerResources = util.ResourceRequirementsWithGoMemLimit{

--- a/internal/collectors/otelcolresources/exporter.go
+++ b/internal/collectors/otelcolresources/exporter.go
@@ -91,6 +91,31 @@ func (e *otlpExporters) NamespaceSC() map[string]namespaceSC {
 	return result
 }
 
+// DefaultDash0Exporters returns the default-path Dash0 exporters, i.e. the ones that receive Signal Control
+// (Signal Control is only supported for Dash0 exporters). The SC dataset for the default path remains the
+// cluster-wide .SignalControl.Dataset (first default export's dataset).
+func (e *otlpExporters) DefaultDash0Exporters() []otlpExporter {
+	out := make([]otlpExporter, 0, len(e.Default))
+	for _, exp := range e.Default {
+		if exp.IsDash0() {
+			out = append(out, exp)
+		}
+	}
+	return out
+}
+
+// DefaultPassthrough returns the default-path non-Dash0 exporters (generic gRPC/HTTP). They receive the raw
+// telemetry without any Signal Control, mirroring the per-namespace passthrough behavior.
+func (e *otlpExporters) DefaultPassthrough() []otlpExporter {
+	out := make([]otlpExporter, 0, len(e.Default))
+	for _, exp := range e.Default {
+		if !exp.IsDash0() {
+			out = append(out, exp)
+		}
+	}
+	return out
+}
+
 type defaultOtlpExporters = []otlpExporter
 
 type namespacedOtlpExporters = map[string][]otlpExporter

--- a/internal/collectors/otelcolresources/exporter.go
+++ b/internal/collectors/otelcolresources/exporter.go
@@ -91,6 +91,18 @@ func (e *otlpExporters) NamespaceSC() map[string]namespaceSC {
 	return result
 }
 
+// HasNamespacedDash0Exporters reports whether any namespace has at least one Dash0 exporter (i.e. at least one
+// dataset branch). Used to decide whether the post-sampling router / per-namespace sampled-export pipelines are
+// needed: when no namespace has a Dash0 exporter, sampled traces have only the default destination.
+func (e *otlpExporters) HasNamespacedDash0Exporters() bool {
+	for _, sc := range e.NamespaceSC() {
+		if len(sc.DatasetBranches) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
 // DefaultDash0Exporters returns the default-path Dash0 exporters, i.e. the ones that receive Signal Control
 // (Signal Control is only supported for Dash0 exporters). The SC dataset for the default path remains the
 // cluster-wide .SignalControl.Dataset (first default export's dataset).

--- a/internal/collectors/otelcolresources/exporter.go
+++ b/internal/collectors/otelcolresources/exporter.go
@@ -27,6 +27,68 @@ type otlpExporter struct {
 	InsecureSkipVerify bool
 	Keepalive          *dash0common.KeepaliveClientConfig
 	BalancerName       string
+	// Dataset is the Dash0 dataset this exporter targets. It is only meaningful for Dash0 exporters
+	// (IsDash0 == true); for generic gRPC/HTTP exporters it is empty. An empty value on a Dash0 exporter
+	// means the default dataset.
+	Dataset string
+}
+
+// IsDash0 reports whether this is a Dash0 exporter (as opposed to a generic gRPC/HTTP exporter). Only Dash0
+// exporters carry a dataset and receive Signal Control processing; generic exporters are exported raw.
+func (e *otlpExporter) IsDash0() bool {
+	return e.Authorization != nil
+}
+
+// datasetBranch is one Signal Control dataset branch within a namespace: all of the namespace's Dash0 exporters
+// that share Dataset. Branches are ordered by the dataset's first appearance in the namespace's exporter list.
+// DatasetIndex (an integer) is used in the ID-safe pipeline/component names, while Dataset is emitted only as a
+// rendered value (unquoted, consistent with the existing default path's .SignalControl.Dataset). Tail sampling
+// runs only on the first branch (DatasetIndex 0).
+type datasetBranch struct {
+	DatasetIndex int
+	Dataset      string
+	Exporters    []otlpExporter
+}
+
+// namespaceSC is the per-namespace Signal Control grouping consumed by the collector config templates. The
+// namespace's Dash0 exporters are grouped into one datasetBranch per distinct dataset (DatasetBranches, ordered by
+// first appearance). Every branch runs the non-sampling SC components (resource/operation, spam filter, RED, s2m)
+// against its own dataset. Tail sampling is applied ONLY to the first branch (DatasetIndex 0), because a single
+// trace must not be run through the sampling processor under more than one dataset (the Decision Maker coordinates
+// per trace-id, dataset-blind). Non-Dash0 exporters (Passthrough) receive the raw telemetry without SC.
+type namespaceSC struct {
+	DatasetBranches []datasetBranch
+	Passthrough     []otlpExporter
+}
+
+// NamespaceSC groups each namespace's exporters into per-dataset SC branches plus a passthrough branch. Dash0
+// exporters are grouped by dataset (an empty dataset resolves to util.DatasetDefault), preserving the order in
+// which datasets first appear in the namespace's exporter list, so DatasetIndex 0 is the first exporter's dataset.
+func (e *otlpExporters) NamespaceSC() map[string]namespaceSC {
+	result := make(map[string]namespaceSC, len(e.Namespaced))
+	for _, ns := range e.AllNamespaceKeys() {
+		var sc namespaceSC
+		indexByDataset := map[string]int{}
+		for _, exp := range e.Namespaced[ns] {
+			if !exp.IsDash0() {
+				sc.Passthrough = append(sc.Passthrough, exp)
+				continue
+			}
+			dataset := exp.Dataset
+			if dataset == "" {
+				dataset = util.DatasetDefault
+			}
+			idx, ok := indexByDataset[dataset]
+			if !ok {
+				idx = len(sc.DatasetBranches)
+				indexByDataset[dataset] = idx
+				sc.DatasetBranches = append(sc.DatasetBranches, datasetBranch{DatasetIndex: idx, Dataset: dataset})
+			}
+			sc.DatasetBranches[idx].Exporters = append(sc.DatasetBranches[idx].Exporters, exp)
+		}
+		result[ns] = sc
+	}
+	return result
 }
 
 type defaultOtlpExporters = []otlpExporter
@@ -214,6 +276,7 @@ func convertDash0ExporterToOtlpExporter(
 		Endpoint:      d0.Endpoint,
 		Headers:       headers,
 		Authorization: auth,
+		Dataset:       d0.Dataset,
 		Keepalive:     d0.Keepalive,
 		// For the dash0 exporter we always use pick_first, since client-side load balancing is
 		// not needed and it avoids the issue of the exporter trying both the IPv4 and IPv6


### PR DESCRIPTION
Restructures the collector pipelines so that

- the SC components run after the non-SC processors
- the dataset is correctly stamped onto the telemetry before it flows through the SC components (it's required to look up spam filters, s2m rules, sampling rules)
- in case of multiple exporters, tail sampling is only applied to the telemetry on the first exporter branch - this is because of a current limitation in the decision maker backend
- for tail sampling, the dataset is first stamped on and then a single sampling processor is reused - otherwise the memory consumption (for the reservoir) would grow with the number of exporters/datasets

Other minor changes

- ensures the SC components are not inserted on non-Dash0 exporter branches