### PR TITLE
ci(python): remove outdated dependabot entry

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -54,23 +54,6 @@ updates:
     commit-message:
       prefix: "chore(deps)"
 
-  # OpenTelemetry Distro for Python
-  - package-ecosystem: "pip"
-    directory: "images/instrumentation/python/"
-    schedule:
-      interval: "daily"
-      time: "09:15"
-      timezone: "Europe/Berlin"
-    commit-message:
-      prefix: "chore(deps)"
-    # The OpenTelemetry Python packages are pinned in lockstep (the 0.x beta instrumentation packages together with
-    # the matching 1.x stable exporter). Group them into a single pull request so they are always updated together;
-    # updating them individually would break the lockstep and likely fail pip's dependency resolution.
-    groups:
-      all:
-        patterns:
-          - "*"
-
   # Docker
   - package-ecosystem: "docker"
     directories:


### PR DESCRIPTION
This is no longer required (and fails) since the Dash0 Python distro is updated via the update script.