### PR TITLE
fix(collector): improve kubeletstat endpoint probe

### DIFF
--- a/internal/collectors/otelcolresources/kubeletstats_endpoint_probe.go
+++ b/internal/collectors/otelcolresources/kubeletstats_endpoint_probe.go
@@ -1,0 +1,434 @@
+// SPDX-FileCopyrightText: Copyright 2026 Dash0 Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package otelcolresources
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/dash0hq/dash0-operator/internal/util"
+	"github.com/dash0hq/dash0-operator/internal/util/logd"
+)
+
+type endpointProbeFn func(util.CollectorConfig, logd.Logger) (KubeletStatsReceiverConfig, bool)
+
+const (
+	kubeletStatsNodeIpEndpoint       = "https://${env:K8S_NODE_IP}:10250"
+	kubeletStatsNodeIpEndpointIpv6   = "https://[${env:K8S_NODE_IP}]:10250"
+	kubeletStatsReadOnlyEndpoint     = "http://${env:K8S_NODE_IP}:10255"
+	kubeletStatsReadOnlyEndpointIpv6 = "http://[${env:K8S_NODE_IP}]:10255"
+	kubeletStatsNodeNameEndpoint     = "https://${env:K8S_NODE_NAME}:10250"
+
+	kubeletStatsAuthTypeServiceAccount   = "serviceAccount"
+	kubeletStatsAuthTypeNone             = "none"
+	kubeletStatsSummaryPath              = "/stats/summary"
+	usingKubeletStatsReceiverEndpointMsg = "Using %s as kubeletstats receiver endpoint."
+
+	// serviceAccountCACertPath is the CA bundle the kubeletstats receiver adds to the system cert pool when verifying
+	// TLS certificates with auth_type: serviceAccount (see the saClientProvider in
+	// https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/internal/kubelet/client.go). The
+	// TLS-verifying probe requests must use the same trust anchors, otherwise the probe outcome does not predict the
+	// receiver's behavior: kubelet serving certificates are signed by the cluster CA (if at all), never by a public CA,
+	// so verifying against the system cert pool alone would fail even on clusters where the receiver could verify the
+	// certificate.
+	serviceAccountCACertPath = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+
+	// probeRequestTimeout bounds each probe request, so that an unreachable (e.g. blackholed) endpoint does not stall
+	// the collector reconciliation for the duration of the OS-level TCP timeout.
+	probeRequestTimeout = 5 * time.Second
+)
+
+var (
+	secureClientOnce sync.Once
+	secureClient     *http.Client
+
+	insecureClient = &http.Client{
+		Timeout: probeRequestTimeout,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
+
+	configNodeIpSecureTls = KubeletStatsReceiverConfig{
+		Enabled:            true,
+		Endpoint:           kubeletStatsNodeIpEndpoint,
+		AuthType:           kubeletStatsAuthTypeServiceAccount,
+		InsecureSkipVerify: false,
+	}
+	configNodeIpSecureTlsIpv6 = KubeletStatsReceiverConfig{
+		Enabled:            true,
+		Endpoint:           kubeletStatsNodeIpEndpointIpv6,
+		AuthType:           kubeletStatsAuthTypeServiceAccount,
+		InsecureSkipVerify: false,
+	}
+
+	configNodeIpInsecureSkipVerify = KubeletStatsReceiverConfig{
+		Enabled:            true,
+		Endpoint:           kubeletStatsNodeIpEndpoint,
+		AuthType:           kubeletStatsAuthTypeServiceAccount,
+		InsecureSkipVerify: true,
+	}
+	configNodeIpInsecureSkipVerifyIpv6 = KubeletStatsReceiverConfig{
+		Enabled:            true,
+		Endpoint:           kubeletStatsNodeIpEndpointIpv6,
+		AuthType:           kubeletStatsAuthTypeServiceAccount,
+		InsecureSkipVerify: true,
+	}
+
+	configNodeIpReadOnlyEndpointUnencrypted = KubeletStatsReceiverConfig{
+		Enabled:            true,
+		Endpoint:           kubeletStatsReadOnlyEndpoint,
+		AuthType:           kubeletStatsAuthTypeNone,
+		InsecureSkipVerify: false,
+	}
+	configNodeIpReadOnlyEndpointUnencryptedIpv6 = KubeletStatsReceiverConfig{
+		Enabled:            true,
+		Endpoint:           kubeletStatsReadOnlyEndpointIpv6,
+		AuthType:           kubeletStatsAuthTypeNone,
+		InsecureSkipVerify: false,
+	}
+
+	configNodeNameSecureTls = KubeletStatsReceiverConfig{
+		Enabled:            true,
+		Endpoint:           kubeletStatsNodeNameEndpoint,
+		AuthType:           kubeletStatsAuthTypeServiceAccount,
+		InsecureSkipVerify: false,
+	}
+
+	configNodeNameInsecureSkipVerify = KubeletStatsReceiverConfig{
+		Enabled:            true,
+		Endpoint:           kubeletStatsNodeNameEndpoint,
+		AuthType:           kubeletStatsAuthTypeServiceAccount,
+		InsecureSkipVerify: true,
+	}
+
+	configDisabled = KubeletStatsReceiverConfig{Enabled: false}
+)
+
+// kubeletStatsEndpointProbes bundles the external interactions performed while probing for a viable kubeletstats
+// receiver endpoint. This exists so the steps can be replaced in unit tests.
+type kubeletStatsEndpointProbes struct {
+	// sendProbeRequest performs an HTTP GET; for https endpoints, TLS certificates are verified against the system cert
+	// pool plus the cluster CA at serviceAccountCACertPath, matching the trust anchors of the kubeletstats receiver
+	// with auth_type: serviceAccount. Note: the probe sends no bearer token while the kubeletstat receiver does. This
+	// asymmetry does not affect outcomes, because executeHttpRequest only fails on transport errors, a 401 response is
+	// counted as a successful probe.
+	sendProbeRequest func(endpoint string) error
+	// sendProbeRequestInsecure performs an HTTP GET with TLS certificate verification disabled. It is used to check if
+	// falling back to insecure_skip_verify is viable.
+	sendProbeRequestInsecure func(endpoint string) error
+}
+
+// probeKubeletStatsEndpoint determines the best endpoint for the kubeletstats receiver configuration, depending on the
+// specifics of the cluster (TLS certificates, available ports, ...).
+func probeKubeletStatsEndpoint(
+	collectorConfig util.CollectorConfig,
+	logger logd.Logger,
+) (KubeletStatsReceiverConfig, bool) {
+	httpClient := getSecureProbeClient(logger)
+	probes := kubeletStatsEndpointProbes{
+		sendProbeRequest:         func(endpoint string) error { return executeHttpRequest(httpClient, endpoint) },
+		sendProbeRequestInsecure: func(endpoint string) error { return executeHttpRequest(insecureClient, endpoint) },
+	}
+	return executeProbes(collectorConfig, probes, logger)
+}
+
+// getSecureProbeClient lazily creates (and then reuses) the HTTP client for the TLS-verifying probe requests, trusting
+// the system cert pool plus the cluster CA at serviceAccountCACertPath (see the comment there). If the cluster CA
+// cannot be loaded, the client degrades to verifying against the system cert pool only, which in practice means the
+// TLS probes will fail and the probe falls back to the insecure_skip_verify / read-only options.
+func getSecureProbeClient(logger logd.Logger) *http.Client {
+	secureClientOnce.Do(func() {
+		rootCAs, err := x509.SystemCertPool()
+		if err != nil {
+			logger.Info(fmt.Sprintf("Cannot load the system cert pool: %v.", err))
+			rootCAs = x509.NewCertPool()
+		}
+		if caCert, err := os.ReadFile(serviceAccountCACertPath); err != nil {
+			logger.Info(fmt.Sprintf(
+				"Cannot read %s (%v), TLS probe requests will verify certificates against the system cert pool only.",
+				serviceAccountCACertPath,
+				err,
+			))
+		} else if !rootCAs.AppendCertsFromPEM(caCert) {
+			logger.Info(fmt.Sprintf(
+				"No certificates could be parsed from %s, TLS probe requests will verify certificates against the "+
+					"system cert pool only.",
+				serviceAccountCACertPath,
+			))
+		}
+		secureClient = &http.Client{
+			Timeout: probeRequestTimeout,
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{RootCAs: rootCAs},
+			},
+		}
+	})
+	return secureClient
+}
+
+// executeProbes runs different probes to determine the best endpoint for the kubeletstats receiver configuration,
+// depending on the specifics of the cluster (TLS certificates, available ports, ...).
+//
+// Options in order of preference:
+// 1. Node IP with verified TLS
+// 2. Node IP with insecure_skip_verify
+// 3. Node IP with read-only port (:10255) (no auth, no encryption)
+// 4. Node name with verified TLS
+// 5. Node name with insecure_skip_verify
+// 6. Receiver disabled
+//
+// Every node IP based option is preferred over any node name based option because the node IP options do not depend
+// on DNS at scrape time: the collector pods run with the default dnsPolicy (ClusterFirst), so resolving the node name
+// requires the cluster DNS service (e.g. CoreDNS) to be healthy, and -- since node names are never part of the
+// cluster-local DNS zone -- also the upstream resolver behind it, at every connection (re-)establishment. Cluster DNS
+// outages are a common incident class, and kubelet metrics are most valuable exactly during incidents, so not
+// depending on DNS at all ranks higher than a stricter TLS posture.
+//
+// Preferring insecure_skip_verify (option 2) or even the unencrypted, unauthenticated read-only endpoint (option 3)
+// over the node name based options is not a security issue in practice: each collector daemonset pod scrapes the
+// kubelet of the node it runs on (K8S_NODE_IP is the pod's status.hostIP, provided via the downward API). Traffic
+// from a pod to its own node's IP travels from the pod's network namespace via a veth pair directly into the host's
+// network stack and never leaves the node. (We run the collectors with hostNetwork: false.)
+// Intercepting or redirecting it therefore requires root-level access to that very node -- and an attacker with that
+// level of access already controls the kubelet and its TLS certificates, so TLS certificate verification would not
+// protect against them. In detail:
+//   - With insecure_skip_verify (options 2 and 5), the connection is still encrypted -- the TLS key exchange defeats
+//     passive eavesdropping even without certificate verification -- and the client still authenticates itself to the
+//     kubelet via its service account token. The residual risk is sending that bearer token to a server whose
+//     identity has not been verified, which, per the above, is only exploitable by an attacker who already controls
+//     the node.
+//   - The read-only endpoint (option 3) uses plaintext HTTP, but transmits no credential at all (auth_type: none), so
+//     there is nothing to steal; in that respect it is even less risky than insecure_skip_verify. The payload that
+//     could theoretically be observed (again: only from within the node itself) is low-sensitivity metadata -- pod,
+//     container and volume names plus resource usage. Whether the read-only port is enabled at all is a property of
+//     the cluster, not of this configuration: if it is enabled, every pod in the cluster can read from it anyway, so
+//     scraping it does not add any exposure. Note that the read-only port is mostly a legacy option that is usually not
+//     enabled on modern clusters.
+func executeProbes(
+	collectorConfig util.CollectorConfig,
+	probes kubeletStatsEndpointProbes,
+	logger logd.Logger,
+) (KubeletStatsReceiverConfig, bool) {
+	if collectorConfig.NodeName == "" && collectorConfig.NodeIp == "" {
+		logger.Warn(
+			"No K8s_NODE_NAME and no K8S_NODE_IP available, skipping kubeletstats receiver endpoint lookup. " +
+				"The kubeletstats receiver will be disabled. Some Kubernetes infrastructure metrics will be missing.",
+		)
+		return configDisabled, false
+	}
+
+	if collectorConfig.NodeIp != "" {
+		if config, ok := probeNodeIpEndpoints(collectorConfig, probes, logger); ok {
+			return config, true
+		}
+	} else {
+		logger.Info("Skipping all node IP based kubeletstats receiver endpoints, the node IP is not available.")
+	}
+
+	if collectorConfig.NodeName != "" {
+		if config, ok := probeNodeNameEndpoint(collectorConfig, probes, logger); ok {
+			return config, true
+		}
+	} else {
+		logger.Info("Skipping the node name based kubeletstats receiver endpoints, the node name is not available.")
+	}
+
+	logger.Warn(
+		"No viable kubeletstats receiver endpoint found. The kubeletstats receiver will be disabled. Some Kubernetes " +
+			"infrastructure metrics will be missing.",
+	)
+	return configDisabled, false
+}
+
+// probeNodeIpEndpoints probes the node IP based endpoints in their order of preference: verified TLS on port 10250,
+// insecure_skip_verify on port 10250, and finally the unencrypted read-only port 10255.
+//
+// The caller guarantees collectorConfig.NodeIp is non-empty.
+func probeNodeIpEndpoints(
+	collectorConfig util.CollectorConfig,
+	probes kubeletStatsEndpointProbes,
+	logger logd.Logger,
+) (KubeletStatsReceiverConfig, bool) {
+	logger.Info(fmt.Sprintf("Checking the address family of the node IP %s.", collectorConfig.NodeIp))
+	isIPv6 := util.IsIPv6Address(collectorConfig.NodeIp)
+	if isIPv6 {
+		logger.Info(fmt.Sprintf("The node IP %s is an IPv6 address.", collectorConfig.NodeIp))
+	} else {
+		logger.Info(fmt.Sprintf("The node IP %s is an IPv4 address.", collectorConfig.NodeIp))
+	}
+	configSecure := configNodeIpSecureTls
+	configInsecure := configNodeIpInsecureSkipVerify
+	configReadOnly := configNodeIpReadOnlyEndpointUnencrypted
+	if isIPv6 {
+		configSecure = configNodeIpSecureTlsIpv6
+		configInsecure = configNodeIpInsecureSkipVerifyIpv6
+		configReadOnly = configNodeIpReadOnlyEndpointUnencryptedIpv6
+	}
+
+	nodeIpEndpointWithPath :=
+		fmt.Sprintf("https://%s%s", net.JoinHostPort(collectorConfig.NodeIp, "10250"), kubeletStatsSummaryPath)
+	logger.Info(fmt.Sprintf("Attempting probe request to %s.", nodeIpEndpointWithPath))
+	nodeIpProbeErr := probes.sendProbeRequest(nodeIpEndpointWithPath)
+	if nodeIpProbeErr == nil {
+		logger.Info(fmt.Sprintf("Probe request to %s has been successful.", nodeIpEndpointWithPath))
+		logger.Info(fmt.Sprintf(usingKubeletStatsReceiverEndpointMsg, configSecure.Endpoint))
+		return configSecure, true
+	}
+
+	if isTlsError(nodeIpProbeErr) {
+		logger.Info(
+			fmt.Sprintf(
+				"Failed to verify certificate for %s. (%s)",
+				nodeIpEndpointWithPath,
+				nodeIpProbeErr.Error(),
+			))
+		// The node IP endpoint did not pass the TLS probe. Try it again with insecure_skip_verify before falling back
+		// to the read-only port: the connection stays encrypted and authenticated (serviceAccount token, RBAC), which
+		// is a smaller compromise than the plaintext, unauthenticated read-only port.
+		logger.Info(
+			fmt.Sprintf("Attempting probe request to %s without TLS certificate verification.", nodeIpEndpointWithPath),
+		)
+		nodeIpInsecureProbeErr := probes.sendProbeRequestInsecure(nodeIpEndpointWithPath)
+		if nodeIpInsecureProbeErr == nil {
+			logger.Info(
+				fmt.Sprintf(
+					"Probe request to %s without TLS certificate verification has been successful.",
+					nodeIpEndpointWithPath,
+				))
+			logger.Info(fmt.Sprintf(
+				"Using %s as kubeletstats receiver endpoint with insecure_skip_verify: true.",
+				configInsecure.Endpoint,
+			))
+			return configInsecure, true
+		}
+		logger.Info(
+			fmt.Sprintf(
+				"The probe request to %s without TLS certificate verification resulted in an error: %s",
+				nodeIpEndpointWithPath,
+				nodeIpInsecureProbeErr.Error(),
+			))
+	} else {
+		logger.Info(
+			fmt.Sprintf(
+				"The probe request to %s resulted in an error: %s.",
+				nodeIpEndpointWithPath,
+				nodeIpProbeErr.Error(),
+			))
+	}
+
+	// Note: The read-only endpoint is plain HTTP, so no TLS is involved in this probe request, despite using the
+	// TLS-verifying client.
+	readOnlyNodeIpEndpointWithPath :=
+		fmt.Sprintf("http://%s%s", net.JoinHostPort(collectorConfig.NodeIp, "10255"), kubeletStatsSummaryPath)
+	logger.Info(fmt.Sprintf("Attempting probe request to read-only endpoint %s.", readOnlyNodeIpEndpointWithPath))
+	nodeIpReadOnlyProbeErr := probes.sendProbeRequest(readOnlyNodeIpEndpointWithPath)
+	if nodeIpReadOnlyProbeErr == nil {
+		logger.Info(
+			fmt.Sprintf(
+				"Probe request to read-only endpoint %s has been successful.",
+				readOnlyNodeIpEndpointWithPath,
+			),
+		)
+		logger.Info(fmt.Sprintf(
+			"Using read-only endpoint %s as kubeletstats receiver endpoint.",
+			configReadOnly.Endpoint,
+		))
+		return configReadOnly, true
+	}
+	logger.Info(
+		fmt.Sprintf(
+			"The probe request to %s resulted in an error: %s. No viable node IP based endpoint found.",
+			readOnlyNodeIpEndpointWithPath,
+			nodeIpReadOnlyProbeErr.Error(),
+		))
+	return configDisabled, false
+}
+
+// probeNodeNameEndpoint probes the node name endpoint (https://${env:K8S_NODE_NAME}:10250), the last resort before
+// disabling the receiver.
+//
+// No explicit DNS lookup for the node name is required: the probe request resolves the node name itself, and a
+// resolution failure surfaces as a non-TLS error, which disqualifies the node name endpoint.
+//
+// The caller guarantees collectorConfig.NodeName is non-empty.
+func probeNodeNameEndpoint(
+	collectorConfig util.CollectorConfig,
+	probes kubeletStatsEndpointProbes,
+	logger logd.Logger,
+) (KubeletStatsReceiverConfig, bool) {
+	nodeNameEndpointWithPath := fmt.Sprintf("https://%s:10250%s", collectorConfig.NodeName, kubeletStatsSummaryPath)
+	logger.Info(fmt.Sprintf("Attempting probe request to %s.", nodeNameEndpointWithPath))
+	nodeNameProbeErr := probes.sendProbeRequest(nodeNameEndpointWithPath)
+	if nodeNameProbeErr == nil {
+		logger.Info(fmt.Sprintf("Probe request to %s has been successful.", nodeNameEndpointWithPath))
+		logger.Info(fmt.Sprintf(usingKubeletStatsReceiverEndpointMsg, configNodeNameSecureTls.Endpoint))
+		return configNodeNameSecureTls, true
+	}
+
+	if isTlsError(nodeNameProbeErr) {
+		logger.Info(
+			fmt.Sprintf(
+				"Failed to verify certificate for %s. (%s)",
+				nodeNameEndpointWithPath,
+				nodeNameProbeErr.Error(),
+			))
+		logger.Info(
+			fmt.Sprintf("Attempting probe request to %s without TLS certificate verification.", nodeNameEndpointWithPath),
+		)
+		nodeNameInsecureProbeErr := probes.sendProbeRequestInsecure(nodeNameEndpointWithPath)
+		if nodeNameInsecureProbeErr == nil {
+			logger.Info(
+				fmt.Sprintf(
+					"Probe request to %s without TLS certificate verification has been successful.",
+					nodeNameEndpointWithPath,
+				))
+			logger.Info(fmt.Sprintf(
+				"Using %s as kubeletstats receiver endpoint with insecure_skip_verify: true.",
+				configNodeNameInsecureSkipVerify.Endpoint,
+			))
+			return configNodeNameInsecureSkipVerify, true
+		}
+		logger.Info(
+			fmt.Sprintf(
+				"The probe request to %s without TLS certificate verification resulted in an error: %s. The node name "+
+					"endpoint cannot be used.",
+				nodeNameEndpointWithPath,
+				nodeNameInsecureProbeErr.Error(),
+			))
+		return configDisabled, false
+	}
+	// nodeNameTlsProbeErr != nil, but not a TLS error. This also includes the inability to resolve the node name via DNS.
+	logger.Info(
+		fmt.Sprintf(
+			"The probe request to %s resulted in an error: %s. The node name endpoint cannot be used.",
+			nodeNameEndpointWithPath,
+			nodeNameProbeErr.Error(),
+		))
+	return configDisabled, false
+}
+
+func executeHttpRequest(httpClient *http.Client, endpoint string) error {
+	res, err := httpClient.Get(endpoint)
+	defer func() {
+		if res != nil {
+			_, _ = io.Copy(io.Discard, res.Body)
+			_ = res.Body.Close()
+		}
+	}()
+	return err
+}
+
+// isTlsError reports whether err (or any error it wraps) is a TLS certificate verification failure.
+func isTlsError(err error) bool {
+	return errors.As(err, new(*tls.CertificateVerificationError))
+}

--- a/internal/collectors/otelcolresources/kubeletstats_endpoint_probe_test.go
+++ b/internal/collectors/otelcolresources/kubeletstats_endpoint_probe_test.go
@@ -1,0 +1,328 @@
+// SPDX-FileCopyrightText: Copyright 2026 Dash0 Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package otelcolresources
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net"
+	"net/url"
+
+	"github.com/dash0hq/dash0-operator/internal/util"
+	"github.com/dash0hq/dash0-operator/internal/util/logd"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+const (
+	probeTestNodeName = "test-node-name-123456789ab"
+	probeTestNodeIp   = "10.1.2.34"
+	probeTestNodeIpV6 = "fd00:1:2:3::9"
+)
+
+var (
+	probeTestNodeNameEndpoint = fmt.Sprintf("https://%s:10250%s", probeTestNodeName, kubeletStatsSummaryPath)
+	probeTestNodeIpEndpoint   = fmt.Sprintf("https://%s:10250%s", probeTestNodeIp, kubeletStatsSummaryPath)
+	probeTestReadOnlyEndpoint = fmt.Sprintf("http://%s:10255%s", probeTestNodeIp, kubeletStatsSummaryPath)
+
+	// The IPv6 node IP endpoints are bracketed via net.JoinHostPort, matching what probeNodeIpEndpoints builds.
+	probeTestNodeIpV6Endpoint   = fmt.Sprintf("https://%s%s", net.JoinHostPort(probeTestNodeIpV6, "10250"), kubeletStatsSummaryPath)
+	probeTestReadOnlyV6Endpoint = fmt.Sprintf("http://%s%s", net.JoinHostPort(probeTestNodeIpV6, "10255"), kubeletStatsSummaryPath)
+
+	probeTestTlsError = &url.Error{
+		Op:  "Get",
+		URL: "https://host:10250/stats/summary",
+		Err: &tls.CertificateVerificationError{Err: x509.UnknownAuthorityError{}},
+	}
+	probeTestGenericError = fmt.Errorf(`Get "https://host:10250/stats/summary": dial tcp: connection refused`)
+)
+
+// fakeKubeletStatsEndpointProbes builds a kubeletStatsEndpointProbes backed by lookup tables. Any endpoint absent
+// from the result maps is treated as a generic (non-TLS) probe error. A nil value in the result maps denotes a
+// successful probe. Note that DNS resolution failures for the node name also surface as generic probe errors, since
+// the probe request resolves the node name itself.
+func fakeKubeletStatsEndpointProbes(
+	verifiedResults map[string]error,
+	insecureResults map[string]error,
+) kubeletStatsEndpointProbes {
+	return kubeletStatsEndpointProbes{
+		sendProbeRequest: func(endpoint string) error {
+			if err, ok := verifiedResults[endpoint]; ok {
+				return err
+			}
+			return probeTestGenericError
+		},
+		sendProbeRequestInsecure: func(endpoint string) error {
+			if err, ok := insecureResults[endpoint]; ok {
+				return err
+			}
+			return probeTestGenericError
+		},
+	}
+}
+
+var _ = Describe("probeKubeletStatsEndpoint", func() {
+	logger := logd.FromContext(context.Background())
+	collectorConfig := util.CollectorConfig{NodeName: probeTestNodeName, NodeIp: probeTestNodeIp}
+
+	It("disables the receiver when neither node name nor node IP is available", func() {
+		result, ok := executeProbes(
+			util.CollectorConfig{}, fakeKubeletStatsEndpointProbes(nil, nil), logger)
+		Expect(ok).To(BeFalse())
+		Expect(result.Enabled).To(BeFalse())
+	})
+
+	It("prefers the node IP endpoint over the node name endpoint when both certificates verify", func() {
+		// Both endpoints verify. The node IP endpoint is equally secure but does not depend on DNS resolution at
+		// scrape time at all, so it is preferred.
+		probes := fakeKubeletStatsEndpointProbes(
+			map[string]error{
+				probeTestNodeNameEndpoint: nil,
+				probeTestNodeIpEndpoint:   nil,
+			},
+			nil,
+		)
+		result, ok := executeProbes(collectorConfig, probes, logger)
+		Expect(ok).To(BeTrue())
+		Expect(result.Enabled).To(BeTrue())
+		Expect(result.Endpoint).To(Equal(kubeletStatsNodeIpEndpoint))
+		Expect(result.InsecureSkipVerify).To(BeFalse())
+		Expect(result.AuthType).To(Equal(kubeletStatsAuthTypeServiceAccount))
+	})
+
+	It("prefers the insecure node IP endpoint over the node name endpoint with verified TLS", func() {
+		// The node IP endpoint's certificate does not verify, the node name endpoint's does. The node IP endpoint
+		// with insecure_skip_verify is still preferred: it does not depend on DNS resolution at scrape time, and the
+		// scrape traffic never leaves the node, so the missing certificate verification is not a security issue in
+		// practice.
+		probes := fakeKubeletStatsEndpointProbes(
+			map[string]error{
+				probeTestNodeNameEndpoint: nil,
+				probeTestNodeIpEndpoint:   probeTestTlsError,
+			},
+			map[string]error{probeTestNodeIpEndpoint: nil},
+		)
+		result, ok := executeProbes(collectorConfig, probes, logger)
+		Expect(ok).To(BeTrue())
+		Expect(result.Enabled).To(BeTrue())
+		Expect(result.Endpoint).To(Equal(kubeletStatsNodeIpEndpoint))
+		Expect(result.InsecureSkipVerify).To(BeTrue())
+		Expect(result.AuthType).To(Equal(kubeletStatsAuthTypeServiceAccount))
+	})
+
+	It("prefers the insecure node IP endpoint over the unencrypted read-only endpoint", func() {
+		// The secure node IP probe fails with a TLS error, but both the insecure node IP probe and the read-only
+		// endpoint would succeed. The insecure node IP endpoint must be preferred: it stays encrypted and
+		// authenticated (serviceAccount token, RBAC), whereas the read-only port is plaintext HTTP with no
+		// authentication.
+		probes := fakeKubeletStatsEndpointProbes(
+			map[string]error{
+				probeTestNodeIpEndpoint:   probeTestTlsError,
+				probeTestReadOnlyEndpoint: nil,
+			},
+			map[string]error{probeTestNodeIpEndpoint: nil},
+		)
+		result, ok := executeProbes(collectorConfig, probes, logger)
+		Expect(ok).To(BeTrue())
+		Expect(result.Endpoint).To(Equal(kubeletStatsNodeIpEndpoint))
+		Expect(result.InsecureSkipVerify).To(BeTrue())
+		Expect(result.AuthType).To(Equal(kubeletStatsAuthTypeServiceAccount))
+	})
+
+	It("prefers the read-only endpoint over the node name endpoint with verified TLS", func() {
+		// The port 10250 endpoints are not reachable via the node IP, but the read-only endpoint is, and the node
+		// name endpoint's certificate would even verify. The read-only endpoint is still preferred, because it does
+		// not depend on DNS resolution at scrape time. It transmits no credentials whatsoever (auth_type: none), and
+		// the unencrypted scrape traffic never leaves the node, so the plaintext HTTP transport is not a security
+		// issue in practice.
+		probes := fakeKubeletStatsEndpointProbes(
+			map[string]error{
+				probeTestNodeNameEndpoint: nil,
+				probeTestNodeIpEndpoint:   probeTestGenericError,
+				probeTestReadOnlyEndpoint: nil,
+			},
+			nil,
+		)
+		result, ok := executeProbes(collectorConfig, probes, logger)
+		Expect(ok).To(BeTrue())
+		Expect(result.Endpoint).To(Equal(kubeletStatsReadOnlyEndpoint))
+		Expect(result.AuthType).To(Equal(kubeletStatsAuthTypeNone))
+		Expect(result.InsecureSkipVerify).To(BeFalse())
+	})
+
+	It("uses the read-only endpoint when no other node IP based endpoint is viable", func() {
+		probes := fakeKubeletStatsEndpointProbes(
+			map[string]error{
+				probeTestNodeIpEndpoint:   probeTestGenericError,
+				probeTestReadOnlyEndpoint: nil,
+			},
+			nil,
+		)
+		result, ok := executeProbes(collectorConfig, probes, logger)
+		Expect(ok).To(BeTrue())
+		Expect(result.Endpoint).To(Equal(kubeletStatsReadOnlyEndpoint))
+		Expect(result.AuthType).To(Equal(kubeletStatsAuthTypeNone))
+	})
+
+	It("falls back to the node name endpoint when no node IP based endpoint is viable", func() {
+		// No node IP based endpoint works at all, but the node name endpoint's certificate verifies. The node name
+		// endpoint is then used, accepting the dependency on DNS resolution at scrape time.
+		probes := fakeKubeletStatsEndpointProbes(
+			map[string]error{probeTestNodeNameEndpoint: nil},
+			nil,
+		)
+		result, ok := executeProbes(collectorConfig, probes, logger)
+		Expect(ok).To(BeTrue())
+		Expect(result.Enabled).To(BeTrue())
+		Expect(result.Endpoint).To(Equal(kubeletStatsNodeNameEndpoint))
+		Expect(result.InsecureSkipVerify).To(BeFalse())
+		Expect(result.AuthType).To(Equal(kubeletStatsAuthTypeServiceAccount))
+	})
+
+	It("falls back to the insecure node name endpoint as a last resort", func() {
+		// No node IP based endpoint works at all, and the node name endpoint's certificate does not verify, but the
+		// node name endpoint does accept the request with insecure_skip_verify. The node name endpoint with
+		// insecure_skip_verify is then used as the last resort rather than disabling the receiver.
+		probes := fakeKubeletStatsEndpointProbes(
+			map[string]error{
+				probeTestNodeNameEndpoint: probeTestTlsError,
+				probeTestNodeIpEndpoint:   probeTestTlsError,
+				probeTestReadOnlyEndpoint: probeTestGenericError,
+			},
+			map[string]error{
+				probeTestNodeIpEndpoint:   probeTestGenericError,
+				probeTestNodeNameEndpoint: nil,
+			},
+		)
+		result, ok := executeProbes(collectorConfig, probes, logger)
+		Expect(ok).To(BeTrue())
+		Expect(result.Enabled).To(BeTrue())
+		Expect(result.Endpoint).To(Equal(kubeletStatsNodeNameEndpoint))
+		Expect(result.InsecureSkipVerify).To(BeTrue())
+	})
+
+	It("disables the receiver when the node name cert does not verify and insecure_skip_verify also fails", func() {
+		// No node IP based endpoint works at all, and the node name endpoint's certificate does not verify either.
+		// Unlike a mere certificate verification failure, the insecure_skip_verify probe request itself also fails
+		// (e.g. the endpoint is not reachable at all under a different network path, or rejects the request for a
+		// reason unrelated to TLS verification), so the node name endpoint must not be used and the receiver is
+		// disabled instead of blindly trusting insecure_skip_verify.
+		probes := fakeKubeletStatsEndpointProbes(
+			map[string]error{
+				probeTestNodeNameEndpoint: probeTestTlsError,
+				probeTestNodeIpEndpoint:   probeTestTlsError,
+				probeTestReadOnlyEndpoint: probeTestGenericError,
+			},
+			map[string]error{
+				probeTestNodeIpEndpoint:   probeTestGenericError,
+				probeTestNodeNameEndpoint: probeTestGenericError,
+			},
+		)
+		result, ok := executeProbes(collectorConfig, probes, logger)
+		Expect(ok).To(BeFalse())
+		Expect(result.Enabled).To(BeFalse())
+	})
+
+	It("disables the receiver when the node name probe fails for a non-TLS reason", func() {
+		// No node IP based endpoint works, and the node name probe fails with a generic (non-TLS) error, which means
+		// the endpoint is not reachable (this includes DNS resolution failures for the node name). The receiver is
+		// disabled.
+		probes := fakeKubeletStatsEndpointProbes(
+			map[string]error{
+				probeTestNodeNameEndpoint: probeTestGenericError,
+				probeTestNodeIpEndpoint:   probeTestGenericError,
+				probeTestReadOnlyEndpoint: probeTestGenericError,
+			},
+			nil,
+		)
+		result, ok := executeProbes(collectorConfig, probes, logger)
+		Expect(ok).To(BeFalse())
+		Expect(result.Enabled).To(BeFalse())
+	})
+
+	It("skips the node IP based endpoints and uses the node name endpoint when only the node name is available", func() {
+		// The node IP is not available at all, only the node name is. executeProbes must skip the node IP based
+		// endpoints entirely (the collectorConfig.NodeIp != "" guard) and go straight to the node name endpoint.
+		nodeNameOnlyConfig := util.CollectorConfig{NodeName: probeTestNodeName}
+		probes := fakeKubeletStatsEndpointProbes(
+			map[string]error{probeTestNodeNameEndpoint: nil},
+			nil,
+		)
+		result, ok := executeProbes(nodeNameOnlyConfig, probes, logger)
+		Expect(ok).To(BeTrue())
+		Expect(result.Enabled).To(BeTrue())
+		Expect(result.Endpoint).To(Equal(kubeletStatsNodeNameEndpoint))
+		Expect(result.InsecureSkipVerify).To(BeFalse())
+		Expect(result.AuthType).To(Equal(kubeletStatsAuthTypeServiceAccount))
+	})
+
+	It("disables the receiver when only the node IP is available and all node IP based probes fail", func() {
+		// The node name is not available at all, only the node IP is. executeProbes must skip the node name endpoint
+		// (the collectorConfig.NodeName != "" guard); once all node IP based probes fail, the receiver is disabled
+		// rather than falling back to a node name endpoint that cannot be built.
+		nodeIpOnlyConfig := util.CollectorConfig{NodeIp: probeTestNodeIp}
+		probes := fakeKubeletStatsEndpointProbes(
+			map[string]error{
+				probeTestNodeIpEndpoint:   probeTestGenericError,
+				probeTestReadOnlyEndpoint: probeTestGenericError,
+			},
+			nil,
+		)
+		result, ok := executeProbes(nodeIpOnlyConfig, probes, logger)
+		Expect(ok).To(BeFalse())
+		Expect(result.Enabled).To(BeFalse())
+	})
+
+	Context("with an IPv6 node IP", func() {
+		// The node IP is a raw IPv6 address. probeNodeIpEndpoints must enclose it in brackets, both in the probe
+		// request URLs and in the resulting endpoint config, so the node IP based endpoints stay usable on IPv6
+		// clusters instead of falling through to the DNS-dependent node name endpoint.
+		ipv6CollectorConfig := util.CollectorConfig{NodeName: probeTestNodeName, NodeIp: probeTestNodeIpV6}
+
+		It("uses the bracketed node IP endpoint with verified TLS", func() {
+			probes := fakeKubeletStatsEndpointProbes(
+				map[string]error{probeTestNodeIpV6Endpoint: nil},
+				nil,
+			)
+			result, ok := executeProbes(ipv6CollectorConfig, probes, logger)
+			Expect(ok).To(BeTrue())
+			Expect(result.Enabled).To(BeTrue())
+			Expect(result.Endpoint).To(Equal(kubeletStatsNodeIpEndpointIpv6))
+			Expect(result.InsecureSkipVerify).To(BeFalse())
+			Expect(result.AuthType).To(Equal(kubeletStatsAuthTypeServiceAccount))
+		})
+
+		It("falls back to the bracketed node IP endpoint with insecure_skip_verify", func() {
+			probes := fakeKubeletStatsEndpointProbes(
+				map[string]error{probeTestNodeIpV6Endpoint: probeTestTlsError},
+				map[string]error{probeTestNodeIpV6Endpoint: nil},
+			)
+			result, ok := executeProbes(ipv6CollectorConfig, probes, logger)
+			Expect(ok).To(BeTrue())
+			Expect(result.Enabled).To(BeTrue())
+			Expect(result.Endpoint).To(Equal(kubeletStatsNodeIpEndpointIpv6))
+			Expect(result.InsecureSkipVerify).To(BeTrue())
+			Expect(result.AuthType).To(Equal(kubeletStatsAuthTypeServiceAccount))
+		})
+
+		It("falls back to the bracketed read-only node IP endpoint", func() {
+			probes := fakeKubeletStatsEndpointProbes(
+				map[string]error{
+					probeTestNodeIpV6Endpoint:   probeTestGenericError,
+					probeTestReadOnlyV6Endpoint: nil,
+				},
+				nil,
+			)
+			result, ok := executeProbes(ipv6CollectorConfig, probes, logger)
+			Expect(ok).To(BeTrue())
+			Expect(result.Enabled).To(BeTrue())
+			Expect(result.Endpoint).To(Equal(kubeletStatsReadOnlyEndpointIpv6))
+			Expect(result.InsecureSkipVerify).To(BeFalse())
+			Expect(result.AuthType).To(Equal(kubeletStatsAuthTypeNone))
+		})
+	})
+})

--- a/internal/collectors/otelcolresources/otelcol_resources.go
+++ b/internal/collectors/otelcolresources/otelcol_resources.go
@@ -5,12 +5,8 @@ package otelcolresources
 
 import (
 	"context"
-	"crypto/tls"
 	"errors"
 	"fmt"
-	"io"
-	"net"
-	"net/http"
 	"slices"
 	"strings"
 	"sync/atomic"
@@ -42,18 +38,8 @@ type OTelColResourceManager struct {
 	kubeletStatsReceiverConfig       atomic.Pointer[KubeletStatsReceiverConfig]
 }
 
-type endpointProbeFn func(util.CollectorConfig, logd.Logger) (KubeletStatsReceiverConfig, bool)
-
 const (
 	bogusDeploymentPatch = "{\"spec\":{\"strategy\":{\"$retainKeys\":[\"type\"],\"rollingUpdate\":null}}}"
-
-	kubeletStatsNodeNameEndpoint         = "https://${env:K8S_NODE_NAME}:10250"
-	kubeletStatsNodeIpEndpoint           = "https://${env:K8S_NODE_IP}:10250"
-	kubetletStatsReadyOnlyEndpoint       = "http://${env:K8S_NODE_IP}:10255"
-	kubeletStatsAuthTypeServiceAccount   = "serviceAccount"
-	kubeletStatsAuthTypeNone             = "none"
-	kubeletStatsSummaryPath              = "/stats/summary"
-	usingKubeletStatsReceiverEndpointMsg = "Using %s as kubeletstats receiver endpoint."
 )
 
 var (
@@ -66,13 +52,6 @@ var (
 		ConfigurationReloaderImage:        "ghcr.io/dash0hq/configuration-reloader:latest",
 		FilelogOffsetSyncImage:            "ghcr.io/dash0hq/filelog-offset-sync:latest",
 		FilelogOffsetVolumeOwnershipImage: "ghcr.io/dash0hq/filelog-offset-volume-ownership:latest",
-	}
-
-	httpClient     = &http.Client{}
-	insecureClient = &http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-		},
 	}
 )
 
@@ -591,171 +570,6 @@ func (m *OTelColResourceManager) determineKubeletstatsReceiverEndpoint(
 	// collector reconcile.
 	m.kubeletStatsReceiverConfig.Store(&kubeletStatsReceiverConfig)
 	return kubeletStatsReceiverConfig
-}
-
-func probeKubeletStatsEndpoint(collectorConfig util.CollectorConfig, logger logd.Logger) (KubeletStatsReceiverConfig, bool) {
-	if collectorConfig.NodeName == "" && collectorConfig.NodeIp == "" {
-		logger.Info(
-			"No K8s_NODE_NAME and no K8S_NODE_IP available, skipping kubeletstats receiver endpoint lookup. " +
-				"The kubeletstats receiver will be disabled. Some Kubernetes infrastructure metrics will be missing.",
-		)
-		return KubeletStatsReceiverConfig{Enabled: false}, false
-	}
-
-	logger.Info(fmt.Sprintf("Attempting DNS lookup for Kubernetes node name %s.", collectorConfig.NodeName))
-	_, err := net.LookupIP(collectorConfig.NodeName)
-	if err == nil {
-		logger.Info(fmt.Sprintf("DNS lookup for Kubernetes node name %s has been successful.", collectorConfig.NodeName))
-		endpoint := kubeletStatsNodeNameEndpoint
-
-		nodeNameEndpointWithPath := fmt.Sprintf("https://%s:10250%s", collectorConfig.NodeName, kubeletStatsSummaryPath)
-		logger.Info(fmt.Sprintf("Attempting probe request to %s.", nodeNameEndpointWithPath))
-		err = executeHttpRequest(httpClient, nodeNameEndpointWithPath)
-		if err == nil {
-			logger.Info(fmt.Sprintf("Probe request request to %s has been successful.", nodeNameEndpointWithPath))
-			logger.Info(fmt.Sprintf(usingKubeletStatsReceiverEndpointMsg, endpoint))
-			return KubeletStatsReceiverConfig{
-				Enabled:            true,
-				Endpoint:           endpoint,
-				AuthType:           kubeletStatsAuthTypeServiceAccount,
-				InsecureSkipVerify: false,
-			}, true
-		} else if isTlsError(err) {
-			logger.Info(
-				fmt.Sprintf(
-					"Failed to verify certificate for %s, adding insecure_skip_verify to kubeletstats receiver "+
-						"configuration. (%s)",
-					nodeNameEndpointWithPath,
-					err.Error(),
-				))
-			logger.Info(fmt.Sprintf(usingKubeletStatsReceiverEndpointMsg, endpoint))
-			return KubeletStatsReceiverConfig{
-				Enabled:            true,
-				Endpoint:           endpoint,
-				AuthType:           kubeletStatsAuthTypeServiceAccount,
-				InsecureSkipVerify: true,
-			}, true
-		}
-		logger.Info(
-			fmt.Sprintf(
-				"DNS lookup for Kubernetes node name %s has been successful, but the probe request to %s resulted "+
-					"in an error: %s. Will try using K8S_NODE_IP next.",
-				collectorConfig.NodeName,
-				nodeNameEndpointWithPath,
-				err.Error(),
-			))
-	} else {
-		logger.Info(
-			fmt.Sprintf(
-				"DNS lookup for Kubernetes node name %s failed with error: %s, will try K8S_NODE_IP next.",
-				collectorConfig.NodeName,
-				err.Error(),
-			))
-	}
-
-	nodeIpEndpointResultsInTlsError := false
-	nodeIpEndpointWithPath := fmt.Sprintf("https://%s:10250%s", collectorConfig.NodeIp, kubeletStatsSummaryPath)
-	logger.Info(fmt.Sprintf("Attempting probe request %s.", nodeIpEndpointWithPath))
-	err = executeHttpRequest(httpClient, nodeIpEndpointWithPath)
-	if err == nil {
-		endpoint := kubeletStatsNodeIpEndpoint
-		logger.Info(fmt.Sprintf("Probe request request %s has been successful.", nodeIpEndpointWithPath))
-		logger.Info(fmt.Sprintf(usingKubeletStatsReceiverEndpointMsg, endpoint))
-		return KubeletStatsReceiverConfig{
-			Enabled:            true,
-			Endpoint:           endpoint,
-			AuthType:           kubeletStatsAuthTypeServiceAccount,
-			InsecureSkipVerify: false,
-		}, true
-	}
-	if isTlsError(err) {
-		logger.Info(
-			fmt.Sprintf(
-				"Failed to verify certificate for %s. (%s)",
-				nodeIpEndpointWithPath,
-				err.Error(),
-			))
-		nodeIpEndpointResultsInTlsError = true
-	} else {
-		logger.Info(
-			fmt.Sprintf(
-				"The probe request to %s resulted in an error: %s. Will try the read-only endpoint next.",
-				nodeIpEndpointWithPath,
-				err.Error(),
-			))
-	}
-
-	readOnlyNodeIpEndpointWithPath := fmt.Sprintf("http://%s:10255%s", collectorConfig.NodeIp, kubeletStatsSummaryPath)
-	logger.Info(fmt.Sprintf("Attempting probe request to to read-only endpoint %s.", readOnlyNodeIpEndpointWithPath))
-	err = executeHttpRequest(httpClient, readOnlyNodeIpEndpointWithPath)
-	if err == nil {
-		endpoint := kubetletStatsReadyOnlyEndpoint
-		logger.Info(
-			fmt.Sprintf(
-				"Probe request request to read-only endpoint %s has been successful.",
-				readOnlyNodeIpEndpointWithPath,
-			),
-		)
-		logger.Info(fmt.Sprintf("Using read-only endpoint %s as kubeletstats receiver endpoint.", endpoint))
-		return KubeletStatsReceiverConfig{
-			Enabled:            true,
-			Endpoint:           endpoint,
-			AuthType:           kubeletStatsAuthTypeNone,
-			InsecureSkipVerify: false,
-		}, true
-	}
-	logger.Info(
-		fmt.Sprintf(
-			"The probe request to %s resulted in an error: %s.",
-			readOnlyNodeIpEndpointWithPath,
-			err.Error(),
-		))
-
-	if !nodeIpEndpointResultsInTlsError {
-		return KubeletStatsReceiverConfig{Enabled: false}, false
-	}
-
-	logger.Info(
-		fmt.Sprintf("Attempting probe request to %s without TLS certificate verification.", nodeIpEndpointWithPath),
-	)
-	err = executeHttpRequest(insecureClient, nodeIpEndpointWithPath)
-	if err == nil {
-		endpoint := kubeletStatsNodeIpEndpoint
-		logger.Info(
-			fmt.Sprintf(
-				"Probe request request to %s without TLS certificate verification has been successful.",
-				nodeIpEndpointWithPath,
-			))
-		logger.Info(fmt.Sprintf("Using %s as kubeletstats receiver endpoint with insecure_skip_verify: true.", endpoint))
-		return KubeletStatsReceiverConfig{
-			Enabled:            true,
-			Endpoint:           endpoint,
-			AuthType:           kubeletStatsAuthTypeServiceAccount,
-			InsecureSkipVerify: true,
-		}, true
-	}
-	logger.Info(
-		fmt.Sprintf(
-			"The probe request to %s without TLS certificate verification resulted in an error: %s.",
-			readOnlyNodeIpEndpointWithPath,
-			err.Error(),
-		))
-	return KubeletStatsReceiverConfig{Enabled: false}, false
-}
-
-func executeHttpRequest(httpClient *http.Client, endpoint string) error {
-	res, err := httpClient.Get(endpoint)
-	defer func() {
-		if res != nil {
-			_, _ = io.Copy(io.Discard, res.Body)
-			_ = res.Body.Close()
-		}
-	}()
-	return err
-}
-
-func isTlsError(err error) bool {
-	return strings.Contains(err.Error(), "tls: failed to verify certificate:")
 }
 
 func signalControlConfigFromResource(

--- a/internal/startup/operator_manager_startup.go
+++ b/internal/startup/operator_manager_startup.go
@@ -1454,7 +1454,7 @@ func startDash0Controllers(
 		images.GetOperatorVersion(),
 	)
 
-	isIPv6Cluster := strings.Count(envVars.podIp, ":") >= 2
+	isIPv6Cluster := util.IsIPv6Address(envVars.podIp)
 	possibleCollectorUrls := collectors.RenderCollectorBaseUrls(
 		envVars.oTelCollectorNamePrefix,
 		envVars.operatorNamespace,

--- a/internal/util/ip.go
+++ b/internal/util/ip.go
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: Copyright 2026 Dash0 Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package util
+
+import "net"
+
+// IsIPv6Address reports whether the given string is a valid IPv6 address literal. It returns false for IPv4 addresses
+// and for strings that are not valid IP addresses at all.
+func IsIPv6Address(ip string) bool {
+	parsed := net.ParseIP(ip)
+	return parsed != nil && parsed.To4() == nil
+}


### PR DESCRIPTION
This changes the probing logic used to auto-detect the endpoint used to configure the kubeletstats receiver.

Previously, the kubeletstats endpoint probe preferred the node-name endpoint (`https://${env:K8S_NODE_NAME}:10250`) for most cases.

The new order of preference is now:

1. Node IP with verified TLS
2. Node IP with insecure_skip_verify
3. Node IP with read-only port (:10255) (no auth, no encryption)
4. Node name with verified TLS
5. Node name with insecure_skip_verify
6. Receiver disabled

This is based on the design decision to prioritize robustness against in-cluster DNS issues over avoiding insecure_skip_verify (and also over avoiding unencrypted traffic via the read-only port). The metric scraping traffic
is node-local, it goes veth → host network stack and never touches the wire. To man-in-the-middle it, an attacker would need root/CAP_NET_ADMIN on that node. At that point they already own the kubelet and its cert, and TLS verification does no longer offer any protection.

The probe logic is also extracted into a separate file now. Its external interactions (HTTP probes) are extracted into an injectable struct so the endpoint selection logic can be unit-tested without relying on real DNS or network access.

Additionally, this fixes a bug that would have led to insecure_skip_verify in clusters that do not need it: Previously, the
http probe would have been executed only with the system cert pool of the operator manager container, without the in-cluster certs.

Now the probe trusts the system cert pool plus the cluster CA at "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt". This mirrors how kubeletstats receiver scrapes metrics. Hence, the probe more often correctly determines that insecure_skip_verify is not required.

Last but not least, IPv6 node IPs are now handled correctly by the probe.

Note: The probe is still only run once at startup, and the results will be used for the lifetime of the operator manager pod. Re-running the probe is out of scope for this PR.

Fixes #1203.