### PR TITLE
fix(workloads): use kubelet versions to resolve delivery=auto

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,3 +125,25 @@ instruments) must be added to the `selfMonitoringClients` slice in `internal/sta
 Missing that step is silent: the metric handle stays `nil`, `Reconcile` skips the counter update via its nil-guard,
 and the reconciler emits nothing for the entire process lifetime — no build error, no test failure, no runtime
 warning. When wiring a new reconciler, grep for `selfMonitoringClients` and add the new entry before opening the PR.
+
+### Listing Kubernetes resources with pagination
+
+The `Limit` and `Continue` fields of controller-runtime's `client.ListOptions` compile with every client, but they only
+work with an uncached client (created via `client.New`, for example `startupTasksK8sClient`). The cache-backed client
+(`mgr.GetClient()`) fails at runtime: it rejects a non-empty `Continue` with "continue list option is not supported by
+the cache", and it sets the continue token of every list result to the literal string "continue-not-supported". A
+hand-written loop that feeds the returned token back into the next call therefore breaks on the second iteration, on
+every cluster, no matter how many objects there are.
+
+Do not paginate resources that the controller-runtime cache holds anyway. The informer keeps every object of a watched
+resource in memory for the lifetime of the operator, so paging the reads saves nothing.
+
+When pagination is actually needed - an uncached read of a resource the operator does not watch, with potentially many
+or large objects - use client-go's pager together with the clientset instead of a controller-runtime client:
+`pager.New(pager.SimplePageFunc(...))` plus `pgr.PageSize`, see `internal/instrumentation/instrumenter.go` and
+`internal/util/cluster/kubernetes_version.go`. The pager owns the continue token and falls back to a full relist when
+the API server expires it (410 Gone).
+
+Note for unit tests: the controller-runtime fake client ignores `Limit` and never sets a continue token, so it always
+returns a single page and a broken pagination implementation passes unnoticed. Use `k8s.io/client-go/kubernetes/fake`
+with a `PrependReactor` that hands out more than one chunk to cover the paging behaviour.

--- a/api/operator/v1alpha1/operator_configuration_types.go
+++ b/api/operator/v1alpha1/operator_configuration_types.go
@@ -203,12 +203,13 @@ type InstrumentationDelivery string
 
 const (
 	// InstrumentationDeliveryAuto lets the operator decide which delivery mechanism to use, based on the Kubernetes
-	// version. If the cluster runs Kubernetes 1.36 or later, the operator uses image volumes; otherwise it falls back to
-	// the init container approach.
+	// version. If the Kubernetes API server version and the kubelet version of every node are 1.36 or later, the
+	// operator uses image volumes; otherwise it falls back to the init container approach.
 	InstrumentationDeliveryAuto InstrumentationDelivery = "auto"
 
 	// InstrumentationDeliveryImageVolume forces the operator to use the image volume delivery mechanisms on Kubernetes
-	// versions 1.31 - 1.35. The setting is ignored on Kubernetes versions older than 1.31.
+	// versions 1.31 - 1.35. The setting is ignored if the Kubernetes API server version or the kubelet version of any
+	// node is older than 1.31.
 	InstrumentationDeliveryImageVolume InstrumentationDelivery = "image-volume"
 
 	// InstrumentationDeliveryInitContainer forces the operator to use the init container plus emptyDir volume delivery
@@ -220,11 +221,16 @@ const (
 type InstrumentWorkloads struct {
 	// InstrumentationDelivery controls how the Dash0 instrumentation files are made available to instrumented
 	// workload containers. Allowed values:
-	//   - "auto": use image volumes if the Kubernetes version is 1.36 or later, otherwise use the init container approach.
+	//   - "auto": use image volumes if the Kubernetes API server version and the kubelet version of all nodes is 1.36 or
+	//     later, otherwise use the init container approach. The operator determines the minimum kubelet version by
+	//     inspecting the cluster's nodes once at startup, until that has finished it uses the init container approach.
+	//     Nodes joining the cluster later are not taken into account.
 	//   - "image-volume": always use a Kubernetes image volume sourced from the Dash0 instrumentation image. If the
-	//     Kubernetes version is older than 1.31, the operator logs a warning and falls back to the init container
-	//     approach. Note that on Kubernetes 1.34 and earlier, image volumes need to be enabled at cluster
-	//     creation time, since the feature gate is disabled by default in versions older than 1.35.
+	//     operator has already detected that the Kubernetes API server version or the kubelet version of a node is
+	//     older than 1.31, it logs a warning and falls back to the init container approach. That fallback is
+	//     best-effort: it does not cover workloads instrumented before the operator has inspected the cluster's nodes,
+	//     nor nodes that join the cluster later. Note that on Kubernetes 1.34 and earlier, image volumes need to be
+	//     enabled at cluster creation time, since the feature gate is disabled by default in versions older than 1.35.
 	//   - "init-container" (default): always use the traditional init container plus emptyDir volume approach, regardless
 	//     of the Kubernetes version.
 	//

--- a/config/crd/bases/operator.dash0.com_dash0operatorconfigurations.yaml
+++ b/config/crd/bases/operator.dash0.com_dash0operatorconfigurations.yaml
@@ -739,11 +739,16 @@ spec:
                     description: |-
                       InstrumentationDelivery controls how the Dash0 instrumentation files are made available to instrumented
                       workload containers. Allowed values:
-                        - "auto": use image volumes if the Kubernetes version is 1.36 or later, otherwise use the init container approach.
+                        - "auto": use image volumes if the Kubernetes API server version and the kubelet version of all nodes is 1.36 or
+                          later, otherwise use the init container approach. The operator determines the minimum kubelet version by
+                          inspecting the cluster's nodes once at startup, until that has finished it uses the init container approach.
+                          Nodes joining the cluster later are not taken into account.
                         - "image-volume": always use a Kubernetes image volume sourced from the Dash0 instrumentation image. If the
-                          Kubernetes version is older than 1.31, the operator logs a warning and falls back to the init container
-                          approach. Note that on Kubernetes 1.34 and earlier, image volumes need to be enabled at cluster
-                          creation time, since the feature gate is disabled by default in versions older than 1.35.
+                          operator has already detected that the Kubernetes API server version or the kubelet version of a node is
+                          older than 1.31, it logs a warning and falls back to the init container approach. That fallback is
+                          best-effort: it does not cover workloads instrumented before the operator has inspected the cluster's nodes,
+                          nor nodes that join the cluster later. Note that on Kubernetes 1.34 and earlier, image volumes need to be
+                          enabled at cluster creation time, since the feature gate is disabled by default in versions older than 1.35.
                         - "init-container" (default): always use the traditional init container plus emptyDir volume approach, regardless
                           of the Kubernetes version.
 

--- a/helm-chart/dash0-operator/docs/auto-instrumentation.md
+++ b/helm-chart/dash0-operator/docs/auto-instrumentation.md
@@ -54,11 +54,24 @@ They were introduced in Kubernetes 1.31 as an alpha feature behind a feature gat
 Set the `instrumentationDelivery` setting in the operator configuration resource to determine under which circumstances image volumes will be used instead of the init container approach. When using the operator manager to create and manage the operator configuration resource (i.e. with `operator.dash0Export.enabled=true`), set `operator.instrumentation.delivery` in Helm to configure image volumes.
 
 Allowed values for the instrumentation delivery setting:
-- `auto`: use image volumes if the Kubernetes version is 1.36 or later, otherwise use the init container approach.
-- `image-volume`: always use image volumes, also on Kubernetes versions older than 1.36. If the Kubernetes version is older than 1.31, the operator manager will log a warning and fall back to the init container approach, since image volumes are not supported in that version. Note that if you are using Kubernetes 1.34 or earlier, and you want to use this setting, you need to enable image volumes when configuring your cluster, since image volumes are disabled by default in versions older than 1.35.
+- `auto`: use image volumes if the Kubernetes API server version and the kubelet version of all nodes of the cluster is
+   1.36 or later, otherwise use the init container approach. The operator manager determines the minimum kubelet version
+   by inspecting all nodes of the cluster once, shortly after it has started; until that has finished, it uses the init
+   container approach. Nodes that join the cluster later on are not taken into account.
+- `image-volume`: always use image volumes, also on Kubernetes versions older than 1.36. If the operator manager has
+   already detected that the Kubernetes API server version or the kubelet version of a node is older than 1.31, it will
+   log a warning and fall back to the init container approach, since image volumes are not supported in that version.
+   That fallback is best-effort: it does not cover workloads instrumented before the operator manager has inspected the
+   cluster's nodes, nor nodes that join the cluster later on. Note that if you are using Kubernetes 1.34 or earlier, and
+   you want to use this setting, you need to enable image volumes when configuring your cluster, since image volumes are
+   disabled by default in versions older than 1.35.
 - `init-container`: always use the init container approach, regardless of the Kubernetes version. This is the default.
 
-Note: Changing the instrumentation delivery setting for an existing operator installation will not trigger a bulk re-instrumentation of all existing workloads, even for namespaces that are set to `instrumentWorkloadsMode=all`. Once a workload has been successfully instrumented, there is no benefit in re-instrumenting it with a different delivery mechanism. The new setting will be applied when instrumenting newly deployed workloads, or when a workload is updated/re-deployed.
+Note: Changing the instrumentation delivery setting for an existing operator installation will not trigger a bulk
+re-instrumentation of all existing workloads, even for namespaces that are set to `instrumentWorkloadsMode=all`.
+Once a workload has been successfully instrumented, there is no benefit in re-instrumenting it with a different delivery
+mechanism.
+The new setting will be applied when instrumenting newly deployed workloads, or when a workload is updated/re-deployed.
 
 ## Python Auto-Instrumentation
 

--- a/helm-chart/dash0-operator/docs/configuration.md
+++ b/helm-chart/dash0-operator/docs/configuration.md
@@ -148,13 +148,18 @@ Here is a list of configuration options for this resource:
   workloads when applying auto-instrumentation.
   See [Using Image Volumes for Auto-Instrumentation Files](#using-image-volumes-for-auto-instrumentation-files).
   Allowed values:
-  - `auto`: use image volumes if the Kubernetes version is 1.36 or later, otherwise use the init container
-    approach.
-  - `image-volume`: always use image volumes, also on Kubernetes versions older than 1.36. If the Kubernetes
-    version is older than 1.31, the operator manager will log a warning and fall back to the init container
-    approach, since image volumes are not supported in that version. Note that if you are using
-    Kubernetes 1.34 or earlier, and you want to use this setting, you need to enable image volumes when configuring
-    your cluster, since image volumes are disabled by default in versions older than 1.35.
+  - `auto`: use image volumes if the Kubernetes API server version and the kubelet version of all nodes of the cluster
+    is 1.36 or later, otherwise use the init container approach.
+    The operator manager determines the minimum kubelet version by inspecting all nodes of the cluster once, shortly
+    after it has started; until that has finished, it uses the init container approach.
+    Nodes that join the cluster later on are not taken into account.
+  - `image-volume`: always use image volumes, also on Kubernetes versions older than 1.36. If the operator manager has
+    already detected that the Kubernetes API server version or the kubelet version of a node is older than 1.31, it
+    will log a warning and fall back to the init container approach, since image volumes are not supported in that
+    version. That fallback is best-effort: it does not cover workloads instrumented before the operator manager has
+    inspected the cluster's nodes, nor nodes that join the cluster later on. Note that if you are using Kubernetes 1.34
+    or earlier, and you want to use this setting, you need to enable image volumes when configuring your cluster, since
+    image volumes are disabled by default in versions older than 1.35.
   - `init-container`: always use the init container approach, regardless of the Kubernetes version.
     This is the default.
 
@@ -790,13 +795,18 @@ When using the operator manager to create and manage the operator configuration 
 `operator.dash0Export.enabled=true`), set `operator.instrumentation.delivery` in Helm to configure image volumes.
 
 Allowed values for the instrumentation delivery setting:
-- `auto`: use image volumes if the Kubernetes version is 1.36 or later, otherwise use the init container
-  approach.
-- `image-volume`: always use image volumes, also on Kubernetes versions older than 1.36. If the Kubernetes
-  version is older than 1.31, the operator manager will log a warning and fall back to the init container
-  approach, since image volumes are not supported in that version. Note that if you are using
-  Kubernetes 1.34 or earlier, and you want to use this setting, you need to enable image volumes when configuring
-  your cluster, since image volumes are disabled by default in versions older than 1.35.
+- `auto`: use image volumes if the Kubernetes API server version and the kubelet version of all nodes of the cluster is
+  1.36 or later, otherwise use the init container approach.
+  The operator manager determines the minimum kubelet version by inspecting all nodes of the cluster once, shortly after
+  it has started; until that has finished, it uses the init container approach.
+  Nodes that join the cluster later on are not taken into account.
+- `image-volume`: always use image volumes, also on Kubernetes versions older than 1.36. If the operator manager has
+  already detected that the Kubernetes API server version or the kubelet version of a node is older than 1.31, it will
+  log a warning and fall back to the init container approach, since image volumes are not supported in that version.
+  That fallback is best-effort: it does not cover workloads instrumented before the operator manager has inspected the
+  cluster's nodes, nor nodes that join the cluster later on. Note that if you are using Kubernetes 1.34 or earlier, and
+  you want to use this setting, you need to enable image volumes when configuring your cluster, since image volumes are
+  disabled by default in versions older than 1.35.
 - `init-container`: always use the init container approach, regardless of the Kubernetes version.
   This is the default.
 

--- a/helm-chart/dash0-operator/templates/operator/custom-resource-definition-operator-configuration.yaml
+++ b/helm-chart/dash0-operator/templates/operator/custom-resource-definition-operator-configuration.yaml
@@ -744,11 +744,16 @@ spec:
                     description: |-
                       InstrumentationDelivery controls how the Dash0 instrumentation files are made available to instrumented
                       workload containers. Allowed values:
-                        - "auto": use image volumes if the Kubernetes version is 1.36 or later, otherwise use the init container approach.
+                        - "auto": use image volumes if the Kubernetes API server version and the kubelet version of all nodes is 1.36 or
+                          later, otherwise use the init container approach. The operator determines the minimum kubelet version by
+                          inspecting the cluster's nodes once at startup, until that has finished it uses the init container approach.
+                          Nodes joining the cluster later are not taken into account.
                         - "image-volume": always use a Kubernetes image volume sourced from the Dash0 instrumentation image. If the
-                          Kubernetes version is older than 1.31, the operator logs a warning and falls back to the init container
-                          approach. Note that on Kubernetes 1.34 and earlier, image volumes need to be enabled at cluster
-                          creation time, since the feature gate is disabled by default in versions older than 1.35.
+                          operator has already detected that the Kubernetes API server version or the kubelet version of a node is
+                          older than 1.31, it logs a warning and falls back to the init container approach. That fallback is
+                          best-effort: it does not cover workloads instrumented before the operator has inspected the cluster's nodes,
+                          nor nodes that join the cluster later. Note that on Kubernetes 1.34 and earlier, image volumes need to be
+                          enabled at cluster creation time, since the feature gate is disabled by default in versions older than 1.35.
                         - "init-container" (default): always use the traditional init container plus emptyDir volume approach, regardless
                           of the Kubernetes version.
 

--- a/helm-chart/dash0-operator/tests/operator/__snapshot__/custom-resource-definition-operator-configuration_test.yaml.snap
+++ b/helm-chart/dash0-operator/tests/operator/__snapshot__/custom-resource-definition-operator-configuration_test.yaml.snap
@@ -681,11 +681,16 @@ custom resource definition for operator configuration should match snapshot:
                           description: |-
                             InstrumentationDelivery controls how the Dash0 instrumentation files are made available to instrumented
                             workload containers. Allowed values:
-                              - "auto": use image volumes if the Kubernetes version is 1.36 or later, otherwise use the init container approach.
+                              - "auto": use image volumes if the Kubernetes API server version and the kubelet version of all nodes is 1.36 or
+                                later, otherwise use the init container approach. The operator determines the minimum kubelet version by
+                                inspecting the cluster's nodes once at startup, until that has finished it uses the init container approach.
+                                Nodes joining the cluster later are not taken into account.
                               - "image-volume": always use a Kubernetes image volume sourced from the Dash0 instrumentation image. If the
-                                Kubernetes version is older than 1.31, the operator logs a warning and falls back to the init container
-                                approach. Note that on Kubernetes 1.34 and earlier, image volumes need to be enabled at cluster
-                                creation time, since the feature gate is disabled by default in versions older than 1.35.
+                                operator has already detected that the Kubernetes API server version or the kubelet version of a node is
+                                older than 1.31, it logs a warning and falls back to the init container approach. That fallback is
+                                best-effort: it does not cover workloads instrumented before the operator has inspected the cluster's nodes,
+                                nor nodes that join the cluster later. Note that on Kubernetes 1.34 and earlier, image volumes need to be
+                                enabled at cluster creation time, since the feature gate is disabled by default in versions older than 1.35.
                               - "init-container" (default): always use the traditional init container plus emptyDir volume approach, regardless
                                 of the Kubernetes version.
 

--- a/internal/allowlistreadycheck/allowlist_synchronizer_ready_check_handler.go
+++ b/internal/allowlistreadycheck/allowlist_synchronizer_ready_check_handler.go
@@ -134,15 +134,13 @@ func (h *OperatorPreInstallHandler) WaitForAllowlistSynchronizerToBecomeReady() 
 		dash0AllowlistSynchronizerName,
 	)
 	h.logger.Info(message)
-	if err := retry.RetryWithCustomBackoff(
+	if err := retry.Retry(
 		message,
 		func() error {
 			return h.checkAllowlistSynchronizerReadiness(ctx)
 		},
 		h.retryBackoff,
-		true,
-		true,
-		h.logger,
+		&h.logger,
 	); err != nil {
 		return fmt.Errorf(
 			"waiting for AllowlistSynchronizer %s to become ready has timed out (no more retries left): %v",

--- a/internal/allowlistreadycheck/allowlist_synchronizer_ready_check_handler.go
+++ b/internal/allowlistreadycheck/allowlist_synchronizer_ready_check_handler.go
@@ -21,8 +21,8 @@ import (
 
 	dash0v1alpha1 "github.com/dash0hq/dash0-operator/api/operator/v1alpha1"
 	dash0v1beta1 "github.com/dash0hq/dash0-operator/api/operator/v1beta1"
-	"github.com/dash0hq/dash0-operator/internal/util"
 	"github.com/dash0hq/dash0-operator/internal/util/logd"
+	"github.com/dash0hq/dash0-operator/internal/util/retry"
 )
 
 const (
@@ -134,7 +134,7 @@ func (h *OperatorPreInstallHandler) WaitForAllowlistSynchronizerToBecomeReady() 
 		dash0AllowlistSynchronizerName,
 	)
 	h.logger.Info(message)
-	if err := util.RetryWithCustomBackoff(
+	if err := retry.RetryWithCustomBackoff(
 		message,
 		func() error {
 			return h.checkAllowlistSynchronizerReadiness(ctx)

--- a/internal/collectors/otelcolresources/desired_state_test.go
+++ b/internal/collectors/otelcolresources/desired_state_test.go
@@ -730,7 +730,7 @@ var _ = Describe("The desired state of the OpenTelemetry Collector resources", f
 
 	DescribeTable("should set spec.trafficDistribution on the Signal Control collector service depending on the "+
 		"Kubernetes version",
-		func(versionInfo cluster.KubernetesVersionInfo, versionDetected bool, expectedValue *string) {
+		func(version cluster.KubernetesVersion, versionDetected bool, expectedValue *string) {
 			config := &oTelColConfig{
 				OperatorNamespace: OperatorNamespace,
 				NamePrefix:        namePrefix,
@@ -744,8 +744,10 @@ var _ = Describe("The desired state of the OpenTelemetry Collector resources", f
 				},
 				KubernetesInfrastructureMetricsCollectionEnabled: true,
 			}
-			config.ServiceTrafficDistribution =
-				cluster.ResolveServiceTrafficDistribution(versionInfo, versionDetected, logd.Discard())
+			config.ServiceTrafficDistribution = cluster.ResolveServiceTrafficDistribution(
+				cluster.KubernetesVersionInfo{Version: version, Detected: versionDetected},
+				logd.Discard(),
+			)
 
 			service := assembleSignalControlCollectorService(config)
 			if expectedValue == nil {
@@ -761,11 +763,11 @@ var _ = Describe("The desired state of the OpenTelemetry Collector resources", f
 			Expect(daemonSetService.Spec.TrafficDistribution).To(BeNil())
 			Expect(*daemonSetService.Spec.InternalTrafficPolicy).To(Equal(corev1.ServiceInternalTrafficPolicyLocal))
 		},
-		Entry("omitted on 1.29", cluster.KubernetesVersionInfo{Major: 1, Minor: 29}, true, nil),
-		Entry("omitted on 1.30", cluster.KubernetesVersionInfo{Major: 1, Minor: 30}, true, nil),
-		Entry("set on 1.31", cluster.KubernetesVersionInfo{Major: 1, Minor: 31}, true, ptr.To("PreferClose")),
-		Entry("set on 1.34", cluster.KubernetesVersionInfo{Major: 1, Minor: 34}, true, ptr.To("PreferClose")),
-		Entry("omitted when the version is unknown", cluster.KubernetesVersionInfo{}, false, nil),
+		Entry("omitted on 1.29", cluster.KubernetesVersion{Major: 1, Minor: 29}, true, nil),
+		Entry("omitted on 1.30", cluster.KubernetesVersion{Major: 1, Minor: 30}, true, nil),
+		Entry("set on 1.31", cluster.KubernetesVersion{Major: 1, Minor: 31}, true, ptr.To("PreferClose")),
+		Entry("set on 1.34", cluster.KubernetesVersion{Major: 1, Minor: 34}, true, ptr.To("PreferClose")),
+		Entry("omitted when the version is unknown", cluster.KubernetesVersion{}, false, nil),
 	)
 
 	It("should not deploy a Signal Control collector when Signal Control is enabled but no Signal Control collector image is provided", func() {

--- a/internal/collectors/otelcolresources/otelcol_resources.go
+++ b/internal/collectors/otelcolresources/otelcol_resources.go
@@ -195,8 +195,7 @@ func (m *OTelColResourceManager) CreateOrUpdateOpenTelemetryCollectorResources(
 		IsIPv6Cluster:          m.collectorConfig.IsIPv6Cluster,
 		IsGkeAutopilot:         m.collectorConfig.IsGkeAutopilot,
 		ServiceTrafficDistribution: cluster.ResolveServiceTrafficDistribution(
-			m.collectorConfig.KubernetesVersion,
-			m.collectorConfig.KubernetesVersionDetected,
+			m.collectorConfig.KubernetesApiServerVersion,
 			logger,
 		),
 		SignalControl:          signalControlConfigFromResource(signalControlResource, operatorConfigurationResource, m.collectorConfig.OperatorNamespace, m.collectorConfig.OTelCollectorNamePrefix, logger),

--- a/internal/controller/monitoring_controller.go
+++ b/internal/controller/monitoring_controller.go
@@ -31,6 +31,7 @@ import (
 	"github.com/dash0hq/dash0-operator/internal/util"
 	"github.com/dash0hq/dash0-operator/internal/util/logd"
 	"github.com/dash0hq/dash0-operator/internal/util/pointers"
+	"github.com/dash0hq/dash0-operator/internal/util/retry"
 )
 
 type MonitoringReconciler struct {
@@ -532,7 +533,7 @@ func (r *MonitoringReconciler) attachDanglingEvents(
 	legacyEventApi := r.clientset.CoreV1().Events(namespace)
 	backoff := r.danglingEventsTimeouts.Backoff
 	for _, eventType := range util.AllEvents {
-		retryErr := util.RetryWithCustomBackoff(
+		retryErr := retry.RetryWithCustomBackoff(
 			"attaching dangling event to involved object",
 			func() error {
 				danglingEvents, listErr := legacyEventApi.List(

--- a/internal/controller/monitoring_controller.go
+++ b/internal/controller/monitoring_controller.go
@@ -533,7 +533,7 @@ func (r *MonitoringReconciler) attachDanglingEvents(
 	legacyEventApi := r.clientset.CoreV1().Events(namespace)
 	backoff := r.danglingEventsTimeouts.Backoff
 	for _, eventType := range util.AllEvents {
-		retryErr := retry.RetryWithCustomBackoff(
+		retryErr := retry.Retry(
 			"attaching dangling event to involved object",
 			func() error {
 				danglingEvents, listErr := legacyEventApi.List(
@@ -580,9 +580,7 @@ func (r *MonitoringReconciler) attachDanglingEvents(
 				return nil
 			},
 			backoff,
-			false,
-			false,
-			logger,
+			nil,
 		)
 
 		if retryErr != nil {

--- a/internal/controller/monitoring_controller_test.go
+++ b/internal/controller/monitoring_controller_test.go
@@ -25,6 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	dash0common "github.com/dash0hq/dash0-operator/api/operator/common"
+	dash0v1alpha1 "github.com/dash0hq/dash0-operator/api/operator/v1alpha1"
 	dash0v1beta1 "github.com/dash0hq/dash0-operator/api/operator/v1beta1"
 	"github.com/dash0hq/dash0-operator/internal/collectors"
 	"github.com/dash0hq/dash0-operator/internal/collectors/otelcolresources"
@@ -32,7 +33,6 @@ import (
 	"github.com/dash0hq/dash0-operator/internal/targetallocator"
 	"github.com/dash0hq/dash0-operator/internal/targetallocator/taresources"
 	"github.com/dash0hq/dash0-operator/internal/util"
-	"github.com/dash0hq/dash0-operator/internal/util/cluster"
 	"github.com/dash0hq/dash0-operator/internal/workloads"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -87,7 +87,7 @@ var _ = Describe(
 						PossibleCollectorUrlsTest,
 						OTelCollectorNodeLocalBaseUrlTest,
 						util.ExtraConfigDefaults,
-						cluster.ResolvedInstrumentationDeliveryInitContainer,
+						dash0v1alpha1.InstrumentationDeliveryInitContainer,
 						nil,
 						false,
 						false,

--- a/internal/controller/operator_configuration_controller.go
+++ b/internal/controller/operator_configuration_controller.go
@@ -24,7 +24,6 @@ import (
 	"github.com/dash0hq/dash0-operator/internal/signalcontrol"
 	"github.com/dash0hq/dash0-operator/internal/targetallocator"
 	"github.com/dash0hq/dash0-operator/internal/util"
-	"github.com/dash0hq/dash0-operator/internal/util/cluster"
 	"github.com/dash0hq/dash0-operator/internal/util/logd"
 )
 
@@ -230,7 +229,7 @@ func (r *OperatorConfigurationReconciler) Reconcile(ctx context.Context, req ctr
 
 	r.applyApiAccessSettings(ctx, operatorConfigurationResource, logger)
 
-	r.applyInstrumentationDelivery(operatorConfigurationResource, logger)
+	r.updateRequestedInstrumentationDelivery(operatorConfigurationResource, logger)
 
 	if err = r.reconcileOpenTelemetryCollector(ctx, logger); err != nil {
 		return ctrl.Result{}, err
@@ -362,31 +361,32 @@ func (r *OperatorConfigurationReconciler) applyApiAccessSettings(
 	}
 }
 
-// applyInstrumentationDelivery resolves spec.instrumentWorkloads.instrumentationDelivery against the detected
-// Kubernetes version and stores the result into the clusterInstrumentationConfig.
-func (r *OperatorConfigurationReconciler) applyInstrumentationDelivery(
+// updateRequestedInstrumentationDelivery resolves spec.instrumentWorkloads.instrumentationDelivery against the detected
+// Kubernetes version knowledge (the Kubernetes API server version and the minimum kubelet version) and stores the
+// result into the clusterInstrumentationConfig. Subsequent workload instrumentation actions then use the new resolved delivery
+// mechanism. Existing instrumented workloads are not re-instrumented, even if the delivery mechanism changes.
+func (r *OperatorConfigurationReconciler) updateRequestedInstrumentationDelivery(
 	operatorConfigurationResource *dash0v1alpha1.Dash0OperatorConfiguration,
 	logger logd.Logger,
 ) {
 	if r.clusterInstrumentationConfig == nil {
 		return
 	}
-	originalDeliverySetting := string(operatorConfigurationResource.Spec.InstrumentWorkloads.InstrumentationDelivery)
-	resolvedDelivery := cluster.ResolveInstrumentationDelivery(
-		originalDeliverySetting,
-		r.clusterInstrumentationConfig.KubernetesVersion,
-		r.clusterInstrumentationConfig.KubernetesVersionDetected,
-		true,
-		logger,
-	)
-	previous := r.clusterInstrumentationConfig.SetInstrumentationDelivery(resolvedDelivery)
-	if previous != resolvedDelivery {
+	originalDeliverySetting := operatorConfigurationResource.Spec.InstrumentWorkloads.InstrumentationDelivery
+	previousResolvedDelivery, newResolvedDelivery :=
+		r.clusterInstrumentationConfig.UpdateRequestedInstrumentationDelivery(
+			originalDeliverySetting,
+			true,
+			logger,
+		)
+	if previousResolvedDelivery != newResolvedDelivery {
 		logger.Info(
-			"Changed spec.instrumentWorkloads.instrumentationDelivery detected. The new setting will become effective for "+
-				"subsequent workload instrumentations. (Existing instrumented workloads will not be re-instrumented.)",
+			"The instrumentation delivery mechanism resolved from spec.instrumentWorkloads.instrumentationDelivery has "+
+				"changed. The new setting will become effective for subsequent workload instrumentations. (Existing "+
+				"instrumented workloads will not be re-instrumented.)",
 			"instrumentation delivery setting in operator configuration", originalDeliverySetting,
-			"previous instrumentation delivery setting", previous,
-			"updated instrumentation delivery setting", resolvedDelivery,
+			"previous resolved instrumentation delivery setting", previousResolvedDelivery,
+			"updated resolved instrumentation delivery setting", newResolvedDelivery,
 		)
 	}
 }

--- a/internal/controller/operator_configuration_controller_test.go
+++ b/internal/controller/operator_configuration_controller_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/dash0hq/dash0-operator/internal/targetallocator"
 	"github.com/dash0hq/dash0-operator/internal/targetallocator/taresources"
 	"github.com/dash0hq/dash0-operator/internal/util"
-	"github.com/dash0hq/dash0-operator/internal/util/cluster"
 	"github.com/dash0hq/dash0-operator/internal/util/logd"
 	zaputil "github.com/dash0hq/dash0-operator/internal/util/zap"
 
@@ -1333,7 +1332,7 @@ func createReconciler(apiClient1 *DummyApiClient, apiClient2 *DummyApiClient) (*
 			PossibleCollectorUrlsTest,
 			OTelCollectorNodeLocalBaseUrlTest,
 			util.ExtraConfigDefaults,
-			cluster.ResolvedInstrumentationDeliveryInitContainer,
+			dash0v1alpha1.InstrumentationDeliveryInitContainer,
 			nil,
 			false,
 			false,

--- a/internal/instrumentation/instrumenter.go
+++ b/internal/instrumentation/instrumenter.go
@@ -26,6 +26,7 @@ import (
 	"github.com/dash0hq/dash0-operator/internal/resources"
 	"github.com/dash0hq/dash0-operator/internal/util"
 	"github.com/dash0hq/dash0-operator/internal/util/logd"
+	"github.com/dash0hq/dash0-operator/internal/util/retry"
 	"github.com/dash0hq/dash0-operator/internal/workloads"
 )
 
@@ -439,7 +440,7 @@ func (i *Instrumenter) handleJobOnInstrumentation(
 
 	logger.Debug("determined required action for immutable job", "required action", requiredAction, "modifyLabels", modifyLabels)
 	modificationResult := workloads.NewNotModifiedReasonUnknownResult()
-	retryErr := util.Retry("handling immutable job", func() error {
+	retryErr := retry.Retry("handling immutable job", func() error {
 		if !modifyLabels {
 			return nil
 		}
@@ -629,7 +630,7 @@ func (i *Instrumenter) instrumentWorkload(
 
 	logger.Debug("determined required action for workload", "required action", requiredAction)
 	modificationResult := workloads.NewNotModifiedReasonUnknownResult()
-	retryErr := util.Retry(fmt.Sprintf("instrumenting %s", kind), func() error {
+	retryErr := retry.Retry(fmt.Sprintf("instrumenting %s", kind), func() error {
 		if err := i.Get(ctx, client.ObjectKey{
 			Namespace: workloadMeta.GetNamespace(),
 			Name:      workloadMeta.GetName(),
@@ -952,7 +953,7 @@ func (i *Instrumenter) handleJobOnUninstrumentation(
 
 	createImmutableWorkloadsError := false
 	modificationResult := workloads.NewNotModifiedReasonUnknownResult()
-	retryErr := util.Retry("removing labels from immutable job", func() error {
+	retryErr := retry.Retry("removing labels from immutable job", func() error {
 		if err := i.Get(ctx, client.ObjectKey{
 			Namespace: job.GetNamespace(),
 			Name:      job.GetName(),
@@ -1119,7 +1120,7 @@ func (i *Instrumenter) revertWorkloadInstrumentation(
 
 	logger.Debug("reverting instrumentation for workload")
 	modificationResult := workloads.NewNotModifiedReasonUnknownResult()
-	retryErr := util.Retry(fmt.Sprintf("uninstrumenting %s", kind), func() error {
+	retryErr := retry.Retry(fmt.Sprintf("uninstrumenting %s", kind), func() error {
 		if err := i.Get(ctx, client.ObjectKey{
 			Namespace: objectMeta.GetNamespace(),
 			Name:      objectMeta.GetName(),

--- a/internal/instrumentation/instrumenter.go
+++ b/internal/instrumentation/instrumenter.go
@@ -15,6 +15,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/events"
 	"k8s.io/client-go/tools/pager"
@@ -56,6 +57,13 @@ const (
 
 var (
 	timeoutForListingPods int64 = 2
+
+	instrumentationRetryBackoff = wait.Backoff{
+		Duration: 10 * time.Millisecond,
+		Factor:   1.0,
+		Steps:    5,
+		Jitter:   0.1,
+	}
 )
 
 func (e ImmutableWorkloadError) Error() string {
@@ -476,7 +484,7 @@ func (i *Instrumenter) handleJobOnInstrumentation(
 		} else {
 			return nil
 		}
-	}, logger)
+	}, instrumentationRetryBackoff, &logger)
 
 	postProcess := i.postProcessInstrumentation
 	if requiredAction == util.ModificationModeUninstrumentation {
@@ -667,7 +675,7 @@ func (i *Instrumenter) instrumentWorkload(
 		} else {
 			return nil
 		}
-	}, logger)
+	}, instrumentationRetryBackoff, &logger)
 
 	switch requiredAction {
 	case util.ModificationModeInstrumentation:
@@ -988,7 +996,7 @@ func (i *Instrumenter) handleJobOnUninstrumentation(
 			modificationResult = workloads.NewNotModifiedNoChangesResult()
 			return nil
 		}
-	}, logger)
+	}, instrumentationRetryBackoff, &logger)
 
 	if retryErr != nil {
 		// For the case that the job was instrumented, and we could not uninstrument it, we create a
@@ -1147,7 +1155,7 @@ func (i *Instrumenter) revertWorkloadInstrumentation(
 		} else {
 			return nil
 		}
-	}, logger)
+	}, instrumentationRetryBackoff, &logger)
 
 	return i.postProcessUninstrumentation(workload.asRuntimeObject(), modificationResult, retryErr, logger)
 }

--- a/internal/instrumentation/instrumenter_test.go
+++ b/internal/instrumentation/instrumenter_test.go
@@ -12,9 +12,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	dash0v1alpha1 "github.com/dash0hq/dash0-operator/api/operator/v1alpha1"
 	dash0v1beta1 "github.com/dash0hq/dash0-operator/api/operator/v1beta1"
 	"github.com/dash0hq/dash0-operator/internal/util"
-	"github.com/dash0hq/dash0-operator/internal/util/cluster"
 	"github.com/dash0hq/dash0-operator/internal/util/logd"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -60,7 +60,7 @@ var _ = Describe("The instrumenter", Ordered, func() {
 				PossibleCollectorUrlsTest,
 				OTelCollectorNodeLocalBaseUrlTest,
 				util.ExtraConfigDefaults,
-				cluster.ResolvedInstrumentationDeliveryInitContainer,
+				dash0v1alpha1.InstrumentationDeliveryInitContainer,
 				nil,
 				false,
 				false,
@@ -803,7 +803,7 @@ var _ = Describe("The instrumenter", Ordered, func() {
 					PossibleCollectorUrlsTest,
 					OTelCollectorNodeLocalBaseUrlTest,
 					util.ExtraConfigDefaults,
-					cluster.ResolvedInstrumentationDeliveryInitContainer,
+					dash0v1alpha1.InstrumentationDeliveryInitContainer,
 					nil,
 					true,
 					false,

--- a/internal/postinstall/operator_post_install_handler.go
+++ b/internal/postinstall/operator_post_install_handler.go
@@ -18,6 +18,7 @@ import (
 	dash0v1beta1 "github.com/dash0hq/dash0-operator/api/operator/v1beta1"
 	"github.com/dash0hq/dash0-operator/internal/util"
 	"github.com/dash0hq/dash0-operator/internal/util/logd"
+	"github.com/dash0hq/dash0-operator/internal/util/retry"
 )
 
 // OperatorPostInstallHandler handle the post-install Helm hook that is responsible for waiting until the operator
@@ -76,7 +77,7 @@ func (h *OperatorPostInstallHandler) WaitForOperatorConfigurationResourceToBecom
 			util.OperatorConfigurationAutoResourceName,
 		)
 	h.logger.Info(message)
-	if err := util.RetryWithCustomBackoff(
+	if err := retry.RetryWithCustomBackoff(
 		message,
 		func() error {
 			return h.checkOperatorConfigurationResourceAvailability(ctx)

--- a/internal/postinstall/operator_post_install_handler.go
+++ b/internal/postinstall/operator_post_install_handler.go
@@ -77,15 +77,13 @@ func (h *OperatorPostInstallHandler) WaitForOperatorConfigurationResourceToBecom
 			util.OperatorConfigurationAutoResourceName,
 		)
 	h.logger.Info(message)
-	if err := retry.RetryWithCustomBackoff(
+	if err := retry.Retry(
 		message,
 		func() error {
 			return h.checkOperatorConfigurationResourceAvailability(ctx)
 		},
 		h.retryBackoff,
-		false,
-		true,
-		h.logger,
+		nil,
 	); err != nil {
 		return fmt.Errorf(
 			"waiting for %s to become available has timed out (no more retries left): %v",

--- a/internal/predelete/pre_delete_suite_test.go
+++ b/internal/predelete/pre_delete_suite_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/dash0hq/dash0-operator/internal/targetallocator"
 	"github.com/dash0hq/dash0-operator/internal/targetallocator/taresources"
 	"github.com/dash0hq/dash0-operator/internal/util"
-	"github.com/dash0hq/dash0-operator/internal/util/cluster"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -110,7 +109,7 @@ var _ = BeforeSuite(func() {
 			PossibleCollectorUrlsTest,
 			OTelCollectorNodeLocalBaseUrlTest,
 			util.ExtraConfigDefaults,
-			cluster.ResolvedInstrumentationDeliveryInitContainer,
+			dash0v1alpha1.InstrumentationDeliveryInitContainer,
 			nil,
 			false,
 			false,

--- a/internal/startup/auto_operator_configuration_handler.go
+++ b/internal/startup/auto_operator_configuration_handler.go
@@ -19,6 +19,7 @@ import (
 	dash0v1alpha1 "github.com/dash0hq/dash0-operator/api/operator/v1alpha1"
 	"github.com/dash0hq/dash0-operator/internal/util"
 	"github.com/dash0hq/dash0-operator/internal/util/logd"
+	"github.com/dash0hq/dash0-operator/internal/util/retry"
 )
 
 type SecretRef struct {
@@ -37,7 +38,7 @@ type OperatorConfigurationValues struct {
 	KeepalivePermitWithoutStream                     bool
 	SelfMonitoringEnabled                            bool
 	KubernetesInfrastructureMetricsCollectionEnabled bool
-	InstrumentationDelivery                          string
+	InstrumentationDelivery                          dash0v1alpha1.InstrumentationDelivery
 	CollectPodLabelsAndAnnotationsEnabled            bool
 	CollectNamespaceLabelsAndAnnotationsEnabled      bool
 	CollectNodeLabelsAndAnnotationsEnabled           bool
@@ -237,7 +238,7 @@ func (r *AutoOperatorConfigurationResourceHandler) createOrUpdateOperatorConfigu
 	operatorConfigurationResource *dash0v1alpha1.Dash0OperatorConfiguration,
 	logger logd.Logger,
 ) error {
-	return util.RetryWithCustomBackoff(
+	return retry.RetryWithCustomBackoff(
 		"create/update operator configuration resource",
 		func() error {
 			return r.createOrUpdateOperatorConfigurationResourceOnce(ctx, operatorConfigurationResource, logger)
@@ -270,7 +271,7 @@ func (r *AutoOperatorConfigurationResourceHandler) createOrUpdateOperatorConfigu
 		// If this is a manually created operator configuration resource, we refuse to overwrite it.
 		if existingOperatorConfigurationResource.Name != util.OperatorConfigurationAutoResourceName {
 			//nolint:staticcheck
-			return util.NewRetryableErrorWithFlag(
+			return retry.NewRetryableError(
 				fmt.Errorf(
 					"The configuration provided via Helm instructs the operator manager to create an operator "+
 						"configuration resource at startup, that is, operator.dash0Export.enabled is true and "+
@@ -394,7 +395,7 @@ func convertValuesToResource(
 	}
 	if operatorConfigurationValues.InstrumentationDelivery != "" {
 		spec.InstrumentWorkloads = dash0v1alpha1.InstrumentWorkloads{
-			InstrumentationDelivery: dash0v1alpha1.InstrumentationDelivery(operatorConfigurationValues.InstrumentationDelivery),
+			InstrumentationDelivery: operatorConfigurationValues.InstrumentationDelivery,
 		}
 	}
 

--- a/internal/startup/auto_operator_configuration_handler.go
+++ b/internal/startup/auto_operator_configuration_handler.go
@@ -238,7 +238,7 @@ func (r *AutoOperatorConfigurationResourceHandler) createOrUpdateOperatorConfigu
 	operatorConfigurationResource *dash0v1alpha1.Dash0OperatorConfiguration,
 	logger logd.Logger,
 ) error {
-	return retry.RetryWithCustomBackoff(
+	return retry.Retry(
 		"create/update operator configuration resource",
 		func() error {
 			return r.createOrUpdateOperatorConfigurationResourceOnce(ctx, operatorConfigurationResource, logger)
@@ -248,9 +248,7 @@ func (r *AutoOperatorConfigurationResourceHandler) createOrUpdateOperatorConfigu
 			Factor:   1.5,
 			Steps:    6,
 		},
-		true,
-		true,
-		logger,
+		&logger,
 	)
 }
 

--- a/internal/startup/instrument_at_startup.go
+++ b/internal/startup/instrument_at_startup.go
@@ -9,6 +9,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	"github.com/dash0hq/dash0-operator/internal/instrumentation"
+	"github.com/dash0hq/dash0-operator/internal/util/cluster"
 	"github.com/dash0hq/dash0-operator/internal/util/logd"
 )
 
@@ -40,6 +41,16 @@ func (r *InstrumentAtStartupRunnable) NeedLeaderElection() bool {
 func (r *InstrumentAtStartupRunnable) Start(ctx context.Context) error {
 	logger := logd.FromContext(ctx)
 	r.instrumenter.Client = r.manager.GetClient()
+	logger.Info("waiting for instrumentation delivery resolution before instrumenting workloads at startup")
+	// The minimum kubelet version detection runs concurrently with the operator manager startup, so it can still be in
+	// progress here. Instrumenting workloads now would pin them to the init container fallback, since they are not
+	// re-instrumented when the resolved delivery mechanism changes later.
+	resolvedInstrumentationDelivery := r.instrumenter.ClusterInstrumentationConfig.
+		WaitForInstrumentationDeliveryAutoToBeResolved(ctx, cluster.InstrumentAtStartUpDeliverySettleTimeout)
+	logger.Info(
+		"instrumenting existing workloads at startup",
+		"resolved instrumentation delivery", resolvedInstrumentationDelivery,
+	)
 	r.instrumenter.InstrumentAtStartup(ctx, logger)
 	return nil
 }

--- a/internal/startup/operator_manager_startup.go
+++ b/internal/startup/operator_manager_startup.go
@@ -151,7 +151,7 @@ type commandLineArguments struct {
 	operatorConfigurationClusterName                                      string
 	operatorConfigurationAutoMonitorNamespacesEnabled                     bool
 	operatorConfigurationAutoMonitorNamespacesLabelSelector               string
-	operatorConfigurationInstrumentationDelivery                          string
+	operatorConfigurationInstrumentationDelivery                          dash0v1alpha1.InstrumentationDelivery
 	telemetryCollectionEnabled                                            bool
 	featureSignalControlEnabled                                           bool
 	forceUseOpenTelemetryCollectorServiceUrl                              bool
@@ -642,13 +642,15 @@ func defineCommandLineArguments() *commandLineArguments {
 		"The value for autoMonitorNamespaces.labelSelector on the operator configuration resource; "+
 			"will be ignored if operator-configuration-endpoint is not set.",
 	)
-	flag.StringVar(
-		&cliArgs.operatorConfigurationInstrumentationDelivery,
+	flag.Func(
 		"operator-configuration-instrumentation-delivery",
-		"",
 		"The value for spec.instrumentWorkloads.instrumentationDelivery on the operator configuration resource. "+
 			"Allowed values are \"auto\", \"image-volume\" and \"init-container\". Will be ignored if "+
 			"operator-configuration-endpoint is not set.",
+		func(value string) error {
+			cliArgs.operatorConfigurationInstrumentationDelivery = dash0v1alpha1.InstrumentationDelivery(value)
+			return nil
+		},
 	)
 	flag.BoolVar(
 		&cliArgs.forceUseOpenTelemetryCollectorServiceUrl,
@@ -1306,14 +1308,7 @@ func startOperatorManager(
 		return fmt.Errorf("unable to create the metadata client")
 	}
 
-	kubernetesVersionInfo, kubernetesVersionDetected := cluster.DetectKubernetesVersion(clientset, setupLog)
-	resolvedInstrumentationDelivery := cluster.ResolveInstrumentationDelivery(
-		cliArgs.operatorConfigurationInstrumentationDelivery,
-		kubernetesVersionInfo,
-		kubernetesVersionDetected,
-		operatorConfigurationIsManagedViaHelm(cliArgs),
-		setupLog,
-	)
+	kubernetesApiServerVersionInfo := cluster.DetectKubernetesApiServerVersion(clientset, setupLog)
 
 	operatorConfigurationTokenRedacted := ""
 	if cliArgs.operatorConfigurationToken != "" {
@@ -1422,8 +1417,6 @@ func startOperatorManager(
 
 		"requested instrumentation delivery",
 		cliArgs.operatorConfigurationInstrumentationDelivery,
-		"resolved instrumentation delivery",
-		resolvedInstrumentationDelivery,
 		"instrumentation delays",
 		cliArgs.instrumentationDelays,
 		"development mode",
@@ -1442,10 +1435,8 @@ func startOperatorManager(
 		envVars.enableRubyAutoInstrumentation,
 		"watch collector resources",
 		!envVars.disableCollectorResourceWatches,
-		"Kubernetes version",
-		kubernetesVersionInfo.VersionString,
-		"Kubernetes version detected",
-		kubernetesVersionDetected,
+		"Kubernetes API server version",
+		kubernetesApiServerVersionInfo,
 	)
 
 	err = startDash0Controllers(
@@ -1455,9 +1446,7 @@ func startOperatorManager(
 		nodeMetadataClient,
 		cliArgs,
 		operatorConfigurationValues,
-		kubernetesVersionInfo,
-		kubernetesVersionDetected,
-		resolvedInstrumentationDelivery,
+		kubernetesApiServerVersionInfo,
 		delegatingZapCoreWrapper,
 		developmentMode,
 	)
@@ -1514,9 +1503,7 @@ func startDash0Controllers(
 	nodeMetadataClient metadata.Interface,
 	cliArgs *commandLineArguments,
 	operatorConfigurationValues *OperatorConfigurationValues,
-	kubernetesVersionInfo cluster.KubernetesVersionInfo,
-	kubernetesVersionDetected bool,
-	instrumentationDelivery cluster.ResolvedInstrumentationDelivery,
+	kubernetesApiServerVersionInfo cluster.KubernetesVersionInfo,
 	delegatingZapCoreWrapper *zaputil.DelegatingZapCoreWrapper,
 	developmentMode bool,
 ) error {
@@ -1591,13 +1578,21 @@ func startDash0Controllers(
 		possibleCollectorUrls,
 		oTelCollectorBaseUrl,
 		extraConfig,
-		instrumentationDelivery,
+		cliArgs.operatorConfigurationInstrumentationDelivery,
 		cliArgs.instrumentationDelays,
 		envVars.instrumentationDebug,
 		envVars.enablePythonAutoInstrumentation,
 		envVars.enableRubyAutoInstrumentation,
 	)
-	clusterInstrumentationConfig.SetKubernetesVersion(kubernetesVersionInfo, kubernetesVersionDetected)
+
+	startMinimumKubeletVersionDetection(
+		ctx,
+		clientset,
+		clusterInstrumentationConfig,
+		kubernetesApiServerVersionInfo,
+		cliArgs.operatorConfigurationInstrumentationDelivery,
+	)
+
 	clusterUid, err := cluster.ReadPseudoClusterUidOrFail(ctx, startupTasksK8sClient, setupLog)
 	if err != nil {
 		return err
@@ -1652,8 +1647,7 @@ func startDash0Controllers(
 			KubeletStatsAutoDetectEndpoint:         envVars.kubeletStatsAutoDetectEndpoint,
 			KubeletStatsReceiverConfig:             envVars.kubeletStatsReceiverConfig,
 			PseudoClusterUid:                       clusterUid,
-			KubernetesVersion:                      kubernetesVersionInfo,
-			KubernetesVersionDetected:              kubernetesVersionDetected,
+			KubernetesApiServerVersion:             kubernetesApiServerVersionInfo,
 			IsIPv6Cluster:                          isIPv6Cluster,
 			IsDocker:                               isDocker,
 			DisableHostPorts:                       cliArgs.disableOpenTelemetryCollectorHostPorts,
@@ -2126,6 +2120,35 @@ func createOrUpdateAutoOperatorConfigurationResource(
 		extraConfigMapWatcher.AddClient(autoOperatorConfigurationResourceHandler)
 		return operatorConfigurationResource
 	}
+}
+
+func startMinimumKubeletVersionDetection(
+	ctx context.Context,
+	clientset *kubernetes.Clientset,
+	clusterInstrumentationConfig *util.ClusterInstrumentationConfig,
+	kubernetesApiServerVersionInfo cluster.KubernetesVersionInfo,
+	requestedInstrumentationDelivery dash0v1alpha1.InstrumentationDelivery,
+) {
+	minimumKubeletVersionDetector := cluster.NewMinimumKubeletVersionDetector()
+	clusterInstrumentationConfig.SetKubernetesVersions(
+		kubernetesApiServerVersionInfo,
+		minimumKubeletVersionDetector,
+	)
+	minimumKubeletVersionDetector.StartDetection(
+		ctx,
+		clientset,
+		func() {
+			setupLog.Info(
+				"the instrumentation delivery mechanism has been re-evaluated after determining the minimum "+
+					"kubelet version among the cluster's nodes",
+				"requested instrumentation delivery",
+				requestedInstrumentationDelivery,
+				"resolved instrumentation delivery",
+				clusterInstrumentationConfig.ResolveInstrumentationDelivery(),
+			)
+		},
+		setupLog,
+	)
 }
 
 // setupCollectorReconciler sets up the reconciler that watches the OpenTelemetry collector resources managed by the

--- a/internal/startup/ready_check.go
+++ b/internal/startup/ready_check.go
@@ -101,15 +101,13 @@ func (c *ReadyCheckExecuter) pollWebhookServiceEndpoint(ctx context.Context, log
 			"starting to poll the webhook service endpoint until %s",
 			conditionLabel,
 		))
-	if err := retry.RetryWithCustomBackoff(
+	if err := retry.Retry(
 		"waiting for webhook service endpoint",
 		func() error {
 			return c.checkWebhookServiceEndpoint(ctx, waitForReadyCondition)
 		},
 		c.retryBackoff,
-		false,
-		true,
-		logger,
+		nil,
 	); err != nil {
 		e := fmt.Errorf("waiting for the webhook service endpoint has timed out (no more retries left): %v", err)
 		return e

--- a/internal/startup/ready_check.go
+++ b/internal/startup/ready_check.go
@@ -15,8 +15,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/dash0hq/dash0-operator/internal/util"
 	"github.com/dash0hq/dash0-operator/internal/util/logd"
+	"github.com/dash0hq/dash0-operator/internal/util/retry"
 )
 
 type ReadyCheckExecuter struct {
@@ -101,7 +101,7 @@ func (c *ReadyCheckExecuter) pollWebhookServiceEndpoint(ctx context.Context, log
 			"starting to poll the webhook service endpoint until %s",
 			conditionLabel,
 		))
-	if err := util.RetryWithCustomBackoff(
+	if err := retry.RetryWithCustomBackoff(
 		"waiting for webhook service endpoint",
 		func() error {
 			return c.checkWebhookServiceEndpoint(ctx, waitForReadyCondition)

--- a/internal/util/cluster/instrumentation_delivery.go
+++ b/internal/util/cluster/instrumentation_delivery.go
@@ -18,66 +18,78 @@ const (
 )
 
 // ResolveInstrumentationDelivery converts the operator configuration's spec.instrumentWorkloads.instrumentationDelivery
-// value into the final decision which delivery mechanism is used by the workload modifier), taking the detected
-// Kubernetes version into account.
+// value into the actual delivery mechanism used by the workload modifier, taking the detected Kubernetes versions into
+// account.
 //
-// If delivery is "image-volume" and the Kubernetes version is older than 1.31, the function logs a warning and
-// returns init container anyway. If the Kubernetes version could not be detected, the function trusts the explicit
-// choice. For "auto" without a detected version, the function falls back to init container, since image volumes need a
-// sufficiently recent Kubernetes version.
+// Image volumes need support from the kubelet, so the decision depends on the minimum kubelet version among the
+// cluster's nodes (see MinimumKubeletVersionDetector) as well as on the Kubernetes API server version.
+//
+// If delivery is "image-volume", the function honors the explicit choice unless one of the two versions is known to be
+// older than 1.31; in that case it logs a warning and returns init container. For "auto", the function returns image
+// volume only if both the Kubernetes API server version and the minimum kubelet version are known to be at least 1.36;
+// in particular it returns init container while the minimum kubelet version detection is still running.
 func ResolveInstrumentationDelivery(
-	delivery string,
-	versionInfo KubernetesVersionInfo,
-	versionDetected bool,
+	delivery dash0v1alpha1.InstrumentationDelivery,
+	apiServerVersionInfo KubernetesVersionInfo,
+	minimumKubeletVersionInfo KubernetesVersionInfo,
 	logWarningForEmptyValue bool,
 	logger logd.Logger,
 ) ResolvedInstrumentationDelivery {
 	// maintenance note: this switch statement needs to be updated once we move to the default being "auto"
 	switch delivery {
 
-	case string(dash0v1alpha1.InstrumentationDeliveryImageVolume):
-		if !versionDetected {
-			// no K8s version detected, use the requested delivery mechanism without further checks
-			return ResolvedInstrumentationDeliveryImageVolume
+	case dash0v1alpha1.InstrumentationDeliveryImageVolume:
+		// Versions that have not been detected (yet) do not veto the explicit choice, only versions that are known to
+		// be too old do.
+		if apiServerVersionInfo.Detected &&
+			!apiServerVersionInfo.IsAtLeast(imageVolumesHardMinimumVersion) {
+			logger.WarnTelemetryCollectionIssue(fmt.Sprintf(
+				"spec.instrumentWorkloads.instrumentationDelivery is set to %q, but the Kubernetes API server version is %s, "+
+					"which does not support image volumes. The setting will be ignored, the operator will use the "+
+					"init container approach for instrumenting workloads.",
+				ResolvedInstrumentationDeliveryImageVolume, apiServerVersionInfo,
+			))
+			return ResolvedInstrumentationDeliveryInitContainer
 		}
-		if versionInfo.Major > imageVolumesAutoMinimumMajorVersion {
-			// K8s version >= 2.x, image-volume has been requested, use image volume
-			return ResolvedInstrumentationDeliveryImageVolume
+		if minimumKubeletVersionInfo.Detected &&
+			!minimumKubeletVersionInfo.IsAtLeast(imageVolumesHardMinimumVersion) {
+			logger.WarnTelemetryCollectionIssue(fmt.Sprintf(
+				"spec.instrumentWorkloads.instrumentationDelivery is set to %q, but the cluster has nodes with "+
+					"kubelet version %s, which does not support image volumes. The setting will be ignored, the "+
+					"operator will use the init container approach for instrumenting workloads.",
+				ResolvedInstrumentationDeliveryImageVolume, minimumKubeletVersionInfo,
+			))
+			return ResolvedInstrumentationDeliveryInitContainer
 		}
-		if versionInfo.Major == imageVolumesAutoMinimumMajorVersion && versionInfo.Minor >= imageVolumesAlwaysMinimumMinorVersion {
-			// K8s version >= 1.31, image-volume has been requested, use image volume
-			return ResolvedInstrumentationDeliveryImageVolume
-		}
-		// K8s version < 1.31, reject using image volume
-		logger.WarnTelemetryCollectionIssue(fmt.Sprintf(
-			"spec.instrumentWorkloads.instrumentationDelivery is set to %q, but the Kubernetes version is %s, "+
-				"which does not support image volumes. The setting will be ignored, the operator will use the init "+
-				"container approach for instrumenting workloads.",
-			ResolvedInstrumentationDeliveryImageVolume, versionInfo.VersionString,
-		))
-		return ResolvedInstrumentationDeliveryInitContainer
+		return ResolvedInstrumentationDeliveryImageVolume
 
-	case string(dash0v1alpha1.InstrumentationDeliveryAuto):
-		if !versionDetected {
+	case dash0v1alpha1.InstrumentationDeliveryAuto:
+		if !apiServerVersionInfo.Detected {
 			// no K8s version detected, and no explicit delivery mechanism requested, fall back to init container
 			logger.WarnTelemetryCollectionIssue(
 				"spec.instrumentWorkloads.instrumentationDelivery is set to \"auto\", but the operator has not been able to " +
-					"detect the Kubernetes version. Falling back to the init container approach for instrumenting workloads.",
+					"detect the Kubernetes API server version. Falling back to the init container approach for instrumenting " +
+					"workloads.",
 			)
 			return ResolvedInstrumentationDeliveryInitContainer
 		}
-		if versionInfo.Major > imageVolumesAutoMinimumMajorVersion {
-			// K8s version >= 2.x, use image volume
+		if !minimumKubeletVersionInfo.Detected {
+			// The nodes have not been inspected (successfully) yet, we cannot rule out that some of them are too old
+			// for image volumes.
+			logger.Debug("spec.instrumentWorkloads.instrumentationDelivery is set to \"auto\", but the minimum " +
+				"kubelet version among the cluster's nodes is not known (yet). Using the init container approach " +
+				"for instrumenting workloads until all nodes have been inspected for their kubelet version.")
+			return ResolvedInstrumentationDeliveryInitContainer
+		}
+		if apiServerVersionInfo.IsAtLeast(imageVolumesAutoMinimumVersion) &&
+			minimumKubeletVersionInfo.IsAtLeast(imageVolumesAutoMinimumVersion) {
+			// API server and all kubelets are on version >= 1.36, use image volume
 			return ResolvedInstrumentationDeliveryImageVolume
 		}
-		if versionInfo.Major == imageVolumesAutoMinimumMajorVersion && versionInfo.Minor >= imageVolumesAutoMinimumMinorVersion {
-			// K8s version >= 1.36, use image volume
-			return ResolvedInstrumentationDeliveryImageVolume
-		}
-		// K8s version < 1.36, use init container
+		// API server or at least one kubelet is on version < 1.36, use init container
 		return ResolvedInstrumentationDeliveryInitContainer
 
-	case string(dash0v1alpha1.InstrumentationDeliveryInitContainer):
+	case dash0v1alpha1.InstrumentationDeliveryInitContainer:
 		// init container has been requested explicitly, no further checks necessary
 		return ResolvedInstrumentationDeliveryInitContainer
 

--- a/internal/util/cluster/instrumentation_delivery_test.go
+++ b/internal/util/cluster/instrumentation_delivery_test.go
@@ -13,115 +13,159 @@ import (
 
 var _ = Describe("ResolveInstrumentationDelivery", func() {
 	type resolveDeliveryTest struct {
-		delivery         string
-		versionInfo      KubernetesVersionInfo
-		versionDetected  bool
-		expectedDelivery ResolvedInstrumentationDelivery
+		delivery                      dash0v1alpha1.InstrumentationDelivery
+		apiServerVersion              KubernetesVersion
+		apiServerVersionDetected      bool
+		minimumKubeletVersion         KubernetesVersion
+		minimumKubeletVersionDetected bool
+		expectedDelivery              ResolvedInstrumentationDelivery
 	}
 
 	DescribeTable("should resolve the instrumentation delivery mechanism",
 		func(testConfig resolveDeliveryTest) {
 			result := ResolveInstrumentationDelivery(
 				testConfig.delivery,
-				testConfig.versionInfo,
-				testConfig.versionDetected,
+				KubernetesVersionInfo{
+					Version:  testConfig.apiServerVersion,
+					Detected: testConfig.apiServerVersionDetected,
+				},
+				KubernetesVersionInfo{
+					Version:  testConfig.minimumKubeletVersion,
+					Detected: testConfig.minimumKubeletVersionDetected,
+				},
 				true,
 				logd.Discard(),
 			)
 			Expect(result).To(Equal(testConfig.expectedDelivery))
 		},
 
-		// image-volume: explicit request honored whenever the K8s version permits it
-		Entry("image-volume with undetected version trusts the explicit choice", resolveDeliveryTest{
-			delivery:         string(dash0v1alpha1.InstrumentationDeliveryImageVolume),
-			versionDetected:  false,
+		// image-volume: explicit request honored unless one of the two versions is known to be too old
+		Entry("image-volume with undetected versions trusts the explicit choice", resolveDeliveryTest{
+			delivery:         dash0v1alpha1.InstrumentationDeliveryImageVolume,
 			expectedDelivery: ResolvedInstrumentationDeliveryImageVolume,
+		}),
+		Entry("image-volume with an undetected minimum kubelet version trusts the explicit choice", resolveDeliveryTest{
+			delivery:                 dash0v1alpha1.InstrumentationDeliveryImageVolume,
+			apiServerVersion:         KubernetesVersion{Major: 1, Minor: 31},
+			apiServerVersionDetected: true,
+			expectedDelivery:         ResolvedInstrumentationDeliveryImageVolume,
 		}),
 		Entry("image-volume on K8s 1.31 (lowest supported) resolves to image volume", resolveDeliveryTest{
-			delivery:         string(dash0v1alpha1.InstrumentationDeliveryImageVolume),
-			versionInfo:      KubernetesVersionInfo{Major: 1, Minor: 31, VersionString: "1.31"},
-			versionDetected:  true,
-			expectedDelivery: ResolvedInstrumentationDeliveryImageVolume,
-		}),
-		Entry("image-volume on K8s 1.36 resolves to image volume", resolveDeliveryTest{
-			delivery:         string(dash0v1alpha1.InstrumentationDeliveryImageVolume),
-			versionInfo:      KubernetesVersionInfo{Major: 1, Minor: 36, VersionString: "1.36"},
-			versionDetected:  true,
-			expectedDelivery: ResolvedInstrumentationDeliveryImageVolume,
+			delivery:                      dash0v1alpha1.InstrumentationDeliveryImageVolume,
+			apiServerVersion:              KubernetesVersion{Major: 1, Minor: 31},
+			apiServerVersionDetected:      true,
+			minimumKubeletVersion:         KubernetesVersion{Major: 1, Minor: 31},
+			minimumKubeletVersionDetected: true,
+			expectedDelivery:              ResolvedInstrumentationDeliveryImageVolume,
 		}),
 		Entry("image-volume on K8s 2.0 resolves to image volume", resolveDeliveryTest{
-			delivery:         string(dash0v1alpha1.InstrumentationDeliveryImageVolume),
-			versionInfo:      KubernetesVersionInfo{Major: 2, Minor: 0, VersionString: "2.0"},
-			versionDetected:  true,
-			expectedDelivery: ResolvedInstrumentationDeliveryImageVolume,
+			delivery:                      dash0v1alpha1.InstrumentationDeliveryImageVolume,
+			apiServerVersion:              KubernetesVersion{Major: 2, Minor: 0},
+			apiServerVersionDetected:      true,
+			minimumKubeletVersion:         KubernetesVersion{Major: 2, Minor: 0},
+			minimumKubeletVersionDetected: true,
+			expectedDelivery:              ResolvedInstrumentationDeliveryImageVolume,
 		}),
-		Entry("image-volume on K8s 1.30 falls back to init container", resolveDeliveryTest{
-			delivery:         string(dash0v1alpha1.InstrumentationDeliveryImageVolume),
-			versionInfo:      KubernetesVersionInfo{Major: 1, Minor: 30, VersionString: "1.30"},
-			versionDetected:  true,
-			expectedDelivery: ResolvedInstrumentationDeliveryInitContainer,
+		Entry("image-volume on K8s server 1.30 falls back to init container", resolveDeliveryTest{
+			delivery:                 dash0v1alpha1.InstrumentationDeliveryImageVolume,
+			apiServerVersion:         KubernetesVersion{Major: 1, Minor: 30},
+			apiServerVersionDetected: true,
+			expectedDelivery:         ResolvedInstrumentationDeliveryInitContainer,
+		}),
+		Entry("image-volume with a node on K8s 1.30 falls back to init container", resolveDeliveryTest{
+			delivery:                      dash0v1alpha1.InstrumentationDeliveryImageVolume,
+			apiServerVersion:              KubernetesVersion{Major: 1, Minor: 36},
+			apiServerVersionDetected:      true,
+			minimumKubeletVersion:         KubernetesVersion{Major: 1, Minor: 30},
+			minimumKubeletVersionDetected: true,
+			expectedDelivery:              ResolvedInstrumentationDeliveryInitContainer,
 		}),
 
-		// auto: picks image volume only when the version is >= 1.36
-		Entry("auto with undetected version falls back to init container", resolveDeliveryTest{
-			delivery:         string(dash0v1alpha1.InstrumentationDeliveryAuto),
-			versionDetected:  false,
+		// auto: picks image volume only when the Kubernetes API server version and all kubelet versions are >= 1.36
+		Entry("auto with undetected versions falls back to init container", resolveDeliveryTest{
+			delivery:         dash0v1alpha1.InstrumentationDeliveryAuto,
 			expectedDelivery: ResolvedInstrumentationDeliveryInitContainer,
+		}),
+		Entry("auto with a pending minimum kubelet version detection falls back to init container", resolveDeliveryTest{
+			delivery:                 dash0v1alpha1.InstrumentationDeliveryAuto,
+			apiServerVersion:         KubernetesVersion{Major: 1, Minor: 36},
+			apiServerVersionDetected: true,
+			expectedDelivery:         ResolvedInstrumentationDeliveryInitContainer,
 		}),
 		Entry("auto on K8s 1.36 (lowest auto-enabled) resolves to image volume", resolveDeliveryTest{
-			delivery:         string(dash0v1alpha1.InstrumentationDeliveryAuto),
-			versionInfo:      KubernetesVersionInfo{Major: 1, Minor: 36, VersionString: "1.36"},
-			versionDetected:  true,
-			expectedDelivery: ResolvedInstrumentationDeliveryImageVolume,
+			delivery:                      dash0v1alpha1.InstrumentationDeliveryAuto,
+			apiServerVersion:              KubernetesVersion{Major: 1, Minor: 36},
+			apiServerVersionDetected:      true,
+			minimumKubeletVersion:         KubernetesVersion{Major: 1, Minor: 36},
+			minimumKubeletVersionDetected: true,
+			expectedDelivery:              ResolvedInstrumentationDeliveryImageVolume,
 		}),
 		Entry("auto on K8s 1.37 resolves to image volume", resolveDeliveryTest{
-			delivery:         string(dash0v1alpha1.InstrumentationDeliveryAuto),
-			versionInfo:      KubernetesVersionInfo{Major: 1, Minor: 37, VersionString: "1.37"},
-			versionDetected:  true,
-			expectedDelivery: ResolvedInstrumentationDeliveryImageVolume,
+			delivery:                      dash0v1alpha1.InstrumentationDeliveryAuto,
+			apiServerVersion:              KubernetesVersion{Major: 1, Minor: 37},
+			apiServerVersionDetected:      true,
+			minimumKubeletVersion:         KubernetesVersion{Major: 1, Minor: 37},
+			minimumKubeletVersionDetected: true,
+			expectedDelivery:              ResolvedInstrumentationDeliveryImageVolume,
 		}),
 		Entry("auto on K8s 2.0 resolves to image volume", resolveDeliveryTest{
-			delivery:         string(dash0v1alpha1.InstrumentationDeliveryAuto),
-			versionInfo:      KubernetesVersionInfo{Major: 2, Minor: 0, VersionString: "2.0"},
-			versionDetected:  true,
-			expectedDelivery: ResolvedInstrumentationDeliveryImageVolume,
+			delivery:                      dash0v1alpha1.InstrumentationDeliveryAuto,
+			apiServerVersion:              KubernetesVersion{Major: 2, Minor: 0},
+			apiServerVersionDetected:      true,
+			minimumKubeletVersion:         KubernetesVersion{Major: 2, Minor: 0},
+			minimumKubeletVersionDetected: true,
+			expectedDelivery:              ResolvedInstrumentationDeliveryImageVolume,
 		}),
-		Entry("auto on K8s 1.35 resolves to init container", resolveDeliveryTest{
-			delivery:         string(dash0v1alpha1.InstrumentationDeliveryAuto),
-			versionInfo:      KubernetesVersionInfo{Major: 1, Minor: 35, VersionString: "1.35"},
-			versionDetected:  true,
-			expectedDelivery: ResolvedInstrumentationDeliveryInitContainer,
+		Entry("auto on K8s server 1.35 resolves to init container", resolveDeliveryTest{
+			delivery:                      dash0v1alpha1.InstrumentationDeliveryAuto,
+			apiServerVersion:              KubernetesVersion{Major: 1, Minor: 35},
+			apiServerVersionDetected:      true,
+			minimumKubeletVersion:         KubernetesVersion{Major: 1, Minor: 36},
+			minimumKubeletVersionDetected: true,
+			expectedDelivery:              ResolvedInstrumentationDeliveryInitContainer,
+		}),
+		Entry("auto with a node on K8s 1.35 resolves to init container", resolveDeliveryTest{
+			delivery:                      dash0v1alpha1.InstrumentationDeliveryAuto,
+			apiServerVersion:              KubernetesVersion{Major: 1, Minor: 36},
+			apiServerVersionDetected:      true,
+			minimumKubeletVersion:         KubernetesVersion{Major: 1, Minor: 35},
+			minimumKubeletVersionDetected: true,
+			expectedDelivery:              ResolvedInstrumentationDeliveryInitContainer,
 		}),
 
 		// init-container: explicit request honored unconditionally
-		Entry("init-container with undetected version resolves to init container", resolveDeliveryTest{
-			delivery:         string(dash0v1alpha1.InstrumentationDeliveryInitContainer),
-			versionDetected:  false,
+		Entry("init-container with undetected versions resolves to init container", resolveDeliveryTest{
+			delivery:         dash0v1alpha1.InstrumentationDeliveryInitContainer,
 			expectedDelivery: ResolvedInstrumentationDeliveryInitContainer,
 		}),
 		Entry("init-container on K8s 1.36 still resolves to init container", resolveDeliveryTest{
-			delivery:         string(dash0v1alpha1.InstrumentationDeliveryInitContainer),
-			versionInfo:      KubernetesVersionInfo{Major: 1, Minor: 36, VersionString: "1.36"},
-			versionDetected:  true,
-			expectedDelivery: ResolvedInstrumentationDeliveryInitContainer,
+			delivery:                      dash0v1alpha1.InstrumentationDeliveryInitContainer,
+			apiServerVersion:              KubernetesVersion{Major: 1, Minor: 36},
+			apiServerVersionDetected:      true,
+			minimumKubeletVersion:         KubernetesVersion{Major: 1, Minor: 36},
+			minimumKubeletVersionDetected: true,
+			expectedDelivery:              ResolvedInstrumentationDeliveryInitContainer,
 		}),
 		Entry("init-container on K8s 2.0 still resolves to init container", resolveDeliveryTest{
-			delivery:         string(dash0v1alpha1.InstrumentationDeliveryInitContainer),
-			versionInfo:      KubernetesVersionInfo{Major: 2, Minor: 0, VersionString: "2.0"},
-			versionDetected:  true,
-			expectedDelivery: ResolvedInstrumentationDeliveryInitContainer,
+			delivery:                      dash0v1alpha1.InstrumentationDeliveryInitContainer,
+			apiServerVersion:              KubernetesVersion{Major: 2, Minor: 0},
+			apiServerVersionDetected:      true,
+			minimumKubeletVersion:         KubernetesVersion{Major: 2, Minor: 0},
+			minimumKubeletVersionDetected: true,
+			expectedDelivery:              ResolvedInstrumentationDeliveryInitContainer,
 		}),
 
 		// unknown/invalid values fall back to init container
 		Entry("unknown delivery value falls back to init container", resolveDeliveryTest{
-			delivery:         "nonsense",
-			versionInfo:      KubernetesVersionInfo{Major: 1, Minor: 36, VersionString: "1.36"},
-			versionDetected:  true,
-			expectedDelivery: ResolvedInstrumentationDeliveryInitContainer,
+			delivery:                      "nonsense",
+			apiServerVersion:              KubernetesVersion{Major: 1, Minor: 36},
+			apiServerVersionDetected:      true,
+			minimumKubeletVersion:         KubernetesVersion{Major: 1, Minor: 36},
+			minimumKubeletVersionDetected: true,
+			expectedDelivery:              ResolvedInstrumentationDeliveryInitContainer,
 		}),
 		Entry("empty delivery value falls back to init container", resolveDeliveryTest{
 			delivery:         "",
-			versionDetected:  false,
 			expectedDelivery: ResolvedInstrumentationDeliveryInitContainer,
 		}),
 	)

--- a/internal/util/cluster/kubernetes_version.go
+++ b/internal/util/cluster/kubernetes_version.go
@@ -195,7 +195,7 @@ func (d *MinimumKubeletVersionDetector) StartDetection(
 ) {
 	go func() {
 		defer d.settledOnce.Do(func() { close(d.settled) })
-		if err := retry.RetryWithCustomBackoff(
+		if err := retry.Retry(
 			"determining the minimum kubelet version of the cluster's nodes",
 			func() error {
 				if ctx.Err() != nil {
@@ -210,9 +210,7 @@ func (d *MinimumKubeletVersionDetector) StartDetection(
 				return nil
 			},
 			minimumKubeletVersionDetectionBackoff,
-			true,
-			false,
-			logger,
+			&logger,
 		); err != nil {
 			if ctx.Err() == nil {
 				logger.ErrorAsWarnTelemetryCollectionIssue(err,

--- a/internal/util/cluster/kubernetes_version.go
+++ b/internal/util/cluster/kubernetes_version.go
@@ -4,72 +4,321 @@
 package cluster
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
 
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/pager"
 
 	"github.com/dash0hq/dash0-operator/internal/util/logd"
+	"github.com/dash0hq/dash0-operator/internal/util/retry"
 )
 
 const (
-	// imageVolumesAutoMinimumMinorVersion is the lowest Kubernetes major version where image volumes are stable.
-	// Used together with imageVolumesAutoMinimumMinorVersion.
-	imageVolumesAutoMinimumMajorVersion = 1
+	// nodeListPageSize is the number of nodes the minimum kubelet version detection requests per API server call.
+	nodeListPageSize = 100
 
-	// imageVolumesAutoMinimumMinorVersion is the lowest 1.x Kubernetes minor version where image volumes are stable
-	// (1.36), and where instrumentationDelivery=auto resolves to image volumes. Used together with
-	// imageVolumesAutoMinimumMajorVersion.
-	imageVolumesAutoMinimumMinorVersion = 36
-
-	// imageVolumesAlwaysMinimumMinorVersion is the lowest 1.x Kubernetes minor version that supports image volumes at
-	// all (1.31).
-	imageVolumesAlwaysMinimumMinorVersion = 31
-
-	// trafficDistributionMinimumMajorVersion is the lowest Kubernetes major version that enables the service field
-	// spec.trafficDistribution by default. Used together with trafficDistributionMinimumMinorVersion.
-	trafficDistributionMinimumMajorVersion = 1
-
-	// trafficDistributionMinimumMinorVersion is the lowest 1.x Kubernetes minor version that enables the service field
-	// spec.trafficDistribution by default (1.31, beta; GA in 1.33). 1.30 has the field but its feature gate defaults to
-	// false, so the API server prunes it. Used together with trafficDistributionMinimumMajorVersion.
-	trafficDistributionMinimumMinorVersion = 31
+	// InstrumentAtStartUpDeliverySettleTimeout bounds how long the startup instrumentation waits for the minimum kubelet
+	// version detection. See also: minimumKubeletVersionDetectionBackoff.
+	InstrumentAtStartUpDeliverySettleTimeout = 95 * time.Second
 )
 
-var leadingDigitsRegex = regexp.MustCompile(`^[0-9]+`)
+var (
+	// minimumKubeletVersionDetectionBackoff governs how often the minimum kubelet version detection is retried after a
+	// failure (Steps) and how long it waits in between attempts (Duration), before it gives up for the lifetime of the
+	// operator manager process. See also: InstrumentAtStartUpDeliverySettleTimeout.
+	minimumKubeletVersionDetectionBackoff = wait.Backoff{
+		Duration: 30 * time.Second,
+		Factor:   1.0,
+		Steps:    3,
+		Jitter:   0.1,
+	}
 
-type KubernetesVersionInfo struct {
-	Major         int
-	Minor         int
-	VersionString string
+	// imageVolumesAutoMinimumVersion is the lowest Kubernetes version where instrumentationDelivery=auto is resolved to
+	// image-volume; this is the version in which the feature became stable.
+	imageVolumesAutoMinimumVersion = KubernetesVersion{Major: 1, Minor: 36}
+
+	// imageVolumesHardMinimumVersion is the lowest 1.x Kubernetes minor version that supports image volumes at all
+	// (1.31), via a feature gate.
+	imageVolumesHardMinimumVersion = KubernetesVersion{Major: 1, Minor: 31}
+
+	// trafficDistributionMinimumVersion is the lowest Kubernetes version that enables the service field
+	// spec.trafficDistribution by default (1.31, beta; GA in 1.33). 1.30 has the field but its feature gate defaults to
+	// false, so the API server prunes it.
+	trafficDistributionMinimumVersion = KubernetesVersion{Major: 1, Minor: 31}
+
+	leadingDigitsRegex = regexp.MustCompile(`^[0-9]+`)
+)
+
+// KubernetesVersion holds the major and minor version of a Kubernetes component.
+type KubernetesVersion struct {
+	Major int
+	Minor int
 }
 
-// DetectKubernetesVersion reads the Kubernetes version of the cluster from clientset.Discovery().ServerVersion().
-func DetectKubernetesVersion(clientset *kubernetes.Clientset, logger logd.Logger) (KubernetesVersionInfo, bool) {
-	if serverVersion, err := clientset.Discovery().ServerVersion(); err != nil {
-		logger.Error(err, "could not determine the Kubernetes version")
-		return KubernetesVersionInfo{Major: 0, Minor: 0, VersionString: ""}, false
+// IsAtLeast reports whether this version is at least the given version.
+func (v KubernetesVersion) IsAtLeast(min KubernetesVersion) bool {
+	if v.Major != min.Major {
+		return v.Major > min.Major
+	}
+	return v.Minor >= min.Minor
+}
+
+func (v KubernetesVersion) String() string {
+	return fmt.Sprintf("%d.%d", v.Major, v.Minor)
+}
+
+// KubernetesVersionInfo holds KubernetesVersion (e.g. the major and minor version of a Kubernetes component), with all
+// vendor-specific suffixes (like "+" on GKE or "-eks-abc1234" on EKS) removed from the numeric fields, plus the version
+// string it was originally parsed from. Depending on the context, the value can refer to the Kubernetes API server
+// version (see DetectKubernetesApiServerVersion) or the kubelet version of a node (see MinimumKubeletVersionDetector).
+type KubernetesVersionInfo struct {
+	// KubernetesVersion the Kubernetes version, if the version has been parsed successfully.
+	Version KubernetesVersion
+
+	// The original version string(s) this version was parsed from, if available.
+	OriginalVersionString string
+
+	// Detected reports whether the version is actually known: it is false if the version could not be determined (or not
+	// yet), and then Version is the zero value. Callers must check Detected before acting on Version, and fall back to
+	// behavior that is safe for old Kubernetes versions if it is false.
+	Detected bool
+}
+
+// IsAtLeast reports whether the version from this KubernetesVersionInfo is at least the given major.minor version. It
+// does not take Detected into account, an undetected version is not at least any version.
+func (v KubernetesVersionInfo) IsAtLeast(min KubernetesVersion) bool {
+	return v.Version.IsAtLeast(min)
+}
+
+func (v KubernetesVersionInfo) String() string {
+	if v.Detected {
+		return v.Version.String()
+	} else if v.OriginalVersionString != "" {
+		return fmt.Sprintf("? (%s)", v.OriginalVersionString)
+	}
+	return "?"
+}
+
+// DetectKubernetesApiServerVersion reads the Kubernetes API server version of the cluster from
+// clientset.Discovery().ServerVersion(). A node can run an older kubelet version than the Kubernetes API server
+// version, see MinimumKubeletVersionDetector.
+func DetectKubernetesApiServerVersion(
+	clientset kubernetes.Interface,
+	logger logd.Logger,
+) KubernetesVersionInfo {
+	if apiServerVersion, err := clientset.Discovery().ServerVersion(); err != nil {
+		logger.Error(err, "could not determine the Kubernetes API server version")
+		return KubernetesVersionInfo{}
 	} else {
-		return parseKubernetesVersion(serverVersion, logger)
+		return parseKubernetesApiServerVersion(apiServerVersion, logger)
 	}
 }
 
-func parseKubernetesVersion(serverVersion *version.Info, logger logd.Logger) (KubernetesVersionInfo, bool) {
-	logger.Debug("Kubernetes version", "version info", serverVersion)
-	major, majorErr := extractLeadingDigits(serverVersion.Major)
-	minor, minorErr := extractLeadingDigits(serverVersion.Minor)
-	versionString := fmt.Sprintf("%s.%s", serverVersion.Major, serverVersion.Minor)
+// MinimumKubeletVersionDetector determines the minimum kubelet version among all nodes of the cluster. A node can lag
+// behind the Kubernetes API server version, so features that need support from the kubelet (image volumes, for example)
+// must not be enabled based on the Kubernetes API server version alone.
+//
+// Clusters can have a lot of nodes, therefore the detection runs in a background goroutine instead of blocking the
+// operator manager startup. Until it has finished, Get reports the minimum kubelet version as unknown, and callers are
+// expected to fall back to the behavior for old Kubernetes versions.
+//
+// The nodes are inspected exactly once at startup. Nodes joining the cluster later are not taken into account.
+type MinimumKubeletVersionDetector struct {
+	minimumKubeletVersion atomic.Pointer[KubernetesVersionInfo]
+
+	// settled is closed when the detection has come to an end, that is, when it has either determined the minimum
+	// kubelet version or given up permanently.
+	settled     chan struct{}
+	settledOnce sync.Once
+}
+
+// NewMinimumKubeletVersionDetector creates a detector whose minimum kubelet version is unknown until StartDetection
+// has been called and the detection has finished.
+func NewMinimumKubeletVersionDetector() *MinimumKubeletVersionDetector {
+	return &MinimumKubeletVersionDetector{settled: make(chan struct{})}
+}
+
+// Get returns the minimum kubelet version among all nodes of the cluster. Its Detected flag is false while the
+// detection is still in progress, as well as when it has failed permanently. See WaitForDetection for a variant that
+// blocks until the detection is done.
+func (d *MinimumKubeletVersionDetector) Get() KubernetesVersionInfo {
+	if d == nil {
+		return KubernetesVersionInfo{}
+	}
+	if minimumKubeletVersion := d.minimumKubeletVersion.Load(); minimumKubeletVersion != nil {
+		return *minimumKubeletVersion
+	}
+	return KubernetesVersionInfo{}
+}
+
+// WaitForDetection blocks until the minimum kubelet version detection has settled, that is, until it has either
+// determined the version or given up permanently, and returns the result. It stops waiting when the given timeout
+// elapses or when ctx is done, and then reports the version as undetected. Callers must check the Detected flag either
+// way and fall back to behavior that is safe for old Kubernetes versions if it is false.
+func (d *MinimumKubeletVersionDetector) WaitForDetection(
+	ctx context.Context,
+	timeout time.Duration,
+) KubernetesVersionInfo {
+	if d == nil {
+		return KubernetesVersionInfo{}
+	}
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case <-d.settled:
+	case <-timer.C:
+	case <-ctx.Done():
+	}
+	return d.Get()
+}
+
+// StartDetection inspects all nodes of the cluster in a background goroutine and records the minimum kubelet version
+// it finds, so the detection does not delay the operator manager startup. The optional onDetected callback is invoked
+// once the minimum kubelet version is available.
+func (d *MinimumKubeletVersionDetector) StartDetection(
+	ctx context.Context,
+	clientset kubernetes.Interface,
+	onDetected func(),
+	logger logd.Logger,
+) {
+	go func() {
+		defer d.settledOnce.Do(func() { close(d.settled) })
+		if err := retry.RetryWithCustomBackoff(
+			"determining the minimum kubelet version of the cluster's nodes",
+			func() error {
+				if ctx.Err() != nil {
+					// the operator manager is shutting down, stop retrying
+					return retry.NewRetryableError(ctx.Err(), false)
+				}
+				minimumKubeletVersion, err := detectMinimumKubeletVersion(ctx, clientset, logger)
+				if err != nil {
+					return err
+				}
+				d.minimumKubeletVersion.Store(&minimumKubeletVersion)
+				return nil
+			},
+			minimumKubeletVersionDetectionBackoff,
+			true,
+			false,
+			logger,
+		); err != nil {
+			if ctx.Err() == nil {
+				logger.ErrorAsWarnTelemetryCollectionIssue(err,
+					"The minimum kubelet version of nodes in the cluster could not be determined. "+
+						"Features that require a minimum kubelet version on all nodes will remain disabled.")
+			}
+			return
+		}
+		logger.Info(
+			fmt.Sprintf("The minimum kubelet version of all nodes in the cluster has been detected as %s.", d.Get()),
+		)
+		if onDetected != nil {
+			onDetected()
+		}
+	}()
+}
+
+// detectMinimumKubeletVersion lists all nodes of the cluster and returns the minimum kubelet version among them. It
+// returns an error if the nodes could not be listed, or if the kubelet version of at least one node could not be
+// parsed: only knowing the kubelet version of a subset of the nodes is not enough to conclude that all nodes have a
+// certain minimum kubelet version. An unparseable kubelet version is reported as a non-retryable error, retrying would
+// not produce a different result.
+func detectMinimumKubeletVersion(
+	ctx context.Context,
+	clientset kubernetes.Interface,
+	logger logd.Logger,
+) (KubernetesVersionInfo, error) {
+	// The nodes are fetched in chunks, since a node object is fairly large (its status carries the list of all images
+	// present on the node) and a cluster can have a lot of nodes. This uses client-go's pager directly; the
+	// controller-runtime cache-backed clients do not support pagination.
+	pgr := pager.New(pager.SimplePageFunc(
+		func(opts metav1.ListOptions) (runtime.Object, error) {
+			return clientset.CoreV1().Nodes().List(ctx, opts)
+		},
+	))
+	pgr.PageSize = nodeListPageSize
+
+	var minimumKubeletVersion *KubernetesVersionInfo
+	if err := pgr.EachListItem(ctx, metav1.ListOptions{}, func(object runtime.Object) error {
+		node, isNode := object.(*corev1.Node)
+		if !isNode {
+			return retry.NewRetryableError(fmt.Errorf("expected a node, but got %T", object), false)
+		}
+		kubeletVersionInfo, err := parseKubeletVersion(node.Status.NodeInfo.KubeletVersion, logger)
+		if err != nil {
+			return retry.NewRetryableError(
+				fmt.Errorf("cannot parse the kubelet version of node %s: %w", node.Name, err), false)
+		}
+		if minimumKubeletVersion == nil || !kubeletVersionInfo.IsAtLeast(minimumKubeletVersion.Version) {
+			minimumKubeletVersion = &kubeletVersionInfo
+		}
+		return nil
+	}); err != nil {
+		return KubernetesVersionInfo{}, err
+	}
+	if minimumKubeletVersion == nil {
+		return KubernetesVersionInfo{}, fmt.Errorf("the cluster has no nodes")
+	}
+	return *minimumKubeletVersion, nil
+}
+
+func parseKubernetesApiServerVersion(apiServerVersion *version.Info, logger logd.Logger) KubernetesVersionInfo {
+	logger.Debug("Kubernetes API server version", "version info", apiServerVersion)
+	major, majorErr := extractLeadingDigits(apiServerVersion.Major)
+	minor, minorErr := extractLeadingDigits(apiServerVersion.Minor)
+	versionString := fmt.Sprintf("%s.%s", apiServerVersion.Major, apiServerVersion.Minor)
 	if majorErr != nil || minorErr != nil {
 		logger.Error(
-			fmt.Errorf("could not parse Kubernetes version major=%q minor=%q", serverVersion.Major, serverVersion.Minor),
-			"could not parse the Kubernetes version",
+			fmt.Errorf("could not parse Kubernetes API server version major=%q minor=%q; errors: %v, %v",
+				apiServerVersion.Major, apiServerVersion.Minor, majorErr, minorErr),
+			"could not parse the Kubernetes API server version",
 		)
-		return KubernetesVersionInfo{Major: 0, Minor: 0, VersionString: versionString}, false
+		return KubernetesVersionInfo{OriginalVersionString: versionString}
 	}
-	logger.Debug("Kubernetes version parsed as", "major", major, "minor", minor, "versionString", versionString)
-	return KubernetesVersionInfo{Major: major, Minor: minor, VersionString: versionString}, true
+	logger.Debug("Kubernetes API server version parsed as",
+		"major", major, "minor", minor, "versionString", versionString)
+	return KubernetesVersionInfo{
+		Version:               KubernetesVersion{Major: major, Minor: minor},
+		OriginalVersionString: versionString,
+		Detected:              true,
+	}
+}
+
+// parseKubeletVersion parses the kubelet version reported in a node's status.nodeInfo.kubeletVersion, for example
+// "v1.36.0", "v1.31.5-gke.1000" or "v1.30.14-eks-3abbec1". Only the major and minor version are retained, the patch
+// version and any vendor suffix are discarded.
+func parseKubeletVersion(kubeletVersion string, logger logd.Logger) (KubernetesVersionInfo, error) {
+	logger.Debug("kubelet version", "version", kubeletVersion)
+	segments := strings.SplitN(strings.TrimPrefix(strings.TrimSpace(kubeletVersion), "v"), ".", 3)
+	if len(segments) < 2 {
+		return KubernetesVersionInfo{
+			OriginalVersionString: kubeletVersion,
+		}, fmt.Errorf("cannot parse kubelet version %q", kubeletVersion)
+	}
+	major, majorErr := extractLeadingDigits(segments[0])
+	minor, minorErr := extractLeadingDigits(segments[1])
+	if majorErr != nil || minorErr != nil {
+		return KubernetesVersionInfo{
+			OriginalVersionString: kubeletVersion,
+		}, fmt.Errorf("cannot parse kubelet version %q; errors: %v, %v", kubeletVersion, majorErr, minorErr)
+	}
+	return KubernetesVersionInfo{
+		Version:               KubernetesVersion{Major: major, Minor: minor},
+		Detected:              true,
+		OriginalVersionString: kubeletVersion,
+	}, nil
 }
 
 // extractLeadingDigits extracts and returns the integer formed by the longest prefix of s that consists only of ASCII

--- a/internal/util/cluster/kubernetes_version_test.go
+++ b/internal/util/cluster/kubernetes_version_test.go
@@ -4,125 +4,152 @@
 package cluster
 
 import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/version"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 
 	"github.com/dash0hq/dash0-operator/internal/util/logd"
+	"github.com/dash0hq/dash0-operator/internal/util/retry"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Cluster utilities", func() {
+var _ = Describe("Kubernetes Version", func() {
 
-	Describe("parseKubernetesVersion", func() {
+	Describe("parseKubernetesApiServerVersion", func() {
 		type parseVersionTest struct {
-			major            string
-			minor            string
-			expectedMajor    int
-			expectedMinor    int
-			expectedString   string
-			expectedDetected bool
+			major                  string
+			minor                  string
+			expectedMajor          int
+			expectedMinor          int
+			expectedString         string
+			expectedOriginalString string
+			expectedDetected       bool
 		}
 
-		DescribeTable("should parse the major/minor of a Kubernetes version",
+		DescribeTable("should parse the major/minor of a Kubernetes API server version",
 			func(testConfig parseVersionTest) {
-				info, detected := parseKubernetesVersion(
+				info := parseKubernetesApiServerVersion(
 					&version.Info{Major: testConfig.major, Minor: testConfig.minor},
 					logd.Discard(),
 				)
-				Expect(detected).To(Equal(testConfig.expectedDetected))
-				Expect(info.VersionString).To(Equal(testConfig.expectedString))
-				if !testConfig.expectedDetected {
-					Expect(info.Major).To(Equal(0))
-					Expect(info.Minor).To(Equal(0))
-					return
+				Expect(info.Detected).To(Equal(testConfig.expectedDetected))
+				Expect(info.String()).To(Equal(testConfig.expectedString))
+				Expect(info.OriginalVersionString).To(Equal(testConfig.expectedOriginalString))
+				if testConfig.expectedDetected {
+					Expect(info.Version.Major).To(Equal(testConfig.expectedMajor))
+					Expect(info.Version.Minor).To(Equal(testConfig.expectedMinor))
+				} else {
+					Expect(info.Version.Major).To(Equal(0))
+					Expect(info.Version.Minor).To(Equal(0))
 				}
-				Expect(info.Major).To(Equal(testConfig.expectedMajor))
-				Expect(info.Minor).To(Equal(testConfig.expectedMinor))
 			},
 			Entry("1.36", parseVersionTest{
-				major:            "1",
-				minor:            "36",
-				expectedMajor:    1,
-				expectedMinor:    36,
-				expectedString:   "1.36",
-				expectedDetected: true,
+				major:                  "1",
+				minor:                  "36",
+				expectedMajor:          1,
+				expectedMinor:          36,
+				expectedString:         "1.36",
+				expectedOriginalString: "1.36",
+				expectedDetected:       true,
 			}),
 			Entry("1.31", parseVersionTest{
-				major:            "1",
-				minor:            "31",
-				expectedMajor:    1,
-				expectedMinor:    31,
-				expectedString:   "1.31",
-				expectedDetected: true,
+				major:                  "1",
+				minor:                  "31",
+				expectedMajor:          1,
+				expectedMinor:          31,
+				expectedString:         "1.31",
+				expectedOriginalString: "1.31",
+				expectedDetected:       true,
 			}),
 			Entry("GKE-style minor with plus suffix", parseVersionTest{
-				major:            "1",
-				minor:            "31+",
-				expectedMajor:    1,
-				expectedMinor:    31,
-				expectedString:   "1.31+",
-				expectedDetected: true,
+				major:                  "1",
+				minor:                  "31+",
+				expectedMajor:          1,
+				expectedMinor:          31,
+				expectedString:         "1.31",
+				expectedOriginalString: "1.31+",
+				expectedDetected:       true,
 			}),
 			Entry("EKS-style minor with text suffix", parseVersionTest{
-				major:            "1",
-				minor:            "30-eks-abc1234",
-				expectedMajor:    1,
-				expectedMinor:    30,
-				expectedString:   "1.30-eks-abc1234",
-				expectedDetected: true,
+				major:                  "1",
+				minor:                  "30-eks-abc1234",
+				expectedMajor:          1,
+				expectedMinor:          30,
+				expectedString:         "1.30",
+				expectedOriginalString: "1.30-eks-abc1234",
+				expectedDetected:       true,
 			}),
 			Entry("hypothetical major version 2", parseVersionTest{
-				major:            "2",
-				minor:            "0",
-				expectedMajor:    2,
-				expectedMinor:    0,
-				expectedString:   "2.0",
-				expectedDetected: true,
+				major:                  "2",
+				minor:                  "0",
+				expectedMajor:          2,
+				expectedMinor:          0,
+				expectedString:         "2.0",
+				expectedOriginalString: "2.0",
+				expectedDetected:       true,
 			}),
 			Entry("2.34", parseVersionTest{
-				major:            "2",
-				minor:            "34",
-				expectedMajor:    2,
-				expectedMinor:    34,
-				expectedString:   "2.34",
-				expectedDetected: true,
+				major:                  "2",
+				minor:                  "34",
+				expectedMajor:          2,
+				expectedMinor:          34,
+				expectedString:         "2.34",
+				expectedOriginalString: "2.34",
+				expectedDetected:       true,
 			}),
 			Entry("empty major", parseVersionTest{
-				major:            "",
-				minor:            "31",
-				expectedString:   ".31",
-				expectedDetected: false,
+				major:                  "",
+				minor:                  "31",
+				expectedString:         "? (.31)",
+				expectedOriginalString: ".31",
+				expectedDetected:       false,
 			}),
 			Entry("empty minor", parseVersionTest{
-				major:            "1",
-				minor:            "",
-				expectedString:   "1.",
-				expectedDetected: false,
+				major:                  "1",
+				minor:                  "",
+				expectedString:         "? (1.)",
+				expectedOriginalString: "1.",
+				expectedDetected:       false,
 			}),
 			Entry("both empty", parseVersionTest{
-				major:            "",
-				minor:            "",
-				expectedString:   ".",
-				expectedDetected: false,
+				major:                  "",
+				minor:                  "",
+				expectedString:         "? (.)",
+				expectedOriginalString: ".",
+				expectedDetected:       false,
 			}),
 			Entry("non-numeric major", parseVersionTest{
-				major:            "abc",
-				minor:            "31",
-				expectedString:   "abc.31",
-				expectedDetected: false,
+				major:                  "abc",
+				minor:                  "31",
+				expectedString:         "? (abc.31)",
+				expectedOriginalString: "abc.31",
+				expectedDetected:       false,
 			}),
 			Entry("non-numeric minor", parseVersionTest{
-				major:            "1",
-				minor:            "thirty-one",
-				expectedString:   "1.thirty-one",
-				expectedDetected: false,
+				major:                  "1",
+				minor:                  "thirty-one",
+				expectedString:         "? (1.thirty-one)",
+				expectedOriginalString: "1.thirty-one",
+				expectedDetected:       false,
 			}),
 			Entry("minor with leading non-digit", parseVersionTest{
-				major:            "1",
-				minor:            "+31",
-				expectedString:   "1.+31",
-				expectedDetected: false,
+				major:                  "1",
+				minor:                  "+31",
+				expectedString:         "? (1.+31)",
+				expectedOriginalString: "1.+31",
+				expectedDetected:       false,
 			}),
 		)
 	})
@@ -194,4 +221,415 @@ var _ = Describe("Cluster utilities", func() {
 			}),
 		)
 	})
+
+	Describe("KubernetesVersionInfo.IsAtLeast", func() {
+		type isAtLeastTest struct {
+			actualVersion  KubernetesVersion
+			minimumVersion KubernetesVersion
+			expected       bool
+		}
+
+		DescribeTable("should compare the major/minor version",
+			func(testConfig isAtLeastTest) {
+				actualVersionInfo := KubernetesVersionInfo{Version: testConfig.actualVersion}
+				Expect(
+					actualVersionInfo.IsAtLeast(testConfig.minimumVersion)).
+					To(Equal(testConfig.expected))
+			},
+			Entry("same version", isAtLeastTest{
+				actualVersion:  KubernetesVersion{Major: 1, Minor: 36},
+				minimumVersion: KubernetesVersion{Major: 1, Minor: 36},
+				expected:       true,
+			}),
+			Entry("higher minor version", isAtLeastTest{
+				actualVersion:  KubernetesVersion{Major: 1, Minor: 37},
+				minimumVersion: KubernetesVersion{Major: 1, Minor: 36},
+				expected:       true,
+			}),
+			Entry("lower minor version", isAtLeastTest{
+				actualVersion:  KubernetesVersion{Major: 1, Minor: 35},
+				minimumVersion: KubernetesVersion{Major: 1, Minor: 36},
+				expected:       false,
+			}),
+			Entry("higher major version with lower minor version", isAtLeastTest{
+				actualVersion:  KubernetesVersion{Major: 2, Minor: 0},
+				minimumVersion: KubernetesVersion{Major: 1, Minor: 36},
+				expected:       true,
+			}),
+			Entry("lower major version with higher minor version", isAtLeastTest{
+				actualVersion:  KubernetesVersion{Major: 1, Minor: 99},
+				minimumVersion: KubernetesVersion{Major: 2, Minor: 0},
+				expected:       false,
+			}),
+			Entry("zero value", isAtLeastTest{
+				actualVersion:  KubernetesVersion{},
+				minimumVersion: KubernetesVersion{Major: 1, Minor: 31},
+				expected:       false,
+			}),
+		)
+	})
+
+	Describe("parseKubeletVersion", func() {
+		type parseKubeletVersionTest struct {
+			kubeletVersion         string
+			expectedMajor          int
+			expectedMinor          int
+			expectedString         string
+			expectedOriginalString string
+			expectError            bool
+		}
+
+		DescribeTable("should parse the kubelet version of a node",
+			func(testConfig parseKubeletVersionTest) {
+				versionInfo, err := parseKubeletVersion(testConfig.kubeletVersion, logd.Discard())
+				if testConfig.expectError {
+					Expect(err).To(HaveOccurred())
+					Expect(versionInfo.Detected).To(BeFalse())
+					Expect(versionInfo.Version.Major).To(Equal(0))
+					Expect(versionInfo.Version.Minor).To(Equal(0))
+				} else {
+					Expect(err).NotTo(HaveOccurred())
+					Expect(versionInfo.Detected).To(BeTrue())
+					Expect(versionInfo.Version.Major).To(Equal(testConfig.expectedMajor))
+					Expect(versionInfo.Version.Minor).To(Equal(testConfig.expectedMinor))
+				}
+				Expect(versionInfo.String()).To(Equal(testConfig.expectedString))
+				Expect(versionInfo.OriginalVersionString).To(Equal(testConfig.expectedOriginalString))
+			},
+			Entry("plain version", parseKubeletVersionTest{
+				kubeletVersion:         "v1.36.0",
+				expectedMajor:          1,
+				expectedMinor:          36,
+				expectedString:         "1.36",
+				expectedOriginalString: "v1.36.0",
+			}),
+			Entry("version without the v prefix", parseKubeletVersionTest{
+				kubeletVersion:         "1.31.5",
+				expectedMajor:          1,
+				expectedMinor:          31,
+				expectedString:         "1.31",
+				expectedOriginalString: "1.31.5",
+			}),
+			Entry("GKE-style vendor suffix", parseKubeletVersionTest{
+				kubeletVersion:         "v1.31.5-gke.1000",
+				expectedMajor:          1,
+				expectedMinor:          31,
+				expectedString:         "1.31",
+				expectedOriginalString: "v1.31.5-gke.1000",
+			}),
+			Entry("EKS-style vendor suffix", parseKubeletVersionTest{
+				kubeletVersion:         "v1.30.14-eks-3abbec1",
+				expectedMajor:          1,
+				expectedMinor:          30,
+				expectedString:         "1.30",
+				expectedOriginalString: "v1.30.14-eks-3abbec1",
+			}),
+			Entry("k3s-style vendor suffix", parseKubeletVersionTest{
+				kubeletVersion:         "v1.33.0+k3s1",
+				expectedMajor:          1,
+				expectedMinor:          33,
+				expectedString:         "1.33",
+				expectedOriginalString: "v1.33.0+k3s1",
+			}),
+			Entry("minor version with suffix but no patch version", parseKubeletVersionTest{
+				kubeletVersion:         "v1.36+",
+				expectedMajor:          1,
+				expectedMinor:          36,
+				expectedString:         "1.36",
+				expectedOriginalString: "v1.36+",
+			}),
+			Entry("surrounding whitespace", parseKubeletVersionTest{
+				kubeletVersion:         " v2.0.1 ",
+				expectedMajor:          2,
+				expectedMinor:          0,
+				expectedString:         "2.0",
+				expectedOriginalString: " v2.0.1 ",
+			}),
+			Entry("empty string", parseKubeletVersionTest{
+				kubeletVersion:         "",
+				expectError:            true,
+				expectedString:         "?",
+				expectedOriginalString: "",
+			}),
+			Entry("no minor version", parseKubeletVersionTest{
+				kubeletVersion:         "v1",
+				expectError:            true,
+				expectedString:         "? (v1)",
+				expectedOriginalString: "v1",
+			}),
+			Entry("non-numeric minor version", parseKubeletVersionTest{
+				kubeletVersion:         "v1.abc.0",
+				expectError:            true,
+				expectedString:         "? (v1.abc.0)",
+				expectedOriginalString: "v1.abc.0",
+			}),
+			Entry("non-numeric major version", parseKubeletVersionTest{
+				kubeletVersion:         "vX.36.0",
+				expectError:            true,
+				expectedString:         "? (vX.36.0)",
+				expectedOriginalString: "vX.36.0",
+			}),
+		)
+	})
+
+	Describe("detectMinimumKubeletVersion", func() {
+		type detectMinimumKubeletVersionTest struct {
+			kubeletVersions        []string
+			expectedDetected       bool
+			expectedMajor          int
+			expectedMinor          int
+			expectedOriginalString string
+			expectedRetryable      bool
+		}
+
+		DescribeTable("should determine the minimum kubelet version of all nodes",
+			func(testConfig detectMinimumKubeletVersionTest) {
+				clientset := fake.NewClientset(nodesWithKubeletVersions(testConfig.kubeletVersions)...)
+
+				minimumKubeletVersion, err := detectMinimumKubeletVersion(context.Background(), clientset, logd.Discard())
+
+				if !testConfig.expectedDetected {
+					Expect(err).To(HaveOccurred())
+					Expect(retry.IsRetryable(err)).To(Equal(testConfig.expectedRetryable))
+					Expect(minimumKubeletVersion.Detected).To(BeFalse())
+					return
+				}
+				Expect(err).NotTo(HaveOccurred())
+				Expect(minimumKubeletVersion.Detected).To(BeTrue())
+				Expect(minimumKubeletVersion.Version.Major).To(Equal(testConfig.expectedMajor))
+				Expect(minimumKubeletVersion.Version.Minor).To(Equal(testConfig.expectedMinor))
+				Expect(minimumKubeletVersion.OriginalVersionString).To(Equal(testConfig.expectedOriginalString))
+			},
+			Entry("single node", detectMinimumKubeletVersionTest{
+				kubeletVersions:        []string{"v1.36.0"},
+				expectedDetected:       true,
+				expectedMajor:          1,
+				expectedMinor:          36,
+				expectedOriginalString: "v1.36.0",
+			}),
+			Entry("all nodes on the same version", detectMinimumKubeletVersionTest{
+				kubeletVersions:  []string{"v1.36.1", "v1.36.0", "v1.36.2"},
+				expectedDetected: true,
+				expectedMajor:    1,
+				expectedMinor:    36,
+				// The minimum version comparison does not differentiate between patch versions, only major and minor versions
+				// are compared. If different patch versions have the same major/minor, the first one wins.
+				expectedOriginalString: "v1.36.1",
+			}),
+			Entry("one node lagging behind", detectMinimumKubeletVersionTest{
+				kubeletVersions:        []string{"v1.36.0", "v1.35.4", "v1.37.0"},
+				expectedDetected:       true,
+				expectedMajor:          1,
+				expectedMinor:          35,
+				expectedOriginalString: "v1.35.4",
+			}),
+			Entry("nodes with vendor suffixes", detectMinimumKubeletVersionTest{
+				kubeletVersions:        []string{"v1.31.5-gke.1000", "v1.30.14-eks-3abbec1"},
+				expectedDetected:       true,
+				expectedMajor:          1,
+				expectedMinor:          30,
+				expectedOriginalString: "v1.30.14-eks-3abbec1",
+			}),
+			Entry("nodes across major versions", detectMinimumKubeletVersionTest{
+				kubeletVersions:        []string{"v2.0.0", "v1.99.0"},
+				expectedDetected:       true,
+				expectedMajor:          1,
+				expectedMinor:          99,
+				expectedOriginalString: "v1.99.0",
+			}),
+			Entry("an unparseable kubelet version is a non-retryable failure", detectMinimumKubeletVersionTest{
+				kubeletVersions:  []string{"v1.36.0", "not-a-version"},
+				expectedDetected: false,
+			}),
+			Entry("a cluster without nodes is a retryable failure", detectMinimumKubeletVersionTest{
+				kubeletVersions:   []string{},
+				expectedDetected:  false,
+				expectedRetryable: true,
+			}),
+		)
+
+		It("should use pagination when inspecting nodes", func() {
+			clientset := fake.NewClientset()
+			listOptionsPerRequest := make([]metav1.ListOptions, 0, 2)
+			clientset.PrependReactor("list", "nodes", func(action k8stesting.Action) (bool, runtime.Object, error) {
+				listOptionsPerRequest = append(listOptionsPerRequest, action.(k8stesting.ListActionImpl).ListOptions)
+				if len(listOptionsPerRequest) == 1 {
+					return true, &corev1.NodeList{
+						ListMeta: metav1.ListMeta{Continue: "second-chunk"},
+						Items: []corev1.Node{
+							*nodeWithKubeletVersion("node-0", "v1.39.0"),
+							*nodeWithKubeletVersion("node-0", "v1.38.0"),
+							*nodeWithKubeletVersion("node-0", "v1.37.0"),
+						},
+					}, nil
+				}
+				return true, &corev1.NodeList{
+					Items: []corev1.Node{
+						*nodeWithKubeletVersion("node-1", "v1.35.1"),
+						*nodeWithKubeletVersion("node-1", "v1.36.2"),
+						*nodeWithKubeletVersion("node-1", "v1.34.3"),
+					},
+				}, nil
+			})
+
+			minimumKubeletVersion, err := detectMinimumKubeletVersion(context.Background(), clientset, logd.Discard())
+
+			Expect(err).NotTo(HaveOccurred())
+			// the lowest version only occurs on the second chunk
+			Expect(minimumKubeletVersion.Version.Major).To(Equal(1))
+			Expect(minimumKubeletVersion.Version.Minor).To(Equal(34))
+			Expect(listOptionsPerRequest).To(HaveLen(2))
+			Expect(listOptionsPerRequest[0].Limit).To(Equal(int64(nodeListPageSize)))
+			Expect(listOptionsPerRequest[0].Continue).To(BeEmpty())
+			Expect(listOptionsPerRequest[1].Continue).To(Equal("second-chunk"))
+		})
+	})
+
+	Describe("MinimumKubeletVersionDetector.StartDetection", func() {
+
+		BeforeEach(func() {
+			originalBackoff := minimumKubeletVersionDetectionBackoff
+			minimumKubeletVersionDetectionBackoff = wait.Backoff{
+				Duration: time.Millisecond,
+				Factor:   1.0,
+				Steps:    3,
+			}
+			DeferCleanup(func() {
+				minimumKubeletVersionDetectionBackoff = originalBackoff
+			})
+		})
+
+		It("should report the minimum kubelet version and notify the callback once detection succeeds", func() {
+			clientset := fake.NewClientset(nodesWithKubeletVersions([]string{"v1.38.0", "v1.36.2", "v1.37.1"})...)
+			detector := NewMinimumKubeletVersionDetector()
+			onDetectedCalls := atomic.Int32{}
+
+			detector.StartDetection(context.Background(), clientset, func() { onDetectedCalls.Add(1) }, logd.Discard())
+
+			Eventually(func(g Gomega) {
+				minimumKubeletVersion := detector.Get()
+				g.Expect(minimumKubeletVersion.Detected).To(BeTrue())
+				g.Expect(minimumKubeletVersion.Version.Major).To(Equal(1))
+				g.Expect(minimumKubeletVersion.Version.Minor).To(Equal(36))
+			}).Should(Succeed())
+			Eventually(onDetectedCalls.Load).Should(Equal(int32(1)))
+			Consistently(onDetectedCalls.Load).Should(Equal(int32(1)))
+		})
+
+		It("should keep reporting the version as undetected and never notify the callback when it gives up", func() {
+			clientset := fake.NewClientset()
+			listRequests := atomic.Int32{}
+			clientset.PrependReactor("list", "nodes", func(k8stesting.Action) (bool, runtime.Object, error) {
+				listRequests.Add(1)
+				return true, nil, apierrors.NewInternalError(fmt.Errorf("the API server is unavailable"))
+			})
+			detector := NewMinimumKubeletVersionDetector()
+			onDetectedCalls := atomic.Int32{}
+
+			detector.StartDetection(context.Background(), clientset, func() { onDetectedCalls.Add(1) }, logd.Discard())
+
+			Eventually(listRequests.Load).Should(
+				Equal(int32(minimumKubeletVersionDetectionBackoff.Steps)))
+			Consistently(func(g Gomega) {
+				g.Expect(detector.Get().Detected).To(BeFalse())
+				g.Expect(onDetectedCalls.Load()).To(BeZero())
+				g.Expect(listRequests.Load()).To(Equal(int32(minimumKubeletVersionDetectionBackoff.Steps)))
+			}).Should(Succeed())
+		})
+
+		It("should stop retrying without notifying the callback when the context is cancelled", func() {
+			clientset := fake.NewClientset()
+			clientset.PrependReactor("list", "nodes", func(k8stesting.Action) (bool, runtime.Object, error) {
+				return true, nil, apierrors.NewInternalError(fmt.Errorf("the API server is unavailable"))
+			})
+			cancellableCtx, cancel := context.WithCancel(context.Background())
+			cancel()
+			detector := NewMinimumKubeletVersionDetector()
+			onDetectedCalls := atomic.Int32{}
+
+			detector.StartDetection(cancellableCtx, clientset, func() { onDetectedCalls.Add(1) }, logd.Discard())
+
+			Consistently(func(g Gomega) {
+				g.Expect(detector.Get().Detected).To(BeFalse())
+				g.Expect(onDetectedCalls.Load()).To(BeZero())
+			}).Should(Succeed())
+		})
+	})
+
+	Describe("MinimumKubeletVersionDetector.WaitForDetection", func() {
+
+		BeforeEach(func() {
+			originalBackoff := minimumKubeletVersionDetectionBackoff
+			minimumKubeletVersionDetectionBackoff = wait.Backoff{
+				Duration: time.Millisecond,
+				Factor:   1.0,
+				Steps:    3,
+			}
+			DeferCleanup(func() {
+				minimumKubeletVersionDetectionBackoff = originalBackoff
+			})
+		})
+
+		It("should return the version once the detection has succeeded", func() {
+			clientset := fake.NewClientset(nodesWithKubeletVersions([]string{"v1.38.0", "v1.36.2"})...)
+			detector := NewMinimumKubeletVersionDetector()
+			detector.StartDetection(context.Background(), clientset, nil, logd.Discard())
+
+			minimumKubeletVersion := detector.WaitForDetection(context.Background(), 30*time.Second)
+
+			Expect(minimumKubeletVersion.Detected).To(BeTrue())
+			Expect(minimumKubeletVersion.Version.Minor).To(Equal(36))
+		})
+
+		It("should return an undetected version once the detection has given up, without waiting for the timeout",
+			func() {
+				clientset := fake.NewClientset()
+				clientset.PrependReactor("list", "nodes", func(k8stesting.Action) (bool, runtime.Object, error) {
+					return true, nil, apierrors.NewInternalError(fmt.Errorf("the API server is unavailable"))
+				})
+				detector := NewMinimumKubeletVersionDetector()
+				detector.StartDetection(context.Background(), clientset, nil, logd.Discard())
+
+				// A timeout far beyond the test's own budget: returning at all proves the wait ends when the detection
+				// gives up, rather than when the timeout elapses.
+				Expect(detector.WaitForDetection(context.Background(), time.Hour).Detected).To(BeFalse())
+			})
+
+		It("should give up waiting when the timeout elapses while the detection is still in progress", func() {
+			detector := NewMinimumKubeletVersionDetector()
+
+			// Detection is never started, so it never settles.
+			Expect(detector.WaitForDetection(context.Background(), time.Millisecond).Detected).To(BeFalse())
+		})
+
+		It("should stop waiting when the context is done", func() {
+			detector := NewMinimumKubeletVersionDetector()
+			cancelledCtx, cancel := context.WithCancel(context.Background())
+			cancel()
+
+			Expect(detector.WaitForDetection(cancelledCtx, time.Hour).Detected).To(BeFalse())
+		})
+
+		It("should report an undetected version for a nil detector", func() {
+			var detector *MinimumKubeletVersionDetector
+
+			Expect(detector.WaitForDetection(context.Background(), time.Hour).Detected).To(BeFalse())
+		})
+	})
 })
+
+// nodesWithKubeletVersions creates one node object per given kubelet version, for seeding a fake clientset.
+func nodesWithKubeletVersions(kubeletVersions []string) []runtime.Object {
+	nodes := make([]runtime.Object, 0, len(kubeletVersions))
+	for i, kubeletVersion := range kubeletVersions {
+		nodes = append(nodes, nodeWithKubeletVersion(fmt.Sprintf("node-%d", i), kubeletVersion))
+	}
+	return nodes
+}
+
+func nodeWithKubeletVersion(name string, kubeletVersion string) *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Status:     corev1.NodeStatus{NodeInfo: corev1.NodeSystemInfo{KubeletVersion: kubeletVersion}},
+	}
+}

--- a/internal/util/cluster/service_traffic_distribution.go
+++ b/internal/util/cluster/service_traffic_distribution.go
@@ -30,25 +30,20 @@ import (
 // later.
 func ResolveServiceTrafficDistribution(
 	versionInfo KubernetesVersionInfo,
-	versionDetected bool,
 	logger logd.Logger,
 ) *string {
 	preferClose := corev1.ServiceTrafficDistributionPreferClose
-	if !versionDetected {
-		logger.Debug("the Kubernetes version could not be detected, omitting spec.trafficDistribution on the " +
-			"operator's services; zone-aware routing is not available")
+	if !versionInfo.Detected {
+		logger.Debug("the Kubernetes API server version could not be detected, omitting spec.trafficDistribution on " +
+			"the operator's services; zone-aware routing is not available")
 		return nil
 	}
-	if versionInfo.Major > trafficDistributionMinimumMajorVersion {
-		return &preferClose
-	}
-	if versionInfo.Major == trafficDistributionMinimumMajorVersion &&
-		versionInfo.Minor >= trafficDistributionMinimumMinorVersion {
+	if versionInfo.IsAtLeast(trafficDistributionMinimumVersion) {
 		return &preferClose
 	}
 	logger.Debug(fmt.Sprintf(
-		"the Kubernetes version is %s, which does not enable spec.trafficDistribution by default (requires 1.%d or "+
-			"later); zone-aware routing is not available",
-		versionInfo.VersionString, trafficDistributionMinimumMinorVersion))
+		"the Kubernetes API server version is %s, which does not enable spec.trafficDistribution by default (requires "+
+			"1.%d or later); zone-aware routing is not available",
+		versionInfo, trafficDistributionMinimumVersion.Minor))
 	return nil
 }

--- a/internal/util/cluster/service_traffic_distribution_test.go
+++ b/internal/util/cluster/service_traffic_distribution_test.go
@@ -12,7 +12,7 @@ import (
 
 var _ = Describe("ResolveServiceTrafficDistribution", func() {
 	type resolveTrafficDistributionTest struct {
-		versionInfo     KubernetesVersionInfo
+		version         KubernetesVersion
 		versionDetected bool
 		expectOmitted   bool
 	}
@@ -20,8 +20,7 @@ var _ = Describe("ResolveServiceTrafficDistribution", func() {
 	DescribeTable("should resolve the service traffic distribution",
 		func(testConfig resolveTrafficDistributionTest) {
 			result := ResolveServiceTrafficDistribution(
-				testConfig.versionInfo,
-				testConfig.versionDetected,
+				KubernetesVersionInfo{Version: testConfig.version, Detected: testConfig.versionDetected},
 				logd.Discard(),
 			)
 			if testConfig.expectOmitted {
@@ -35,31 +34,31 @@ var _ = Describe("ResolveServiceTrafficDistribution", func() {
 		},
 
 		Entry("omits the field on Kubernetes 1.29", resolveTrafficDistributionTest{
-			versionInfo:     KubernetesVersionInfo{Major: 1, Minor: 29, VersionString: "1.29"},
+			version:         KubernetesVersion{Major: 1, Minor: 29},
 			versionDetected: true,
 			expectOmitted:   true,
 		}),
 		// 1.30 has the field, but its ServiceTrafficDistribution feature gate defaults to false there, so the API
 		// server would prune the value and the service would never converge.
 		Entry("omits the field on Kubernetes 1.30", resolveTrafficDistributionTest{
-			versionInfo:     KubernetesVersionInfo{Major: 1, Minor: 30, VersionString: "1.30"},
+			version:         KubernetesVersion{Major: 1, Minor: 30},
 			versionDetected: true,
 			expectOmitted:   true,
 		}),
 		Entry("sets the field on Kubernetes 1.31, where the feature gate defaults to true", resolveTrafficDistributionTest{
-			versionInfo:     KubernetesVersionInfo{Major: 1, Minor: 31, VersionString: "1.31"},
+			version:         KubernetesVersion{Major: 1, Minor: 31},
 			versionDetected: true,
 		}),
 		Entry("sets the field on Kubernetes 1.33", resolveTrafficDistributionTest{
-			versionInfo:     KubernetesVersionInfo{Major: 1, Minor: 33, VersionString: "1.33"},
+			version:         KubernetesVersion{Major: 1, Minor: 33},
 			versionDetected: true,
 		}),
 		Entry("sets PreferClose (not PreferSameZone) on Kubernetes 1.34", resolveTrafficDistributionTest{
-			versionInfo:     KubernetesVersionInfo{Major: 1, Minor: 34, VersionString: "1.34"},
+			version:         KubernetesVersion{Major: 1, Minor: 34},
 			versionDetected: true,
 		}),
 		Entry("sets the field on a hypothetical Kubernetes 2.0", resolveTrafficDistributionTest{
-			versionInfo:     KubernetesVersionInfo{Major: 2, Minor: 0, VersionString: "2.0"},
+			version:         KubernetesVersion{Major: 2, Minor: 0},
 			versionDetected: true,
 		}),
 		// Setting a field the API server does not know would make the desired and the live object never converge,

--- a/internal/util/labels.go
+++ b/internal/util/labels.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 
 	dash0common "github.com/dash0hq/dash0-operator/api/operator/common"
+	"github.com/dash0hq/dash0-operator/internal/util/cluster"
 )
 
 const (
@@ -43,6 +44,7 @@ func AddInstrumentationLabelsAndAnnotations(
 	objectMeta *metav1.ObjectMeta,
 	instrumentationSuccess bool,
 	clusterInstrumentationConfig *ClusterInstrumentationConfig,
+	resolvedInstrumentationDelivery cluster.ResolvedInstrumentationDelivery,
 	actor WorkloadModifierActor,
 ) {
 	if instrumentationSuccess {
@@ -56,7 +58,7 @@ func AddInstrumentationLabelsAndAnnotations(
 	addAnnotation(
 		objectMeta,
 		instrumentationDeliveryAnnotationKey,
-		string(clusterInstrumentationConfig.GetInstrumentationDelivery()),
+		string(resolvedInstrumentationDelivery),
 	)
 	removeLabel(objectMeta, legacyInitContainerImageLabelKey)
 }

--- a/internal/util/logd/logd.go
+++ b/internal/util/logd/logd.go
@@ -68,7 +68,7 @@ func (l Logger) ErrorAsWarnTelemetryCollectionIssue(err error, msg string, keysA
 
 // ErrorTelemetryCollectionIssue logs an error as a telemetry collection issue at level at zapcore.ErrorLevel.
 func (l Logger) ErrorTelemetryCollectionIssue(err error, msg string, keysAndValues ...any) {
-	l.ErrorAsWarn(err, msg, append([]any{telemetryCollectionIssueMarker, true}, keysAndValues...)...)
+	l.Error(err, msg, append([]any{telemetryCollectionIssueMarker, true}, keysAndValues...)...)
 }
 
 // WithValues returns a new Logger with additional key-value pairs.

--- a/internal/util/retry/retry.go
+++ b/internal/util/retry/retry.go
@@ -1,21 +1,22 @@
 // SPDX-FileCopyrightText: Copyright 2024 Dash0 Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-package util
+package retry
 
 import (
 	"errors"
 	"fmt"
 	"time"
 
-	"github.com/dash0hq/dash0-operator/internal/util/logd"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/util/retry"
+	k8sretry "k8s.io/client-go/util/retry"
+
+	"github.com/dash0hq/dash0-operator/internal/util/logd"
 )
 
 var (
-	// The documentation for the wait.Backoff struct when used with retry.OnError is a bit confusing, because
-	// retry.OnError apparently uses some fields differently then what the wait.Backoff struct documentation says.
+	// The documentation for the wait.Backoff struct when used with k8sretry.OnError is a bit confusing, because
+	// k8sretry.OnError apparently uses some fields differently then what the wait.Backoff struct documentation says.
 	// Here goes:
 	//
 	// wait.Backoff{
@@ -27,21 +28,21 @@ var (
 	//   Jitter: ...
 	//
 	// ^ The parameters above are used as documented in wait.Backoff; but Steps and Cap are used differently. Basically,
-	//   when wait.Backoff would stop increasing Duration due to either Steps or Cap, retry.OnError instead uses this as
-	//   a trigger to stop retrying, and it returns the last error to the client.
+	//   when wait.Backoff would stop increasing Duration due to either Steps or Cap, k8sretry.OnError instead uses this
+	//   as a trigger to stop retrying, and it returns the last error to the client.
 	//
 	//   // wait.Backoff effectively says that after Steps retries, the duration will no longer change due to `Factor`,
 	//   // but remain constant.
 	//   // However, according to the function godoc comment on wait.backoff.ExponentialBackoff, backoff.Steps is the
-	//   // maximum number of retries. So when the number of unsuccessful retries is equal to "Steps", retry.OnError
+	//   // maximum number of retries. So when the number of unsuccessful retries is equal to "Steps", k8sretry.OnError
 	//   // gives up and the most recent error is returned to the client.
 	//   Steps: ...
 	//
 	//   // wait.Backoff effectively says that Cap is another way to limit the increase of Duration between retries, in
 	//   // addition to or as an alternative to Steps. When Duration hits Cap, it will no longer be incremented.
-	//   // However, according to the function godoc comment on wait.backoff.ExponentialBackoff, retry.OnError gives up
+	//   // However, according to the function godoc comment on wait.backoff.ExponentialBackoff, k8sretry.OnError gives up
 	//   // once "a sleep truncated by the cap on duration has been completed." That is, when the Duration hits Cap,
-	//   // there is exactly one more retry, and if that is not successful, retry.OnError gives up. Note that Cap is not
+	//   // there is exactly one more retry, and if that is not successful, k8sretry.OnError gives up. Note that Cap is not
 	//   // a limit to the aggregated duration of all retries, but a limit to the Duration between retries, when it is
 	//   // increased via a Factor > 1.0.
 	//   Cap: ...
@@ -54,10 +55,14 @@ var (
 	}
 )
 
+// Retry executes the given operation and retries with the defaultRetryBackoff.
+// If the final attempt fails with an error or if a non-retryable error occurs, the error is returned the caller.
+// Individual attempts are logged, and if the final attempt fails, this is logged as an error as well.
 func Retry(operationLabel string, operation func() error, logger logd.Logger) error {
 	return RetryWithCustomBackoff(operationLabel, operation, defaultRetryBackoff, true, true, logger)
 }
 
+// RetryWithCustomBackoff executes the given operation and retries with the provided backoff settings.
 func RetryWithCustomBackoff(
 	operationLabel string,
 	operation func() error,
@@ -67,19 +72,16 @@ func RetryWithCustomBackoff(
 	logger logd.Logger,
 ) error {
 	attempt := 0
-	return retry.OnError(
+	return k8sretry.OnError(
 		backoff,
 		func(err error) bool {
-			// Per default, we assume errors are retriable, use RetryableError with retryable=false to stop retrying.
-			canBeRetried := true
-
-			var retryErr *RetryableError
-			if errors.As(err, &retryErr) {
-				canBeRetried = retryErr.retryable
-			}
-
-			if !canBeRetried {
-				return canBeRetried
+			if !IsRetryable(err) {
+				if logFinalFailureAsError {
+					logger.Error(err,
+						fmt.Sprintf(
+							"%s failed with non-retryable error", operationLabel))
+				}
+				return false
 			}
 
 			attempt += 1
@@ -108,7 +110,7 @@ func RetryWithCustomBackoff(
 				))
 			}
 
-			// Note: retry.OnError stops retrying correctly after the specified number of Steps, returning this
+			// Note: k8sretry.OnError stops retrying correctly after the specified number of Steps, returning this
 			// most recent error, no matter whether we return true or false. The bool return value is only used to
 			// inspect errors and decide whether they even can be retried or not.
 			return true
@@ -117,16 +119,22 @@ func RetryWithCustomBackoff(
 	)
 }
 
+// IsRetryable reports whether the operation that produced err should be retried. Errors are retryable per default,
+// wrap them via NewRetryableError with retryable set to false to mark them as non-retryable.
+func IsRetryable(err error) bool {
+	var retryErr *RetryableError
+	if errors.As(err, &retryErr) {
+		return retryErr.retryable
+	}
+	return true
+}
+
 type RetryableError struct {
 	err       error
 	retryable bool
 }
 
-func NewRetryableError(err error) *RetryableError {
-	return &RetryableError{err: err, retryable: false}
-}
-
-func NewRetryableErrorWithFlag(err error, retryable bool) *RetryableError {
+func NewRetryableError(err error, retryable bool) *RetryableError {
 	return &RetryableError{err: err, retryable: retryable}
 }
 
@@ -135,13 +143,6 @@ func (e *RetryableError) Error() string {
 		return "unknown retryable error"
 	}
 	return e.err.Error()
-}
-
-func (e *RetryableError) SetRetryable(retryable bool) {
-	if e == nil {
-		return
-	}
-	e.retryable = retryable
 }
 
 func (e *RetryableError) IsRetryable() bool {

--- a/internal/util/retry/retry.go
+++ b/internal/util/retry/retry.go
@@ -6,7 +6,6 @@ package retry
 import (
 	"errors"
 	"fmt"
-	"time"
 
 	"k8s.io/apimachinery/pkg/util/wait"
 	k8sretry "k8s.io/client-go/util/retry"
@@ -14,80 +13,73 @@ import (
 	"github.com/dash0hq/dash0-operator/internal/util/logd"
 )
 
-var (
-	// The documentation for the wait.Backoff struct when used with k8sretry.OnError is a bit confusing, because
-	// k8sretry.OnError apparently uses some fields differently then what the wait.Backoff struct documentation says.
-	// Here goes:
-	//
-	// wait.Backoff{
-	//   // The initial duration -- that is, the initial wait between retries.
-	//   Duration: ...
-	//   // Duration (the wait between retries) is multiplied by factor after each retry.
-	//   Factor: ...
-	//   // Additional random element for adding to the wait between retries.
-	//   Jitter: ...
-	//
-	// ^ The parameters above are used as documented in wait.Backoff; but Steps and Cap are used differently. Basically,
-	//   when wait.Backoff would stop increasing Duration due to either Steps or Cap, k8sretry.OnError instead uses this
-	//   as a trigger to stop retrying, and it returns the last error to the client.
-	//
-	//   // wait.Backoff effectively says that after Steps retries, the duration will no longer change due to `Factor`,
-	//   // but remain constant.
-	//   // However, according to the function godoc comment on wait.backoff.ExponentialBackoff, backoff.Steps is the
-	//   // maximum number of retries. So when the number of unsuccessful retries is equal to "Steps", k8sretry.OnError
-	//   // gives up and the most recent error is returned to the client.
-	//   Steps: ...
-	//
-	//   // wait.Backoff effectively says that Cap is another way to limit the increase of Duration between retries, in
-	//   // addition to or as an alternative to Steps. When Duration hits Cap, it will no longer be incremented.
-	//   // However, according to the function godoc comment on wait.backoff.ExponentialBackoff, k8sretry.OnError gives up
-	//   // once "a sleep truncated by the cap on duration has been completed." That is, when the Duration hits Cap,
-	//   // there is exactly one more retry, and if that is not successful, k8sretry.OnError gives up. Note that Cap is not
-	//   // a limit to the aggregated duration of all retries, but a limit to the Duration between retries, when it is
-	//   // increased via a Factor > 1.0.
-	//   Cap: ...
-	// }
-	defaultRetryBackoff = wait.Backoff{
-		Duration: 10 * time.Millisecond,
-		Factor:   1.0,
-		Steps:    5,
-		Jitter:   0.1,
-	}
-)
-
-// Retry executes the given operation and retries with the defaultRetryBackoff.
-// If the final attempt fails with an error or if a non-retryable error occurs, the error is returned the caller.
-// Individual attempts are logged, and if the final attempt fails, this is logged as an error as well.
-func Retry(operationLabel string, operation func() error, logger logd.Logger) error {
-	return RetryWithCustomBackoff(operationLabel, operation, defaultRetryBackoff, true, true, logger)
-}
-
-// RetryWithCustomBackoff executes the given operation and retries with the provided backoff settings.
-func RetryWithCustomBackoff(
+// Retry executes the given operation and retries with the provided backoff settings. If the optional logger
+// logAttemptsTo is provided, individual failed attempts are logged at level info. If logAttemptsTo is nil, this
+// function logs nothing. If the final attempt fails with an error or if a non-retryable error occurs, this function
+// does neither log nor handle it. The final or non-retryable error is instead returned to the caller. It is expected
+// that the caller then handles it appropriately (by logging it or otherwise). A backoff with Steps <= 0 is normalized
+// to a single attempt, so that the operation is always executed at least once.
+//
+// Note: The documentation for the wait.Backoff struct when used with k8sretry.OnError is a bit confusing, because
+// k8sretry.OnError apparently uses some fields differently then what the wait.Backoff struct documentation says.
+// Here goes:
+//
+//	wait.Backoff{
+//	  // The initial duration -- that is, the initial wait between retries.
+//	  Duration: ...
+//	  // Duration (the wait between retries) is multiplied by factor after each retry.
+//	  Factor: ...
+//	  // Additional random element for adding to the wait between retries.
+//	  Jitter: ...
+//
+// ^ The parameters above are used as documented in wait.Backoff; but Steps and Cap are used differently. Basically,
+//
+//	  when wait.Backoff would stop increasing Duration due to either Steps or Cap, k8sretry.OnError instead uses this
+//	  as a trigger to stop retrying, and it returns the last error to the client.
+//
+//	  // wait.Backoff effectively says that after Steps retries, the duration will no longer change due to `Factor`,
+//	  // but remain constant.
+//	  // However, according to the function godoc comment on wait.backoff.ExponentialBackoff, backoff.Steps is the
+//	  // maximum number of retries. So when the number of unsuccessful retries is equal to "Steps", k8sretry.OnError
+//	  // gives up and the most recent error is returned to the client.
+//	  Steps: ...
+//
+//	  // wait.Backoff effectively says that Cap is another way to limit the increase of Duration between retries, in
+//	  // addition to or as an alternative to Steps. When Duration hits Cap, it will no longer be incremented.
+//	  // However, according to the function godoc comment on wait.backoff.ExponentialBackoff, k8sretry.OnError gives up
+//	  // once "a sleep truncated by the cap on duration has been completed." That is, when the Duration hits Cap,
+//	  // there is exactly one more retry, and if that is not successful, k8sretry.OnError gives up. Note that Cap is not
+//	  // a limit to the aggregated duration of all retries, but a limit to the Duration between retries, when it is
+//	  // increased via a Factor > 1.0.
+//	  Cap: ...
+//	}
+func Retry(
 	operationLabel string,
 	operation func() error,
 	backoff wait.Backoff,
-	logAttempts bool,
-	logFinalFailureAsError bool,
-	logger logd.Logger,
+	logAttemptsTo *logd.Logger,
 ) error {
+	if backoff.Steps <= 0 {
+		// k8sretry.OnError would not call the operation at all and return nil, that is, report success without ever
+		// having executed the operation.
+		backoff.Steps = 1
+	}
+
 	attempt := 0
+
 	return k8sretry.OnError(
 		backoff,
+
+		// This function is called for every error, for the purpose of determining whether it is a retryable or non-retryable
+		// error.
 		func(err error) bool {
 			if !IsRetryable(err) {
-				if logFinalFailureAsError {
-					logger.Error(err,
-						fmt.Sprintf(
-							"%s failed with non-retryable error", operationLabel))
-				}
 				return false
 			}
-
 			attempt += 1
 			if attempt < backoff.Steps {
-				if logAttempts {
-					logger.Info(
+				if logAttemptsTo != nil {
+					logAttemptsTo.Info(
 						fmt.Sprintf(
 							"%s failed in attempt %d/%d, will be retried: %v",
 							operationLabel,
@@ -96,31 +88,22 @@ func RetryWithCustomBackoff(
 							err,
 						))
 				}
-			} else if logFinalFailureAsError {
-				logger.Error(err,
-					fmt.Sprintf(
-						"%s failed after attempt %d/%d, no more retries left.", operationLabel, attempt, backoff.Steps))
-			} else {
-				logger.Info(fmt.Sprintf(
-					"%s failed after attempt %d/%d, no more retries left, final error: %v.",
-					operationLabel,
-					attempt,
-					backoff.Steps,
-					err,
-				))
 			}
 
-			// Note: k8sretry.OnError stops retrying correctly after the specified number of Steps, returning this
-			// most recent error, no matter whether we return true or false. The bool return value is only used to
-			// inspect errors and decide whether they even can be retried or not.
+			// Note: k8sretry.OnError stops retrying correctly after the specified number of Steps, no matter whether we
+			// return true or false here. The bool we return here is only used if there are still retries left, then it is
+			// used to decide whether the error can be retried or aborts the retrying before the final attempt due to a
+			// non-retryable error.
 			return true
 		},
+
+		// This is the action/operation that is being retried.
 		operation,
 	)
 }
 
-// IsRetryable reports whether the operation that produced err should be retried. Errors are retryable per default,
-// wrap them via NewRetryableError with retryable set to false to mark them as non-retryable.
+// IsRetryable reports whether the operation that produced err should be retried. Errors are retryable per default.
+// To mark them as non-retryable, wrap them via NewRetryableError with retryable set to false.
 func IsRetryable(err error) bool {
 	var retryErr *RetryableError
 	if errors.As(err, &retryErr) {

--- a/internal/util/retry/retry_suite_test.go
+++ b/internal/util/retry/retry_suite_test.go
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: Copyright 2026 Dash0 Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// The tests for this package live in the external test package retry_test, since they use the shared test helpers from
+// test/util, which in turn depend on this package.
+package retry_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestRetry(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Retry Util Suite")
+}

--- a/internal/util/retry/retry_test.go
+++ b/internal/util/retry/retry_test.go
@@ -1,0 +1,219 @@
+// SPDX-FileCopyrightText: Copyright 2026 Dash0 Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package retry_test
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/dash0hq/dash0-operator/internal/util/logd"
+	"github.com/dash0hq/dash0-operator/internal/util/retry"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	. "github.com/dash0hq/dash0-operator/test/util"
+)
+
+const operationLabel = "test operation"
+
+var (
+	logger           logd.Logger
+	capturingLogSink *CapturingLogSink
+)
+
+// backoffWithSteps returns a backoff with a negligible wait between attempts, so that the tests do not spend time
+// sleeping.
+func backoffWithSteps(steps int) wait.Backoff {
+	return wait.Backoff{
+		Duration: time.Microsecond,
+		Factor:   1.0,
+		Steps:    steps,
+	}
+}
+
+var _ = Describe("Retry", func() {
+
+	BeforeEach(func() {
+		logger, capturingLogSink = NewCapturingLogger()
+	})
+
+	It("does not retry a successful operation", func() {
+		attempts := 0
+		err := retry.Retry(operationLabel, func() error {
+			attempts++
+			return nil
+		}, backoffWithSteps(5), &logger)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(attempts).To(Equal(1))
+		capturingLogSink.HasNoLogMessages(Default)
+	})
+
+	It("stops retrying once the operation succeeds", func() {
+		attempts := 0
+		err := retry.Retry(operationLabel, func() error {
+			attempts++
+			if attempts < 3 {
+				return fmt.Errorf("attempt %d failed", attempts)
+			}
+			return nil
+		}, backoffWithSteps(5), &logger)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(attempts).To(Equal(3))
+	})
+
+	It("returns the error of the final attempt after exhausting all steps", func() {
+		attempts := 0
+		err := retry.Retry(operationLabel, func() error {
+			attempts++
+			return fmt.Errorf("attempt %d failed", attempts)
+		}, backoffWithSteps(3), &logger)
+
+		Expect(err).To(MatchError("attempt 3 failed"))
+		Expect(attempts).To(Equal(3))
+	})
+
+	It("aborts immediately when the first error is non-retryable", func() {
+		attempts := 0
+		nonRetryable := retry.NewRetryableError(errors.New("do not retry this"), false)
+		err := retry.Retry(operationLabel, func() error {
+			attempts++
+			return nonRetryable
+		}, backoffWithSteps(5), &logger)
+
+		Expect(err).To(MatchError(nonRetryable))
+		Expect(attempts).To(Equal(1))
+		capturingLogSink.HasNoLogMessages(Default)
+	})
+
+	It("aborts as soon as a non-retryable error occurs, even with retries left", func() {
+		attempts := 0
+		nonRetryable := retry.NewRetryableError(errors.New("do not retry this"), false)
+		err := retry.Retry(operationLabel, func() error {
+			attempts++
+			if attempts < 3 {
+				return fmt.Errorf("attempt %d failed", attempts)
+			}
+			return nonRetryable
+		}, backoffWithSteps(10), &logger)
+
+		Expect(err).To(MatchError(nonRetryable))
+		Expect(attempts).To(Equal(3))
+	})
+
+	Describe("normalizing the number of steps", func() {
+		// Without normalization, k8sretry.OnError never executes the operation for a backoff with Steps <= 0 and
+		// reports success, that is, it silently pretends the operation has succeeded.
+		for _, steps := range []int{0, -1} {
+			It(fmt.Sprintf("executes the operation once for a backoff with Steps=%d", steps), func() {
+				attempts := 0
+				err := retry.Retry(operationLabel, func() error {
+					attempts++
+					return errors.New("operation failed")
+				}, backoffWithSteps(steps), &logger)
+
+				Expect(err).To(MatchError("operation failed"))
+				Expect(attempts).To(Equal(1))
+			})
+		}
+
+		It("executes a successful operation once for a zero value backoff", func() {
+			attempts := 0
+			err := retry.Retry(operationLabel, func() error {
+				attempts++
+				return nil
+			}, wait.Backoff{}, &logger)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(attempts).To(Equal(1))
+		})
+	})
+
+	It("executes the operation once for a backoff with a single step", func() {
+		attempts := 0
+		err := retry.Retry(operationLabel, func() error {
+			attempts++
+			return errors.New("operation failed")
+		}, backoffWithSteps(1), &logger)
+
+		Expect(err).To(MatchError("operation failed"))
+		Expect(attempts).To(Equal(1))
+	})
+
+	Describe("logging attempts", func() {
+		It("logs every failed attempt that will be retried, but not the final one", func() {
+			err := retry.Retry(operationLabel, func() error {
+				return errors.New("operation failed")
+			}, backoffWithSteps(3), &logger)
+
+			Expect(err).To(HaveOccurred())
+			capturingLogSink.HasLogMessage(
+				Default,
+				"test operation failed in attempt 1/3, will be retried: operation failed",
+			)
+			capturingLogSink.HasLogMessage(
+				Default,
+				"test operation failed in attempt 2/3, will be retried: operation failed",
+			)
+			// The final attempt is not logged, the caller is expected to handle the returned error.
+			capturingLogSink.HasNoLogMessage(
+				Default,
+				"test operation failed in attempt 3/3, will be retried: operation failed",
+			)
+		})
+
+		It("retries and returns the final error without a logger", func() {
+			attempts := 0
+			err := retry.Retry(operationLabel, func() error {
+				attempts++
+				return fmt.Errorf("attempt %d failed", attempts)
+			}, backoffWithSteps(3), nil)
+
+			Expect(err).To(MatchError("attempt 3 failed"))
+			Expect(attempts).To(Equal(3))
+			capturingLogSink.HasNoLogMessages(Default)
+		})
+	})
+})
+
+var _ = Describe("IsRetryable", func() {
+
+	It("reports a plain error as retryable", func() {
+		Expect(retry.IsRetryable(errors.New("some error"))).To(BeTrue())
+	})
+
+	It("reports a RetryableError marked as retryable as retryable", func() {
+		Expect(retry.IsRetryable(retry.NewRetryableError(errors.New("some error"), true))).To(BeTrue())
+	})
+
+	It("reports a RetryableError marked as non-retryable as non-retryable", func() {
+		Expect(retry.IsRetryable(retry.NewRetryableError(errors.New("some error"), false))).To(BeFalse())
+	})
+
+	It("unwraps a non-retryable error", func() {
+		wrapped := fmt.Errorf("outer: %w", retry.NewRetryableError(errors.New("inner"), false))
+		Expect(retry.IsRetryable(wrapped)).To(BeFalse())
+	})
+})
+
+var _ = Describe("RetryableError", func() {
+
+	It("renders the message of the wrapped error", func() {
+		Expect(retry.NewRetryableError(errors.New("some error"), false).Error()).To(Equal("some error"))
+	})
+
+	It("renders a placeholder message when no error is wrapped", func() {
+		Expect(retry.NewRetryableError(nil, false).Error()).To(Equal("unknown retryable error"))
+	})
+
+	It("reports its retryable flag", func() {
+		Expect(retry.NewRetryableError(errors.New("some error"), true).IsRetryable()).To(BeTrue())
+		Expect(retry.NewRetryableError(errors.New("some error"), false).IsRetryable()).To(BeFalse())
+	})
+})

--- a/internal/util/types.go
+++ b/internal/util/types.go
@@ -4,6 +4,7 @@
 package util
 
 import (
+	"context"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -13,7 +14,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	dash0common "github.com/dash0hq/dash0-operator/api/operator/common"
+	dash0v1alpha1 "github.com/dash0hq/dash0-operator/api/operator/v1alpha1"
 	"github.com/dash0hq/dash0-operator/internal/util/cluster"
+	"github.com/dash0hq/dash0-operator/internal/util/logd"
 )
 
 type Action string
@@ -75,19 +78,18 @@ type CollectorConfig struct {
 	// KubeletStatsAutoDetectEndpoint is false and is used verbatim instead of probing the node's kubelet.
 	KubeletStatsReceiverConfig *KubeletStatsReceiverConfig
 	PseudoClusterUid           types.UID
-	// KubernetesVersion is the Kubernetes version detected at operator manager startup, and
-	// KubernetesVersionDetected reports whether that detection succeeded. Used to decide whether the operator's
-	// services can carry spec.trafficDistribution.
-	KubernetesVersion         cluster.KubernetesVersionInfo
-	KubernetesVersionDetected bool
-	IsIPv6Cluster             bool
-	IsDocker                  bool
-	DisableHostPorts          bool
-	IsGkeAutopilot            bool
-	DevelopmentMode           bool
-	DebugVerbosityDetailed    bool
-	EnableProfExtension       bool
-	CompressConfigMap         bool
+	// KubernetesApiServerVersion is the Kubernetes API server version, detected at operator manager startup; its
+	// Detected flag reports whether that detection succeeded. Used to decide whether the operator's services can carry
+	// spec.trafficDistribution.
+	KubernetesApiServerVersion cluster.KubernetesVersionInfo
+	IsIPv6Cluster              bool
+	IsDocker                   bool
+	DisableHostPorts           bool
+	IsGkeAutopilot             bool
+	DevelopmentMode            bool
+	DebugVerbosityDetailed     bool
+	EnableProfExtension        bool
+	CompressConfigMap          bool
 }
 
 // KubeletStatsReceiverConfig holds the configuration for the kubeletstats receiver in the DaemonSet collector. It is
@@ -197,18 +199,21 @@ type ClusterInstrumentationConfig struct {
 	OTelCollectorBaseUrl  string
 	ExtraConfig           atomic.Pointer[ExtraConfig]
 
-	// KubernetesVersion holds the Kubernetes version of the cluster detected at operator manager startup.
-	// KubernetesVersionDetected indicates whether detection succeeded; if false, KubernetesVersion is the zero value.
-	KubernetesVersion         cluster.KubernetesVersionInfo
-	KubernetesVersionDetected bool
+	// kubernetesApiServerVersion holds the Kubernetes API server version, detected at operator manager startup. Its
+	// Detected flag indicates whether that detection succeeded.
+	kubernetesApiServerVersion cluster.KubernetesVersionInfo
 
-	// ResolvedDelivery is the resolved decision (based on the operator configuration's
-	// spec.instrumentWorkloads.instrumentationDelivery and the Kubernetes version) on whether Kubernetes image volumes
-	// or the legacy init container plus emptyDir volume approach is used for instrumentation delivery. The value is
-	// initialized at operator manager startup from the --operator-configuration-instrumentation-delivery flag (if
-	// available) and may be updated at runtime by the operator configuration reconciler when
-	// spec.instrumentWorkloads.instrumentationDelivery is changed.
-	ResolvedDelivery atomic.Pointer[cluster.ResolvedInstrumentationDelivery]
+	// minimumKubeletVersionDetector provides the minimum kubelet version among the cluster's nodes, which is determined
+	// asynchronously after the operator manager has started.
+	minimumKubeletVersionDetector *cluster.MinimumKubeletVersionDetector
+
+	// requestedInstrumentationDelivery is the unresolved value of the operator configuration's
+	// spec.instrumentWorkloads.instrumentationDelivery setting. It is initialized at operator manager startup from the
+	// --operator-configuration-instrumentation-delivery flag (if available) and may be updated at runtime by the
+	// operator configuration reconciler when spec.instrumentWorkloads.instrumentationDelivery is changed. The decision
+	// whether Kubernetes image volumes or the legacy init container plus emptyDir volume approach is used is derived
+	// from this value on demand, see ResolveInstrumentationDelivery.
+	requestedInstrumentationDelivery atomic.Pointer[dash0v1alpha1.InstrumentationDelivery]
 
 	InstrumentationDelays           *DelayConfig
 	InstrumentationDebug            bool
@@ -221,7 +226,7 @@ func NewClusterInstrumentationConfig(
 	possibleCollectorUrls PossibleCollectorUrls,
 	oTelCollectorBaseUrl string,
 	extraConfig ExtraConfig,
-	instrumentationDelivery cluster.ResolvedInstrumentationDelivery,
+	requestedInstrumentationDelivery dash0v1alpha1.InstrumentationDelivery,
 	instrumentationDelays *DelayConfig,
 	instrumentationDebug bool,
 	enablePythonAutoInstrumentation bool,
@@ -237,42 +242,80 @@ func NewClusterInstrumentationConfig(
 		EnableRubyAutoInstrumentation:   enableRubyAutoInstrumentation,
 	}
 	c.ExtraConfig.Store(&extraConfig)
-	c.ResolvedDelivery.Store(&instrumentationDelivery)
+	c.requestedInstrumentationDelivery.Store(&requestedInstrumentationDelivery)
 	return c
 }
 
-// SetKubernetesVersion records the detected Kubernetes version on the config. Intended to be called once at
-// operator manager startup, before the config is shared with reconcilers and webhooks.
-func (c *ClusterInstrumentationConfig) SetKubernetesVersion(info cluster.KubernetesVersionInfo, detected bool) {
-	c.KubernetesVersion = info
-	c.KubernetesVersionDetected = detected
+// SetKubernetesVersions stores the detected Kubernetes API server version and the detector for the minimum kubelet
+// version in the ClusterInstrumentationConfig. Intended to be called once at operator manager startup, before the
+// config is shared with reconcilers and webhooks.
+func (c *ClusterInstrumentationConfig) SetKubernetesVersions(
+	apiServerVersion cluster.KubernetesVersionInfo,
+	minimumKubeletVersionDetector *cluster.MinimumKubeletVersionDetector,
+) {
+	c.kubernetesApiServerVersion = apiServerVersion
+	c.minimumKubeletVersionDetector = minimumKubeletVersionDetector
 }
 
-// SetInstrumentationDelivery sets the resolved instrumentation delivery mechanism. The previously stored value is
-// returned for logging purposes.
-func (c *ClusterInstrumentationConfig) SetInstrumentationDelivery(instrumentationDelivery cluster.ResolvedInstrumentationDelivery) cluster.ResolvedInstrumentationDelivery {
-	previous := c.ResolvedDelivery.Swap(&instrumentationDelivery)
-	if previous == nil {
-		return ""
+// WaitForInstrumentationDeliveryAutoToBeResolved returns the instrumentation delivery mechanism to use, waiting for the
+// minimum kubelet version detection first if the outcome depends on it, e.g. if the requested mode is "auto". Use it
+// before instrumenting workloads in bulk: while the detection is still in progress, "auto" resolves to the
+// init-container fallback, and workloads that have been instrumented already are not re-instrumented when the resolved
+// mechanism changes later. It gives up waiting after the given timeout and then returns the mechanism that is effective
+// at that point.
+//
+// If the requested delivery is not "auto", the method will not wait.
+func (c *ClusterInstrumentationConfig) WaitForInstrumentationDeliveryAutoToBeResolved(
+	ctx context.Context,
+	timeout time.Duration,
+) cluster.ResolvedInstrumentationDelivery {
+	requestedInstrumentationDelivery := c.requestedInstrumentationDelivery.Load()
+	if requestedInstrumentationDelivery != nil &&
+		*requestedInstrumentationDelivery == dash0v1alpha1.InstrumentationDeliveryAuto {
+		c.minimumKubeletVersionDetector.WaitForDetection(ctx, timeout)
 	}
-	return *previous
+	return c.ResolveInstrumentationDelivery()
 }
 
-func (c *ClusterInstrumentationConfig) IsInstrumentationDeliveryInitContainer() bool {
-	return !c.IsInstrumentationDeliveryImageVolume()
+// UpdateRequestedInstrumentationDelivery stores the requested (unresolved) instrumentation delivery setting that has
+// been read from the Dash0OperatorConfiguration resource. It returns the resolved delivery mechanism that has been
+// effective before the update and the new resolved mechanism that is effective now, after updating it.
+func (c *ClusterInstrumentationConfig) UpdateRequestedInstrumentationDelivery(
+	requestedInstrumentationDelivery dash0v1alpha1.InstrumentationDelivery,
+	logWarningForEmptyValue bool,
+	logger logd.Logger,
+) (cluster.ResolvedInstrumentationDelivery, cluster.ResolvedInstrumentationDelivery) {
+	previous := c.ResolveInstrumentationDelivery()
+	c.requestedInstrumentationDelivery.Store(&requestedInstrumentationDelivery)
+	return previous, c.resolveInstrumentationDelivery(logWarningForEmptyValue, logger)
 }
 
-func (c *ClusterInstrumentationConfig) IsInstrumentationDeliveryImageVolume() bool {
-	delivery := c.ResolvedDelivery.Load()
-	return delivery != nil && *delivery == cluster.ResolvedInstrumentationDeliveryImageVolume
+// ResolveInstrumentationDelivery resolves the stored requested instrumentation delivery setting to the effective
+// delivery mechanism depending on the current knowledge about the Kubernetes API server version and the minimum kubelet
+// version among all nodes of the cluster.
+//
+// This is derived on demand, because the minimum kubelet version is detected asynchronously after the operator manager
+// has started. The mode "auto" resolves to init-container until all nodes have been inspected, and potentially to
+// image-volumes afterwards (if all kubelets are recent enough).
+func (c *ClusterInstrumentationConfig) ResolveInstrumentationDelivery() cluster.ResolvedInstrumentationDelivery {
+	return c.resolveInstrumentationDelivery(false, logd.Discard())
 }
 
-func (c *ClusterInstrumentationConfig) GetInstrumentationDelivery() cluster.ResolvedInstrumentationDelivery {
-	delivery := c.ResolvedDelivery.Load()
-	if delivery == nil {
-		return ""
+func (c *ClusterInstrumentationConfig) resolveInstrumentationDelivery(
+	logWarningForEmptyValue bool,
+	logger logd.Logger,
+) cluster.ResolvedInstrumentationDelivery {
+	requestedInstrumentationDelivery := c.requestedInstrumentationDelivery.Load()
+	if requestedInstrumentationDelivery == nil {
+		return cluster.ResolvedInstrumentationDeliveryInitContainer
 	}
-	return *delivery
+	return cluster.ResolveInstrumentationDelivery(
+		*requestedInstrumentationDelivery,
+		c.kubernetesApiServerVersion,
+		c.minimumKubeletVersionDetector.Get(),
+		logWarningForEmptyValue,
+		logger,
+	)
 }
 
 type DelayConfig struct {

--- a/internal/util/types_test.go
+++ b/internal/util/types_test.go
@@ -1,0 +1,169 @@
+// SPDX-FileCopyrightText: Copyright 2026 Dash0 Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package util
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+
+	dash0v1alpha1 "github.com/dash0hq/dash0-operator/api/operator/v1alpha1"
+	"github.com/dash0hq/dash0-operator/internal/util/cluster"
+	"github.com/dash0hq/dash0-operator/internal/util/logd"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("the cluster instrumentation config", func() {
+
+	Describe("resolving the instrumentation delivery mechanism", func() {
+
+		It("should resolve auto to init container while the minimum kubelet version is unknown", func() {
+			config := newTestClusterInstrumentationConfig(
+				dash0v1alpha1.InstrumentationDeliveryAuto,
+				cluster.KubernetesVersion{Major: 1, Minor: 36},
+				cluster.NewMinimumKubeletVersionDetector(),
+			)
+			Expect(config.ResolveInstrumentationDelivery()).
+				To(Equal(cluster.ResolvedInstrumentationDeliveryInitContainer))
+		})
+
+		It("should resolve auto to image volume once all kubelets have been seen to be recent enough", func() {
+			config := newTestClusterInstrumentationConfig(
+				dash0v1alpha1.InstrumentationDeliveryAuto,
+				cluster.KubernetesVersion{Major: 1, Minor: 36},
+				startDetection("v1.36.0", "v1.37.1"),
+			)
+			Eventually(config.ResolveInstrumentationDelivery).
+				Should(Equal(cluster.ResolvedInstrumentationDeliveryImageVolume))
+		})
+
+		It("should keep resolving auto to init container when one kubelet lags behind", func() {
+			config := newTestClusterInstrumentationConfig(
+				dash0v1alpha1.InstrumentationDeliveryAuto,
+				cluster.KubernetesVersion{Major: 1, Minor: 36},
+				startDetection("v1.36.0", "v1.35.4"),
+			)
+			Consistently(config.ResolveInstrumentationDelivery).
+				Should(Equal(cluster.ResolvedInstrumentationDeliveryInitContainer))
+		})
+
+		It("should keep resolving auto to init container when the Kubernetes API server version is too old", func() {
+			config := newTestClusterInstrumentationConfig(
+				dash0v1alpha1.InstrumentationDeliveryAuto,
+				cluster.KubernetesVersion{Major: 1, Minor: 35},
+				startDetection("v1.36.0"),
+			)
+			Consistently(config.ResolveInstrumentationDelivery).
+				Should(Equal(cluster.ResolvedInstrumentationDeliveryInitContainer))
+		})
+
+		It("should resolve an explicitly requested image volume delivery immediately", func() {
+			config := newTestClusterInstrumentationConfig(
+				dash0v1alpha1.InstrumentationDeliveryImageVolume,
+				cluster.KubernetesVersion{Major: 1, Minor: 31},
+				cluster.NewMinimumKubeletVersionDetector(),
+			)
+			Expect(config.ResolveInstrumentationDelivery()).
+				To(Equal(cluster.ResolvedInstrumentationDeliveryImageVolume))
+		})
+
+		It("should report the previous and the current delivery mechanism when the setting changes", func() {
+			config := newTestClusterInstrumentationConfig(
+				dash0v1alpha1.InstrumentationDeliveryInitContainer,
+				cluster.KubernetesVersion{Major: 1, Minor: 36},
+				cluster.NewMinimumKubeletVersionDetector(),
+			)
+			previous, current := config.UpdateRequestedInstrumentationDelivery(
+				dash0v1alpha1.InstrumentationDeliveryImageVolume,
+				true,
+				logd.Discard(),
+			)
+			Expect(previous).To(Equal(cluster.ResolvedInstrumentationDeliveryInitContainer))
+			Expect(current).To(Equal(cluster.ResolvedInstrumentationDeliveryImageVolume))
+			Expect(config.ResolveInstrumentationDelivery()).
+				To(Equal(cluster.ResolvedInstrumentationDeliveryImageVolume))
+		})
+	})
+
+	Describe("waiting for the instrumentation delivery mechanism to settle", func() {
+
+		It("should wait for the minimum kubelet version detection when auto is requested", func() {
+			config := newTestClusterInstrumentationConfig(
+				dash0v1alpha1.InstrumentationDeliveryAuto,
+				cluster.KubernetesVersion{Major: 1, Minor: 36},
+				startDetection("v1.36.0", "v1.37.1"),
+			)
+
+			Expect(config.WaitForInstrumentationDeliveryAutoToBeResolved(context.Background(), time.Minute)).
+				To(Equal(cluster.ResolvedInstrumentationDeliveryImageVolume))
+		})
+
+		DescribeTable("should not wait for the detection when the mechanism has been requested explicitly",
+			func(
+				requested dash0v1alpha1.InstrumentationDelivery,
+				expected cluster.ResolvedInstrumentationDelivery,
+			) {
+				// The detection is never started, so it never settles. Passing a timeout far beyond the test's own
+				// budget means the call can only return by skipping the wait altogether.
+				config := newTestClusterInstrumentationConfig(
+					requested,
+					cluster.KubernetesVersion{Major: 1, Minor: 36},
+					cluster.NewMinimumKubeletVersionDetector(),
+				)
+
+				Expect(config.WaitForInstrumentationDeliveryAutoToBeResolved(context.Background(), time.Hour)).
+					To(Equal(expected))
+			},
+			Entry("init container",
+				dash0v1alpha1.InstrumentationDeliveryInitContainer,
+				cluster.ResolvedInstrumentationDeliveryInitContainer),
+			Entry("image volume",
+				dash0v1alpha1.InstrumentationDeliveryImageVolume,
+				cluster.ResolvedInstrumentationDeliveryImageVolume),
+		)
+	})
+})
+
+func newTestClusterInstrumentationConfig(
+	requestedInstrumentationDelivery dash0v1alpha1.InstrumentationDelivery,
+	apiServerVersion cluster.KubernetesVersion,
+	minimumKubeletVersionDetector *cluster.MinimumKubeletVersionDetector,
+) *ClusterInstrumentationConfig {
+	config := NewClusterInstrumentationConfig(
+		Images{},
+		PossibleCollectorUrls{},
+		"",
+		ExtraConfigDefaults,
+		requestedInstrumentationDelivery,
+		nil,
+		false,
+		false,
+		false,
+	)
+	config.SetKubernetesVersions(
+		cluster.KubernetesVersionInfo{Version: apiServerVersion, Detected: true},
+		minimumKubeletVersionDetector,
+	)
+	return config
+}
+
+func startDetection(kubeletVersions ...string) *cluster.MinimumKubeletVersionDetector {
+	nodes := make([]runtime.Object, 0, len(kubeletVersions))
+	for i, kubeletVersion := range kubeletVersions {
+		nodes = append(nodes, &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("node-%d", i)},
+			Status:     corev1.NodeStatus{NodeInfo: corev1.NodeSystemInfo{KubeletVersion: kubeletVersion}},
+		})
+	}
+	detector := cluster.NewMinimumKubeletVersionDetector()
+	detector.StartDetection(context.Background(), fake.NewClientset(nodes...), nil, logd.Discard())
+	return detector
+}

--- a/internal/webhooks/attach_dangling_events_test.go
+++ b/internal/webhooks/attach_dangling_events_test.go
@@ -15,6 +15,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	dash0v1alpha1 "github.com/dash0hq/dash0-operator/api/operator/v1alpha1"
 	dash0v1beta1 "github.com/dash0hq/dash0-operator/api/operator/v1beta1"
 	"github.com/dash0hq/dash0-operator/internal/collectors"
 	"github.com/dash0hq/dash0-operator/internal/collectors/otelcolresources"
@@ -23,7 +24,6 @@ import (
 	"github.com/dash0hq/dash0-operator/internal/targetallocator"
 	"github.com/dash0hq/dash0-operator/internal/targetallocator/taresources"
 	"github.com/dash0hq/dash0-operator/internal/util"
-	"github.com/dash0hq/dash0-operator/internal/util/cluster"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -49,7 +49,7 @@ var _ = Describe("The Dash0 webhook and the Dash0 controller", Ordered, func() {
 				PossibleCollectorUrlsTest,
 				OTelCollectorNodeLocalBaseUrlTest,
 				util.ExtraConfigDefaults,
-				cluster.ResolvedInstrumentationDeliveryInitContainer,
+				dash0v1alpha1.InstrumentationDeliveryInitContainer,
 				nil,
 				false,
 				false,

--- a/internal/webhooks/webhook_suite_test.go
+++ b/internal/webhooks/webhook_suite_test.go
@@ -30,7 +30,6 @@ import (
 	dash0v1alpha1 "github.com/dash0hq/dash0-operator/api/operator/v1alpha1"
 	dash0v1beta1 "github.com/dash0hq/dash0-operator/api/operator/v1beta1"
 	"github.com/dash0hq/dash0-operator/internal/util"
-	"github.com/dash0hq/dash0-operator/internal/util/cluster"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -137,7 +136,7 @@ var _ = BeforeSuite(func() {
 			PossibleCollectorUrlsTest,
 			OTelCollectorNodeLocalBaseUrlTest,
 			util.ExtraConfigDefaults,
-			cluster.ResolvedInstrumentationDeliveryInitContainer,
+			dash0v1alpha1.InstrumentationDeliveryInitContainer,
 			nil,
 			false,
 			false,

--- a/internal/workloads/workload_modifier.go
+++ b/internal/workloads/workload_modifier.go
@@ -21,6 +21,7 @@ import (
 	dash0v1beta1 "github.com/dash0hq/dash0-operator/api/operator/v1beta1"
 	"github.com/dash0hq/dash0-operator/images/pkg/common"
 	"github.com/dash0hq/dash0-operator/internal/util"
+	"github.com/dash0hq/dash0-operator/internal/util/cluster"
 	"github.com/dash0hq/dash0-operator/internal/util/logd"
 	"github.com/dash0hq/dash0-operator/internal/util/pointers"
 )
@@ -291,6 +292,9 @@ type ResourceModifier struct {
 	// monitoring resource.
 	namespaceInstrumentationConfig dash0v1beta1.NamespaceInstrumentationConfig
 
+	// the instrumentation delivery mechanism to use for all modifications this modifier applies.
+	resolvedInstrumentationDelivery cluster.ResolvedInstrumentationDelivery
+
 	// the name of the component that applies the resource modifications, this will be written to the
 	// dash0.com/instrumented-by label
 	actor util.WorkloadModifierActor
@@ -306,11 +310,23 @@ func NewResourceModifier(
 	logger logd.Logger,
 ) *ResourceModifier {
 	return &ResourceModifier{
-		clusterInstrumentationConfig:   clusterInstrumentationConfig,
-		namespaceInstrumentationConfig: namespaceInstrumentationConfig,
-		actor:                          actor,
-		logger:                         logger,
+		clusterInstrumentationConfig:    clusterInstrumentationConfig,
+		namespaceInstrumentationConfig:  namespaceInstrumentationConfig,
+		resolvedInstrumentationDelivery: clusterInstrumentationConfig.ResolveInstrumentationDelivery(),
+		actor:                           actor,
+		logger:                          logger,
 	}
+}
+
+// isInstrumentationDeliveryImageVolume reports whether this modifier delivers the instrumentation via an image volume.
+func (m *ResourceModifier) isInstrumentationDeliveryImageVolume() bool {
+	return m.resolvedInstrumentationDelivery == cluster.ResolvedInstrumentationDeliveryImageVolume
+}
+
+// isInstrumentationDeliveryInitContainer reports whether this modifier delivers the instrumentation via an init
+// container.
+func (m *ResourceModifier) isInstrumentationDeliveryInitContainer() bool {
+	return !m.isInstrumentationDeliveryImageVolume()
 }
 
 func (m *ResourceModifier) ModifyCronJob(cronJob *batchv1.CronJob) ModificationResult {
@@ -346,7 +362,7 @@ func (m *ResourceModifier) ModifyJob(job *batchv1.Job) ModificationResult {
 }
 
 func (m *ResourceModifier) AddLabelsToImmutableJob(job *batchv1.Job) ModificationResult {
-	util.AddInstrumentationLabelsAndAnnotations(&job.ObjectMeta, false, m.clusterInstrumentationConfig, m.actor)
+	util.AddInstrumentationLabelsAndAnnotations(&job.ObjectMeta, false, m.clusterInstrumentationConfig, m.resolvedInstrumentationDelivery, m.actor)
 	// adding labels always works and is a modification that requires an update
 	return NewHasBeenModifiedResult(len(job.Spec.Template.Spec.Containers), nil)
 }
@@ -368,7 +384,7 @@ func (m *ResourceModifier) ModifyPod(pod *corev1.Pod) ModificationResult {
 	if !podSpecResult.hasBeenModified {
 		return NewNotModifiedNoChangesResult()
 	}
-	util.AddInstrumentationLabelsAndAnnotations(&pod.ObjectMeta, true, m.clusterInstrumentationConfig, m.actor)
+	util.AddInstrumentationLabelsAndAnnotations(&pod.ObjectMeta, true, m.clusterInstrumentationConfig, m.resolvedInstrumentationDelivery, m.actor)
 	return NewHasBeenModifiedResult(len(pod.Spec.Containers), podSpecResult.instrumentationIssuesPerContainer)
 }
 
@@ -395,8 +411,8 @@ func (m *ResourceModifier) modifyResource(
 	if !podSpecResult.hasBeenModified {
 		return NewNotModifiedNoChangesResult()
 	}
-	util.AddInstrumentationLabelsAndAnnotations(workloadMeta, true, m.clusterInstrumentationConfig, m.actor)
-	util.AddInstrumentationLabelsAndAnnotations(&podTemplateSpec.ObjectMeta, true, m.clusterInstrumentationConfig, m.actor)
+	util.AddInstrumentationLabelsAndAnnotations(workloadMeta, true, m.clusterInstrumentationConfig, m.resolvedInstrumentationDelivery, m.actor)
+	util.AddInstrumentationLabelsAndAnnotations(&podTemplateSpec.ObjectMeta, true, m.clusterInstrumentationConfig, m.resolvedInstrumentationDelivery, m.actor)
 	return NewHasBeenModifiedResult(len(podTemplateSpec.Spec.Containers), podSpecResult.instrumentationIssuesPerContainer)
 }
 
@@ -407,7 +423,7 @@ func (m *ResourceModifier) modifyPodSpec(
 ) modifyPodSpecResult {
 	originalSpec := podSpec.DeepCopy()
 	m.addInstrumentationVolume(podSpec)
-	if m.clusterInstrumentationConfig.IsInstrumentationDeliveryInitContainer() {
+	if m.isInstrumentationDeliveryInitContainer() {
 		// The safe-to-evict-local-volumes annotation only matters for emptyDir local volumes; image volumes are
 		// sourced from container images and managed by the kubelet, so they do not prevent eviction.
 		m.addSafeToEvictLocalVolumesAnnotation(podMeta)
@@ -455,7 +471,7 @@ func (m *ResourceModifier) addInstrumentationVolume(podSpec *corev1.PodSpec) {
 }
 
 func (m *ResourceModifier) dash0VolumeSource() corev1.VolumeSource {
-	if m.clusterInstrumentationConfig.IsInstrumentationDeliveryImageVolume() {
+	if m.isInstrumentationDeliveryImageVolume() {
 		imageVolume := &corev1.ImageVolumeSource{
 			Reference: m.clusterInstrumentationConfig.InitContainerImage,
 		}
@@ -614,7 +630,7 @@ func (m *ResourceModifier) addMount(container *corev1.Container) {
 		Name:      dash0VolumeName,
 		MountPath: otelAutoInstrumentationBaseDirectory,
 	}
-	if m.clusterInstrumentationConfig.IsInstrumentationDeliveryImageVolume() {
+	if m.isInstrumentationDeliveryImageVolume() {
 		// Selecting the directory inside the init container image whose contents the legacy init container approach
 		// would have copied into the emptyDir volume via copy-instrumentation.sh.
 		volume.SubPath = imageVolumeSubPath
@@ -1901,7 +1917,7 @@ func (m *ResourceModifier) checkEligibleForModification(podSpec *corev1.PodSpec)
 			}
 		}
 	}
-	if m.clusterInstrumentationConfig.IsInstrumentationDeliveryInitContainer() {
+	if m.isInstrumentationDeliveryInitContainer() {
 		if notModifiedResult := m.checkEphemeralStorageLimit(podSpec); notModifiedResult != nil {
 			return notModifiedResult
 		}

--- a/internal/workloads/workload_modifier_test.go
+++ b/internal/workloads/workload_modifier_test.go
@@ -14,6 +14,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
+	dash0v1alpha1 "github.com/dash0hq/dash0-operator/api/operator/v1alpha1"
 	dash0v1beta1 "github.com/dash0hq/dash0-operator/api/operator/v1beta1"
 	"github.com/dash0hq/dash0-operator/images/pkg/common"
 	"github.com/dash0hq/dash0-operator/internal/util"
@@ -40,7 +41,7 @@ var (
 		PossibleCollectorUrlsTest,
 		OTelCollectorNodeLocalBaseUrlTest,
 		util.ExtraConfigDefaults,
-		cluster.ResolvedInstrumentationDeliveryInitContainer,
+		dash0v1alpha1.InstrumentationDeliveryInitContainer,
 		nil,
 		false,
 		false,
@@ -52,7 +53,7 @@ var (
 		PossibleCollectorUrlsTest,
 		OTelCollectorNodeLocalBaseUrlTest,
 		util.ExtraConfigDefaults,
-		cluster.ResolvedInstrumentationDeliveryImageVolume,
+		dash0v1alpha1.InstrumentationDeliveryImageVolume,
 		nil,
 		false,
 		false,
@@ -64,7 +65,7 @@ var (
 		PossibleCollectorUrlsTest,
 		OTelCollectorServiceBaseUrlTest,
 		util.ExtraConfigDefaults,
-		cluster.ResolvedInstrumentationDeliveryInitContainer,
+		dash0v1alpha1.InstrumentationDeliveryInitContainer,
 		nil,
 		false,
 		false,
@@ -83,7 +84,7 @@ func clusterInstrumentationConfigWithOptIns(
 		PossibleCollectorUrlsTest,
 		OTelCollectorNodeLocalBaseUrlTest,
 		util.ExtraConfigDefaults,
-		cluster.ResolvedInstrumentationDeliveryInitContainer,
+		dash0v1alpha1.InstrumentationDeliveryInitContainer,
 		nil,
 		false,
 		enablePythonAutoInstrumentation,
@@ -155,7 +156,7 @@ var _ = Describe("Dash0 Workload Modification", func() {
 						PossibleCollectorUrlsTest,
 						OTelCollectorServiceBaseUrlTest,
 						util.ExtraConfigDefaults,
-						cluster.ResolvedInstrumentationDeliveryInitContainer,
+						dash0v1alpha1.InstrumentationDeliveryInitContainer,
 						nil,
 						false,
 						false,

--- a/test/e2e/dash0_monitoring_resource.go
+++ b/test/e2e/dash0_monitoring_resource.go
@@ -123,7 +123,7 @@ func deployRenderedMonitoringResourceWithRetry(
 		"deploying the Dash0 monitoring resource to namespace %s with values %v from file %s, operator namespace is %s",
 		namespace, dash0MonitoringValues, renderedResourceFileName, operatorNamespace))
 	retryLogger := logd.NewLogger(zap.New())
-	err := retry.RetryWithCustomBackoff("deploying the Dash0 monitoring resource to namespace", func() error {
+	err := retry.Retry("deploying the Dash0 monitoring resource to namespace", func() error {
 		return runAndIgnoreOutput(exec.Command(
 			"kubectl",
 			"apply",
@@ -137,9 +137,7 @@ func deployRenderedMonitoringResourceWithRetry(
 			Duration: 10 * time.Second,
 			Steps:    3,
 		},
-		true,
-		true,
-		retryLogger,
+		new(retryLogger),
 	)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/test/e2e/dash0_monitoring_resource.go
+++ b/test/e2e/dash0_monitoring_resource.go
@@ -16,8 +16,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	dash0common "github.com/dash0hq/dash0-operator/api/operator/common"
-	"github.com/dash0hq/dash0-operator/internal/util"
 	"github.com/dash0hq/dash0-operator/internal/util/logd"
+	"github.com/dash0hq/dash0-operator/internal/util/retry"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -123,7 +123,7 @@ func deployRenderedMonitoringResourceWithRetry(
 		"deploying the Dash0 monitoring resource to namespace %s with values %v from file %s, operator namespace is %s",
 		namespace, dash0MonitoringValues, renderedResourceFileName, operatorNamespace))
 	retryLogger := logd.NewLogger(zap.New())
-	err := util.RetryWithCustomBackoff("deploying the Dash0 monitoring resource to namespace", func() error {
+	err := retry.RetryWithCustomBackoff("deploying the Dash0 monitoring resource to namespace", func() error {
 		return runAndIgnoreOutput(exec.Command(
 			"kubectl",
 			"apply",

--- a/test/util/mock_logger.go
+++ b/test/util/mock_logger.go
@@ -58,6 +58,10 @@ func (s *CapturingLogSink) HasLogMessage(g Gomega, message string) {
 	g.Expect(s.messages).To(ContainElement(message))
 }
 
+func (s *CapturingLogSink) HasNoLogMessage(g Gomega, message string) {
+	g.Expect(s.messages).ToNot(ContainElement(message))
+}
+
 func (s *CapturingLogSink) HasNoLogMessages(g Gomega) {
 	g.Expect(s.messages).To(BeEmpty())
 }


### PR DESCRIPTION
Previously, the decision how to resolve the instrumentation delivery setting "auto" to either init-container or image-volume was based only on the the Kubernetes API server version. This can lead to scheduling issues in mixed clusters, in particular when there are kubelets running version < 1.35, and the API server is >= 1.36.