### PR TITLE
fix(collectors): extract k8s.node.uid via k8sattributes

### DIFF
--- a/internal/collectors/otelcolresources/daemonset.config.yaml.template
+++ b/internal/collectors/otelcolresources/daemonset.config.yaml.template
@@ -784,6 +784,7 @@ processors:
       - k8s.job.uid
       - k8s.namespace.name
       - k8s.node.name
+      - k8s.node.uid
       - k8s.pod.hostname
       - k8s.pod.ip
       - k8s.pod.name
@@ -870,6 +871,7 @@ processors:
       - k8s.job.uid
       - k8s.namespace.name
       - k8s.node.name
+      - k8s.node.uid
       - k8s.pod.hostname
       - k8s.pod.ip
       - k8s.pod.name

--- a/internal/collectors/otelcolresources/deployment.config.yaml.template
+++ b/internal/collectors/otelcolresources/deployment.config.yaml.template
@@ -297,6 +297,7 @@ processors:
       - k8s.job.uid
       - k8s.namespace.name
       - k8s.node.name
+      - k8s.node.uid
       - k8s.pod.hostname
       - k8s.pod.ip
       - k8s.pod.name


### PR DESCRIPTION
`k8s.pod.*` / `k8s.container.*` metrics from the k8s_cluster receiver, and Pod-kind Kubernetes events normalized by transform/k8s_events, only ever carried the node by name (a plain string), never by uid. Anything that resolves node identity by uid saw these as a different node than the one described by `k8s.node.*` metrics, which do carry `k8s.node.uid`.

Adding `k8s.node.uid` to the k8sattributes metadata list lets it resolve the uid via the pod association it already performs, reusing the Node informer it already maintains.