### PR TITLE
ci(deps): let Dependabot update Python instrumentation requirements

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,6 +41,21 @@ updates:
     schedule:
       interval: "daily"
 
+  # OpenTelemetry Distro for Python
+  - package-ecosystem: "pip"
+    directory: "images/instrumentation/python/"
+    schedule:
+      interval: "daily"
+      time: "09:15"
+      timezone: "Europe/Berlin"
+    # The OpenTelemetry Python packages are pinned in lockstep (the 0.x beta instrumentation packages together with
+    # the matching 1.x stable exporter). Group them into a single pull request so they are always updated together;
+    # updating them individually would break the lockstep and likely fail pip's dependency resolution.
+    groups:
+      all:
+        patterns:
+          - "*"
+
   # Docker
   - package-ecosystem: "docker"
     directories:

--- a/images/instrumentation/python/requirements.txt
+++ b/images/instrumentation/python/requirements.txt
@@ -1,6 +1,3 @@
-# Modelled after
-# https://github.com/open-telemetry/opentelemetry-operator/blob/v0.143.0/autoinstrumentation/python/requirements.txt
-
 opentelemetry-distro==0.60b1
 
 urllib3 <2.6.4


### PR DESCRIPTION
Add a pip ecosystem entry for images/instrumentation/python so Dependabot checks images/instrumentation/python/requirements.txt for newer versions and opens update PRs.