### PR TITLE
fix(target-allocator): assign targets that have no node

### DIFF
--- a/internal/targetallocator/taresources/desired_state.go
+++ b/internal/targetallocator/taresources/desired_state.go
@@ -78,7 +78,18 @@ type ConfigMapParams struct {
 	CertsDir    string
 }
 
+// The per-node strategy assigns each target to the collector running on that
+// target's node, which is what gives the collector DaemonSet its node locality.
+// A target that is not a pod -- anything a ScrapeConfig points at outside the
+// cluster, such as a hosted message broker or database -- has no node, so
+// per-node on its own can never assign it: the allocator reports "could not
+// find collector for node" for it indefinitely and it is never scraped.
+//
+// The fallback is consulted only for targets with no node name, so pod scraping
+// keeps its locality unchanged while external targets are distributed across
+// the collectors by consistent hashing instead of being dropped.
 const targetAllocatorTemplate = `allocation_strategy: per-node
+allocation_fallback_strategy: consistent-hashing
 collector_namespace: {{ .CollectorNamespace }}
 collector_selector:
   matchLabels:

--- a/test/util/targetallocator/resources.go
+++ b/test/util/targetallocator/resources.go
@@ -193,6 +193,10 @@ func VerifyTargetAllocatorConfigMap(
 	Expect(cm.Data).To(HaveKey("targetallocator.yaml"))
 	config := cm.Data["targetallocator.yaml"]
 	Expect(config).To(ContainSubstring("allocation_strategy: per-node"))
+	// Without the fallback, targets that have no node -- everything a
+	// ScrapeConfig points at outside the cluster -- are never assigned to a
+	// collector and are silently never scraped.
+	Expect(config).To(ContainSubstring("allocation_fallback_strategy: consistent-hashing"))
 	Expect(config).To(ContainSubstring("prometheus_cr:"))
 	Expect(config).To(ContainSubstring("enabled: true"))
 	return cm


### PR DESCRIPTION
### The problem

The generated target-allocator config sets `allocation_strategy: per-node` with no fallback strategy. `per-node` assigns a target to the collector running on that target's node, which is what gives the collector DaemonSet its locality for pod targets. A target that has no node is assigned to no collector at all: `perNodeStrategy.GetCollectorForTarget` returns `could not find collector for node` unless a fallback is configured.

Targets without a node are exactly the ones a `ScrapeConfig` points at outside the cluster — a hosted broker, a managed database, anything reached by `staticConfigs` or `httpSDConfigs`. With `operator.prometheusCrdSupportEnabled: true`, applying such a ScrapeConfig currently appears to work at every step an operator can observe:

- the `ScrapeConfig` is accepted,
- the allocator picks it up (`Service Discovery watch event received`),
- the collector receives the job (`Scrape job added`),

and then collects nothing, permanently. The only signal is one info-level line per cycle:

```
{"level":"info","logger":"allocator","msg":"Could not assign targets for some jobs",
 "allocator":"per-node","targets":1,"error":"could not find collector for node "}
```

We hit this scraping CloudAMQP and MongoDB Atlas from a GKE Autopilot cluster and spent a while looking for the fault in our own ScrapeConfigs, certificates and credentials before finding it here.

### The change

Set `allocation_fallback_strategy: consistent-hashing` in the template. Upstream consults the fallback [only when the target has no node name](https://github.com/open-telemetry/opentelemetry-operator/blob/main/cmd/otel-allocator/internal/allocation/per_node.go#L37-L40):

```go
targetNodeName := item.GetNodeName()
if targetNodeName == "" && s.fallbackStrategy != nil {
    return s.fallbackStrategy.GetCollectorForTarget(collectors, item)
}
```

so pod scraping keeps its node locality unchanged and only the targets `per-node` cannot place are distributed by consistent hashing.

### Verification

Built from this branch and run on a kind cluster with `prometheusCrdSupportEnabled: true`, one namespace with `prometheusScraping` enabled, and a single ScrapeConfig with an external static target.

Before, querying the allocator for that job:

```json
{"...collector-agent-daemonset-6j2rt":{"targets":[]}}
```

After, same cluster, same ScrapeConfig, only the operator image changed:

```json
{"...collector-agent-daemonset-6kh8p":{"targets":[
  {"targets":["example.com:443"],"labels":{"__address__":"example.com:443"}}]}}
```

and the `could not find collector for node` line is gone.

`make go-unit-tests` passes. `VerifyTargetAllocatorConfigMap` asserts the new key, since its absence is invisible until someone points a ScrapeConfig outside the cluster.

### Note

We could not verify this on our own GKE Autopilot cluster: the warden webhook pins the operator image to `^ghcr\.io/dash0hq/(gke-ap-)?operator-controller$`, so a patched build is rejected at admission. On Autopilot there is no workaround available to users — an upstream release is the only route.