### PR TITLE
ci: use gh to commit, so commits are automatically signed

### DIFF
--- a/.github/workflows/scripts/sync-go-version-with-dockerfile.sh
+++ b/.github/workflows/scripts/sync-go-version-with-dockerfile.sh
@@ -18,6 +18,11 @@ if [[ -z "${HEAD_REF:-}" ]]; then
   exit 1
 fi
 
+if ! command -v gh &> /dev/null; then
+  echo "Error: the gh executable is not available." >&2
+  exit 1
+fi
+
 # Mapping of "Dockerfile:go.mod" pairs. Each Dockerfile's golang base image tag is the source of truth; the `go`
 # directive in the associated go.mod is updated to match it. The list intentionally only contains Dockerfiles that
 # build from a golang:* base image and have an associated go.mod file. images/collector has no tracked go.mod (the
@@ -79,14 +84,44 @@ if [[ "$changed" != "true" ]]; then
   exit 0
 fi
 
-git config user.name "github-actions[bot]"
-git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
-if git diff --quiet; then
+# Determine which go.mod files actually changed on disk.
+mapfile -t changed_files < <(git diff --name-only -- '*go.mod')
+if [[ ${#changed_files[@]} -eq 0 ]]; then
   echo "No file changes detected after processing, no commit needed."
   exit 0
 fi
 
-git add -- '*go.mod'
-git commit --message "chore(deps): sync go directive in go.mod with golang base image"
-git push origin "HEAD:${HEAD_REF}"
+commit_message="chore(deps): sync go directive in go.mod with golang base image"
+
+# The tip of the pull request's head branch, which the signed commit will be based on. We checked out this branch
+# (github.head_ref), so HEAD points at its tip.
+base_sha=$(git rev-parse HEAD)
+
+# Create the commit via the GitHub API rather than "git commit"/"git push", so commits are automatically signed.
+# Build the fileChanges.additions array, one entry per changed go.mod with its contents base64-encoded.
+additions=$(
+  for f in "${changed_files[@]}"; do
+    jq -n --arg path "$f" --arg contents "$(base64 -w0 "$f")" '{path: $path, contents: $contents}'
+  done | jq -s '.'
+)
+
+# expectedHeadOid is an optimistic lock: if Dependabot force-pushed the branch in the meantime, its tip no longer
+# matches base_sha and the mutation fails instead of clobbering that push (the concurrency group also cancels
+# superseded runs).
+jq -n \
+  --arg repo "$GITHUB_REPOSITORY" \
+  --arg branch "$HEAD_REF" \
+  --arg headline "$commit_message" \
+  --arg oid "$base_sha" \
+  --argjson additions "$additions" \
+  '{
+    query: "mutation($input: CreateCommitOnBranchInput!) { createCommitOnBranch(input: $input) { commit { oid } } }",
+    variables: {
+      input: {
+        branch:          { repositoryNameWithOwner: $repo, branchName: $branch },
+        message:         { headline: $headline },
+        expectedHeadOid: $oid,
+        fileChanges:     { additions: $additions }
+      }
+    }
+  }' | gh api graphql --input - >/dev/null

--- a/.github/workflows/scripts/update-opentelemetry-injector-check-if-pr-exists.sh
+++ b/.github/workflows/scripts/update-opentelemetry-injector-check-if-pr-exists.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright 2026 Dash0 Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+if ! command -v gh &> /dev/null; then
+  echo "Error: the gh executable is not available." >&2
+  exit 1
+fi
+
+gh pr list --json title | grep "chore(deps): update opentelemetry-injector" || true
+if gh pr list --json title | grep "chore(deps): update opentelemetry-injector"; then
+  echo pr_exists=true >> "$GITHUB_OUTPUT"
+  echo "There is already an open pull request to update the opentelemetry-injector, remaining steps will be skipped."
+else
+  echo pr_exists=false >> "$GITHUB_OUTPUT"
+  echo "No open pull request to update the opentelemetry-injector exists, continuing with the workflow."
+fi

--- a/.github/workflows/scripts/update-opentelemetry-injector-create-pr.sh
+++ b/.github/workflows/scripts/update-opentelemetry-injector-create-pr.sh
@@ -10,40 +10,26 @@ if ! command -v gh &> /dev/null; then
   exit 1
 fi
 
-branch_name="update-dash0-collector-components"
-config_file="images/collector/src/builder/config.yaml"
+branch_name="update-opentelemetry-injector"
+version_file="images/instrumentation/opentelemetry-injector/version"
 
 # Base commit that the new branch will be based on.
 base_sha=$(git rev-parse HEAD)
 
-COLLECTOR_VERSIONS_OUTPUT=$(mktemp)
-export COLLECTOR_VERSIONS_OUTPUT
-trap 'rm -f "$COLLECTOR_VERSIONS_OUTPUT"' EXIT
-.github/workflows/scripts/update-collector-components-check-and-bump-versions.sh
-# shellcheck source=/dev/null
-source "$COLLECTOR_VERSIONS_OUTPUT"
+images/instrumentation/opentelemetry-injector/update.sh
 
 # git diff-files --quiet exits with 1 if there were differences, exit code 0 means no differences.
-if git diff-files --quiet "$config_file"; then
+if git diff-files --quiet "$version_file"; then
   echo "There are no changes, everything up to date."
   exit 0
 fi
 
 echo "There are changes, creating a pull request."
-
-commit_message="chore(deps): bump Dash0 collector components"
-pr_body=""
-# Note: new_stable_version etc. are sourced from $COLLECTOR_VERSIONS_OUTPUT, which is populated by
-# .github/workflows/scripts/update-collector-components-check-and-bump-versions.sh.
-# shellcheck disable=SC2154
-if [[ -n "${new_stable_version:-}" && -n "${new_beta_version:-}" && -n "${new_contrib_version:-}" ]]; then
-  commit_message="chore(deps): bump Dash0 collector components (${new_stable_version}/${new_beta_version}/${new_contrib_version})"
-  pr_body=$(printf 'Update to:\n- core stable version: %s\n- core beta version: v%s\n- contrib version: v%s' \
-    "$new_stable_version" "$new_beta_version" "$new_contrib_version")
-fi
+new_version=$(cat "$version_file")
+commit_message="chore(deps): update opentelemetry-injector to ${new_version}"
 
 # Remove any branch lingering from a previous failed run (no-op if it does not exist). Note: We abort early if an open
-# PR still exists, see .github/workflows/scripts/update-collector-components-check-if-pr-exists.sh.
+# PR still exists, see .github/workflows/scripts/update-opentelemetry-injector-check-if-pr-exists.sh.
 gh api --method DELETE "repos/${GITHUB_REPOSITORY}/git/refs/heads/${branch_name}" >/dev/null 2>&1 || true
 
 # createCommitOnBranch can only commit onto a branch that already exists. Create the PR branch at the base commit.
@@ -58,16 +44,15 @@ jq -n \
   --arg repo "$GITHUB_REPOSITORY" \
   --arg branch "$branch_name" \
   --arg headline "$commit_message" \
-  --arg body "$pr_body" \
   --arg oid "$base_sha" \
-  --arg path "$config_file" \
-  --arg contents "$(base64 -w0 "$config_file")" \
+  --arg path "$version_file" \
+  --arg contents "$(base64 -w0 "$version_file")" \
   '{
     query: "mutation($input: CreateCommitOnBranchInput!) { createCommitOnBranch(input: $input) { commit { oid } } }",
     variables: {
       input: {
         branch:          { repositoryNameWithOwner: $repo, branchName: $branch },
-        message:         { headline: $headline, body: $body },
+        message:         { headline: $headline },
         expectedHeadOid: $oid,
         fileChanges:     { additions: [ { path: $path, contents: $contents } ] }
       }
@@ -78,4 +63,4 @@ gh pr create \
   -B main \
   -H "$branch_name" \
   --title "$commit_message" \
-  --body "$pr_body"
+  --body "This PR updates the opentelemetry-injector version to ${new_version}."

--- a/.github/workflows/sync-go-version-with-dockerfile.yaml
+++ b/.github/workflows/sync-go-version-with-dockerfile.yaml
@@ -54,4 +54,5 @@ jobs:
         shell: bash
         env:
           HEAD_REF: ${{ github.head_ref }}
+          GH_TOKEN: ${{ github.token }}
         run: .github/workflows/scripts/sync-go-version-with-dockerfile.sh

--- a/.github/workflows/update-opentelemetry-injector.yaml
+++ b/.github/workflows/update-opentelemetry-injector.yaml
@@ -20,42 +20,11 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
-        run: |
-          gh pr list --json title | grep "chore(deps): update opentelemetry-injector" || true
-          if gh pr list --json title | grep "chore(deps): update opentelemetry-injector"; then
-            echo pr_exists=true >> $GITHUB_OUTPUT
-            echo "There is already an open pull request to update the opentelemetry-injector, remaining steps will be skipped."
-          else
-            echo pr_exists=false >> $GITHUB_OUTPUT
-            echo "No open pull request to update the opentelemetry-injector exists, continuing with the workflow."
-          fi
+        run: .github/workflows/scripts/update-opentelemetry-injector-check-if-pr-exists.sh
 
       - name: update opentelemetry-injector version and create PR
         if: steps.open_pr_exists.outputs.pr_exists != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         shell: bash
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          branch_name="update-opentelemetry-injector"
-          git checkout -b $branch_name
-
-          images/instrumentation/opentelemetry-injector/update.sh
-
-          # git diff-files --quiet exits with 1 if there were differences, exit code 0 means no differences.
-          if git diff-files --quiet images/instrumentation/opentelemetry-injector/version; then
-            echo "There are no changes, everything up to date."
-          else
-            echo "There are changes, creating a pull request."
-            new_version=$(cat images/instrumentation/opentelemetry-injector/version)
-            git add images/instrumentation/opentelemetry-injector/version
-            git commit --message "chore(deps): update opentelemetry-injector to ${new_version}"
-
-            git push -u origin "$branch_name"
-            gh pr create \
-              -B main \
-              -H $branch_name \
-              --title "chore(deps): update opentelemetry-injector to ${new_version}" \
-              --body "This PR updates the opentelemetry-injector version to ${new_version}."
-          fi
+        run: .github/workflows/scripts/update-opentelemetry-injector-create-pr.sh


### PR DESCRIPTION
For all automated workflows that commit and push, that is:
- update-collector-components.yaml
- update-opentelemetry-injector.yaml
- sync-go-version-with-dockerfile.yaml

For the record, I'm aware that we plan to replace sync-go-version-with-dockerfile.yaml with something else, but I don't want to break existing workflows when enforcing signed commits, hence this one gets updated in this PR as well.