### PR TITLE
Revert "test: bump otel/opentelemetry-collector-ebpf-profiler from 0.153.0 to 0.157.0 in /test-resources/ebpf-profiler/helm-chart"

### DIFF
--- a/test-resources/ebpf-profiler/helm-chart/values.yaml
+++ b/test-resources/ebpf-profiler/helm-chart/values.yaml
@@ -3,7 +3,7 @@
 
 image:
   repository: otel/opentelemetry-collector-ebpf-profiler
-  tag: 0.157.0
+  tag: 0.153.0
 
 collector:
   endpoint: dash0-operator-opentelemetry-collector-service.dash0-system.svc.cluster.local:4317


### PR DESCRIPTION
Reverts dash0hq/dash0-operator#1251