### PR TITLE
fix(collectors): exclude high-churn labels/annotations from collection

### DIFF
--- a/internal/collectors/otelcolresources/collector_config_maps.go
+++ b/internal/collectors/otelcolresources/collector_config_maps.go
@@ -8,6 +8,7 @@ import (
 	"compress/gzip"
 	_ "embed"
 	"fmt"
+	"regexp"
 	"slices"
 	"strings"
 	"text/template"
@@ -91,6 +92,7 @@ type collectorConfigurationTemplateValues struct {
 	CollectPodLabelsAndAnnotationsEnabled            bool
 	CollectNamespaceLabelsAndAnnotationsEnabled      bool
 	CollectNodeLabelsAndAnnotationsEnabled           bool
+	LabelAndAnnotationExclusionPatterns              []string
 	K8sAttributesDisableReplicasetInformer           bool
 	K8sAttributesWaitForMetadata                     bool
 	K8sAttributesWaitForMetadataTimeout              string
@@ -144,6 +146,54 @@ var (
 	deploymentCollectorConfigurationTemplate       = template.Must(
 		template.New("deployment-collector-configuration").Parse(deploymentCollectorConfigurationTemplateSource))
 )
+
+type excludedMetadataKey struct {
+	// key is the literal label/annotation key that must not be collected.
+	key string
+	// entities lists the Kubernetes object types ("pod", "namespace", "node") on which the key must not be collected.
+	entities []string
+}
+
+// labelAndAnnotationKeysExcludedFromCollection lists the keys of labels and annotations that must never be collected
+// as resource attributes, even if collecting labels and annotations is enabled for the respective object type. This
+// is meant for metadata that is either controller-internal bookkeeping updated on live objects (which would lead to
+// constant resource attribute churn), or large payloads without telemetry value, or annotations that might contain
+// sensitive information. Customers can always add custom transforms additionally
+var labelAndAnnotationKeysExcludedFromCollection = []excludedMetadataKey{
+	// CAST AI workload autoscaler bookkeeping, updated on running pods whenever a recommendation is applied.
+	{key: "autoscaling.cast.ai/recommendation-applied-at", entities: []string{"pod"}},
+	{key: "autoscaling.cast.ai/vertical-recommendation-hash", entities: []string{"pod"}},
+
+	// Rewritten by the kubelet whenever CSI drivers (re)register on the node.
+	{key: "csi.volume.kubernetes.io/nodeid", entities: []string{"node"}},
+
+	// Karpenter drift-detection bookkeeping, updated on running nodes whenever the owning NodePool/EC2NodeClass
+	// changes.
+	{key: "karpenter.sh/nodepool-hash", entities: []string{"node"}},
+	{key: "karpenter.sh/nodepool-hash-version", entities: []string{"node"}},
+	{key: "karpenter.sh/nodeclaim-termination-timestamp", entities: []string{"node"}},
+	{key: "karpenter.k8s.aws/ec2nodeclass-hash", entities: []string{"node"}},
+	{key: "karpenter.k8s.aws/ec2nodeclass-hash-version", entities: []string{"node"}},
+
+	// Written by kubectl apply (and compatible clients), contains the full previous object spec (up to 256KB) and can
+	// contain sensitive data like environment variable values.
+	{key: "kubectl.kubernetes.io/last-applied-configuration", entities: []string{"pod", "namespace", "node"}},
+
+	// Managed by the node TTL controller, its value changes with the cluster size.
+	{key: "node.alpha.kubernetes.io/ttl", entities: []string{"node"}},
+
+	// Kyverno mutation bookkeeping, contains the JSON patches applied by mutation policies.
+	{key: "policies.kyverno.io/last-applied-patches", entities: []string{"pod", "namespace", "node"}},
+
+	// Vertical pod autoscaler admission controller bookkeeping, written to every pod that is managed by a
+	// VerticalPodAutoscaler.
+	{key: "vpaUpdates", entities: []string{"pod"}},
+	{key: "vpaObservedContainers", entities: []string{"pod"}},
+
+	// kured (Kubernetes reboot daemon) bookkeeping, updated on running nodes during reboot cycles.
+	{key: "weave.works/kured-reboot-in-progress", entities: []string{"node"}},
+	{key: "weave.works/kured-most-recent-reboot-needed", entities: []string{"node"}},
+}
 
 func assembleDaemonSetCollectorConfigMap(
 	config *oTelColConfig,
@@ -256,6 +306,7 @@ func assembleCollectorConfigMap(
 			CollectPodLabelsAndAnnotationsEnabled:            config.CollectPodLabelsAndAnnotationsEnabled,
 			CollectNamespaceLabelsAndAnnotationsEnabled:      config.CollectNamespaceLabelsAndAnnotationsEnabled,
 			CollectNodeLabelsAndAnnotationsEnabled:           config.CollectNodeLabelsAndAnnotationsEnabled,
+			LabelAndAnnotationExclusionPatterns:              labelAndAnnotationExclusionPatterns(),
 			K8sAttributesDisableReplicasetInformer:           config.K8sAttributesDisableReplicasetInformer,
 			K8sAttributesWaitForMetadata:                     config.K8sAttributesWaitForMetadata,
 			K8sAttributesWaitForMetadataTimeout:              config.K8sAttributesWaitForMetadataTimeout,
@@ -394,6 +445,22 @@ func renderOttlNamespaceFilter(
 			fmt.Sprintf("          and resource.attributes[\"k8s.namespace.name\"] != \"%s\"\n", namespace)
 	}
 	return namespaceOttlFilter
+}
+
+// labelAndAnnotationExclusionPatterns renders labelAndAnnotationKeysExcludedFromCollection into regex patterns for
+// the OTTL function delete_matching_keys, each matching both the label and the annotation resource attribute of the
+// excluded key on all affected object types. The patterns are rendered into OTTL string literals, which unescape
+// `\\` to `\`, hence the backslashes of the regex-quoted key need to be doubled.
+func labelAndAnnotationExclusionPatterns() []string {
+	patterns := make([]string, 0, len(labelAndAnnotationKeysExcludedFromCollection))
+	for _, excludedKey := range labelAndAnnotationKeysExcludedFromCollection {
+		patterns = append(patterns, fmt.Sprintf(
+			`^k8s\\.(%s)\\.(label|annotation)\\.%s$`,
+			strings.Join(excludedKey.entities, "|"),
+			strings.ReplaceAll(regexp.QuoteMeta(excludedKey.key), `\`, `\\`),
+		))
+	}
+	return patterns
 }
 
 func aggregateCustomFilters(filtersSpec []NamespacedFilter) customFilters {

--- a/internal/collectors/otelcolresources/collector_config_maps_test.go
+++ b/internal/collectors/otelcolresources/collector_config_maps_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"maps"
+	"regexp"
 	"slices"
 	"strings"
 
@@ -4235,6 +4236,57 @@ var _ = Describe("The OpenTelemetry Collector ConfigMaps", func() {
 			Expect(ReadFromMap(annotationsSnippet, []string{"1", "tag_name"})).To(Equal("k8s.node.annotation.$$1"))
 			Expect(ReadFromMap(annotationsSnippet, []string{"2", "tag_name"})).To(Equal("k8s.pod.annotation.$$1"))
 		}, daemonSetAndDeployment)
+
+		DescribeTable("should remove labels and annotations that are excluded from collection", func(cmTypeDef configMapTypeDefinition) {
+			configMap, err := cmTypeDef.assembleConfigMapFunction(&oTelColConfig{
+				OperatorNamespace: OperatorNamespace,
+				NamePrefix:        namePrefix,
+				Exporters:         cmTestSingleDefaultOtlpExporter(),
+				KubernetesInfrastructureMetricsCollectionEnabled: true,
+				CollectPodLabelsAndAnnotationsEnabled:            true,
+			}, monitoredNamespaces, nil, nil, false)
+			Expect(err).ToNot(HaveOccurred())
+			collectorConfig := parseConfigMapContent(configMap)
+			for _, statementGroup := range []string{"trace_statements", "metric_statements", "log_statements"} {
+				statementsRaw := ReadFromMap(
+					collectorConfig,
+					[]string{"processors", "transform/resources", statementGroup, "0", "statements"},
+				)
+				Expect(statementsRaw).ToNot(BeNil())
+				statements := statementsRaw.([]any)
+				// spot-check a few fully rendered statements to pin down the escaping
+				Expect(statements).To(ContainElement(
+					`delete_matching_keys(resource.attributes, ` +
+						`"^k8s\\.(pod)\\.(label|annotation)\\.autoscaling\\.cast\\.ai/recommendation-applied-at$")`))
+				Expect(statements).To(ContainElement(
+					`delete_matching_keys(resource.attributes, ` +
+						`"^k8s\\.(pod|namespace|node)\\.(label|annotation)\\.kubectl\\.kubernetes\\.io/last-applied-configuration$")`))
+				Expect(statements).To(ContainElement(
+					`delete_matching_keys(resource.attributes, ` +
+						`"^k8s\\.(node)\\.(label|annotation)\\.karpenter\\.sh/nodepool-hash$")`))
+				for _, pattern := range labelAndAnnotationExclusionPatterns() {
+					Expect(statements).To(ContainElement(
+						fmt.Sprintf(`delete_matching_keys(resource.attributes, "%s")`, pattern)))
+				}
+			}
+		}, daemonSetAndDeployment)
+
+		It("should render valid exclusion regexes that match exactly the excluded label/annotation attributes", func() {
+			patterns := labelAndAnnotationExclusionPatterns()
+			Expect(patterns).To(HaveLen(len(labelAndAnnotationKeysExcludedFromCollection)))
+			for i, excludedKey := range labelAndAnnotationKeysExcludedFromCollection {
+				// delete_matching_keys receives the pattern after OTTL string literal unescaping (`\\` becomes `\`).
+				regex, err := regexp.Compile(strings.ReplaceAll(patterns[i], `\\`, `\`))
+				Expect(err).ToNot(HaveOccurred())
+				for _, entity := range excludedKey.entities {
+					Expect(regex.MatchString(fmt.Sprintf("k8s.%s.label.%s", entity, excludedKey.key))).To(BeTrue())
+					Expect(regex.MatchString(fmt.Sprintf("k8s.%s.annotation.%s", entity, excludedKey.key))).To(BeTrue())
+				}
+				// attributes the operator relies on for service attribute mapping must never match
+				Expect(regex.MatchString("k8s.pod.label.app.kubernetes.io/name")).To(BeFalse())
+				Expect(regex.MatchString("k8s.pod.annotation.prometheus.io/port")).To(BeFalse())
+			}
+		})
 	})
 
 	Describe("discard metrics from unmonitored namespaces", func() {

--- a/internal/collectors/otelcolresources/daemonset.config.yaml.template
+++ b/internal/collectors/otelcolresources/daemonset.config.yaml.template
@@ -932,25 +932,38 @@ processors:
 
   # Limit resource attributes to a reasonable maximum length. This is particularly important when transforming
   # Kubernetes pod annotations to resource attributes, which can hold up to 256KB of data.
+  # Also, remove labels and annotations that are deliberately excluded from collection.
   transform/resources:
     error_mode: ignore
     trace_statements:
       - context: resource
         statements:
         - truncate_all(resource.attributes, 2048)
+        {{- range .LabelAndAnnotationExclusionPatterns }}
+        - delete_matching_keys(resource.attributes, "{{ . }}")
+        {{- end }}
     metric_statements:
       - context: resource
         statements:
         - truncate_all(resource.attributes, 2048)
+        {{- range .LabelAndAnnotationExclusionPatterns }}
+        - delete_matching_keys(resource.attributes, "{{ . }}")
+        {{- end }}
     log_statements:
       - context: resource
         statements:
         - truncate_all(resource.attributes, 2048)
+        {{- range .LabelAndAnnotationExclusionPatterns }}
+        - delete_matching_keys(resource.attributes, "{{ . }}")
+        {{- end }}
     {{- if .ProfilingEnabled }}
     profile_statements:
       - context: resource
         statements:
         - truncate_all(resource.attributes, 2048)
+        {{- range .LabelAndAnnotationExclusionPatterns }}
+        - delete_matching_keys(resource.attributes, "{{ . }}")
+        {{- end }}
     {{- end }}
 
   {{- if or $hasPrometheusScrapingEnabledForAtLeastOneNamespace (and .SelfMonitoringEnabled .PrometheusCrdSupportEnabled) }}

--- a/internal/collectors/otelcolresources/deployment.config.yaml.template
+++ b/internal/collectors/otelcolresources/deployment.config.yaml.template
@@ -352,20 +352,30 @@ processors:
 
   # Limit resource attributes to a reasonable maximum length. This is particularly important when transforming
   # Kubernetes pod annotations to resource attributes, which can hold up to 256KB of data.
+  # Also, remove labels and annotations that are deliberately excluded from collection.
   transform/resources:
     error_mode: ignore
     trace_statements:
       - context: resource
         statements:
           - truncate_all(resource.attributes, 2048)
+          {{- range .LabelAndAnnotationExclusionPatterns }}
+          - delete_matching_keys(resource.attributes, "{{ . }}")
+          {{- end }}
     metric_statements:
       - context: resource
         statements:
           - truncate_all(resource.attributes, 2048)
+          {{- range .LabelAndAnnotationExclusionPatterns }}
+          - delete_matching_keys(resource.attributes, "{{ . }}")
+          {{- end }}
     log_statements:
       - context: resource
         statements:
           - truncate_all(resource.attributes, 2048)
+          {{- range .LabelAndAnnotationExclusionPatterns }}
+          - delete_matching_keys(resource.attributes, "{{ . }}")
+          {{- end }}
 
   {{- if $hasEventCollectionEnabledForAtLeastOneNamespace }}
   transform/k8s_events:


### PR DESCRIPTION
Controllers like the Cast AI  autoscaler, Karpenter, the vertical pod autoscaler, Kyverno, etc. write bookkeeping annotations to running pods and nodes. Collecting those as resource attributes changes the resource identity of subsequent telemetry and causes constant resource churn in the Dash0 backend.

Additionally, kubectl.kubernetes.io/last-applied-configuration carries the full previous object spec and can contain sensitive data. We now drop those annotations via OTTL.