### PR TITLE
fix(instrumentation-image): strip unused esm/esnext builds from @opentelemetry packages

### DIFF
--- a/images/instrumentation/Dockerfile
+++ b/images/instrumentation/Dockerfile
@@ -39,7 +39,12 @@ RUN NPM_CONFIG_UPDATE_NOTIFIER=false \
   --ignore-scripts \
   --omit=dev \
   --no-audit \
-  --no-fund=true
+  --no-fund=true \
+  # The upstream OpenTelemetry JS packages ship esm/esnext builds alongside the CJS build used by require() (see the
+  # "exports" map in each package's package.json). Node.js's CJS resolver only ever matches the "default"/"require"
+  # condition, so these two build trees are unused dead weight in this image; every @opentelemetry/* package on the
+  # host is duplicated here for the "-1.x" compatibility line as well, further multiplying the waste.
+  && find node_modules/@opentelemetry -type d \( -name esm -o -name esnext \) -path '*/build/*' -exec rm -rf {} +
 
 # download .NET auto instrumentation
 FROM alpine:3.24.1 AS build-dotnet


### PR DESCRIPTION
## Summary
- The instrumentation image's `node.js` agent (`images/instrumentation/node.js`) is loaded purely via `require()`, which only ever resolves the `default`/`require` export condition — never `module`/`esnext`.
- Every `@opentelemetry/*` package nonetheless ships `build/esm` and `build/esnext` alongside the `build/src` (CJS) tree actually used at runtime. This repo also installs both the current and legacy (`-1.x`) OTel dependency lines side by side (see `opentelemetry-js-distribution`'s version-based branch selection), which multiplies the duplication.
- Stripping `build/esm`/`build/esnext` from the `build-node-js` Docker stage cuts that stage's `node_modules` from ~437MB to ~181MB (~59%), directly reducing the overall `instrumentation` image size, with no behavior change.