### PR TITLE
fix(logging): redact tokens when logging config and resources

### DIFF
--- a/api/operator/common/common_shared_types.go
+++ b/api/operator/common/common_shared_types.go
@@ -11,7 +11,7 @@ type ConditionType string
 const (
 	ConditionTypeAvailable ConditionType = "Available"
 	ConditionTypeDegraded  ConditionType = "Degraded"
-	redactedValue                        = "<redacted>"
+	RedactedValue                        = "<redacted>"
 )
 
 // Export describes the observability backend to which telemetry data will be sent. This can either be Dash0 or another
@@ -292,21 +292,21 @@ func (e *Export) ToExports() []Export {
 // to only call it on exports that are not intended to be used for actual exporting later.
 func (e *Export) Redact() {
 	if e.Dash0 != nil && e.Dash0.Authorization.Token != nil && len(*e.Dash0.Authorization.Token) > 0 {
-		e.Dash0.Authorization.Token = new(redactedValue)
+		e.Dash0.Authorization.Token = new(RedactedValue)
 	}
 	if e.Http != nil {
 		// Any header value can potentially be a secret, so we redact all values. Headers whose values are sourced from a
 		// secret (valueFrom) carry are left untouched.
 		for i := range e.Http.Headers {
 			if e.Http.Headers[i].Value != "" {
-				e.Http.Headers[i].Value = redactedValue
+				e.Http.Headers[i].Value = RedactedValue
 			}
 		}
 	}
 	if e.Grpc != nil {
 		for i := range e.Grpc.Headers {
 			if e.Grpc.Headers[i].Value != "" {
-				e.Grpc.Headers[i].Value = redactedValue
+				e.Grpc.Headers[i].Value = RedactedValue
 			}
 		}
 	}

--- a/api/operator/v1alpha1/operator_configuration_types.go
+++ b/api/operator/v1alpha1/operator_configuration_types.go
@@ -620,6 +620,8 @@ func (d *Dash0OperatorConfiguration) cloneAndRedact() Dash0OperatorConfiguration
 	redactedResource := Dash0OperatorConfiguration{}
 	d.DeepCopyInto(&redactedResource)
 	redactedResource.ManagedFields = nil
+	// This annotation embeds a verbatim copy of the spec (including the plaintext token) that Export.Redact() cannot reach.
+	delete(redactedResource.Annotations, "kubectl.kubernetes.io/last-applied-configuration")
 	for _, export := range redactedResource.EffectiveExports() {
 		export.Redact()
 	}

--- a/api/operator/v1alpha1/operator_configuration_types_test.go
+++ b/api/operator/v1alpha1/operator_configuration_types_test.go
@@ -66,6 +66,25 @@ var _ = Describe("v1alpha1 Dash0 operator configuration CRD", func() {
 			Expect(*original.Spec.Exports[0].Dash0.Authorization.Token).To(Equal("my-secret-token"))
 		})
 
+		It("should drop the kubectl last-applied-configuration annotation, which may embed a plaintext token", func() {
+			lastApplied := `{"spec":{"exports":[{"dash0":{"authorization":{"token":"my-secret-token"}}}]}}`
+			original := Dash0OperatorConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"kubectl.kubernetes.io/last-applied-configuration": lastApplied,
+						"some-other-annotation":                            "keep-me",
+					},
+				},
+			}
+
+			redacted := original.cloneAndRedact()
+
+			Expect(redacted.Annotations).ToNot(HaveKey("kubectl.kubernetes.io/last-applied-configuration"))
+			Expect(redacted.Annotations["some-other-annotation"]).To(Equal("keep-me"))
+			// the original resource must not be mutated
+			Expect(original.Annotations).To(HaveKeyWithValue("kubectl.kubernetes.io/last-applied-configuration", lastApplied))
+		})
+
 		It("should not redact a Dash0 export that uses a SecretRef instead of a token", func() {
 			original := Dash0OperatorConfiguration{
 				Spec: Dash0OperatorConfigurationSpec{

--- a/api/operator/v1beta1/dash0monitoring_types.go
+++ b/api/operator/v1beta1/dash0monitoring_types.go
@@ -582,6 +582,8 @@ func (d *Dash0Monitoring) cloneAndRedact() Dash0Monitoring {
 	redactedResource := Dash0Monitoring{}
 	d.DeepCopyInto(&redactedResource)
 	redactedResource.ManagedFields = nil
+	// This annotation embeds a verbatim copy of the spec (including the plaintext token) that Export.Redact() cannot reach.
+	delete(redactedResource.Annotations, "kubectl.kubernetes.io/last-applied-configuration")
 	for _, export := range redactedResource.EffectiveExports() {
 		export.Redact()
 	}

--- a/api/operator/v1beta1/dash0monitoring_types_test.go
+++ b/api/operator/v1beta1/dash0monitoring_types_test.go
@@ -64,6 +64,25 @@ var _ = Describe("v1beta1 Dash0 monitoring CRD", func() {
 			Expect(*original.Spec.Exports[0].Dash0.Authorization.Token).To(Equal("my-secret-token"))
 		})
 
+		It("should drop the kubectl last-applied-configuration annotation, which may embed a plaintext token", func() {
+			lastApplied := `{"spec":{"exports":[{"dash0":{"authorization":{"token":"my-secret-token"}}}]}}`
+			original := Dash0Monitoring{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"kubectl.kubernetes.io/last-applied-configuration": lastApplied,
+						"some-other-annotation":                            "keep-me",
+					},
+				},
+			}
+
+			redacted := original.cloneAndRedact()
+
+			Expect(redacted.Annotations).ToNot(HaveKey("kubectl.kubernetes.io/last-applied-configuration"))
+			Expect(redacted.Annotations["some-other-annotation"]).To(Equal("keep-me"))
+			// the original resource must not be mutated
+			Expect(original.Annotations).To(HaveKeyWithValue("kubectl.kubernetes.io/last-applied-configuration", lastApplied))
+		})
+
 		It("should not redact a Dash0 export that uses a SecretRef instead of a token", func() {
 			original := Dash0Monitoring{
 				Spec: Dash0MonitoringSpec{

--- a/internal/agent0connector/a0cresources/a0c_resources.go
+++ b/internal/agent0connector/a0cresources/a0c_resources.go
@@ -168,7 +168,7 @@ func (m *Agent0ConnectorResourceManager) updateResource(
 			desiredResource.GetName(),
 		),
 			"patch",
-			string(patchResult.Patch),
+			util.RedactSensitiveEnvVarsInPatch(patchResult.Patch),
 		)
 	}
 

--- a/internal/collectors/otelcolresources/otelcol_resources.go
+++ b/internal/collectors/otelcolresources/otelcol_resources.go
@@ -356,7 +356,7 @@ func (m *OTelColResourceManager) updateResource(
 		desiredResource.GetName(),
 	),
 		"patch",
-		string(patchResult.Patch),
+		util.RedactSensitiveEnvVarsInPatch(patchResult.Patch),
 	)
 
 	return hasChanged, nil

--- a/internal/controller/operator_configuration_controller.go
+++ b/internal/controller/operator_configuration_controller.go
@@ -220,7 +220,7 @@ func (r *OperatorConfigurationReconciler) Reconcile(ctx context.Context, req ctr
 		return ctrl.Result{}, err
 	}
 
-	logger.Info("applying self-monitoring configuration", "configuration", selfMonitoringConfiguration)
+	logger.Info("applying self-monitoring configuration", "configuration", selfMonitoringConfiguration.RedactedForLogging())
 	r.applyOperatorManagerSelfMonitoringSettings(
 		ctx,
 		selfMonitoringConfiguration,

--- a/internal/selfmonitoringapiaccess/otel_init_wait.go
+++ b/internal/selfmonitoringapiaccess/otel_init_wait.go
@@ -155,9 +155,9 @@ func (s *OTelSdkStarter) onParametersHaveChanged(ctx context.Context, logger log
 				logger.Info(
 					"restarting the OpenTelemetry SDK for self-monitoring (config has changed)",
 					"old configuration",
-					currentlyActiveConfig,
+					redactOTelSdkConfigForLogging(currentlyActiveConfig),
 					"new configuration",
-					newOTelSDKConfig,
+					redactOTelSdkConfigForLogging(newOTelSDKConfig),
 				)
 				s.ShutDownOTelSdk(ctx, logger)
 				s.startOrRestartOTelSdkChannel <- newOTelSDKConfig
@@ -174,6 +174,23 @@ func (s *OTelSdkStarter) onParametersHaveChanged(ctx context.Context, logger log
 
 func (s *OTelSdkStarter) UpdateOTelSdkState(newState bool) {
 	s.sdkIsActive.Store(newState)
+}
+
+// redactOTelSdkConfigForLogging returns a copy of the config that is safe to log: all header values are replaced
+// with the redaction marker, since any header value (in particular the Authorization header) may carry a secret.
+func redactOTelSdkConfigForLogging(c *common.OTelSdkConfig) *common.OTelSdkConfig {
+	if c == nil {
+		return nil
+	}
+	redacted := *c
+	if len(c.Headers) > 0 {
+		redactedHeaders := make(map[string]string, len(c.Headers))
+		for k := range c.Headers {
+			redactedHeaders[k] = dash0common.RedactedValue
+		}
+		redacted.Headers = redactedHeaders
+	}
+	return &redacted
 }
 
 // convertExportConfigurationToOTelSDKConfig is used when enabling self-monitoring from within an already running

--- a/internal/selfmonitoringapiaccess/otel_init_wait.go
+++ b/internal/selfmonitoringapiaccess/otel_init_wait.go
@@ -176,8 +176,8 @@ func (s *OTelSdkStarter) UpdateOTelSdkState(newState bool) {
 	s.sdkIsActive.Store(newState)
 }
 
-// redactOTelSdkConfigForLogging returns a copy of the config that is safe to log: all header values are replaced
-// with the redaction marker, since any header value (in particular the Authorization header) may carry a secret.
+// redactOTelSdkConfigForLogging returns a copy safe to log: all header values are redacted, since any of them (in
+// particular the Authorization header) may carry a secret.
 func redactOTelSdkConfigForLogging(c *common.OTelSdkConfig) *common.OTelSdkConfig {
 	if c == nil {
 		return nil

--- a/internal/selfmonitoringapiaccess/self_monitoring_and_api_access.go
+++ b/internal/selfmonitoringapiaccess/self_monitoring_and_api_access.go
@@ -35,6 +35,26 @@ type SelfMonitoringConfiguration struct {
 	ResolvedSecretHeaderValues map[string]string
 }
 
+// RedactedForLogging returns a copy of the configuration that is safe to log: the resolved token, the literal
+// export token, gRPC/HTTP header values and resolved secret header values are replaced with the redaction marker.
+func (c SelfMonitoringConfiguration) RedactedForLogging() SelfMonitoringConfiguration {
+	redacted := c
+	redacted.Export = *c.Export.DeepCopy()
+	redacted.Export.Redact() // handles Dash0.Authorization.Token and gRPC/HTTP header values
+	if c.Token != nil && len(*c.Token) > 0 {
+		redactedToken := dash0common.RedactedValue
+		redacted.Token = &redactedToken
+	}
+	if len(c.ResolvedSecretHeaderValues) > 0 {
+		redactedHeaders := make(map[string]string, len(c.ResolvedSecretHeaderValues))
+		for k := range c.ResolvedSecretHeaderValues {
+			redactedHeaders[k] = dash0common.RedactedValue
+		}
+		redacted.ResolvedSecretHeaderValues = redactedHeaders
+	}
+	return redacted
+}
+
 type EndpointAndHeaders struct {
 	Endpoint string
 	Protocol string

--- a/internal/selfmonitoringapiaccess/self_monitoring_and_api_access.go
+++ b/internal/selfmonitoringapiaccess/self_monitoring_and_api_access.go
@@ -35,12 +35,12 @@ type SelfMonitoringConfiguration struct {
 	ResolvedSecretHeaderValues map[string]string
 }
 
-// RedactedForLogging returns a copy of the configuration that is safe to log: the resolved token, the literal
-// export token, gRPC/HTTP header values and resolved secret header values are replaced with the redaction marker.
+// RedactedForLogging returns a copy safe to log: the resolved token, the literal export token, header values and
+// resolved secret header values are replaced with the redaction marker.
 func (c SelfMonitoringConfiguration) RedactedForLogging() SelfMonitoringConfiguration {
 	redacted := c
 	redacted.Export = *c.Export.DeepCopy()
-	redacted.Export.Redact() // handles Dash0.Authorization.Token and gRPC/HTTP header values
+	redacted.Export.Redact()
 	if c.Token != nil && len(*c.Token) > 0 {
 		redactedToken := dash0common.RedactedValue
 		redacted.Token = &redactedToken

--- a/internal/selfmonitoringapiaccess/self_monitoring_and_api_access_test.go
+++ b/internal/selfmonitoringapiaccess/self_monitoring_and_api_access_test.go
@@ -1751,3 +1751,85 @@ func expectedMetricsPipeline(exporterSuffix string) string {
             exporter:
               otlp:` + exporterSuffix
 }
+
+var _ = Describe("redacting the self-monitoring configuration for logging", func() {
+
+	It("redacts the resolved token, the literal export token and resolved secret header values", func() {
+		literalToken := AuthorizationTokenTest
+		resolvedToken := AuthorizationTokenTest
+		cfg := SelfMonitoringConfiguration{
+			SelfMonitoringEnabled: true,
+			Export: dash0common.Export{
+				Dash0: &dash0common.Dash0Configuration{
+					Endpoint:      EndpointDash0Test,
+					Dataset:       DatasetCustomTest,
+					Authorization: dash0common.Authorization{Token: &literalToken},
+				},
+			},
+			Token:                      &resolvedToken,
+			ResolvedSecretHeaderValues: map[string]string{"Authorization": "Bearer secret"},
+		}
+
+		redacted := cfg.RedactedForLogging()
+
+		Expect(redacted.SelfMonitoringEnabled).To(BeTrue())
+		Expect(*redacted.Token).To(Equal(dash0common.RedactedValue))
+		Expect(*redacted.Export.Dash0.Authorization.Token).To(Equal(dash0common.RedactedValue))
+		Expect(redacted.Export.Dash0.Endpoint).To(Equal(EndpointDash0Test))
+		Expect(redacted.Export.Dash0.Dataset).To(Equal(DatasetCustomTest))
+		Expect(redacted.ResolvedSecretHeaderValues["Authorization"]).To(Equal(dash0common.RedactedValue))
+
+		// the original configuration must not be mutated
+		Expect(*cfg.Token).To(Equal(AuthorizationTokenTest))
+		Expect(*cfg.Export.Dash0.Authorization.Token).To(Equal(AuthorizationTokenTest))
+		Expect(cfg.ResolvedSecretHeaderValues["Authorization"]).To(Equal("Bearer secret"))
+	})
+
+	It("leaves a secret-ref-only authorization untouched and does not add a redacted token", func() {
+		secretRef := SecretRefTest
+		cfg := SelfMonitoringConfiguration{
+			Export: dash0common.Export{
+				Dash0: &dash0common.Dash0Configuration{
+					Endpoint:      EndpointDash0Test,
+					Authorization: dash0common.Authorization{SecretRef: &secretRef},
+				},
+			},
+		}
+
+		redacted := cfg.RedactedForLogging()
+
+		Expect(redacted.Token).To(BeNil())
+		Expect(redacted.Export.Dash0.Authorization.Token).To(BeNil())
+		Expect(redacted.Export.Dash0.Authorization.SecretRef).ToNot(BeNil())
+		Expect(redacted.Export.Dash0.Authorization.SecretRef.Name).To(Equal(SecretRefTest.Name))
+	})
+})
+
+var _ = Describe("redacting the OTel SDK config for logging", func() {
+
+	It("redacts all header values while preserving header names and non-header fields", func() {
+		cfg := &common.OTelSdkConfig{
+			Endpoint: EndpointDash0Test,
+			Protocol: common.ProtocolGrpc,
+			Headers: map[string]string{
+				util.AuthorizationHeaderName: "Bearer secret-token",
+				util.Dash0DatasetHeaderName:  DatasetCustomTest,
+			},
+		}
+
+		redacted := redactOTelSdkConfigForLogging(cfg)
+
+		Expect(redacted.Endpoint).To(Equal(EndpointDash0Test))
+		Expect(redacted.Protocol).To(Equal(common.ProtocolGrpc))
+		Expect(redacted.Headers[util.AuthorizationHeaderName]).To(Equal(dash0common.RedactedValue))
+		Expect(redacted.Headers[util.Dash0DatasetHeaderName]).To(Equal(dash0common.RedactedValue))
+
+		// the original config must not be mutated
+		Expect(cfg.Headers[util.AuthorizationHeaderName]).To(Equal("Bearer secret-token"))
+		Expect(cfg.Headers[util.Dash0DatasetHeaderName]).To(Equal(DatasetCustomTest))
+	})
+
+	It("returns nil for a nil config", func() {
+		Expect(redactOTelSdkConfigForLogging(nil)).To(BeNil())
+	})
+})

--- a/internal/targetallocator/taresources/ta_resources.go
+++ b/internal/targetallocator/taresources/ta_resources.go
@@ -173,7 +173,7 @@ func (m *TargetAllocatorResourceManager) updateResource(
 			desiredResource.GetName(),
 		),
 			"patch",
-			string(patchResult.Patch),
+			util.RedactSensitiveEnvVarsInPatch(patchResult.Patch),
 		)
 	}
 

--- a/internal/util/redact_patch.go
+++ b/internal/util/redact_patch.go
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: Copyright 2025 Dash0 Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package util
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+
+	dash0common "github.com/dash0hq/dash0-operator/api/operator/common"
+)
+
+// sensitiveEnvVarNamePrefixes are the (prefixes of the) env var names under which the operator injects plaintext
+// secrets into managed workloads. Prefix-matched because the names carry per-export/-namespace/-index suffixes.
+var sensitiveEnvVarNamePrefixes = []string{
+	"OTELCOL_AUTH_TOKEN",                // collector Dash0 export auth token(s)
+	"SELF_MONITORING_AUTH_TOKEN",        // collector self-monitoring auth token
+	"DASH0_AGENT0_CONNECTOR_AUTH_TOKEN", // agent0-connector auth token
+	"EDGE_PROXY_AUTH_TOKEN",             // signal-control edge proxy auth token
+	"DASH0_HEADER",                      // collector gRPC/HTTP header secrets
+}
+
+func isSensitiveEnvVarName(name string) bool {
+	for _, prefix := range sensitiveEnvVarNamePrefixes {
+		if strings.HasPrefix(name, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// RedactSensitiveEnvVarsInPatch returns the reconcile patch with the values of secret-bearing env vars (see
+// sensitiveEnvVarNamePrefixes) replaced by the redaction marker, so patch logs never expose a literal auth token. An
+// unparseable patch is omitted rather than risk a leak.
+func RedactSensitiveEnvVarsInPatch(patch []byte) string {
+	var parsed any
+	if err := json.Unmarshal(patch, &parsed); err != nil {
+		return "<patch omitted: not parseable as JSON, cannot verify it is free of secrets>"
+	}
+	redactSensitiveEnvVars(parsed)
+	// Encode without HTML escaping to keep the marker and endpoints readable.
+	var buf bytes.Buffer
+	encoder := json.NewEncoder(&buf)
+	encoder.SetEscapeHTML(false)
+	if err := encoder.Encode(parsed); err != nil {
+		return "<patch omitted: redaction failed>"
+	}
+	return strings.TrimSpace(buf.String())
+}
+
+func redactSensitiveEnvVars(node any) {
+	switch n := node.(type) {
+	case map[string]any:
+		if nameRaw, hasName := n["name"]; hasName {
+			if name, ok := nameRaw.(string); ok && isSensitiveEnvVarName(name) {
+				if _, hasValue := n["value"]; hasValue {
+					n["value"] = dash0common.RedactedValue
+				}
+			}
+		}
+		for _, child := range n {
+			redactSensitiveEnvVars(child)
+		}
+	case []any:
+		for _, child := range n {
+			redactSensitiveEnvVars(child)
+		}
+	}
+}

--- a/internal/util/redact_patch_test.go
+++ b/internal/util/redact_patch_test.go
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: Copyright 2025 Dash0 Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package util
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("RedactSensitiveEnvVarsInPatch", func() {
+
+	It("redacts the values of sensitive env vars while preserving non-sensitive ones", func() {
+		patch := []byte(`{
+			"spec": {"template": {"spec": {"containers": [{
+				"name": "opentelemetry-collector",
+				"env": [
+					{"name": "OTELCOL_AUTH_TOKEN_DEFAULT_0", "value": "dummy-token"},
+					{"name": "SELF_MONITORING_AUTH_TOKEN", "value": "dummy-token"},
+					{"name": "DASH0_AGENT0_CONNECTOR_AUTH_TOKEN", "value": "dummy-token"},
+					{"name": "EDGE_PROXY_AUTH_TOKEN", "value": "dummy-token"},
+					{"name": "DASH0_HEADER_GRPC_DEFAULT_0", "value": "dummy-token"},
+					{"name": "OTEL_SERVICE_NAME", "value": "dash0-operator"}
+				]
+			}]}}}
+		}`)
+
+		redacted := RedactSensitiveEnvVarsInPatch(patch)
+
+		Expect(redacted).ToNot(ContainSubstring("dummy-token"))
+		Expect(redacted).To(ContainSubstring("<redacted>"))
+		// non-sensitive values must remain visible for debugging
+		Expect(redacted).To(ContainSubstring("dash0-operator"))
+		Expect(redacted).To(ContainSubstring("OTELCOL_AUTH_TOKEN_DEFAULT_0"))
+	})
+
+	It("redacts a sensitive env var value regardless of JSON key order", func() {
+		patch := []byte(`{"env": [{"value": "dummy-token", "name": "OTELCOL_AUTH_TOKEN_DEFAULT_0"}]}`)
+
+		redacted := RedactSensitiveEnvVarsInPatch(patch)
+
+		Expect(redacted).ToNot(ContainSubstring("dummy-token"))
+		Expect(redacted).To(ContainSubstring("<redacted>"))
+	})
+
+	It("leaves env vars sourced from a secret (no literal value) untouched", func() {
+		patch := []byte(`{"env": [{"name": "OTELCOL_AUTH_TOKEN_DEFAULT_0", "valueFrom": {"secretKeyRef": {"name": "s", "key": "k"}}}]}`)
+
+		redacted := RedactSensitiveEnvVarsInPatch(patch)
+
+		Expect(redacted).To(ContainSubstring("secretKeyRef"))
+		Expect(redacted).ToNot(ContainSubstring("<redacted>"))
+	})
+
+	It("omits the patch entirely when it cannot be parsed as JSON, rather than risk leaking", func() {
+		redacted := RedactSensitiveEnvVarsInPatch([]byte("dummy-token not json"))
+
+		Expect(redacted).ToNot(ContainSubstring("dummy-token"))
+		Expect(redacted).To(ContainSubstring("patch omitted"))
+	})
+})

--- a/test/e2e/collect_logs_on_fail.go
+++ b/test/e2e/collect_logs_on_fail.go
@@ -90,6 +90,19 @@ func collectPodInfoAndLogs(specReport SpecReport) {
 	))
 }
 
+// getOperatorManagerLogs returns the full accumulated stdout of the operator-manager deployment.
+func getOperatorManagerLogs() (string, error) {
+	return run(exec.Command(
+		"kubectl",
+		"-n",
+		operatorNamespace,
+		"logs",
+		"deployment/dash0-operator-controller",
+		"--all-containers=true",
+		"--tail=-1",
+	))
+}
+
 func getPodLogs(namespace string, outputPath string) {
 	podNames := getPodNames(namespace, outputPath)
 	for _, podName := range podNames {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -367,6 +367,7 @@ var _ = Describe("Dash0 Operator", Ordered, ContinueOnFailure, func() {
 						)
 					}, 45*time.Second, pollingInterval).Should(Succeed())
 				})
+
 			})
 
 			Describe("log collection", func() {
@@ -1941,8 +1942,6 @@ trace_statements:
 	}
 
 	Context("with the agent0-connector enabled", Ordered, func() {
-		const agent0ConnectorDummyToken = "auth_e2e-agent0-connector-dummy-token"
-
 		agent0ConnectorDeployment := operatorHelmReleaseName + "-agent0-connector"
 
 		BeforeAll(func() {

--- a/test/e2e/operator.go
+++ b/test/e2e/operator.go
@@ -29,7 +29,17 @@ const (
 
 	publishedChart    = "dash0-operator/dash0-operator"
 	publishedChartUrl = "https://dash0hq.github.io/dash0-operator"
+
+	// agent0ConnectorDummyToken is the auth token configured for the agent0-connector in the corresponding test.
+	agent0ConnectorDummyToken = "auth_e2e-agent0-connector-dummy-token"
 )
+
+// secretsThatMustNeverAppearInLogs enumerates every plaintext secret value the e2e suite configures. The operator
+// manager must never write any of them to its logs; they must be redacted. Extend this list when adding new secrets.
+var secretsThatMustNeverAppearInLogs = []string{
+	defaultToken,
+	agent0ConnectorDummyToken,
+}
 
 var (
 	operatorHelmChart    = localHelmChart
@@ -444,7 +454,43 @@ func ensureDash0OperatorHelmRepoIsInstalledAndUpToDate(
 	}
 }
 
+// verifyNoSecretsLeakedInOperatorManagerLogs fetches the operator manager's accumulated logs and asserts that none of
+// the plaintext secrets configured by the suite appear in them. It is a no-op when the operator manager is not
+// currently deployed (some teardown paths run after it has already been removed).
+func verifyNoSecretsLeakedInOperatorManagerLogs() {
+	deployment, err := run(exec.Command(
+		"kubectl",
+		"-n",
+		operatorNamespace,
+		"get",
+		"deployment",
+		"dash0-operator-controller",
+		"--ignore-not-found",
+		"--output=name",
+	))
+	if err != nil || strings.TrimSpace(deployment) == "" {
+		return
+	}
+	logs, err := getOperatorManagerLogs()
+	if err != nil {
+		return
+	}
+	for _, secret := range secretsThatMustNeverAppearInLogs {
+		if secret == "" {
+			continue
+		}
+		Expect(logs).ToNot(
+			ContainSubstring(secret),
+			fmt.Sprintf("operator manager logs must not contain the plaintext secret %q", secret),
+		)
+	}
+}
+
 func undeployOperator(operatorNamespace string) {
+	// Scan the operator manager's accumulated logs for leaked secrets before tearing it down. undeployOperator is the
+	// common teardown funnel for every operator deployment, so this covers all feature paths exercised in the suite.
+	verifyNoSecretsLeakedInOperatorManagerLogs()
+
 	By("undeploying the operator")
 	Expect(
 		runAndIgnoreOutput(

--- a/test/e2e/operator.go
+++ b/test/e2e/operator.go
@@ -454,10 +454,12 @@ func ensureDash0OperatorHelmRepoIsInstalledAndUpToDate(
 	}
 }
 
-// verifyNoSecretsLeakedInOperatorManagerLogs fetches the operator manager's accumulated logs and asserts that none of
-// the plaintext secrets configured by the suite appear in them. It is a no-op when the operator manager is not
-// currently deployed (some teardown paths run after it has already been removed).
-func verifyNoSecretsLeakedInOperatorManagerLogs() {
+// leakedSecretLogFileCounter makes the artifact file names written on a detected leak unique across deployments.
+var leakedSecretLogFileCounter int
+
+// getOperatorManagerLogsIfDeployed returns the operator manager's logs, or "" when it is not deployed (some teardown
+// paths run after it has been removed) or its logs cannot be retrieved.
+func getOperatorManagerLogsIfDeployed() string {
 	deployment, err := run(exec.Command(
 		"kubectl",
 		"-n",
@@ -469,27 +471,44 @@ func verifyNoSecretsLeakedInOperatorManagerLogs() {
 		"--output=name",
 	))
 	if err != nil || strings.TrimSpace(deployment) == "" {
-		return
+		return ""
 	}
 	logs, err := getOperatorManagerLogs()
 	if err != nil {
-		return
+		return ""
 	}
-	for _, secret := range secretsThatMustNeverAppearInLogs {
-		if secret == "" {
-			continue
+	return logs
+}
+
+// findLeakedSecretLogLines returns each log line containing a configured secret, with the secret masked. The masked
+// line (its message and field key) identifies the offending call site without re-printing the secret.
+func findLeakedSecretLogLines(logs string) []string {
+	var offendingLines []string
+	for _, line := range strings.Split(logs, "\n") {
+		masked := line
+		containsSecret := false
+		for _, secret := range secretsThatMustNeverAppearInLogs {
+			if secret != "" && strings.Contains(masked, secret) {
+				containsSecret = true
+				masked = strings.ReplaceAll(masked, secret, "<redacted>")
+			}
 		}
-		Expect(logs).ToNot(
-			ContainSubstring(secret),
-			fmt.Sprintf("operator manager logs must not contain the plaintext secret %q", secret),
-		)
+		if containsSecret {
+			// Truncate very long lines (e.g. patch dumps) but keep the identifying prefix (timestamp, level, message).
+			if len(masked) > 1500 {
+				masked = masked[:1500] + "…(truncated)"
+			}
+			offendingLines = append(offendingLines, masked)
+		}
 	}
+	return offendingLines
 }
 
 func undeployOperator(operatorNamespace string) {
-	// Scan the operator manager's accumulated logs for leaked secrets before tearing it down. undeployOperator is the
-	// common teardown funnel for every operator deployment, so this covers all feature paths exercised in the suite.
-	verifyNoSecretsLeakedInOperatorManagerLogs()
+	// Capture logs before teardown but assert only after uninstalling below, so a detected leak never aborts teardown
+	// and leaves the release installed. undeployOperator is the teardown funnel for every deployment, covering all paths.
+	operatorManagerLogs := getOperatorManagerLogsIfDeployed()
+	leakedSecretLogLines := findLeakedSecretLogLines(operatorManagerLogs)
 
 	By("undeploying the operator")
 	Expect(
@@ -517,6 +536,24 @@ func undeployOperator(operatorNamespace string) {
 			))).To(Succeed())
 
 	verifyDash0OperatorReleaseIsNotInstalled(Default, operatorNamespace)
+
+	if len(leakedSecretLogLines) > 0 {
+		// The operator is already torn down, so the standard on-failure collection can no longer capture its logs;
+		// persist them as a CI artifact (their only secret is the dummy e2e token).
+		writeToFile(
+			[]byte(operatorManagerLogs),
+			collectedLogsBaseDir,
+			fmt.Sprintf("leaked-secret-operator-manager-logs-%d.log", leakedSecretLogFileCounter),
+		)
+		leakedSecretLogFileCounter++
+	}
+
+	Expect(leakedSecretLogLines).To(
+		BeEmpty(),
+		"the operator manager logged plaintext secret(s); each of the following lines (secret masked here) must be "+
+			"redacted at its source:\n%s",
+		strings.Join(leakedSecretLogLines, "\n"),
+	)
 }
 
 func verifyDash0OperatorReleaseIsNotInstalled(g Gomega, operatorNamespace string) {


### PR DESCRIPTION
- addresses the issue raised in #1214
- also redacts tokens when logging resources, patches, etc... (this only affected clear text tokens, not tokens coming from secrets)
- added a check to e2e tests, so on all paths that we test, we also check that the token wasn't logged