### PR TITLE
test(e2e): collect logs from ingress-nginx and other missing namespaces

### DIFF
--- a/test/e2e/cert_manager.go
+++ b/test/e2e/cert_manager.go
@@ -20,7 +20,8 @@ type certificateValues struct {
 }
 
 const (
-	certmanagerVersion = "v1.18.2"
+	certmanagerVersion   = "v1.18.2"
+	certManagerNamespace = "cert-manager"
 )
 
 var (
@@ -32,7 +33,7 @@ var (
 )
 
 func ensureCertManagerIsInstalled() {
-	err := runAndIgnoreOutput(exec.Command("kubectl", "get", "ns", "cert-manager"), false)
+	err := runAndIgnoreOutput(exec.Command("kubectl", "get", "ns", certManagerNamespace), false)
 	if err != nil {
 		By("installing the cert-manager")
 		e2ePrint(
@@ -78,7 +79,7 @@ func installCertManager() error {
 		"cert-manager",
 		"jetstack/cert-manager",
 		"--namespace",
-		"cert-manager",
+		certManagerNamespace,
 		"--create-namespace",
 		"--version",
 		certmanagerVersion,
@@ -100,7 +101,7 @@ func installCertManager() error {
 			"--for",
 			"condition=Available",
 			"--namespace",
-			"cert-manager",
+			certManagerNamespace,
 			"--timeout",
 			"5m",
 		)); err != nil {
@@ -114,7 +115,7 @@ func installCertManager() error {
 			"--for",
 			"condition=Available",
 			"--namespace",
-			"cert-manager",
+			certManagerNamespace,
 			"--timeout",
 			"60s",
 		)); err != nil {
@@ -128,7 +129,7 @@ func installCertManager() error {
 			"--for",
 			"condition=Available",
 			"--namespace",
-			"cert-manager",
+			certManagerNamespace,
 			"--timeout",
 			"60s",
 		)); err != nil {
@@ -155,7 +156,7 @@ func uninstallCertManager() {
 		"uninstall",
 		"cert-manager",
 		"--namespace",
-		"cert-manager",
+		certManagerNamespace,
 		"--ignore-not-found",
 	)); err != nil {
 		e2ePrint("warning: %v\n", err)
@@ -163,7 +164,7 @@ func uninstallCertManager() {
 
 	if err := runAndIgnoreOutput(
 		exec.Command(
-			"kubectl", "delete", "namespace", "cert-manager", "--ignore-not-found")); err != nil {
+			"kubectl", "delete", "namespace", certManagerNamespace, "--ignore-not-found")); err != nil {
 		e2ePrint("warning: %v\n", err)
 	}
 }

--- a/test/e2e/collect_logs_on_fail.go
+++ b/test/e2e/collect_logs_on_fail.go
@@ -69,9 +69,13 @@ func collectPodInfoAndLogs(specReport SpecReport) {
 
 	e2eTestNamespaces := getNamespacesWithPrefix("e2e-test-ns", outputPath)
 	for _, namespace := range append([]string{
+		certManagerNamespace,
+		controlPlaneMockNamespace,
+		dash0ApiMockNamespace,
+		decisionMakerMockNamespace,
+		ingressNginxNamespace,
 		operatorNamespace,
 		otlpSinkNamespace,
-		dash0ApiMockNamespace,
 		outboundConnectorMockNamespace,
 	}, e2eTestNamespaces...) {
 		executeCommandAndStoreOutput(fmt.Sprintf("kubectl -n %s get pods", namespace), outputPath)

--- a/test/e2e/ingress.go
+++ b/test/e2e/ingress.go
@@ -12,6 +12,10 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+const (
+	ingressNginxNamespace = "ingress-nginx"
+)
+
 func ensureNginxIngressControllerIsInstalled(cleanupSteps *neccessaryCleanupSteps) {
 	if os.Getenv("DEPLOY_NGINX_INGRESS") == "false" {
 		return
@@ -22,7 +26,7 @@ func ensureNginxIngressControllerIsInstalled(cleanupSteps *neccessaryCleanupStep
 			"kubectl",
 			"wait",
 			"--namespace",
-			"ingress-nginx",
+			ingressNginxNamespace,
 			"--for=condition=ready",
 			"pod",
 			"--selector=app.kubernetes.io/component=controller",
@@ -53,7 +57,7 @@ func installNginxIngressController(cleanupSteps *neccessaryCleanupSteps) {
 		"kubectl",
 		"wait",
 		"--namespace",
-		"ingress-nginx",
+		ingressNginxNamespace,
 		"--for=condition=ready",
 		"pod",
 		"--selector=app.kubernetes.io/component=controller",
@@ -72,7 +76,7 @@ func installNginxIngressController(cleanupSteps *neccessaryCleanupSteps) {
 			"kubectl",
 			"get",
 			"--namespace",
-			"ingress-nginx",
+			ingressNginxNamespace,
 			"service",
 			"ingress-nginx-controller-admission",
 		))).To(Succeed())
@@ -80,7 +84,7 @@ func installNginxIngressController(cleanupSteps *neccessaryCleanupSteps) {
 			"kubectl",
 			"get",
 			"--namespace",
-			"ingress-nginx",
+			ingressNginxNamespace,
 			"endpointslice",
 			"-l",
 			"kubernetes.io/service-name=ingress-nginx-controller-admission",
@@ -92,7 +96,7 @@ func installNginxIngressController(cleanupSteps *neccessaryCleanupSteps) {
 			"kubectl",
 			"get",
 			"--namespace",
-			"ingress-nginx",
+			ingressNginxNamespace,
 			"endpointslice",
 			"-l",
 			"kubernetes.io/service-name=ingress-nginx-controller-admission",

--- a/test/e2e/setup_teardown.go
+++ b/test/e2e/setup_teardown.go
@@ -22,9 +22,9 @@ var (
 	kubernetesMinor int
 
 	standardNamespaces = []string{
-		"cert-manager",
+		certManagerNamespace,
 		"default",
-		"ingress-nginx",
+		ingressNginxNamespace,
 	}
 )
 


### PR DESCRIPTION
Add all missing relevant namespaces that are used in e2e tests to collectPodInfoAndLogs.