### PR TITLE
chore(collectors): unpin resourcedetection processor

### DIFF
--- a/images/collector/src/builder/config.yaml
+++ b/images/collector/src/builder/config.yaml
@@ -28,7 +28,7 @@ processors:
   - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.158.0"
   - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor v0.158.0"
   - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.158.0"
-  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.145.0"
+  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.158.0"
   - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.158.0"
 connectors:
   - gomod: "go.opentelemetry.io/collector/connector/forwardconnector v0.158.0"

--- a/internal/collectors/otelcolresources/collector_config_maps_test.go
+++ b/internal/collectors/otelcolresources/collector_config_maps_test.go
@@ -3871,6 +3871,49 @@ var _ = Describe("The OpenTelemetry Collector ConfigMaps", func() {
 		Expect(metricsProcessors).To(ContainElement("resource/clustername"))
 	}, daemonSetAndDeployment)
 
+	Context("the resourcedetection processor", func() {
+		DescribeTable("should render fail_on_missing_metadata: false if Signal Control is disabled",
+			func(cmTypeDef configMapTypeDefinition) {
+				configMap, err := cmTypeDef.assembleConfigMapFunction(&oTelColConfig{
+					OperatorNamespace: OperatorNamespace,
+					NamePrefix:        namePrefix,
+					Exporters:         cmTestSingleDefaultOtlpExporter(),
+					KubernetesInfrastructureMetricsCollectionEnabled: true,
+					SignalControl: SignalControlConfig{Enabled: false},
+				}, monitoredNamespaces, nil, nil, false)
+
+				Expect(err).ToNot(HaveOccurred())
+				collectorConfig := parseConfigMapContent(configMap)
+				resourceDetectionProcessor :=
+					ReadFromMap(collectorConfig, []string{"processors", "resourcedetection"})
+				Expect(resourceDetectionProcessor).ToNot(BeNil())
+				Expect(resourceDetectionProcessor).To(HaveKeyWithValue("fail_on_missing_metadata", false))
+			}, daemonSetAndDeployment)
+
+		DescribeTable("should not render fail_on_missing_metadata if Signal Control is enabled",
+			func(cmTypeDef configMapTypeDefinition) {
+				configMap, err := cmTypeDef.assembleConfigMapFunction(&oTelColConfig{
+					OperatorNamespace: OperatorNamespace,
+					NamePrefix:        namePrefix,
+					Exporters:         cmTestSingleDefaultOtlpExporter(),
+					KubernetesInfrastructureMetricsCollectionEnabled: true,
+					SignalControl: SignalControlConfig{
+						Enabled:     true,
+						Endpoint:    "decision-maker.example.com:443",
+						ApiEndpoint: "https://control-plane-api.dash0.com",
+						Dataset:     "default",
+					},
+				}, monitoredNamespaces, nil, nil, false)
+
+				Expect(err).ToNot(HaveOccurred())
+				collectorConfig := parseConfigMapContent(configMap)
+				resourceDetectionProcessor :=
+					ReadFromMap(collectorConfig, []string{"processors", "resourcedetection"})
+				Expect(resourceDetectionProcessor).ToNot(BeNil())
+				Expect(resourceDetectionProcessor).ToNot(HaveKey("fail_on_missing_metadata"))
+			}, daemonSetAndDeployment)
+	})
+
 	Describe("should enable/disable kubernetes infrastructure metrics collection and the hostmetrics receiver", func() {
 		It("should not render the kubeletstats receiver and hostmetrics if kubernetes infrastructure metrics collection is disabled", func() {
 			configMap, err := assembleDaemonSetCollectorConfigMap(&oTelColConfig{

--- a/internal/collectors/otelcolresources/daemonset.config.yaml.template
+++ b/internal/collectors/otelcolresources/daemonset.config.yaml.template
@@ -734,6 +734,14 @@ processors:
   {{- end }}
 
   resourcedetection:
+    {{- /*
+      Unconditionally add fail_on_missing_metadata and remove
+      "--feature-gates=-processor.resourcedetection.propagateerrors" once the SignalControl Edge image updates to
+      collector-contrib version >= 0.158.0.
+    */}}
+    {{- if not .SignalControl.Enabled }}
+    fail_on_missing_metadata: false
+    {{- end }}
     detectors:
     # Note: Later detectors do *not* overwrite attributes provided by earlier detectors, hence more specific detectors
     # must come first (e.g. eks before ec2 - both write to cloud.platform)

--- a/internal/collectors/otelcolresources/deployment.config.yaml.template
+++ b/internal/collectors/otelcolresources/deployment.config.yaml.template
@@ -210,6 +210,14 @@ processors:
   # cloud.availability_zone, GCE/Azure instance identifiers) here, since that would incorrectly include node attribtues
   # from the collector deployment's node to the telemetry.
   resourcedetection:
+    {{- /*
+      Unconditionally add fail_on_missing_metadata and remove
+      "--feature-gates=-processor.resourcedetection.propagateerrors" once the SignalControl Edge image updates to
+      collector-contrib version >= 0.158.0.
+    */}}
+    {{- if not .SignalControl.Enabled }}
+    fail_on_missing_metadata: false
+    {{- end }}
     detectors:
     # Note: Later detectors do *not* overwrite attributes provided by earlier detectors, hence more specific detectors
     # must come first (e.g. eks before ec2 - both write to cloud.platform).

--- a/internal/collectors/otelcolresources/desired_state.go
+++ b/internal/collectors/otelcolresources/desired_state.go
@@ -1243,7 +1243,12 @@ func assembleDaemonSetCollectorContainer(
 
 	collectorArgs := []string{
 		"--config=file:" + collectorConfigurationFilePath,
-		"--feature-gates=-processor.resourcedetection.propagateerrors",
+	}
+	// The SignalControl Edge image is still based on a collector-contrib version < 0.158.0, which requires this
+	// feature gate instead of the resourcedetection processor's fail_on_missing_metadata attribute. Remove this
+	// once the SignalControl Edge image updates to collector-contrib version >= 0.158.0.
+	if config.SignalControl.Enabled {
+		collectorArgs = append(collectorArgs, "--feature-gates=-processor.resourcedetection.propagateerrors")
 	}
 	if config.ProfilingEnabled {
 		collectorArgs = append(collectorArgs, "--feature-gates=service.profilesSupport")
@@ -1772,12 +1777,19 @@ func assembleDeploymentCollectorContainer(
 		return corev1.Container{}, err
 	}
 
+	collectorArgs := []string{
+		"--config=file:" + collectorConfigurationFilePath,
+	}
+	// The SignalControl Edge image is still based on a collector-contrib version < 0.158.0, which requires this
+	// feature gate instead of the resourcedetection processor's fail_on_missing_metadata attribute. Remove this
+	// once the SignalControl Edge image updates to collector-contrib version >= 0.158.0.
+	if config.SignalControl.Enabled {
+		collectorArgs = append(collectorArgs, "--feature-gates=-processor.resourcedetection.propagateerrors")
+	}
+
 	collectorContainer := corev1.Container{
 		Name: openTelemetryCollector,
-		Args: []string{
-			"--config=file:" + collectorConfigurationFilePath,
-			"--feature-gates=-processor.resourcedetection.propagateerrors",
-		},
+		Args: collectorArgs,
 		SecurityContext: &corev1.SecurityContext{
 			AllowPrivilegeEscalation: new(false),
 			ReadOnlyRootFilesystem:   new(false),

--- a/internal/collectors/otelcolresources/desired_state_test.go
+++ b/internal/collectors/otelcolresources/desired_state_test.go
@@ -548,9 +548,8 @@ var _ = Describe("The desired state of the OpenTelemetry Collector resources", f
 		Expect(daemonSetCollectorContainer.ImagePullPolicy).To(Equal(corev1.PullAlways))
 		Expect(daemonSetCollectorContainer.Resources.Limits.Memory().String()).To(Equal("500Mi"))
 		Expect(daemonSetCollectorContainer.Resources.Requests.Memory().String()).To(Equal("500Mi"))
-		Expect(daemonSetCollectorContainerArgs).To(HaveLen(2))
+		Expect(daemonSetCollectorContainerArgs).To(HaveLen(1))
 		Expect(daemonSetCollectorContainerArgs[0]).To(Equal("--config=file:/etc/otelcol/conf/config.yaml"))
-		Expect(daemonSetCollectorContainerArgs[1]).To(Equal("--feature-gates=-processor.resourcedetection.propagateerrors"))
 		Expect(daemonSetCollectorContainer.VolumeMounts).To(HaveLen(6))
 		Expect(daemonSetCollectorContainer.VolumeMounts).To(
 			ContainElement(MatchVolumeMount("opentelemetry-collector-configmap", "/etc/otelcol/conf")))
@@ -610,9 +609,8 @@ var _ = Describe("The desired state of the OpenTelemetry Collector resources", f
 		Expect(deploymentCollectorContainer.Resources.Limits.Memory().String()).To(Equal("500Mi"))
 		Expect(deploymentCollectorContainer.Resources.Requests.Memory().String()).To(Equal("500Mi"))
 		deploymentCollectorContainerArgs := deploymentCollectorContainer.Args
-		Expect(deploymentCollectorContainerArgs).To(HaveLen(2))
+		Expect(deploymentCollectorContainerArgs).To(HaveLen(1))
 		Expect(deploymentCollectorContainerArgs[0]).To(Equal("--config=file:/etc/otelcol/conf/config.yaml"))
-		Expect(deploymentCollectorContainerArgs[1]).To(Equal("--feature-gates=-processor.resourcedetection.propagateerrors"))
 		Expect(deploymentCollectorContainer.VolumeMounts).To(HaveLen(2))
 		Expect(deploymentCollectorContainer.VolumeMounts).To(
 			ContainElement(MatchVolumeMount("opentelemetry-collector-configmap", "/etc/otelcol/conf")))
@@ -706,10 +704,60 @@ var _ = Describe("The desired state of the OpenTelemetry Collector resources", f
 		daemonSetPodSpec := daemonSet.(*appsv1.DaemonSet).Spec.Template.Spec
 		daemonSetCollectorContainer := daemonSetPodSpec.Containers[0]
 		Expect(daemonSetCollectorContainer.Name).To(Equal("opentelemetry-collector"))
-		Expect(daemonSetCollectorContainer.Args).To(HaveLen(3))
+		Expect(daemonSetCollectorContainer.Args).To(HaveLen(2))
 		Expect(daemonSetCollectorContainer.Args[0]).To(Equal("--config=file:/etc/otelcol/conf/config.yaml"))
-		Expect(daemonSetCollectorContainer.Args[1]).To(Equal("--feature-gates=-processor.resourcedetection.propagateerrors"))
-		Expect(daemonSetCollectorContainer.Args[2]).To(Equal("--feature-gates=service.profilesSupport"))
+		Expect(daemonSetCollectorContainer.Args[1]).To(Equal("--feature-gates=service.profilesSupport"))
+	})
+
+	It("should not add the -processor.resourcedetection.propagateerrors feature gate to the collector args when Signal Control is disabled", func() {
+		desiredState, err := assembleDesiredStateForUpsert(&oTelColConfig{
+			OperatorNamespace: OperatorNamespace,
+			NamePrefix:        namePrefix,
+			Exporters:         defaultDash0ExportersWithToken(),
+			Images:            TestImages,
+			SignalControl:     SignalControlConfig{Enabled: false},
+			KubernetesInfrastructureMetricsCollectionEnabled: true,
+		}, nil, util.ExtraConfigDefaults)
+
+		Expect(err).ToNot(HaveOccurred())
+
+		daemonSetCollectorContainer := getDaemonSet(desiredState).Spec.Template.Spec.Containers[0]
+		Expect(daemonSetCollectorContainer.Args).
+			ToNot(ContainElement("--feature-gates=-processor.resourcedetection.propagateerrors"))
+
+		deploymentCollectorContainer := getDeployment(desiredState).Spec.Template.Spec.Containers[0]
+		Expect(deploymentCollectorContainer.Args).
+			ToNot(ContainElement("--feature-gates=-processor.resourcedetection.propagateerrors"))
+	})
+
+	It("should add the -processor.resourcedetection.propagateerrors feature gate to the collector args when Signal Control is enabled", func() {
+		desiredState, err := assembleDesiredStateForUpsert(&oTelColConfig{
+			OperatorNamespace: OperatorNamespace,
+			NamePrefix:        namePrefix,
+			Exporters:         defaultDash0ExportersWithToken(),
+			Images:            TestImages,
+			SignalControl: SignalControlConfig{
+				Enabled:     true,
+				Endpoint:    "decision-maker.example.com:443",
+				ApiEndpoint: "https://control-plane-api.dash0.com",
+				Dataset:     "default",
+			},
+			KubernetesInfrastructureMetricsCollectionEnabled: true,
+		}, nil, util.ExtraConfigDefaults)
+
+		Expect(err).ToNot(HaveOccurred())
+
+		daemonSetCollectorContainer := getDaemonSet(desiredState).Spec.Template.Spec.Containers[0]
+		Expect(daemonSetCollectorContainer.Args).To(HaveLen(2))
+		Expect(daemonSetCollectorContainer.Args[0]).To(Equal("--config=file:/etc/otelcol/conf/config.yaml"))
+		Expect(daemonSetCollectorContainer.Args[1]).
+			To(Equal("--feature-gates=-processor.resourcedetection.propagateerrors"))
+
+		deploymentCollectorContainer := getDeployment(desiredState).Spec.Template.Spec.Containers[0]
+		Expect(deploymentCollectorContainer.Args).To(HaveLen(2))
+		Expect(deploymentCollectorContainer.Args[0]).To(Equal("--config=file:/etc/otelcol/conf/config.yaml"))
+		Expect(deploymentCollectorContainer.Args[1]).
+			To(Equal("--feature-gates=-processor.resourcedetection.propagateerrors"))
 	})
 
 	It("should omit all resources related to the collector deployment if collecting cluster metrics is disabled", func() {


### PR DESCRIPTION
With
https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/46659 finally merged and released in opentelemetry-collector-contrib 0.158.0:
- do no longer pin the resourcedetection processor at 0.145.0
- remove the -processor.resourcedetection.propagateerrors feature gate cli argument for the collector startup argument
- add the top level fail_on_missing_metadata config attribute

For now, this is conditional on SignalControl Edge not being used.