### PR TITLE
docs: update supported runtimes

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,17 @@ runtimes, automatic log collection and metrics.
 
 ### Distributed tracing
 
-Auto-instrumentation if supported for the following runtimes:
+Auto-instrumentation is supported for the following runtimes:
 
 * Node.js 16+, using
   [Dash0 Node.js OpenTelemetry distribution](https://github.com/dash0hq/opentelemetry-js-distribution)
 * Java 8+, using the [OpenTelemetry Java agent](https://github.com/open-telemetry/opentelemetry-java-instrumentation)
+* .NET, using the
+  [OpenTelemetry .NET automatic instrumentation](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation)
+* Python 3.10+ (opt-in), using the
+  [Dash0 Python OpenTelemetry distribution](https://github.com/dash0hq/opentelemetry-python-distribution)
+* Ruby 3.3+ (opt-in), using the
+  [Dash0 Ruby OpenTelemetry distribution](https://github.com/dash0hq/opentelemetry-ruby-distribution)
 
 For more information on how the Dash0 operator automatically traces your applications, see the
 [Automatic Workload Instrumentation](https://www.dash0.com/docs/dash0/monitoring/kubernetes/dash0-operator/auto-instrumentation)

--- a/helm-chart/dash0-operator/docs/configuration.md
+++ b/helm-chart/dash0-operator/docs/configuration.md
@@ -819,7 +819,7 @@ re-deployment of the workload.
 The setting has no effect on workloads in namespaces that use `instrumentWorkloads.mode=none` or do not have a
 Dash0Monitoring resource.
 
-Python auto-instrumentation is only supported for Python 3.9 or later.
+Python auto-instrumentation is only supported for Python 3.10 or later.
 If the Dash0 Python auto-instrumentation detects an incompatible Python version (i.e. version 3.9 or older), it will
 automatically deactivate itself safely and print a warning to `stderr`:
 ```


### PR DESCRIPTION
The updates supported runtimes for new additions and previous omissions. It will be accurate once #1268 merges.