### PR TITLE
ci: add dry-run step for docs sync

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,11 +6,7 @@ on:
       - 'main'
     tags:
       - '*.*.*'
-    paths-ignore:
-      - '*.md'
   pull_request:
-    paths-ignore:
-      - '*.md'
   merge_group:
   workflow_dispatch:
 
@@ -294,6 +290,17 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           echo "publishing helm chart version ${{ github.ref_name }}"
           helm-chart/bin/publish.sh ${{ github.ref_name }}
+
+  # Verify that docs sync (runs for each release build, see below) still works.
+  sync_docs_to_website_dry_run:
+    name: Synchronize Helm chart docs to dash0.com/docs (dry run)
+    needs: check_for_successful_builds_for_same_commit
+    # The dry run is skipped on release builds (tags), where the actual docs sync (see the sync_docs_to_website job
+    # below) runs after the Helm chart has been published.
+    if: always() && ! contains(github.ref, 'refs/tags/') && needs.check_for_successful_builds_for_same_commit.outputs.should_skip != 'true'
+    uses: ./.github/workflows/sync-docs-to-website.yaml
+    with:
+      dry-run: true
 
   # After publishing a release, sync the Helm chart docs to the documentation on https://www.dash0.com/docs.
   sync_docs_to_website:

--- a/.github/workflows/sync-docs-to-website.yaml
+++ b/.github/workflows/sync-docs-to-website.yaml
@@ -13,7 +13,9 @@ name: Synchronize Helm chart docs to dash0.com/docs
 # in the target repository and is not touched by this sync.
 #
 # This workflow can be run manually (workflow_dispatch) and is also invoked from ci.yaml (workflow_call) after a new
-# release has been published.
+# release has been published. Additionally, ci.yaml invokes it with dry-run: true on every CI build), to verify early
+# that the transformations declared in sync-docs/transformations.yaml still apply cleanly. In dry-run mode, only the
+# transformation step runs; no PR is created for the website docs.
 #
 # The target repository and the target directory within it are configured via the repository secrets
 # SYNC_DOCUMENTATION_TARGET_REPOSITORY and SYNC_DOCUMENTATION_TARGET_DIRECTORY (the path of the directory holding the
@@ -26,17 +28,27 @@ name: Synchronize Helm chart docs to dash0.com/docs
 
 on:
   workflow_dispatch:
+    inputs:
+      dry-run:
+        description: Only verify that the doc transformations still apply cleanly, do not create a pull request in the target repository.
+        type: boolean
+        default: false
   workflow_call:
+    inputs:
+      dry-run:
+        description: Only verify that the doc transformations still apply cleanly, do not create a pull request in the target repository.
+        type: boolean
+        default: false
     secrets:
       DASH0_DOCS_REPO_GITHUB_PAT:
-        description: Fine-grained PAT with contents + pull-requests write access for the documentation repository.
-        required: true
+        description: Fine-grained PAT with contents + pull-requests write access for the documentation repository. Only required when dry-run is false.
+        required: false
       SYNC_DOCUMENTATION_TARGET_REPOSITORY:
-        description: The owner/name of the documentation repository to sync the docs into.
-        required: true
+        description: The owner/name of the documentation repository to sync the docs into. Only required when dry-run is false.
+        required: false
       SYNC_DOCUMENTATION_TARGET_DIRECTORY:
-        description: The path of the directory holding the documentation pages within the target repository.
-        required: true
+        description: The path of the directory holding the documentation pages within the target repository. Only required when dry-run is false.
+        required: false
 
 env:
   PR_BRANCH: sync-dash0-operator-helm-chart-docs
@@ -68,7 +80,14 @@ jobs:
             dash0-operator/.github/workflows/sync-docs/transformations.yaml \
             "${RUNNER_TEMP}/transformed-docs"
 
+      - name: dry run, stopping after applying the doc transformations
+        if: ${{ inputs.dry-run }}
+        run: |
+          echo "This is a dry run: the doc transformations have been applied successfully, all steps involving the" \
+            "target repository are skipped."
+
       - name: checkout target repo
+        if: ${{ ! inputs.dry-run }}
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: ${{ secrets.SYNC_DOCUMENTATION_TARGET_REPOSITORY }}
@@ -76,6 +95,7 @@ jobs:
           path: target-repository
 
       - name: copy transformed docs
+        if: ${{ ! inputs.dry-run }}
         env:
           TARGET_DIRECTORY: ${{ secrets.SYNC_DOCUMENTATION_TARGET_DIRECTORY }}
         run: |
@@ -85,6 +105,7 @@ jobs:
           cp -R "${RUNNER_TEMP}/transformed-docs/." "$target_path/"
 
       - name: create pull request in target repository
+        if: ${{ ! inputs.dry-run }}
         working-directory: target-repository
         env:
           GH_TOKEN: ${{ secrets.DASH0_DOCS_REPO_GITHUB_PAT }}

--- a/.github/workflows/sync-docs/CLAUDE.md
+++ b/.github/workflows/sync-docs/CLAUDE.md
@@ -22,6 +22,16 @@ opening a pull request against the documentation repository.
    is a meaningful diff, commits to the branch `sync-dash0-operator-helm-chart-docs`, force-pushes it, and opens
    a PR against `main` (or relies on the force-push to update an already-open PR).
 
+### Dry-run mode
+
+The workflow accepts a boolean `dry-run` input (for both `workflow_dispatch` and `workflow_call`). With
+`dry-run: true`, only steps 1–3 run — the workflow verifies that the transformations still apply cleanly and then
+stops; the steps involving the target repository (4–6) are skipped and no secrets are required. The `ci.yaml` workflow
+invokes the dry run on every CI build except release builds (job `sync_docs_to_website_dry_run`), so that drift
+between the docs and `transformations.yaml` is caught early instead of only after the next release has been published.
+The real sync (without `dry-run`) is invoked from `ci.yaml` after a release has been published (job
+`sync_docs_to_website`).
+
 ### Configuration (repository secrets)
 
 - `DASH0_DOCS_REPO_GITHUB_PAT` — fine-grained PAT scoped to the target repo with **Contents: Read and write**


### PR DESCRIPTION
Verifies that the docs sync will run successfully with the next release.