### PR TITLE
fix(sc): use namespaced api client for sampling rules sync

### DIFF
--- a/api/operator/v1alpha1/dash0samplingrules_types.go
+++ b/api/operator/v1alpha1/dash0samplingrules_types.go
@@ -10,11 +10,17 @@ import (
 	dash0common "github.com/dash0hq/dash0-operator/api/operator/common"
 )
 
-// Dash0SamplingRule is the Schema for the dash0samplingrules API
+// Dash0SamplingRule is the Schema for the dash0samplingrules API.
+//
+// The resource is namespaced: the namespace only selects which dataset and token the rule is synchronized to (the
+// dataset and token of the Dash0 export of the Dash0 monitoring resource in the same namespace, falling back to the
+// operator configuration resource). It does NOT restrict enforcement to that namespace's traces. Tail sampling is
+// applied cluster-wide and per whole trace by the Signal Control collector; the Decision Maker coordinates keep/drop
+// decisions per trace-id in a dataset-blind manner. Placing a sampling rule in a namespace therefore does not mean
+// "sample only this namespace's traces".
 //
 // +kubebuilder:object:root=true
 // +groupName=operator.dash0.com
-// +kubebuilder:resource:scope=Cluster
 // +kubebuilder:subresource:status
 type Dash0SamplingRule struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/config/crd/bases/operator.dash0.com_dash0samplingrules.yaml
+++ b/config/crd/bases/operator.dash0.com_dash0samplingrules.yaml
@@ -12,12 +12,20 @@ spec:
     listKind: Dash0SamplingRuleList
     plural: dash0samplingrules
     singular: dash0samplingrule
-  scope: Cluster
+  scope: Namespaced
   versions:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: Dash0SamplingRule is the Schema for the dash0samplingrules API
+        description: |-
+          Dash0SamplingRule is the Schema for the dash0samplingrules API.
+
+          The resource is namespaced: the namespace only selects which dataset and token the rule is synchronized to (the
+          dataset and token of the Dash0 export of the Dash0 monitoring resource in the same namespace, falling back to the
+          operator configuration resource). It does NOT restrict enforcement to that namespace's traces. Tail sampling is
+          applied cluster-wide and per whole trace by the Signal Control collector; the Decision Maker coordinates keep/drop
+          decisions per trace-id in a dataset-blind manner. Placing a sampling rule in a namespace therefore does not mean
+          "sample only this namespace's traces".
         properties:
           apiVersion:
             description: |-

--- a/helm-chart/dash0-operator/templates/operator/custom-resource-definition-sampling-rules.yaml
+++ b/helm-chart/dash0-operator/templates/operator/custom-resource-definition-sampling-rules.yaml
@@ -18,12 +18,20 @@ spec:
     listKind: Dash0SamplingRuleList
     plural: dash0samplingrules
     singular: dash0samplingrule
-  scope: Cluster
+  scope: Namespaced
   versions:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: Dash0SamplingRule is the Schema for the dash0samplingrules API
+        description: |-
+          Dash0SamplingRule is the Schema for the dash0samplingrules API.
+
+          The resource is namespaced: the namespace only selects which dataset and token the rule is synchronized to (the
+          dataset and token of the Dash0 export of the Dash0 monitoring resource in the same namespace, falling back to the
+          operator configuration resource). It does NOT restrict enforcement to that namespace's traces. Tail sampling is
+          applied cluster-wide and per whole trace by the Signal Control collector; the Decision Maker coordinates keep/drop
+          decisions per trace-id in a dataset-blind manner. Placing a sampling rule in a namespace therefore does not mean
+          "sample only this namespace's traces".
         properties:
           apiVersion:
             description: |-

--- a/internal/controller/sampling_rule_controller.go
+++ b/internal/controller/sampling_rule_controller.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/url"
 	"reflect"
+	"slices"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -29,6 +30,7 @@ import (
 
 	dash0common "github.com/dash0hq/dash0-operator/api/operator/common"
 	dash0v1alpha1 "github.com/dash0hq/dash0-operator/api/operator/v1alpha1"
+	dash0v1beta1 "github.com/dash0hq/dash0-operator/api/operator/v1beta1"
 	"github.com/dash0hq/dash0-operator/internal/selfmonitoringapiaccess"
 	"github.com/dash0hq/dash0-operator/internal/util"
 	"github.com/dash0hq/dash0-operator/internal/util/logd"
@@ -40,9 +42,11 @@ type SamplingRuleReconciler struct {
 	leaderElectionAware    util.LeaderElectionAware
 	httpClient             *http.Client
 	defaultApiConfigs      selfmonitoringapiaccess.SynchronizedSlice[ApiConfig]
+	namespacedApiConfigs   selfmonitoringapiaccess.SynchronizedMapSlice[ApiConfig]
 	initialSyncMutex       sync.Mutex
 	initialSyncInProgress  atomic.Bool
 	initialSyncHasHappened atomic.Bool
+	namespacedSyncMutex    selfmonitoringapiaccess.NamespaceMutex
 }
 
 var (
@@ -56,11 +60,13 @@ func NewSamplingRuleReconciler(
 	httpClient *http.Client,
 ) *SamplingRuleReconciler {
 	return &SamplingRuleReconciler{
-		Client:              k8sClient,
-		pseudoClusterUid:    pseudoClusterUid,
-		leaderElectionAware: leaderElectionAware,
-		httpClient:          httpClient,
-		defaultApiConfigs:   *selfmonitoringapiaccess.NewSynchronizedSlice[ApiConfig](),
+		Client:               k8sClient,
+		pseudoClusterUid:     pseudoClusterUid,
+		leaderElectionAware:  leaderElectionAware,
+		httpClient:           httpClient,
+		defaultApiConfigs:    *selfmonitoringapiaccess.NewSynchronizedSlice[ApiConfig](),
+		namespacedApiConfigs: *selfmonitoringapiaccess.NewSynchronizedMapSlice[ApiConfig](),
+		namespacedSyncMutex:  *selfmonitoringapiaccess.NewNamespaceMutex(),
 	}
 }
 
@@ -99,8 +105,8 @@ func (r *SamplingRuleReconciler) GetDefaultApiConfigs() []ApiConfig {
 	return r.defaultApiConfigs.Get()
 }
 
-func (r *SamplingRuleReconciler) GetNamespacedApiConfigs(_ string) ([]ApiConfig, bool) {
-	return nil, false
+func (r *SamplingRuleReconciler) GetNamespacedApiConfigs(namespace string) ([]ApiConfig, bool) {
+	return r.namespacedApiConfigs.Get(namespace)
 }
 
 func (r *SamplingRuleReconciler) ControllerName() string {
@@ -120,17 +126,53 @@ func (r *SamplingRuleReconciler) SetDefaultApiConfigs(
 	apiConfigs []ApiConfig,
 	logger logd.Logger,
 ) {
-	if len(apiConfigs) > 1 {
-		logger.Warn("Sampling rules only support a single API config, using the first one and ignoring the rest.",
-			"total", len(apiConfigs))
-		apiConfigs = apiConfigs[:1]
-	}
 	r.defaultApiConfigs.Set(apiConfigs)
 	r.maybeDoInitialSynchronizationOfAllResources(ctx, logger)
 }
 
 func (r *SamplingRuleReconciler) RemoveDefaultApiConfigs(_ context.Context, _ logd.Logger) {
 	r.defaultApiConfigs.Clear()
+}
+
+func (r *SamplingRuleReconciler) SetNamespacedApiConfigs(
+	ctx context.Context,
+	namespace string,
+	updatedApiConfigs []ApiConfig,
+	logger logd.Logger,
+) {
+	if updatedApiConfigs != nil {
+		previousApiConfigs, _ := r.namespacedApiConfigs.Get(namespace)
+
+		r.namespacedApiConfigs.Set(namespace, updatedApiConfigs)
+
+		if !slices.Equal(previousApiConfigs, updatedApiConfigs) {
+			r.synchronizeNamespacedResources(ctx, namespace, logger)
+		}
+	}
+}
+
+func (r *SamplingRuleReconciler) RemoveNamespacedApiConfigs(
+	ctx context.Context,
+	namespace string,
+	logger logd.Logger,
+) {
+	if _, exists := r.namespacedApiConfigs.Get(namespace); exists {
+		r.namespacedApiConfigs.Delete(namespace)
+		r.synchronizeNamespacedResources(ctx, namespace, logger)
+	}
+}
+
+func (r *SamplingRuleReconciler) SetSynchronizationEnabled(
+	_ context.Context,
+	_ string,
+	_ *dash0v1beta1.Dash0Monitoring,
+	_ logd.Logger,
+) {
+	// no-op: sampling rules do not have a per-namespace sync toggle
+}
+
+func (r *SamplingRuleReconciler) RemoveSynchronizationEnabled(_ string) {
+	// no-op: sampling rules do not have a per-namespace sync toggle
 }
 
 func (r *SamplingRuleReconciler) NotifyOperatorManagerJustBecameLeader(ctx context.Context, logger logd.Logger) {
@@ -185,7 +227,8 @@ func (r *SamplingRuleReconciler) maybeDoInitialSynchronizationOfAllResources(
 		for _, samplingRuleResource := range allSamplingRuleResourcesInCluster.Items {
 			pseudoReconcileRequest := ctrl.Request{
 				NamespacedName: client.ObjectKey{
-					Name: samplingRuleResource.Name,
+					Namespace: samplingRuleResource.Namespace,
+					Name:      samplingRuleResource.Name,
 				},
 			}
 			_, _ = r.Reconcile(ctx, pseudoReconcileRequest)
@@ -193,6 +236,56 @@ func (r *SamplingRuleReconciler) maybeDoInitialSynchronizationOfAllResources(
 		}
 		logger.Info("Initial synchronization of sampling rules has finished.")
 		r.initialSyncHasHappened.Store(true)
+	}()
+}
+
+func (r *SamplingRuleReconciler) synchronizeNamespacedResources(
+	ctx context.Context,
+	namespace string,
+	logger logd.Logger,
+) {
+	if !r.leaderElectionAware.IsLeader() {
+		logger.Info(
+			"Waiting for this operator manager replica to become leader before running " +
+				"synchronization of sampling rules.",
+		)
+		return
+	}
+
+	// namespacedSyncMutex is used so we don't trigger multiple syncs in parallel in a single namespace.
+	// That happens for example when the export from a monitoring resource is removed, since that updates both the API
+	// config and auth token at almost the same time, triggering two resyncs.
+	r.namespacedSyncMutex.Lock(namespace)
+
+	logger.Info(fmt.Sprintf("Running synchronization of sampling rules in namespace %s now.", namespace))
+
+	go func() {
+		defer r.namespacedSyncMutex.Unlock(namespace)
+
+		allResources := dash0v1alpha1.Dash0SamplingRuleList{}
+		if err := r.List(
+			ctx,
+			&allResources,
+			&client.ListOptions{
+				Namespace: namespace,
+			},
+		); err != nil {
+			logger.Error(err, fmt.Sprintf("Failed to list Dash0 sampling rule resources in namespace %s.", namespace))
+			return
+		}
+
+		for _, resource := range allResources.Items {
+			pseudoReconcileRequest := ctrl.Request{
+				NamespacedName: client.ObjectKey{
+					Namespace: resource.Namespace,
+					Name:      resource.Name,
+				},
+			}
+			_, _ = r.Reconcile(ctx, pseudoReconcileRequest)
+			// stagger API requests a bit
+			time.Sleep(50 * time.Millisecond)
+		}
+		logger.Info(fmt.Sprintf("Synchronization of sampling rules in namespace %s has finished.", namespace))
 	}()
 }
 
@@ -213,7 +306,8 @@ func (r *SamplingRuleReconciler) Reconcile(ctx context.Context, req reconcile.Re
 			logger.Info("reconciling the deletion of the sampling rule resource", "name", qualifiedName)
 			samplingRuleResource = &dash0v1alpha1.Dash0SamplingRule{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: req.Name,
+					Namespace: req.Namespace,
+					Name:      req.Name,
 				},
 			}
 		} else {
@@ -386,9 +480,12 @@ func (r *SamplingRuleReconciler) renderSamplingRuleUrl(
 ) (string, string) {
 	datasetUrlEncoded := url.QueryEscape(dataset)
 	samplingRuleOrigin := fmt.Sprintf(
-		"dash0-operator_%s_%s_%s",
+		// we deliberately use _ as the separator, since that is an illegal character in Kubernetes names. This avoids
+		// any potential naming collisions (e.g. namespace="abc" & name="def-ghi" vs. namespace="abc-def" & name="ghi").
+		"dash0-operator_%s_%s_%s_%s",
 		r.pseudoClusterUid,
 		datasetUrlEncoded,
+		preconditionChecksResult.k8sNamespace,
 		preconditionChecksResult.k8sName,
 	)
 	return fmt.Sprintf(

--- a/internal/controller/sampling_rule_controller_test.go
+++ b/internal/controller/sampling_rule_controller_test.go
@@ -31,34 +31,46 @@ import (
 )
 
 const (
-	samplingRuleName        = "test-sampling-rule"
-	samplingRuleName2       = "test-sampling-rule-2"
-	samplingRuleApiBasePath = "/api/sampling-rules/"
+	samplingRuleName            = "test-sampling-rule"
+	extraNamespaceSamplingRules = "extra-namespace-sampling-rules"
+	samplingRuleName2           = "test-sampling-rule-2"
+	samplingRuleApiBasePath     = "/api/sampling-rules/"
 
-	samplingRuleId             = "sampling-rule-id"
-	samplingRuleOriginPattern  = "dash0-operator_%s_test-dataset_test-sampling-rule"
-	samplingRuleOriginPattern2 = "dash0-operator_%s_test-dataset_test-sampling-rule-2"
+	samplingRuleId                       = "sampling-rule-id"
+	samplingRuleOriginPattern            = "dash0-operator_%s_test-dataset_test-namespace_test-sampling-rule"
+	samplingRuleOriginPatternExtra       = "dash0-operator_%s_test-dataset_extra-namespace-sampling-rules_test-sampling-rule-2"
+	samplingRuleOriginPatternAlternative = "dash0-operator_%s_test-dataset-alt_test-namespace_test-sampling-rule"
 )
 
 var (
 	defaultExpectedPathSamplingRule = fmt.Sprintf(
 		"%s.*%s",
 		samplingRuleApiBasePath,
-		"dash0-operator_.*_test-dataset_test-sampling-rule",
+		"dash0-operator_.*_test-dataset_test-namespace_test-sampling-rule",
+	)
+	expectedPathSamplingRuleAlternative = fmt.Sprintf(
+		"%s.*%s",
+		samplingRuleApiBasePath,
+		"dash0-operator_.*_test-dataset-alt_test-namespace_test-sampling-rule",
 	)
 	defaultExpectedPathSamplingRule2 = fmt.Sprintf(
 		"%s.*%s",
 		samplingRuleApiBasePath,
-		"dash0-operator_.*_test-dataset_test-sampling-rule-2",
+		"dash0-operator_.*_test-dataset_extra-namespace-sampling-rules_test-sampling-rule-2",
 	)
+	samplingRuleLeaderElectionAware = NewLeaderElectionAwareMock(true)
 )
 
 var _ = Describe(
 	"The Sampling Rule controller", Ordered, func() {
+		var (
+			extraMonitoringResourceNames []types.NamespacedName
+			testStartedAt                time.Time
+			clusterId                    string
+		)
+
 		ctx := context.Background()
 		logger := logd.FromContext(ctx)
-		var testStartedAt time.Time
-		var clusterId string
 
 		BeforeAll(
 			func() {
@@ -71,6 +83,17 @@ var _ = Describe(
 		BeforeEach(
 			func() {
 				testStartedAt = time.Now()
+				extraMonitoringResourceNames = make([]types.NamespacedName, 0)
+			},
+		)
+
+		AfterEach(
+			func() {
+				DeleteMonitoringResource(ctx, k8sClient)
+				for _, name := range extraMonitoringResourceNames {
+					DeleteMonitoringResourceByName(ctx, k8sClient, name, true)
+				}
+				extraMonitoringResourceNames = make([]types.NamespacedName, 0)
 			},
 		)
 
@@ -82,6 +105,10 @@ var _ = Describe(
 					func() {
 						samplingRuleReconciler = createSamplingRuleReconciler(clusterId)
 
+						// Set default API configs directly (not via SetDefaultApiConfigs) to avoid
+						// triggering maybeDoInitialSynchronizationOfAllResources, which would set
+						// initialSyncHasHappened to true and prevent the DescribeTable tests from
+						// verifying initial sync behavior.
 						samplingRuleReconciler.defaultApiConfigs.Set(
 							[]ApiConfig{
 								{
@@ -96,26 +123,46 @@ var _ = Describe(
 
 				AfterEach(
 					func() {
-						VerifyNoUnmatchedGockRequests()
+						DeleteMonitoringResourceIfItExists(ctx, k8sClient)
+						deleteSamplingRuleResourceIfItExists(ctx, k8sClient, TestNamespaceName, samplingRuleName)
+						deleteSamplingRuleResourceIfItExists(ctx, k8sClient, extraNamespaceSamplingRules, samplingRuleName2)
+					},
+				)
 
-						deleteSamplingRuleResourceIfItExists(ctx, k8sClient, samplingRuleName)
-						deleteSamplingRuleResourceIfItExists(ctx, k8sClient, samplingRuleName2)
+				It(
+					"it ignores sampling rule resource changes if no Dash0 monitoring resource exists in the namespace", func() {
+						expectSamplingRulePutRequest(clusterId, defaultExpectedPathSamplingRule)
+						defer gock.Off()
+
+						samplingRuleResource := createSamplingRuleResource(TestNamespaceName, samplingRuleName)
+						Expect(k8sClient.Create(ctx, samplingRuleResource)).To(Succeed())
+
+						Expect(gock.IsPending()).To(BeTrue())
+						verifySamplingRuleHasNoSynchronizationStatus(
+							ctx,
+							k8sClient,
+							TestNamespaceName,
+							samplingRuleName,
+						)
 					},
 				)
 
 				It(
 					"it ignores sampling rule resource changes if the API endpoint is not configured", func() {
+						EnsureMonitoringResourceWithoutExportExistsAndIsAvailable(ctx, k8sClient)
+
 						expectSamplingRulePutRequest(clusterId, defaultExpectedPathSamplingRule)
 						defer gock.Off()
 
 						samplingRuleReconciler.RemoveDefaultApiConfigs(ctx, logger)
 
-						samplingRuleResource := createSamplingRuleResource(samplingRuleName)
+						samplingRuleResource := createSamplingRuleResource(TestNamespaceName, samplingRuleName)
 						Expect(k8sClient.Create(ctx, samplingRuleResource)).To(Succeed())
 						result, err := samplingRuleReconciler.Reconcile(
 							ctx, reconcile.Request{
 								NamespacedName: types.NamespacedName{
-									Name: samplingRuleName,
+									Namespace: TestNamespaceName,
+									Name:      samplingRuleName,
 								},
 							},
 						)
@@ -126,6 +173,7 @@ var _ = Describe(
 						verifySamplingRuleHasNoSynchronizationStatus(
 							ctx,
 							k8sClient,
+							TestNamespaceName,
 							samplingRuleName,
 						)
 					},
@@ -133,16 +181,19 @@ var _ = Describe(
 
 				It(
 					"creates a sampling rule", func() {
+						EnsureMonitoringResourceWithoutExportExistsAndIsAvailable(ctx, k8sClient)
+
 						expectSamplingRulePutRequest(clusterId, defaultExpectedPathSamplingRule)
 						defer gock.Off()
 
-						samplingRuleResource := createSamplingRuleResource(samplingRuleName)
+						samplingRuleResource := createSamplingRuleResource(TestNamespaceName, samplingRuleName)
 						Expect(k8sClient.Create(ctx, samplingRuleResource)).To(Succeed())
 
 						result, err := samplingRuleReconciler.Reconcile(
 							ctx, reconcile.Request{
 								NamespacedName: types.NamespacedName{
-									Name: samplingRuleName,
+									Namespace: TestNamespaceName,
+									Name:      samplingRuleName,
 								},
 							},
 						)
@@ -152,6 +203,7 @@ var _ = Describe(
 						verifySamplingRuleSynchronizationStatus(
 							ctx,
 							k8sClient,
+							TestNamespaceName,
 							samplingRuleName,
 							dash0common.Dash0ApiResourceSynchronizationStatusSuccessful,
 							testStartedAt,
@@ -166,11 +218,66 @@ var _ = Describe(
 				)
 
 				It(
+					"creates a sampling rule with namespaced config from the monitoring resource", func() {
+						monitoringResource := DefaultMonitoringResourceWithCustomApiConfigAndToken(
+							MonitoringResourceQualifiedName,
+							ApiEndpointTestAlternative,
+							DatasetCustomTestAlternative,
+							AuthorizationTokenTestAlternative,
+						)
+						EnsureMonitoringResourceWithSpecExistsAndIsAvailable(ctx, k8sClient, monitoringResource.Spec)
+
+						expectSamplingRulePutRequestCustom(
+							clusterId,
+							expectedPathSamplingRuleAlternative,
+							ApiEndpointTestAlternative,
+							DatasetCustomTestAlternative,
+							AuthorizationTokenTestAlternative,
+							samplingRuleOriginPatternAlternative,
+							1,
+						)
+						defer gock.Off()
+
+						samplingRuleResource := createSamplingRuleResource(TestNamespaceName, samplingRuleName)
+						Expect(k8sClient.Create(ctx, samplingRuleResource)).To(Succeed())
+
+						samplingRuleReconciler.SetNamespacedApiConfigs(
+							ctx, TestNamespaceName, []ApiConfig{
+								{
+									Endpoint: ApiEndpointTestAlternative,
+									Dataset:  DatasetCustomTestAlternative,
+									Token:    AuthorizationTokenTestAlternative,
+								},
+							}, logger,
+						)
+
+						// note: we don't trigger reconcile here because setting the API config and token already triggers a reconciliation
+
+						verifySamplingRuleSynchronizationStatus(
+							ctx,
+							k8sClient,
+							TestNamespaceName,
+							samplingRuleName,
+							dash0common.Dash0ApiResourceSynchronizationStatusSuccessful,
+							testStartedAt,
+							samplingRuleId,
+							fmt.Sprintf(samplingRuleOriginPatternAlternative, clusterId),
+							ApiEndpointStandardizedTestAlternative,
+							DatasetCustomTestAlternative,
+							"",
+						)
+						Expect(gock.IsDone()).To(BeTrue())
+					},
+				)
+
+				It(
 					"updates a sampling rule", func() {
+						EnsureMonitoringResourceWithoutExportExistsAndIsAvailable(ctx, k8sClient)
+
 						expectSamplingRulePutRequest(clusterId, defaultExpectedPathSamplingRule)
 						defer gock.Off()
 
-						samplingRuleResource := createSamplingRuleResource(samplingRuleName)
+						samplingRuleResource := createSamplingRuleResource(TestNamespaceName, samplingRuleName)
 						Expect(k8sClient.Create(ctx, samplingRuleResource)).To(Succeed())
 
 						samplingRuleResource.Spec.Display = &dash0v1alpha1.Dash0SamplingRuleDisplay{
@@ -181,7 +288,8 @@ var _ = Describe(
 						result, err := samplingRuleReconciler.Reconcile(
 							ctx, reconcile.Request{
 								NamespacedName: types.NamespacedName{
-									Name: samplingRuleName,
+									Namespace: TestNamespaceName,
+									Name:      samplingRuleName,
 								},
 							},
 						)
@@ -191,6 +299,7 @@ var _ = Describe(
 						verifySamplingRuleSynchronizationStatus(
 							ctx,
 							k8sClient,
+							TestNamespaceName,
 							samplingRuleName,
 							dash0common.Dash0ApiResourceSynchronizationStatusSuccessful,
 							testStartedAt,
@@ -206,17 +315,20 @@ var _ = Describe(
 
 				It(
 					"deletes a sampling rule", func() {
+						EnsureMonitoringResourceWithoutExportExistsAndIsAvailable(ctx, k8sClient)
+
 						expectSamplingRuleDeleteRequest(defaultExpectedPathSamplingRule)
 						defer gock.Off()
 
-						samplingRuleResource := createSamplingRuleResource(samplingRuleName)
+						samplingRuleResource := createSamplingRuleResource(TestNamespaceName, samplingRuleName)
 						Expect(k8sClient.Create(ctx, samplingRuleResource)).To(Succeed())
 						Expect(k8sClient.Delete(ctx, samplingRuleResource)).To(Succeed())
 
 						result, err := samplingRuleReconciler.Reconcile(
 							ctx, reconcile.Request{
 								NamespacedName: types.NamespacedName{
-									Name: samplingRuleName,
+									Namespace: TestNamespaceName,
+									Name:      samplingRuleName,
 								},
 							},
 						)
@@ -229,17 +341,20 @@ var _ = Describe(
 
 				It(
 					"deletes a sampling rule if labelled with dash0.com/enable=false", func() {
+						EnsureMonitoringResourceWithoutExportExistsAndIsAvailable(ctx, k8sClient)
+
 						expectSamplingRuleDeleteRequestWithHttpStatus(defaultExpectedPathSamplingRule, http.StatusNotFound)
 						defer gock.Off()
 
 						samplingRuleResource :=
-							createSamplingRuleResourceWithEnableLabel(samplingRuleName, "false")
+							createSamplingRuleResourceWithEnableLabel(TestNamespaceName, samplingRuleName, "false")
 						Expect(k8sClient.Create(ctx, samplingRuleResource)).To(Succeed())
 
 						result, err := samplingRuleReconciler.Reconcile(
 							ctx, reconcile.Request{
 								NamespacedName: types.NamespacedName{
-									Name: samplingRuleName,
+									Namespace: TestNamespaceName,
+									Name:      samplingRuleName,
 								},
 							},
 						)
@@ -249,10 +364,11 @@ var _ = Describe(
 						verifySamplingRuleSynchronizationStatus(
 							ctx,
 							k8sClient,
+							TestNamespaceName,
 							samplingRuleName,
 							dash0common.Dash0ApiResourceSynchronizationStatusSuccessful,
 							testStartedAt,
-							"",
+							"", // when deleting an object, we do not get an HTTP response body with an ID
 							fmt.Sprintf(samplingRuleOriginPattern, clusterId),
 							ApiEndpointStandardizedTest,
 							DatasetCustomTest,
@@ -264,6 +380,8 @@ var _ = Describe(
 
 				It(
 					"reports http errors when synchronizing a sampling rule", func() {
+						EnsureMonitoringResourceWithoutExportExistsAndIsAvailable(ctx, k8sClient)
+
 						gock.New(ApiEndpointTest).
 							Put(defaultExpectedPathSamplingRule).
 							MatchParam("dataset", DatasetCustomTest).
@@ -272,13 +390,14 @@ var _ = Describe(
 							JSON(map[string]string{})
 						defer gock.Off()
 
-						samplingRuleResource := createSamplingRuleResource(samplingRuleName)
+						samplingRuleResource := createSamplingRuleResource(TestNamespaceName, samplingRuleName)
 						Expect(k8sClient.Create(ctx, samplingRuleResource)).To(Succeed())
 
 						result, err := samplingRuleReconciler.Reconcile(
 							ctx, reconcile.Request{
 								NamespacedName: types.NamespacedName{
-									Name: samplingRuleName,
+									Namespace: TestNamespaceName,
+									Name:      samplingRuleName,
 								},
 							},
 						)
@@ -288,6 +407,7 @@ var _ = Describe(
 						verifySamplingRuleSynchronizationStatus(
 							ctx,
 							k8sClient,
+							TestNamespaceName,
 							samplingRuleName,
 							dash0common.Dash0ApiResourceSynchronizationStatusFailed,
 							testStartedAt,
@@ -303,6 +423,8 @@ var _ = Describe(
 
 				It(
 					"retries synchronization when synchronizing a sampling rule", func() {
+						EnsureMonitoringResourceWithoutExportExistsAndIsAvailable(ctx, k8sClient)
+
 						gock.New(ApiEndpointTest).
 							Put(defaultExpectedPathSamplingRule).
 							MatchParam("dataset", DatasetCustomTest).
@@ -312,13 +434,14 @@ var _ = Describe(
 						expectSamplingRulePutRequest(clusterId, defaultExpectedPathSamplingRule)
 						defer gock.Off()
 
-						samplingRuleResource := createSamplingRuleResource(samplingRuleName)
+						samplingRuleResource := createSamplingRuleResource(TestNamespaceName, samplingRuleName)
 						Expect(k8sClient.Create(ctx, samplingRuleResource)).To(Succeed())
 
 						result, err := samplingRuleReconciler.Reconcile(
 							ctx, reconcile.Request{
 								NamespacedName: types.NamespacedName{
-									Name: samplingRuleName,
+									Namespace: TestNamespaceName,
+									Name:      samplingRuleName,
 								},
 							},
 						)
@@ -328,6 +451,7 @@ var _ = Describe(
 						verifySamplingRuleSynchronizationStatus(
 							ctx,
 							k8sClient,
+							TestNamespaceName,
 							samplingRuleName,
 							dash0common.Dash0ApiResourceSynchronizationStatusSuccessful,
 							testStartedAt,
@@ -349,26 +473,48 @@ var _ = Describe(
 				DescribeTable(
 					"synchronizes all existing sampling rule resources when the auth token or api endpoint become available",
 					func(testConfig maybeDoInitialSynchronizationOfAllSamplingRulesTest) {
+						EnsureMonitoringResourceWithoutExportExistsAndIsAvailable(ctx, k8sClient)
+
+						// Disable synchronization by removing the auth token or api endpoint.
 						testConfig.disableSync()
+
+						EnsureNamespaceExists(ctx, k8sClient, extraNamespaceSamplingRules)
+						secondMonitoringResource := EnsureMonitoringResourceWithSpecExistsInNamespaceAndIsAvailable(
+							ctx,
+							k8sClient,
+							MonitoringResourceDefaultSpecWithoutExport,
+							types.NamespacedName{Namespace: extraNamespaceSamplingRules, Name: MonitoringResourceName},
+						)
+						extraMonitoringResourceNames = append(
+							extraMonitoringResourceNames, types.NamespacedName{
+								Namespace: secondMonitoringResource.Namespace,
+								Name:      secondMonitoringResource.Name,
+							},
+						)
 
 						expectSamplingRulePutRequest(clusterId, defaultExpectedPathSamplingRule)
 						expectSamplingRulePutRequest(clusterId, defaultExpectedPathSamplingRule2)
 						defer gock.Off()
 
-						samplingRuleResource1 := createSamplingRuleResource(samplingRuleName)
+						samplingRuleResource1 := createSamplingRuleResource(TestNamespaceName, samplingRuleName)
 						Expect(k8sClient.Create(ctx, samplingRuleResource1)).To(Succeed())
-						samplingRuleResource2 := createSamplingRuleResource(samplingRuleName2)
+						samplingRuleResource2 := createSamplingRuleResource(extraNamespaceSamplingRules, samplingRuleName2)
 						Expect(k8sClient.Create(ctx, samplingRuleResource2)).To(Succeed())
 
+						// verify that the sampling rules have not been synchronized yet
 						Expect(gock.IsPending()).To(BeTrue())
-						verifySamplingRuleHasNoSynchronizationStatus(ctx, k8sClient, samplingRuleName)
-						verifySamplingRuleHasNoSynchronizationStatus(ctx, k8sClient, samplingRuleName2)
+						verifySamplingRuleHasNoSynchronizationStatus(ctx, k8sClient, TestNamespaceName, samplingRuleName)
+						verifySamplingRuleHasNoSynchronizationStatus(ctx, k8sClient, extraNamespaceSamplingRules, samplingRuleName2)
 
+						// Now provide the auth token or API endpoint, which was unset before. This should trigger initial
+						// synchronization of all resources.
 						testConfig.enabledSync()
 
+						// Verify both sampling rule resources have been synchronized
 						verifySamplingRuleSynchronizationStatus(
 							ctx,
 							k8sClient,
+							TestNamespaceName,
 							samplingRuleName,
 							dash0common.Dash0ApiResourceSynchronizationStatusSuccessful,
 							testStartedAt,
@@ -381,11 +527,12 @@ var _ = Describe(
 						verifySamplingRuleSynchronizationStatus(
 							ctx,
 							k8sClient,
+							extraNamespaceSamplingRules,
 							samplingRuleName2,
 							dash0common.Dash0ApiResourceSynchronizationStatusSuccessful,
 							testStartedAt,
 							samplingRuleId,
-							fmt.Sprintf(samplingRuleOriginPattern2, clusterId),
+							fmt.Sprintf(samplingRuleOriginPatternExtra, clusterId),
 							ApiEndpointStandardizedTest,
 							DatasetCustomTest,
 							"",
@@ -413,10 +560,10 @@ var _ = Describe(
 					Entry(
 						"when the operator manager becomes leader", maybeDoInitialSynchronizationOfAllSamplingRulesTest{
 							disableSync: func() {
-								leaderElectionAware.SetLeader(false)
+								samplingRuleLeaderElectionAware.SetLeader(false)
 							},
 							enabledSync: func() {
-								leaderElectionAware.SetLeader(true)
+								samplingRuleLeaderElectionAware.SetLeader(true)
 								samplingRuleReconciler.NotifyOperatorManagerJustBecameLeader(ctx, logger)
 							},
 						},
@@ -486,8 +633,9 @@ spec:
 						Token:    AuthorizationTokenTest,
 					}
 					preconditionValidationResult := &preconditionValidationResult{
-						k8sName:  "dash0-sampling-rule",
-						resource: samplingRule,
+						k8sName:      "dash0-sampling-rule",
+						k8sNamespace: TestNamespaceName,
+						resource:     samplingRule,
 						validatedApiConfigs: []ValidatedApiConfigAndToken{
 							*NewValidatedApiConfigAndToken(apiConfig.Endpoint, apiConfig.Dataset, apiConfig.Token),
 						},
@@ -534,7 +682,7 @@ func createSamplingRuleReconciler(clusterId string) *SamplingRuleReconciler {
 	return NewSamplingRuleReconciler(
 		k8sClient,
 		types.UID(clusterId),
-		leaderElectionAware,
+		samplingRuleLeaderElectionAware,
 		TestHTTPClient(),
 	)
 }
@@ -594,16 +742,18 @@ func expectSamplingRuleDeleteRequestWithHttpStatus(expectedPath string, status i
 		Reply(status)
 }
 
-func createSamplingRuleResource(name string) *dash0v1alpha1.Dash0SamplingRule {
-	return createSamplingRuleResourceWithEnableLabel(name, "")
+func createSamplingRuleResource(namespace string, name string) *dash0v1alpha1.Dash0SamplingRule {
+	return createSamplingRuleResourceWithEnableLabel(namespace, name, "")
 }
 
 func createSamplingRuleResourceWithEnableLabel(
+	namespace string,
 	name string,
 	dash0EnableLabelValue string,
 ) *dash0v1alpha1.Dash0SamplingRule {
 	objectMeta := metav1.ObjectMeta{
-		Name: name,
+		Name:      name,
+		Namespace: namespace,
 	}
 	if dash0EnableLabelValue != "" {
 		objectMeta.Labels = map[string]string{
@@ -634,11 +784,13 @@ func createSamplingRuleResourceWithEnableLabel(
 func deleteSamplingRuleResourceIfItExists(
 	ctx context.Context,
 	k8sClient client.Client,
+	namespace string,
 	name string,
 ) {
 	samplingRule := &dash0v1alpha1.Dash0SamplingRule{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
+			Name:      name,
+			Namespace: namespace,
 		},
 	}
 	_ = k8sClient.Delete(
@@ -652,6 +804,7 @@ func deleteSamplingRuleResourceIfItExists(
 func verifySamplingRuleSynchronizationStatus(
 	ctx context.Context,
 	k8sClient client.Client,
+	namespace string,
 	name string,
 	expectedStatus dash0common.Dash0ApiResourceSynchronizationStatus,
 	testStartedAt time.Time,
@@ -666,7 +819,8 @@ func verifySamplingRuleSynchronizationStatus(
 			samplingRule := &dash0v1alpha1.Dash0SamplingRule{}
 			err := k8sClient.Get(
 				ctx, types.NamespacedName{
-					Name: name,
+					Namespace: namespace,
+					Name:      name,
 				}, samplingRule,
 			)
 			g.Expect(err).NotTo(HaveOccurred())
@@ -690,6 +844,7 @@ func verifySamplingRuleSynchronizationStatus(
 func verifySamplingRuleHasNoSynchronizationStatus(
 	ctx context.Context,
 	k8sClient client.Client,
+	namespace string,
 	name string,
 ) {
 	Eventually(
@@ -697,7 +852,8 @@ func verifySamplingRuleHasNoSynchronizationStatus(
 			samplingRule := &dash0v1alpha1.Dash0SamplingRule{}
 			err := k8sClient.Get(
 				ctx, types.NamespacedName{
-					Name: name,
+					Namespace: namespace,
+					Name:      name,
 				}, samplingRule,
 			)
 			g.Expect(err).NotTo(HaveOccurred())

--- a/internal/startup/operator_manager_startup.go
+++ b/internal/startup/operator_manager_startup.go
@@ -1399,6 +1399,18 @@ func startOperatorManager(
 	return nil
 }
 
+// appendSamplingRuleNamespacedApiClient appends the sampling rule reconciler to the given list of namespaced API
+// clients if it is present (it is only instantiated when the Signal Control feature is enabled).
+func appendSamplingRuleNamespacedApiClient(
+	clients []controller.NamespacedApiClient,
+	samplingRuleReconciler *controller.SamplingRuleReconciler,
+) []controller.NamespacedApiClient {
+	if samplingRuleReconciler != nil {
+		return append(clients, samplingRuleReconciler)
+	}
+	return clients
+}
+
 func startDash0Controllers(
 	ctx context.Context,
 	mgr manager.Manager,
@@ -1818,9 +1830,7 @@ func startDash0Controllers(
 	setupLog.Info("The operator configuration resource reconciler has been started.")
 
 	setupLog.Info("Creating the monitoring resource reconciler.")
-	monitoringReconciler := controller.NewMonitoringReconciler(
-		k8sClient,
-		clientset,
+	namespacedApiClients := appendSamplingRuleNamespacedApiClient(
 		[]controller.NamespacedApiClient{
 			syntheticCheckReconciler,
 			viewReconciler,
@@ -1830,6 +1840,12 @@ func startDash0Controllers(
 			persesDashboardCrdReconciler,
 			prometheusRuleCrdReconciler,
 		},
+		samplingRuleReconciler,
+	)
+	monitoringReconciler := controller.NewMonitoringReconciler(
+		k8sClient,
+		clientset,
+		namespacedApiClients,
 		instrumenter,
 		collectorManager,
 		targetallocatorManager,

--- a/test-resources/bin/lib/util
+++ b/test-resources/bin/lib/util
@@ -1140,6 +1140,11 @@ deploy_dash0_api_sync_resources() {
     kubectl apply -n "$target_namespace" -f "test-resources/customresources/dash0signaltometrics/${DEPLOY_SIGNAL_TO_METRICS}.yaml"
     finish_step
   fi
+  if [[ -n "${DEPLOY_SAMPLING_RULE:-}" ]]; then
+    echo "STEP $step_counter: deploy a Dash0 sampling rule resource (${DEPLOY_SAMPLING_RULE}) to namespace ${target_namespace}"
+    kubectl apply -n "$target_namespace" -f "test-resources/customresources/dash0samplingrule/${DEPLOY_SAMPLING_RULE}.yaml"
+    finish_step
+  fi
 }
 
 deploy_signal_control_resource() {

--- a/test/e2e/dash0_api_sync_resources.go
+++ b/test/e2e/dash0_api_sync_resources.go
@@ -427,19 +427,22 @@ func renderSamplingRuleTemplate(values dash0ApiResourceValues) string {
 	return renderResourceTemplate(samplingRuleTemplate, values, "dash0samplingrule")
 }
 
-// Dash0SamplingRule is cluster-scoped, so the helpers below do not take a namespace.
-
-func deploySamplingRuleResource(values dash0ApiResourceValues) {
+func deploySamplingRuleResource(
+	namespace string,
+	values dash0ApiResourceValues,
+) {
 	renderedResourceFileName := renderSamplingRuleTemplate(values)
 	defer func() {
 		Expect(os.Remove(renderedResourceFileName)).To(Succeed())
 	}()
 
 	By(fmt.Sprintf(
-		"deploying a Dash0SamplingRule resource with values %v", values))
+		"deploying a Dash0SamplingRule resource to namespace %s with values %v", namespace, values))
 	Expect(runAndIgnoreOutput(exec.Command(
 		"kubectl",
 		"apply",
+		"-n",
+		namespace,
 		"-f",
 		renderedResourceFileName,
 	))).To(Succeed())
@@ -475,12 +478,14 @@ func deploySpamFilterResource(
 	))).To(Succeed())
 }
 
-func setOptOutLabelInSamplingRule(value string) {
+func setOptOutLabelInSamplingRule(namespace string, value string) {
 	By(fmt.Sprintf("setting the opt-out label in the sampling rule with value %s", value))
 	Expect(
 		runAndIgnoreOutput(exec.Command(
 			"kubectl",
 			"label",
+			"-n",
+			namespace,
 			"--overwrite",
 			"Dash0SamplingRule",
 			samplingRuleName,
@@ -505,11 +510,13 @@ func setOptOutLabelInSpamFilter(namespace string, value string) {
 	).To(Succeed())
 }
 
-func removeSamplingRuleResource() {
+func removeSamplingRuleResource(namespace string) {
 	_ = runAndIgnoreOutput(exec.Command(
 		"kubectl",
 		"delete",
 		"--ignore-not-found",
+		"-n",
+		namespace,
 		"Dash0SamplingRule",
 		samplingRuleName,
 	))
@@ -592,7 +599,7 @@ func removeDash0ApiSyncResources(namespace string) {
 	removePrometheusRuleResource(namespace)
 	removeViewResource(namespace)
 	removeNotificationChannelResource(namespace)
-	removeSamplingRuleResource()
+	removeSamplingRuleResource(namespace)
 	removeSignalToMetricsResource(namespace)
 	removeSpamFilterResource(namespace)
 }

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1627,12 +1627,21 @@ trace_statements:
 
 			//nolint:dupl
 			It("should synchronize a Dash0SamplingRule to the Dash0 API", func() {
-				deploySamplingRuleResource(dash0ApiResourceValues{})
-				defer removeSamplingRuleResource()
+				// Dash0SamplingRule is namespaced and synchronizes to the dataset/token of the Dash0 monitoring
+				// resource in its namespace (falling back to the operator configuration), so a monitoring resource
+				// needs to exist in the namespace.
+				deployDash0MonitoringResourceWithRetry(
+					applicationUnderTestNamespace,
+					dash0MonitoringValuesDefault,
+					operatorNamespace,
+				)
+				defer undeployDash0MonitoringResource(applicationUnderTestNamespace)
 
-				// Dash0SamplingRule is cluster-scoped, so the origin has no namespace segment.
+				deploySamplingRuleResource(applicationUnderTestNamespace, dash0ApiResourceValues{})
+				defer removeSamplingRuleResource(applicationUnderTestNamespace)
+
 				//nolint:lll
-				routeRegex := "/api/sampling-rules/dash0-operator_.*_default_sampling-rule-e2e-test\\?dataset=default"
+				routeRegex := "/api/sampling-rules/dash0-operator_.*_default_e2e-test-ns_sampling-rule-e2e-test\\?dataset=default"
 
 				By("verifying the sampling rule has been synchronized to the Dash0 API via PUT")
 				req := fetchCapturedApiRequest(0)
@@ -1645,13 +1654,13 @@ trace_statements:
 				Expect(*req.Body).To(ContainSubstring("\"dash0.com/dataset\":\"default\""))
 				verifySamplingRuleApiSyncRequest(req)
 
-				setOptOutLabelInSamplingRule("false")
+				setOptOutLabelInSamplingRule(applicationUnderTestNamespace, "false")
 				By("verifying the sampling rule has been deleted via the Dash0 API (after setting dash0.com/enable=false)")
 				req = fetchCapturedApiRequest(1)
 				Expect(req.Method).To(Equal("DELETE"))
 				Expect(req.Url).To(MatchRegexp(routeRegex))
 
-				setOptOutLabelInSamplingRule("true")
+				setOptOutLabelInSamplingRule(applicationUnderTestNamespace, "true")
 				//nolint:lll
 				By("verifying the sampling rule has been synchronized to the Dash0 API via PUT (after setting dash0.com/enable=true)")
 				req = fetchCapturedApiRequest(2)
@@ -1661,7 +1670,7 @@ trace_statements:
 				Expect(*req.Body).To(ContainSubstring("\"rate\":0.1"))
 				verifySamplingRuleApiSyncRequest(req)
 
-				removeSamplingRuleResource()
+				removeSamplingRuleResource(applicationUnderTestNamespace)
 				By("verifying the sampling rule has been deleted via the Dash0 API (after removing the resource)")
 				req = fetchCapturedApiRequest(3)
 				Expect(req.Method).To(Equal("DELETE"))


### PR DESCRIPTION
The cluster-scoped `SamplingRule`s were always synced to the default exporter's dataset - this was a leftover from the time before namespaced routing was supported for SC.

This PR aligns the `SamplingRule` CRD with the spam filter and s2m CRDs by
- making it no longer cluster-scoped
- using the namespaced API client
- and setting the `dash0.com/dataset` to the dataset of the namespace's API config 