### PR TITLE
ci: add weekly update workflows for Python and Ruby distributions

### DIFF
--- a/.github/workflows/scripts/update-python-distribution-check-if-pr-exists.sh
+++ b/.github/workflows/scripts/update-python-distribution-check-if-pr-exists.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright 2026 Dash0 Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+if ! command -v gh &> /dev/null; then
+  echo "Error: the gh executable is not available." >&2
+  exit 1
+fi
+
+gh pr list --json title | grep "chore(deps): update opentelemetry-python-distribution" || true
+if gh pr list --json title | grep "chore(deps): update opentelemetry-python-distribution"; then
+  echo pr_exists=true >> "$GITHUB_OUTPUT"
+  echo "There is already an open pull request to update the opentelemetry-python-distribution, remaining steps will be skipped."
+else
+  echo pr_exists=false >> "$GITHUB_OUTPUT"
+  echo "No open pull request to update the opentelemetry-python-distribution exists, continuing with the workflow."
+fi

--- a/.github/workflows/scripts/update-python-distribution-create-pr.sh
+++ b/.github/workflows/scripts/update-python-distribution-create-pr.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright 2026 Dash0 Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+if ! command -v gh &> /dev/null; then
+  echo "Error: the gh executable is not available." >&2
+  exit 1
+fi
+
+branch_name="update-python-distribution"
+version_file="images/instrumentation/python/dash0-python-distribution-version"
+
+base_sha=$(git rev-parse HEAD)
+
+images/instrumentation/python/update.sh
+
+if git diff-files --quiet "$version_file"; then
+  echo "There are no changes, everything up to date."
+  exit 0
+fi
+
+echo "There are changes, creating a pull request."
+new_version=$(cat "$version_file")
+commit_message="chore(deps): update opentelemetry-python-distribution to ${new_version}"
+
+gh api --method DELETE "repos/${GITHUB_REPOSITORY}/git/refs/heads/${branch_name}" >/dev/null 2>&1 || true
+
+gh api --method POST "repos/${GITHUB_REPOSITORY}/git/refs" \
+  -f ref="refs/heads/${branch_name}" \
+  -f sha="${base_sha}" >/dev/null
+
+jq -n \
+  --arg repo "$GITHUB_REPOSITORY" \
+  --arg branch "$branch_name" \
+  --arg headline "$commit_message" \
+  --arg oid "$base_sha" \
+  --arg path "$version_file" \
+  --arg contents "$(base64 -w0 "$version_file")" \
+  '{
+    query: "mutation($input: CreateCommitOnBranchInput!) { createCommitOnBranch(input: $input) { commit { oid } } }",
+    variables: {
+      input: {
+        branch:          { repositoryNameWithOwner: $repo, branchName: $branch },
+        message:         { headline: $headline },
+        expectedHeadOid: $oid,
+        fileChanges:     { additions: [ { path: $path, contents: $contents } ] }
+      }
+    }
+  }' | gh api graphql --input - >/dev/null
+
+gh pr create \
+  -B main \
+  -H "$branch_name" \
+  --title "$commit_message" \
+  --body "This PR updates the opentelemetry-python-distribution version to ${new_version}."

--- a/.github/workflows/scripts/update-ruby-distribution-check-if-pr-exists.sh
+++ b/.github/workflows/scripts/update-ruby-distribution-check-if-pr-exists.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright 2026 Dash0 Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+if ! command -v gh &> /dev/null; then
+  echo "Error: the gh executable is not available." >&2
+  exit 1
+fi
+
+gh pr list --json title | grep "chore(deps): update opentelemetry-ruby-distribution" || true
+if gh pr list --json title | grep "chore(deps): update opentelemetry-ruby-distribution"; then
+  echo pr_exists=true >> "$GITHUB_OUTPUT"
+  echo "There is already an open pull request to update the opentelemetry-ruby-distribution, remaining steps will be skipped."
+else
+  echo pr_exists=false >> "$GITHUB_OUTPUT"
+  echo "No open pull request to update the opentelemetry-ruby-distribution exists, continuing with the workflow."
+fi

--- a/.github/workflows/scripts/update-ruby-distribution-create-pr.sh
+++ b/.github/workflows/scripts/update-ruby-distribution-create-pr.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright 2026 Dash0 Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+if ! command -v gh &> /dev/null; then
+  echo "Error: the gh executable is not available." >&2
+  exit 1
+fi
+
+branch_name="update-ruby-distribution"
+version_file="images/instrumentation/ruby/dash0-ruby-distribution-version"
+
+base_sha=$(git rev-parse HEAD)
+
+images/instrumentation/ruby/update.sh
+
+if git diff-files --quiet "$version_file"; then
+  echo "There are no changes, everything up to date."
+  exit 0
+fi
+
+echo "There are changes, creating a pull request."
+new_version=$(cat "$version_file")
+commit_message="chore(deps): update opentelemetry-ruby-distribution to ${new_version}"
+
+gh api --method DELETE "repos/${GITHUB_REPOSITORY}/git/refs/heads/${branch_name}" >/dev/null 2>&1 || true
+
+gh api --method POST "repos/${GITHUB_REPOSITORY}/git/refs" \
+  -f ref="refs/heads/${branch_name}" \
+  -f sha="${base_sha}" >/dev/null
+
+jq -n \
+  --arg repo "$GITHUB_REPOSITORY" \
+  --arg branch "$branch_name" \
+  --arg headline "$commit_message" \
+  --arg oid "$base_sha" \
+  --arg path "$version_file" \
+  --arg contents "$(base64 -w0 "$version_file")" \
+  '{
+    query: "mutation($input: CreateCommitOnBranchInput!) { createCommitOnBranch(input: $input) { commit { oid } } }",
+    variables: {
+      input: {
+        branch:          { repositoryNameWithOwner: $repo, branchName: $branch },
+        message:         { headline: $headline },
+        expectedHeadOid: $oid,
+        fileChanges:     { additions: [ { path: $path, contents: $contents } ] }
+      }
+    }
+  }' | gh api graphql --input - >/dev/null
+
+gh pr create \
+  -B main \
+  -H "$branch_name" \
+  --title "$commit_message" \
+  --body "This PR updates the opentelemetry-ruby-distribution version to ${new_version}."

--- a/.github/workflows/update-python-distribution.yaml
+++ b/.github/workflows/update-python-distribution.yaml
@@ -1,0 +1,30 @@
+name: Check for Dash0 Python Distribution Updates
+
+on:
+  schedule:
+    - cron: "35 09 * * MON"
+
+  workflow_dispatch:
+
+jobs:
+  check-and-update:
+    name: check for new opentelemetry-python-distribution release and update version file
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+
+      - name: check if open PR already exists
+        id: open_pr_exists
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: .github/workflows/scripts/update-python-distribution-check-if-pr-exists.sh
+
+      - name: update opentelemetry-python-distribution version and create PR
+        if: steps.open_pr_exists.outputs.pr_exists != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: .github/workflows/scripts/update-python-distribution-create-pr.sh

--- a/.github/workflows/update-ruby-distribution.yaml
+++ b/.github/workflows/update-ruby-distribution.yaml
@@ -1,0 +1,30 @@
+name: Check for Dash0 Ruby Distribution Updates
+
+on:
+  schedule:
+    - cron: "40 09 * * MON"
+
+  workflow_dispatch:
+
+jobs:
+  check-and-update:
+    name: check for new opentelemetry-ruby-distribution release and update version file
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+
+      - name: check if open PR already exists
+        id: open_pr_exists
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: .github/workflows/scripts/update-ruby-distribution-check-if-pr-exists.sh
+
+      - name: update opentelemetry-ruby-distribution version and create PR
+        if: steps.open_pr_exists.outputs.pr_exists != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: .github/workflows/scripts/update-ruby-distribution-create-pr.sh

--- a/images/instrumentation/python/update.sh
+++ b/images/instrumentation/python/update.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright 2026 Dash0 Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+echo "Checking for new opentelemetry-python-distribution releases..."
+
+latest_version=$(gh release list --repo dash0hq/opentelemetry-python-distribution --limit 1 --json tagName --jq '.[0].tagName')
+
+if [[ -z "$latest_version" ]] || [[ "$latest_version" = "null" ]]; then
+  echo "Error: Could not fetch latest release from GitHub" >&2
+  exit 1
+fi
+
+echo "Latest release: $latest_version"
+
+if [[ ! "$latest_version" =~ ^v[0-9]+\.[0-9]+\.[0-9]+.*$ ]]; then
+  echo "Error: Invalid version format: $latest_version" >&2
+  exit 1
+fi
+
+current_version=$(cat dash0-python-distribution-version)
+echo "Current version: $current_version"
+
+if [[ "$current_version" = "$latest_version" ]]; then
+  echo "Already up to date"
+  exit 0
+fi
+
+echo "Updating version from $current_version to $latest_version"
+echo "$latest_version" > dash0-python-distribution-version
+
+echo "Version file updated successfully"

--- a/images/instrumentation/ruby/update.sh
+++ b/images/instrumentation/ruby/update.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright 2026 Dash0 Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+echo "Checking for new opentelemetry-ruby-distribution releases..."
+
+latest_version=$(gh release list --repo dash0hq/opentelemetry-ruby-distribution --limit 1 --json tagName --jq '.[0].tagName')
+
+if [[ -z "$latest_version" ]] || [[ "$latest_version" = "null" ]]; then
+  echo "Error: Could not fetch latest release from GitHub" >&2
+  exit 1
+fi
+
+echo "Latest release: $latest_version"
+
+if [[ ! "$latest_version" =~ ^v[0-9]+\.[0-9]+\.[0-9]+.*$ ]]; then
+  echo "Error: Invalid version format: $latest_version" >&2
+  exit 1
+fi
+
+current_version=$(cat dash0-ruby-distribution-version)
+echo "Current version: $current_version"
+
+if [[ "$current_version" = "$latest_version" ]]; then
+  echo "Already up to date"
+  exit 0
+fi
+
+echo "Updating version from $current_version to $latest_version"
+echo "$latest_version" > dash0-ruby-distribution-version
+
+echo "Version file updated successfully"


### PR DESCRIPTION
Stacked on #1268.

Adds weekly GitHub Actions workflows for the Dash0 Python and Ruby distributions, mirroring the existing `update-opentelemetry-injector` workflow.

Each distribution gets:
- An `update.sh` script in its component directory that queries `gh release list` on the upstream repo and rewrites the version file when a newer `vX.Y.Z` tag is available.
- A `check-if-pr-exists` script that short-circuits the workflow if a bump PR is already open.
- A `create-pr` script that commits the version file change via the GitHub GraphQL API (signed commit) and opens the pull request.
- A workflow file that runs the two scripts every Monday morning (09:35 for Python, 09:40 for Ruby, staggered after the injector at 09:30).

Both distributions currently pin a commit SHA in their version files (no release has been cut yet). Once either repo publishes its first `vX.Y.Z` release, the workflow will open a PR automatically.