### PR TITLE
chore(e2e): exclude profiling e2e tests by default

### DIFF
--- a/test-resources/.env.template
+++ b/test-resources/.env.template
@@ -5,6 +5,9 @@ E2E_KUBECTX=docker-desktop
 # Print details about each request sent to the application under test.
 # E2E_VERBOSE_HTTP=false
 
+# Include the profiling e2e tests (eBPF profiler). Off by default; the eBPF profiler does not work in kind.
+# E2E_INCLUDE_PROFILING_TESTS=true
+
 # A comma separated lists of kube context names that the scripts in test-resources/bin are allowed to talk to. This is a
 # safety measure to prevent local tests to accidentally modify a production cluster.
 ALLOWED_KUBECTXS=docker-desktop,kind-dash0-operator-lab

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -61,6 +61,7 @@ var _ = Describe("Dash0 Operator", Ordered, ContinueOnFailure, func() {
 
 		e2eKubernetesContext = os.Getenv("E2E_KUBECTX")
 		verboseHttp = strings.ToLower(os.Getenv("E2E_VERBOSE_HTTP")) == "true"
+		includeProfilingTests = strings.ToLower(os.Getenv("E2E_INCLUDE_PROFILING_TESTS")) == "true"
 		if e2eKubernetesContext == "" {
 			Fail(
 				fmt.Sprintf(
@@ -3818,6 +3819,10 @@ trace_statements:
 
 	Context("with an existing operator deployment and profiling enabled", func() {
 		BeforeAll(func() {
+			if !includeProfilingTests {
+				Skip("profiling e2e tests are excluded by default because the eBPF profiler does not work in kind; " +
+					"set E2E_INCLUDE_PROFILING_TESTS=true to include them")
+			}
 			By("deploying the Dash0 operator with profiling enabled")
 			deployOperatorWithDefaultAutoOperationConfiguration(
 				operatorNamespace,
@@ -3840,6 +3845,9 @@ trace_statements:
 		})
 
 		AfterAll(func() {
+			if !includeProfilingTests {
+				return
+			}
 			removeAllTestApplications(applicationUnderTestNamespace)
 			undeployDash0MonitoringResource(applicationUnderTestNamespace)
 			teardownEbpfProfiler(operatorNamespace)

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -25,9 +25,10 @@ import (
 )
 
 var (
-	verboseHttp          bool
-	e2eKubernetesContext string
-	testAppBaseUrl       string
+	verboseHttp           bool
+	includeProfilingTests bool
+	e2eKubernetesContext  string
+	testAppBaseUrl        string
 )
 
 func determineTestAppBaseUrl(port string) {


### PR DESCRIPTION
Excludes the profiling e2e tests by default since the `ebpf-profiler` currently doesn't work correctly in kind.

The tests can still be enabled when running the e2e tests on e.g. EKS.