### PR TITLE
fix(webhook): do not record events during dry-run

### DIFF
--- a/internal/webhooks/instrumentation_webhook.go
+++ b/internal/webhooks/instrumentation_webhook.go
@@ -35,6 +35,16 @@ type InstrumentationWebhookHandler struct {
 	ClusterInstrumentationConfig *util.ClusterInstrumentationConfig
 }
 
+type discardingEventRecorder struct{}
+
+func (discardingEventRecorder) Eventf(
+	_ runtime.Object,
+	_ runtime.Object,
+	_, _, _, _ string,
+	_ ...interface{},
+) {
+}
+
 type resourceHandler func(
 	h *InstrumentationWebhookHandler,
 	request admission.Request,
@@ -224,8 +234,14 @@ func (h *InstrumentationWebhookHandler) Handle(ctx context.Context, request admi
 	gvkLabel := fmt.Sprintf("%s/%s.%s", group, version, kind)
 
 	logger.Debug("routing admission request to handler", "group", group, "kind", kind, "version", version)
+	handler := h
+	if request.DryRun != nil && *request.DryRun {
+		dryRunHandler := *h
+		dryRunHandler.Recorder = discardingEventRecorder{}
+		handler = &dryRunHandler
+	}
 	return routes.routeFor(group, kind, version)(
-		h,
+		handler,
 		request,
 		gvkLabel,
 		dash0MonitoringResource.GetNamespaceInstrumentationConfig(),

--- a/internal/webhooks/instrumentation_webhook_dry_run_test.go
+++ b/internal/webhooks/instrumentation_webhook_dry_run_test.go
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: Copyright 2026 Dash0 Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package webhooks
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/events"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	dash0v1beta1 "github.com/dash0hq/dash0-operator/api/operator/v1beta1"
+	"github.com/dash0hq/dash0-operator/internal/util"
+	"github.com/dash0hq/dash0-operator/internal/util/cluster"
+	testutil "github.com/dash0hq/dash0-operator/test/util"
+)
+
+func TestInstrumentationWebhookDryRunReturnsPatchWithoutRecordingEvent(t *testing.T) {
+	testScheme := runtime.NewScheme()
+	if err := dash0v1beta1.AddToScheme(testScheme); err != nil {
+		t.Fatal(err)
+	}
+
+	monitoringResource := testutil.DefaultMonitoringResource()
+	monitoringResource.EnsureResourceIsMarkedAsAvailable()
+	recorder := events.NewFakeRecorder(1)
+	handler := NewInstrumentationWebhookHandler(
+		fake.NewClientBuilder().WithScheme(testScheme).WithObjects(monitoringResource).Build(),
+		recorder,
+		util.NewClusterInstrumentationConfig(
+			testutil.TestImages,
+			testutil.PossibleCollectorUrlsTest,
+			testutil.OTelCollectorNodeLocalBaseUrlTest,
+			util.ExtraConfigDefaults,
+			cluster.ResolvedInstrumentationDeliveryInitContainer,
+			nil,
+			false,
+			false,
+			false,
+		),
+	)
+
+	deployment := testutil.BasicDeployment(testutil.TestNamespaceName, "dry-run-deployment")
+	rawDeployment, err := json.Marshal(deployment)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dryRun := true
+	response := handler.Handle(context.Background(), admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{
+		Operation: admissionv1.Create,
+		DryRun:    &dryRun,
+		Kind: metav1.GroupVersionKind{
+			Group:   "apps",
+			Version: "v1",
+			Kind:    "Deployment",
+		},
+		Namespace: testutil.TestNamespaceName,
+		Name:      deployment.Name,
+		Object:    runtime.RawExtension{Raw: rawDeployment},
+	}})
+
+	if !response.Allowed {
+		t.Fatalf("expected dry-run admission to be allowed: %v", response.Result)
+	}
+	if len(response.Patches) == 0 {
+		t.Fatal("expected dry-run admission to return instrumentation patch")
+	}
+	select {
+	case event := <-recorder.Events:
+		t.Fatalf("expected dry-run admission to record no event, got %q", event)
+	default:
+	}
+}


### PR DESCRIPTION
## Context

Kubernetes dry-run asks webhook what changes it would make without saving anything. Dash0 webhook returned correct workload changes, but also saved a SuccessfulInstrumentation Event. That made read-only request change cluster data while webhook declared sideEffects: None.

## Change

For request with dryRun=true, webhook now sends generated Events to recorder that drops them. Workload still gets same predicted instrumentation patch. Normal create and update requests keep recording Events as before.

No chart change is needed because sideEffects: None is already correct once code follows it.

## Test

- New focused test reproduces old event and proves dry-run still returns patch without recording event.
- Full internal/webhooks test package passes.
- make build passes.
- make golangci-lint passes.

No live cluster, Dash0 query, deployment, or release was run.

Lemma tracking: https://linear.app/uselemma/issue/ENG-636/stop-dash0-webhook-side-effects-during-kubernetes-dry-run