### PR TITLE
feat(agent0-connector): redact env vars from workload resources

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,6 +106,20 @@ and the output formats that can reshape a value (`-o go-template/jsonpath/custom
 because their output cannot be redacted. A credential-bearing CRD that is missing from the list therefore stays fully
 readable through those formats as well.
 
+`dash0ResourceTypesWithSecrets` is one of two lists behind `targetsResourceTypeWithSecrets`. The other is
+`workloadResourceTypes`, the Kubernetes resource types that carry a pod spec (pods, deployments, daemonsets, jobs,
+controller revisions, ...). Any workload can hold a credential in the literal value of an environment variable, so
+`redactEnvVarValues` replaces the value of every environment variable of a pod spec, and these resource types are
+restricted to the same output formats as the Dash0 custom resources. An environment variable that sources its value via
+`valueFrom` is left untouched, and so are the header values of the HTTP probes and lifecycle hooks of a pod spec, which
+are redacted via the same `httpHeaders` case as the header values of an export.
+
+For every resource type that can contain secrets, `--sort-by` is restricted as well (`unsafeSortByRequested`): kubectl
+evaluates the expression against the resources before the connector sees them, so sorting by a redacted field leaks its
+order, and a filter expression such as `{.spec.containers[0].env[?(@.value>"S")].name}` turns a match into a comparison
+oracle that reveals the value over several requests. Only a plain path below `metadata` or `status` is accepted, except
+`metadata.annotations`, which holds the verbatim copy of the spec that `kubectl apply` leaves behind.
+
 When adding or changing a CRD, check all four lists above - grep for `dash0ResourceTypesWithSecrets`,
 `credentialFieldsPerConfigObject` and `urlFieldsPerConfigObject`, and read the `case` clauses of
 `redactDocumentNodeRecursively` for the field names that are credentials wherever they occur - and extend the fixtures

--- a/images/agent0-connector/src/kubectl/kubectl.go
+++ b/images/agent0-connector/src/kubectl/kubectl.go
@@ -46,11 +46,23 @@ const (
 	// kubectl subprocess then runs with HOME set to this directory (see kubectlEnv).
 	KubectlTmpEnvVarName = "DASH0_KUBECTL_TMP"
 
-	// maxOutputBytesPerStream caps how many bytes of stdout and stderr (each) are captured from a kubectl invocation.
-	// The output is buffered in memory and sent back in a single gRPC message, so unbounded output (e.g. "kubectl get
-	// -A -o yaml" on a large cluster, or a noisy "kubectl logs") could exhaust the pod's memory limit or exceed gRPC's
-	// default maximum message size. Output beyond this limit is discarded and a truncation notice is appended.
-	maxOutputBytesPerStream = 1024 * 1024 // 1 MiB
+	// maxStdoutBytes caps how many bytes of stdout are captured from a kubectl invocation. The output is buffered in
+	// memory and sent back in a single gRPC message, so unbounded output (e.g. "kubectl get -A -o yaml" on a large
+	// cluster, or a noisy "kubectl logs") could exhaust the pod's memory limit or exceed gRPC's default maximum message
+	// size of 4 MiB. Output beyond this limit is discarded and a truncation notice is appended.
+	//
+	// A response that has to be redacted is withheld entirely once it is truncated, because a truncated document cannot
+	// be parsed (see redactSecretsInResponse). Redaction covers every workload resource type, so this limit decides how
+	// large a workload listing may be before it becomes unreadable rather than merely incomplete, which is why it is
+	// well above the size of a single resource. It is paired with the pod's memory limit in
+	// internal/agent0connector/a0cresources/desired_state.go: parsing a document of this size into Go maps and
+	// rendering it again needs a multiple of it.
+	maxStdoutBytes = 3 * 1024 * 1024 // 3 MiB
+
+	// maxStderrBytes caps how many bytes of stderr are captured from a kubectl invocation. kubectl writes error
+	// messages and warnings to stderr, never resource content, so it needs far less room than stdout. Keeping it small
+	// holds the whole response below gRPC's default maximum message size of 4 MiB even when both streams are full.
+	maxStderrBytes = 256 * 1024 // 256 KiB
 )
 
 // commandTimeout bounds the execution time of a single kubectl invocation.
@@ -158,7 +170,7 @@ func ExecuteCommandRequest(
 	execCtx, cancel := context.WithTimeout(ctx, commandTimeout)
 	defer cancel()
 
-	stdout, stderr, err := runKubectl(execCtx, kubectlTmpDir, req.GetArguments(), maxOutputBytesPerStream)
+	stdout, stderr, err := runKubectl(execCtx, kubectlTmpDir, req.GetArguments(), maxStdoutBytes, maxStderrBytes)
 
 	resp := &pb.CommandResponse{
 		RequestId: req.GetRequestId(),
@@ -184,14 +196,22 @@ func ExecuteCommandRequest(
 			"reason", redactionErr.Error(),
 		)
 		withholdResponse(resp, redactionErr)
+		if additionalStdErrMsg != "" {
+			resp.Stderr = appendLine(resp.Stderr, additionalStdErrMsg)
+		}
+		if timedOut {
+			// The timeout is why the response could not be parsed, so it stays the reported exit code and keeps the
+			// exit code consistent with resp.Timeout.
+			resp.ExitCode = exitCodeTimedOut
+		}
 		return resp
 	}
 
 	if stdout.truncated {
-		resp.Stdout = withTruncationNotice(resp.Stdout)
+		resp.Stdout = withTruncationNotice(resp.Stdout, maxStdoutBytes)
 	}
 	if stderr.truncated {
-		resp.Stderr = withTruncationNotice(resp.Stderr)
+		resp.Stderr = withTruncationNotice(resp.Stderr, maxStderrBytes)
 	}
 	if additionalStdErrMsg != "" {
 		resp.Stderr = appendLine(resp.Stderr, additionalStdErrMsg)
@@ -200,16 +220,18 @@ func ExecuteCommandRequest(
 	return resp
 }
 
-// runKubectl runs kubectl with the given arguments, capturing at most limit bytes of stdout and of stderr, and returns
-// the two capped buffers together with the error reported by exec (nil if kubectl exited with code zero).
+// runKubectl runs kubectl with the given arguments, capturing at most stdoutLimit bytes of stdout and stderrLimit
+// bytes of stderr, and returns the two capped buffers together with the error reported by exec (nil if kubectl exited
+// with code zero).
 func runKubectl(
 	ctx context.Context,
 	kubectlTmpDir string,
 	arguments []string,
-	limit int,
+	stdoutLimit int,
+	stderrLimit int,
 ) (*cappedBuffer, *cappedBuffer, error) {
-	stdout := &cappedBuffer{limit: limit}
-	stderr := &cappedBuffer{limit: limit}
+	stdout := &cappedBuffer{limit: stdoutLimit}
+	stderr := &cappedBuffer{limit: stderrLimit}
 	cmd := exec.CommandContext(ctx, kubectlCommand, arguments...)
 	cmd.Env = kubectlEnv(kubectlTmpDir)
 	cmd.Stdout = stdout
@@ -266,11 +288,11 @@ func appendLine(existing, line string) string {
 	return existing + "\n" + line
 }
 
-// withTruncationNotice appends a notice that the output was truncated at maxOutputBytesPerStream bytes.
-func withTruncationNotice(output string) string {
+// withTruncationNotice appends a notice that the output was truncated at the given limit.
+func withTruncationNotice(output string, limit int) string {
 	return appendLine(
 		output,
-		fmt.Sprintf("[dash0 agent0-connector truncated the output at %d bytes]", maxOutputBytesPerStream),
+		fmt.Sprintf("[dash0 agent0-connector truncated the output at %d bytes]", limit),
 	)
 }
 

--- a/images/agent0-connector/src/kubectl/kubectl_test.go
+++ b/images/agent0-connector/src/kubectl/kubectl_test.go
@@ -81,6 +81,50 @@ func TestCappedBuffer(t *testing.T) {
 			t.Error("expected truncated to be true after exceeding the limit")
 		}
 	})
+
+	t.Run("does not report output of exactly the limit as truncated", func(t *testing.T) {
+		b := &cappedBuffer{limit: 4}
+		if _, err := b.Write([]byte("abcd")); err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if b.truncated {
+			t.Error("expected truncated to be false for output of exactly the limit")
+		}
+	})
+
+	t.Run("caps stdout and stderr independently", func(t *testing.T) {
+		// stderr gets a much smaller limit than stdout, so the two streams must not share one limit.
+		if maxStderrBytes >= maxStdoutBytes {
+			t.Fatalf("expected maxStderrBytes (%d) to be smaller than maxStdoutBytes (%d)",
+				maxStderrBytes, maxStdoutBytes)
+		}
+		stdout := &cappedBuffer{limit: maxStdoutBytes}
+		stderr := &cappedBuffer{limit: maxStderrBytes}
+		payload := make([]byte, maxStderrBytes+1)
+		if _, err := stdout.Write(payload); err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if _, err := stderr.Write(payload); err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if stdout.truncated {
+			t.Error("expected stdout not to be truncated by an amount that only exceeds the stderr limit")
+		}
+		if !stderr.truncated {
+			t.Error("expected stderr to be truncated at its own, smaller limit")
+		}
+	})
+}
+
+func TestWithTruncationNotice(t *testing.T) {
+	// The notice names the limit of the stream it belongs to, so that stdout and stderr do not both report the stdout
+	// limit.
+	if notice := withTruncationNotice("out", maxStdoutBytes); !strings.Contains(notice, "3145728 bytes") {
+		t.Errorf("expected the stdout notice to name maxStdoutBytes, got %q", notice)
+	}
+	if notice := withTruncationNotice("err", maxStderrBytes); !strings.Contains(notice, "262144 bytes") {
+		t.Errorf("expected the stderr notice to name maxStderrBytes, got %q", notice)
+	}
 }
 
 func TestExecuteCommandRequest(t *testing.T) {

--- a/images/agent0-connector/src/kubectl/redaction.go
+++ b/images/agent0-connector/src/kubectl/redaction.go
@@ -7,12 +7,10 @@
 // within that document, and the document is rendered again.
 //
 // This is only possible for formats the connector can parse, reliably interprete, and render itself. Requests that
-// targets a Dash0 custom resource which can contain secrets are restricted to output formats that satisfy these
-// constraints (see safeOrRedactableOutputFormats in validation.go):
+// target a Dash0 custom resource which can contain secrets, or a workload resource, are restricted to output formats
+// that satisfy these constraints (see safeOrRedactableOutputFormats in validation.go).
 //
-//   - "-o json" and "-o yaml" render the resources as a document. kubectl serializes a custom resource from its
-//     unstructured (map) form, so re-rendering the parsed document reproduces kubectl's output byte for byte, apart
-//     from the redacted values.
+//   - "-o json" and "-o yaml" render the resources as a document.
 //   - the content-free formats ("-o name", "-o wide", the default table) do not expose the content of a resource at
 //     all and are passed through untouched.
 //   - "-o go-template", "-o jsonpath", "-o custom-columns" and "kubectl describe" are rejected for these resource
@@ -23,9 +21,8 @@
 //   - file-related output formats (go-template-file etc.) and --raw are disallowed outright for all resource types, so
 //     they do not require specific treatment with respect to secret redaction
 //
-// A response that cannot be parsed after all - output truncated at maxOutputBytesPerStream, a multi-document YAML
-// stream, or an error message on stderr with nothing on stdout - is withheld rather than handed out, see
-// withholdResponse.
+// A response that cannot be parsed after all - output truncated at maxStdoutBytes, a multi-document YAML stream, or an
+// error message on stderr with nothing on stdout - is withheld rather than handed out, see withholdResponse.
 //
 // stderr is scrubbed by replacing the values that were redacted from the document, since kubectl formats an error
 // with Go's %v verbs rather than as a document.
@@ -113,6 +110,81 @@ var dash0ResourceTypesWithSecrets = map[string]struct{}{
 	"dash0syntheticchecks":        {},
 }
 
+// workloadResourceTypes lists the resource type names of the Kubernetes resource types that carry a pod spec, and with
+// it the literal values of the environment variables of their containers. Any workload can hold a credential in an
+// environment variable. So the environment variable values of these resource types are redacted (see
+// redactEnvVarValues) and the output formats whose result cannot be redacted are rejected for them.
+//
+// Singular form, plural form and short name are listed for each type; kubectl also accepts the kind (e.g.
+// "Deployment"), which normalizes to the singular form. Additionally, "all" is the shorthand that expands to pods,
+// services, daemon sets, deployments, replica sets, stateful sets, jobs and cron jobs, so it renders pod specs as well.
+var workloadResourceTypes = map[string]struct{}{
+	"all":                    {},
+	"controllerrevision":     {},
+	"controllerrevisions":    {},
+	"cronjob":                {},
+	"cronjobs":               {},
+	"cj":                     {},
+	"daemonset":              {},
+	"daemonsets":             {},
+	"ds":                     {},
+	"deployment":             {},
+	"deployments":            {},
+	"deploy":                 {},
+	"job":                    {},
+	"jobs":                   {},
+	"pod":                    {},
+	"pods":                   {},
+	"po":                     {},
+	"podtemplate":            {},
+	"podtemplates":           {},
+	"replicaset":             {},
+	"replicasets":            {},
+	"rs":                     {},
+	"replicationcontroller":  {},
+	"replicationcontrollers": {},
+	"rc":                     {},
+	"statefulset":            {},
+	"statefulsets":           {},
+	"sts":                    {},
+}
+
+// resourceTypeWithSecrets describes a category of resource types whose content can contain secrets, so that the
+// rejection messages of validation.go can name what is being protected and how to read the resource instead.
+type resourceTypeWithSecrets struct {
+	// description names the category in a rejection message, e.g. "a Dash0 custom resource".
+	description string
+	// secrets names what the content of such a resource can expose, e.g. "an authorization token".
+	secrets string
+	// redactedContent names what the connector replaces in a response it can redact, e.g. "its credentials".
+	redactedContent string
+}
+
+var (
+	dash0CustomResourceWithSecrets = resourceTypeWithSecrets{
+		description:     "a Dash0 custom resource",
+		secrets:         "an authorization token or third-party credentials",
+		redactedContent: "its credentials",
+	}
+	workloadResourceWithSecrets = resourceTypeWithSecrets{
+		description:     "a workload resource",
+		secrets:         "credentials in the values of its environment variables",
+		redactedContent: "the values of its environment variables",
+	}
+)
+
+// resourceTypesWithSecrets maps every resource type name whose content can contain secrets to its category.
+var resourceTypesWithSecrets = func() map[string]resourceTypeWithSecrets {
+	types := make(map[string]resourceTypeWithSecrets, len(dash0ResourceTypesWithSecrets)+len(workloadResourceTypes))
+	for resourceType := range dash0ResourceTypesWithSecrets {
+		types[resourceType] = dash0CustomResourceWithSecrets
+	}
+	for resourceType := range workloadResourceTypes {
+		types[resourceType] = workloadResourceWithSecrets
+	}
+	return types
+}()
+
 // credentialFieldsPerConfigObject maps the name of a configuration object in a Dash0 custom resource to the fields
 // within it that hold a credential. Keying on the enclosing object rather than on the field name alone keeps the
 // generic field names ("url", "key") from matching unrelated values, e.g. the attribute keys of the notification
@@ -154,13 +226,14 @@ var parseableOutputFormats = map[string]struct{}{
 }
 
 // redactSecretsInResponse redacts secrets in a command response, in place. The response is parsed into a document, the
-// credential values (Dash0 auth tokens, third-party credentials) are replaced within that document - including in the
-// copy of the spec that kubectl apply leaves behind in the "kubectl.kubernetes.io/last-applied-configuration"
-// annotation - and the document is rendered again in the format the request asked for.
+// credential values (Dash0 auth tokens, third-party credentials, the literal values of environment variables) are
+// replaced within that document - including in the copy of the spec that kubectl apply leaves behind in the
+// "kubectl.kubernetes.io/last-applied-configuration" annotation - and the document is rendered again in the format the
+// request asked for.
 //
-// Only responses that render a Dash0 custom resource which can contain secrets are redacted; for those, validation.go
-// has already restricted the request to an output format the connector can parse and render (see
-// safeOrRedactableOutputFormats).
+// Only responses that render a Dash0 custom resource which can contain secrets, or a workload resource are redacted;
+// for those, validation.go has already restricted the request to an output format the connector can parse and render
+// (see safeOrRedactableOutputFormats).
 //
 // A non-nil error means the response could not be redacted and must not be sent to the backend, see withholdResponse.
 func redactSecretsInResponse(parsed kubectlArguments, resp *pb.CommandResponse, stdoutTruncated bool) error {
@@ -182,8 +255,10 @@ func redactSecretsInResponse(parsed kubectlArguments, resp *pb.CommandResponse, 
 	}
 	if stdoutTruncated {
 		return fmt.Errorf(
-			"the output exceeds the limit of %d bytes and the truncated response cannot be parsed for redaction",
-			maxOutputBytesPerStream,
+			"the output exceeds the limit of %d bytes and the truncated response cannot be parsed for redaction; "+
+				"narrow the request so that its response stays below the limit, e.g. with -n <namespace>, "+
+				"--selector, --field-selector, or by naming a single resource",
+			maxStdoutBytes,
 		)
 	}
 	if resp.GetStdout() == "" {
@@ -210,12 +285,12 @@ func redactSecretsInResponse(parsed kubectlArguments, resp *pb.CommandResponse, 
 	return nil
 }
 
-// responseCanContainSecrets reports whether the response of the given invocation renders the content of a Dash0 custom
-// resource that can contain secrets, and therefore has to be redacted.
+// responseCanContainSecrets reports whether the response of the given invocation renders the content of a resource
+// that can contain secrets, and therefore has to be redacted.
 func responseCanContainSecrets(parsed kubectlArguments) bool {
 	//nolint:goconst
 	if parsed.kubectlCommand != "get" {
-		// No other allowed kubectl command renders the content of a custom resource: "describe" is rejected for these
+		// No other allowed kubectl command renders the content of such a resource: "describe" is rejected for these
 		// resource types (see describeOfResourceTypeWithSecrets), and "explain" only prints the schema.
 		return false
 	}
@@ -223,7 +298,8 @@ func responseCanContainSecrets(parsed kubectlArguments) bool {
 		// kubectl get -o name or similar, no actual resource content in the response.
 		return false
 	}
-	return targetsResourceTypeWithSecrets(parsed)
+	_, hasSecrets := targetsResourceTypeWithSecrets(parsed)
+	return hasSecrets
 }
 
 // parseResponseDocument parses a kubectl response that renders resources in the given output format. It reports false
@@ -280,6 +356,12 @@ func (r *redactor) add(value string) {
 	r.count++
 }
 
+// addWithoutStderrScrub records a replacement whose replaced value must not be scrubbed from stderr, see
+// redactEnvVarValue. Only the count is tracked, so that redactAnnotations still notices that the node changed.
+func (r *redactor) addWithoutStderrScrub() {
+	r.count++
+}
+
 // valuesToScrubFromStderr returns the redacted values that are worth replacing in stderr as well, ordered from longest
 // to shortest so that a longer value is replaced before a shorter one contained in it. Values shorter than
 // minCredentialValueLength are left out: they reveal little, but would frequently match unrelated output and garble
@@ -301,18 +383,18 @@ func (r *redactor) valuesToScrubFromStderr() []string {
 	return sorted
 }
 
-// targetsResourceTypeWithSecrets reports whether the kubectl arguments reference a Dash0 custom resource type whose
-// content can contain secrets (see dash0ResourceTypesWithSecrets). Unlike responseCanContainSecrets it does not look at
-// the kubectl command or the output format, since it answers whether a response could contain a secret at all, not
-// whether the response has to be redacted. It is the basis for rejecting the output formats whose rendering of a secret
-// cannot be redacted reliably, see unredactableOutputRequested in validation.go.
-func targetsResourceTypeWithSecrets(parsed kubectlArguments) bool {
+// targetsResourceTypeWithSecrets returns the category of the first resource type the kubectl arguments reference whose
+// content can contain secrets (see resourceTypesWithSecrets). Unlike responseCanContainSecrets it does not look at the
+// kubectl command or the output format, since it answers whether a response could contain a secret at all, not whether
+// the response has to be redacted. It is the basis for rejecting the output formats whose rendering of a secret cannot
+// be redacted reliably, see unredactableOutputRequested in validation.go.
+func targetsResourceTypeWithSecrets(parsed kubectlArguments) (resourceTypeWithSecrets, bool) {
 	for _, resourceType := range parsed.resourceTypes {
-		if _, hasSecrets := dash0ResourceTypesWithSecrets[resourceType]; hasSecrets {
-			return true
+		if category, hasSecrets := resourceTypesWithSecrets[resourceType]; hasSecrets {
+			return category, true
 		}
 	}
-	return false
+	return resourceTypeWithSecrets{}, false
 }
 
 // redactResourceList redacts the secrets of all resources in a parsed resource document, in place. Such a document
@@ -355,7 +437,10 @@ func redactResourceItem(resource any, redacted *redactor) error {
 //     of a synthetic check, as well as its query parameter values,
 //   - the credentials of the third-party integration of a notification channel and the request body of a synthetic
 //     check (see credentialFieldsPerConfigObject),
-//   - the credential-bearing parts of the URL a synthetic check requests (see urlFieldsPerConfigObject).
+//   - the credential-bearing parts of the URL a synthetic check requests (see urlFieldsPerConfigObject),
+//   - the literal values of the environment variables of every container of a pod spec (see redactEnvVarValues),
+//   - the header values of the HTTP probes and lifecycle hooks of a pod spec, which have the same shape as the header
+//     values of an export.
 //
 // The user name of the basic authentication of a synthetic check is not a credential and is left in place. Values
 // sourced via valueFrom are ignored. Apart from the fields that are only credentials within a particular
@@ -371,8 +456,10 @@ func redactDocumentNodeRecursively(node any, redacted *redactor) {
 			switch key {
 			case "token", "password":
 				redactValueOf(typedNode, key, redacted)
-			case "headers", "queryParameters":
+			case "headers", "queryParameters", "httpHeaders":
 				redactHeaderValues(typedNode, key, redacted)
+			case "env":
+				redactEnvVarValues(typedNode, key, redacted)
 			default:
 				if credentialFields, hasCredentials := credentialFieldsPerConfigObject[key]; hasCredentials {
 					redactCredentialFields(value, credentialFields, redacted)
@@ -391,23 +478,56 @@ func redactDocumentNodeRecursively(node any, redacted *redactor) {
 	}
 }
 
-// redactValueOf replaces the value the given key holds in node with redactedValue and records the
-// replaced value, so that it can be scrubbed from stderr as well. Non-string and empty values are left alone; a
-// value sourced via valueFrom is an object rather than a string and is therefore not a credential the response
-// exposes. No length or plausibility check is applied: the value is replaced where it lives, so an unusually short
-// credential cannot affect anything else in the response.
-//
-// A value that already is the placeholder is left alone as well. Two rules can cover the same field - a credential
-// field of a configuration object that is also a header, or a header whose name happens to be "token" - and replacing
-// it twice would add the placeholder itself to the recorded values and count as another replacement, which
-// redactAnnotations reads as "this annotation held a credential".
+// redactValueOf replaces the value the given key holds in node with redactedValue and records the replaced value, so
+// that it can be scrubbed from stderr as well.
 func redactValueOf(node map[string]any, key string, redacted *redactor) {
+	if value, replaced := replaceValueOf(node, key); replaced {
+		redacted.add(value)
+	}
+}
+
+// replaceValueOf replaces the value the given key holds in node with redactedValue and returns the value it replaced.
+// Non-string and empty values are left alone; a value sourced via valueFrom is an object rather than a string and is
+// therefore not a credential the response exposes.
+//
+// A value that already is the placeholder is left alone as well.
+func replaceValueOf(node map[string]any, key string) (string, bool) {
 	value, isString := node[key].(string)
 	if !isString || value == "" || value == redactedValue {
-		return
+		return "", false
 	}
 	node[key] = redactedValue
-	redacted.add(value)
+	return value, true
+}
+
+// redactEnvVarValues redacts the literal values of the environment variables held by the given key of node, that is,
+// of one container of a pod spec. Every literal value is replaced, without the plausibility check the header values
+// get: any workload can hold a credential in an environment variable - the operator's own daemonset carries the Dash0
+// auth token that way - and there is no way to tell a credential from an innocuous value. An environment variable that
+// sources its value via valueFrom has no "value" field and is left untouched, since the reference it holds is not a
+// credential.
+func redactEnvVarValues(node map[string]any, key string, redacted *redactor) {
+	envVars, isList := node[key].([]any)
+	if !isList {
+		return
+	}
+	for _, envVar := range envVars {
+		envVarMap, isMap := envVar.(map[string]any)
+		if !isMap {
+			continue
+		}
+		redactEnvVarValue(envVarMap, redacted)
+	}
+}
+
+// redactEnvVarValue replaces the literal value of a single environment variable. Unlike redactValueOf it does not
+// record the replaced value for the stderr scrub: kubectl renders the environment variables of a resource on stdout
+// and never quotes them in an error message, while a single response can carry hundreds of them, many of them ordinary
+// words that would garble unrelated stderr output if they were replaced there.
+func redactEnvVarValue(node map[string]any, redacted *redactor) {
+	if _, replaced := replaceValueOf(node, "value"); replaced {
+		redacted.addWithoutStderrScrub()
+	}
 }
 
 // redactHeaderValues redacts the literal header or query parameter values held by the given key of node. Three shapes

--- a/images/agent0-connector/src/kubectl/redaction_test.go
+++ b/images/agent0-connector/src/kubectl/redaction_test.go
@@ -30,6 +30,14 @@ func TestResponseCanContainSecrets(t *testing.T) {
 		{name: "notification channels as yaml", arguments: []string{"get", "dash0notificationchannels", "-o", "yaml"}, expected: true},
 		{name: "synthetic checks as json", arguments: []string{"get", "dash0syntheticchecks", "-o", "json"}, expected: true},
 		{name: "multi-resource list", arguments: []string{"get", "pods,dash0monitorings,dash0operatorconfiguration", "-o", "yaml"}, expected: true},
+		{name: "workload resources as yaml", arguments: []string{"get", "deployments", "-o", "yaml"}, expected: true},
+		{name: "singular workload resource as json", arguments: []string{"get", "daemonset", "my-daemonset", "-o", "json"}, expected: true},
+		{name: "workload short name as yaml", arguments: []string{"get", "sts", "-o", "yaml"}, expected: true},
+		{name: "workload kind form as yaml", arguments: []string{"get", "CronJob", "-o", "yaml"}, expected: true},
+		{name: "fully qualified workload as yaml", arguments: []string{"get", "deployments.v1.apps", "-o", "yaml"}, expected: true},
+		{name: "workload type/name pair as json", arguments: []string{"get", "pod/my-pod", "-o", "json"}, expected: true},
+		{name: "the all shorthand renders pod specs", arguments: []string{"get", "all", "-o", "yaml"}, expected: true},
+		{name: "controller revisions embed a pod template", arguments: []string{"get", "controllerrevisions", "-o", "yaml"}, expected: true},
 		{name: "attached output format", arguments: []string{"get", "dash0monitorings", "-oyaml"}, expected: true},
 		{name: "grouped shorthand output format", arguments: []string{"get", "dash0monitorings", "-Aoyaml"}, expected: true},
 		{name: "leading global flag before the kubectl command", arguments: []string{"-n", "my-namespace", "get", "dash0monitorings", "-o", "yaml"}, expected: true},
@@ -42,10 +50,12 @@ func TestResponseCanContainSecrets(t *testing.T) {
 		{name: "describe is not redacted", arguments: []string{"describe", "dash0monitorings"}, expected: false},
 		{name: "explain only prints the schema", arguments: []string{"explain", "dash0monitorings", "--recursive"}, expected: false},
 		{name: "events do not reference the resource positionally", arguments: []string{"events", "--for", "dash0monitoring/my-resource"}, expected: false},
-		{name: "other resources are unaffected", arguments: []string{"get", "pods", "-o", "yaml"}, expected: false},
+		{name: "workload table output has no resource content", arguments: []string{"get", "deployments", "-o", "wide"}, expected: false},
+		{name: "other resources are unaffected", arguments: []string{"get", "services", "-o", "yaml"}, expected: false},
 		{name: "Dash0 resource types without secrets are unaffected", arguments: []string{"get", "dash0views,dash0teams,dash0samplingrules", "-o", "yaml"}, expected: false},
-		{name: "a resource named like a Dash0 resource is not a resource type", arguments: []string{"get", "pods", "dash0monitorings", "-o", "yaml"}, expected: false},
-		{name: "a namespace named like a Dash0 resource is not a resource type", arguments: []string{"get", "pods", "-n", "dash0monitorings", "-o", "yaml"}, expected: false},
+		{name: "a resource named like a Dash0 resource is not a resource type", arguments: []string{"get", "services", "dash0monitorings", "-o", "yaml"}, expected: false},
+		{name: "a namespace named like a Dash0 resource is not a resource type", arguments: []string{"get", "services", "-n", "dash0monitorings", "-o", "yaml"}, expected: false},
+		{name: "a resource named like a workload type is not a resource type", arguments: []string{"get", "services", "deployments", "-o", "yaml"}, expected: false},
 		{name: "no kubectl command", arguments: []string{"--help"}, expected: false},
 	}
 
@@ -335,6 +345,159 @@ func nestedObject(t *testing.T, node map[string]any, path ...string) map[string]
 		node = child
 	}
 	return node
+}
+
+// TestRedactWorkloadEnvVars covers the environment variables of a pod spec, wherever the pod spec sits.
+func TestRedactWorkloadEnvVars(t *testing.T) {
+	t.Run("redacts the literal value of every environment variable", func(t *testing.T) {
+		rendered, replaced := redactDocument(t, workloadResourcesJson)
+
+		for _, value := range []string{
+			deploymentEnvValue,
+			initContainerEnvValue,
+			ephemeralContainerEnvValue,
+			daemonSetEnvValue,
+			lastAppliedEnvValue,
+			cronJobEnvValue,
+			controllerRevisionEnvValue,
+		} {
+			if strings.Contains(rendered, value) {
+				t.Errorf("expected the environment variable value %q to be redacted, got %q", value, rendered)
+			}
+		}
+		// The values are replaced in the document only. Scrubbing them from stderr as well would replace ordinary words
+		// in unrelated output, see redactEnvVarValue.
+		if len(replaced) > 0 {
+			t.Errorf("expected no environment variable value to be scrubbed from stderr, got %q", replaced)
+		}
+	})
+
+	t.Run("leaves everything that is not a literal value in place", func(t *testing.T) {
+		rendered, _ := redactDocument(t, workloadResourcesJson)
+
+		for _, preserved := range []string{
+			envVarName,
+			envVarSecretKeyName,
+			"DATABASE_URL",
+			"INIT_SECRET",
+			"metadata.name",
+			"secretKeyRef",
+			"envFrom",
+			"app:1.0.0",
+		} {
+			if !strings.Contains(rendered, preserved) {
+				t.Errorf("expected %q to be preserved, got %q", preserved, rendered)
+			}
+		}
+	})
+
+	t.Run("redacts the environment variables of a container in every shape", func(t *testing.T) {
+		tests := []struct {
+			name     string
+			document string
+			expected string
+		}{
+			{
+				name:     "a literal value",
+				document: `{"env":[{"name":"A","value":"secret"}]}`,
+				expected: `{"env":[{"name":"A","value":"(redacted)"}]}`,
+			},
+			{
+				name:     "several variables of one container",
+				document: `{"env":[{"name":"A","value":"a"},{"name":"B","value":"b"}]}`,
+				expected: `{"env":[{"name":"A","value":"(redacted)"},{"name":"B","value":"(redacted)"}]}`,
+			},
+			{
+				// A well-known non-secret value keeps its place in a header, but not in an environment variable: any
+				// workload can hold a credential there, and there is no way to tell one from an innocuous value.
+				name:     "a value that would be well-known for a header",
+				document: `{"env":[{"name":"A","value":"application/json"}]}`,
+				expected: `{"env":[{"name":"A","value":"(redacted)"}]}`,
+			},
+			{
+				name:     "a value sourced via valueFrom",
+				document: `{"env":[{"name":"A","valueFrom":{"secretKeyRef":{"name":"s","key":"k"}}}]}`,
+				expected: `{"env":[{"name":"A","valueFrom":{"secretKeyRef":{"key":"k","name":"s"}}}]}`,
+			},
+			{
+				name:     "an empty value",
+				document: `{"env":[{"name":"A","value":""}]}`,
+				expected: `{"env":[{"name":"A","value":""}]}`,
+			},
+			{
+				// Not the env var list of a pod spec: the walk only replaces a string held by the "value" key of a list
+				// entry, so a field that happens to be called "env" is left alone.
+				name:     "an env field that is not a list",
+				document: `{"env":{"A":"a"}}`,
+				expected: `{"env":{"A":"a"}}`,
+			},
+			{
+				name:     "an env list of strings",
+				document: `{"env":["A=a"]}`,
+				expected: `{"env":["A=a"]}`,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				var parsed any
+				if err := json.Unmarshal([]byte(tt.document), &parsed); err != nil {
+					t.Fatalf("cannot parse the test document: %v", err)
+				}
+				redactDocumentNodeRecursively(parsed, &redactor{values: make(map[string]struct{})})
+				rendered, err := json.Marshal(parsed)
+				if err != nil {
+					t.Fatalf("cannot render the redacted test document: %v", err)
+				}
+				if string(rendered) != tt.expected {
+					t.Errorf("expected %s, got %s", tt.expected, rendered)
+				}
+			})
+		}
+	})
+
+	t.Run("redacts the header values of the probes and lifecycle hooks of a pod spec", func(t *testing.T) {
+		tests := []struct {
+			name     string
+			document string
+			expected string
+		}{
+			{
+				name:     "a liveness probe header",
+				document: `{"livenessProbe":{"httpGet":{"httpHeaders":[{"name":"Authorization","value":"Bearer t0ken"}]}}}`,
+				expected: `{"livenessProbe":{"httpGet":{"httpHeaders":[{"name":"Authorization","value":"(redacted)"}]}}}`,
+			},
+			{
+				name:     "a lifecycle hook header",
+				document: `{"lifecycle":{"preStop":{"httpGet":{"httpHeaders":[{"name":"X-Api-Key","value":"k3y"}]}}}}`,
+				expected: `{"lifecycle":{"preStop":{"httpGet":{"httpHeaders":[{"name":"X-Api-Key","value":"(redacted)"}]}}}}`,
+			},
+			{
+				// The same plausibility check as for the header values of an export: a well-known non-secret value
+				// keeps its place, see redactHeaderValueIfPlausible.
+				name:     "a well-known non-secret header value",
+				document: `{"readinessProbe":{"httpGet":{"httpHeaders":[{"name":"Accept","value":"application/json"}]}}}`,
+				expected: `{"readinessProbe":{"httpGet":{"httpHeaders":[{"name":"Accept","value":"application/json"}]}}}`,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				var parsed any
+				if err := json.Unmarshal([]byte(tt.document), &parsed); err != nil {
+					t.Fatalf("cannot parse the test document: %v", err)
+				}
+				redactDocumentNodeRecursively(parsed, &redactor{values: make(map[string]struct{})})
+				rendered, err := json.Marshal(parsed)
+				if err != nil {
+					t.Fatalf("cannot render the redacted test document: %v", err)
+				}
+				if string(rendered) != tt.expected {
+					t.Errorf("expected %s, got %s", tt.expected, rendered)
+				}
+			})
+		}
+	})
 }
 
 func TestRedactSecrets(t *testing.T) {
@@ -660,15 +823,48 @@ func TestRedactDash0SecretsInCommandResponse(t *testing.T) {
 		}
 	})
 
+	t.Run("redacts the environment variable values of a workload response", func(t *testing.T) {
+		fakeKubectlEchoing(t, workloadResourcesJson)
+
+		resp := ExecuteCommandRequest(context.Background(), logger, "/tmp", &pb.CommandRequest{
+			RequestId: "req-redact-workloads",
+			Command:   "kubectl",
+			Arguments: []string{"get", "deployments,daemonsets,cronjobs,controllerrevisions,pods", "-A", "-o", "json"},
+		})
+
+		if resp.GetExitCode() != 0 {
+			t.Fatalf("expected exit code 0, got %d (stderr: %q)", resp.GetExitCode(), resp.GetStderr())
+		}
+		for _, value := range []string{
+			deploymentEnvValue,
+			initContainerEnvValue,
+			ephemeralContainerEnvValue,
+			daemonSetEnvValue,
+			lastAppliedEnvValue,
+			cronJobEnvValue,
+			controllerRevisionEnvValue,
+		} {
+			if strings.Contains(resp.GetStdout(), value) {
+				t.Errorf("expected the environment variable value %q to be redacted, got %q", value, resp.GetStdout())
+			}
+		}
+		// The rest of the workload stays readable, which is what makes the response useful for diagnosing it.
+		for _, preserved := range []string{envVarName, "app:1.0.0", "my-cron-job"} {
+			if !strings.Contains(resp.GetStdout(), preserved) {
+				t.Errorf("expected %q to be preserved, got %q", preserved, resp.GetStdout())
+			}
+		}
+	})
+
 	t.Run("leaves the response of a request for other resources untouched", func(t *testing.T) {
-		// The fake kubectl echoes a token-like value for any request; a request that does not target a Dash0 resource
-		// must not be post-processed at all.
+		// The fake kubectl echoes a token-like value for any request; a request that targets neither a Dash0 resource nor
+		// a workload resource must not be post-processed at all.
 		fakeKubectlEchoing(t, monitoringToken)
 
 		resp := ExecuteCommandRequest(context.Background(), logger, "/tmp", &pb.CommandRequest{
 			RequestId: "req-other-resource",
 			Command:   "kubectl",
-			Arguments: []string{"get", "pods", "-o", "yaml"},
+			Arguments: []string{"get", "services", "-o", "yaml"},
 		})
 
 		if strings.TrimSpace(resp.GetStdout()) != monitoringToken {
@@ -760,7 +956,7 @@ func TestRedactDash0SecretsWithTruncatedStdout(t *testing.T) {
 	logger := discardLogger()
 
 	t.Run("withholds a response whose stdout was truncated", func(t *testing.T) {
-		// Output beyond maxOutputBytesPerStream is dropped, so the captured stdout is a prefix of the document kubectl
+		// Output beyond maxStdoutBytes is dropped, so the captured stdout is a prefix of the document kubectl
 		// rendered. That prefix cannot be parsed, and a document that cannot be parsed cannot be redacted, so the
 		// response has to be withheld even though its beginning holds the token in plaintext.
 		//
@@ -772,8 +968,9 @@ s=0123456789012345678901234567890123456789012345678901234567890123
 s=$s$s$s$s
 s=$s$s$s$s
 s=$s$s$s$s
+s=$s$s$s$s
 i=0
-while [ $i -lt 300 ]; do
+while [ $i -lt 200 ]; do
   printf '%s' "$s"
   i=$((i+1))
 done
@@ -812,8 +1009,9 @@ s=0123456789012345678901234567890123456789012345678901234567890123
 s=$s$s$s$s
 s=$s$s$s$s
 s=$s$s$s$s
+s=$s$s$s$s
 i=0
-while [ $i -lt 300 ]; do
+while [ $i -lt 200 ]; do
   printf '%s' "$s"
   i=$((i+1))
 done
@@ -842,17 +1040,18 @@ s=0123456789012345678901234567890123456789012345678901234567890123
 s=$s$s$s$s
 s=$s$s$s$s
 s=$s$s$s$s
+s=$s$s$s$s
 i=0
-while [ $i -lt 300 ]; do
+while [ $i -lt 200 ]; do
   printf '%s' "$s"
   i=$((i+1))
 done
 `)
 
 		resp := ExecuteCommandRequest(context.Background(), logger, "/tmp", &pb.CommandRequest{
-			RequestId: "req-truncated-pods",
+			RequestId: "req-truncated-services",
 			Command:   "kubectl",
-			Arguments: []string{"get", "pods", "-o", "json"},
+			Arguments: []string{"get", "services", "-o", "json"},
 		})
 
 		if resp.GetStdout() == "" {
@@ -1256,3 +1455,134 @@ items:
           value: ` + grpcHeaderValue + `
 kind: List
 `
+
+const (
+	deploymentEnvValue         = "postgres://app:my-deployment-db-password@db:5432/app"
+	initContainerEnvValue      = "my-init-container-secret"
+	ephemeralContainerEnvValue = "my-ephemeral-container-secret"
+	daemonSetEnvValue          = "auth_daemonset-token"
+	lastAppliedEnvValue        = "auth_previous-daemonset-token"
+	cronJobEnvValue            = "my-cron-job-secret"
+	controllerRevisionEnvValue = "my-controller-revision-secret"
+
+	// The values that must survive the walk: the name of a variable is not a credential, and a variable that sources
+	// its value via valueFrom holds a reference rather than a value.
+	envVarName          = "DASH0_AUTHORIZATION_TOKEN"
+	envVarSecretKeyName = "my-env-var-secret"
+)
+
+// workloadResourcesJson is a "kubectl get deployments,daemonsets,cronjobs,controllerrevisions,pods -o json" response.
+// It covers every place a pod spec can hold the literal value of an environment variable: the containers and the init
+// containers of a deployment, the ephemeral containers of a pod, the pod template a cron job nests two levels deep,
+// the copy of a pod template that a controller revision keeps in its "data" field, and the copy of the manifest that
+// kubectl apply leaves behind in the last-applied-configuration annotation. It also contains what must not be
+// redacted: the names of the variables, a value sourced via valueFrom, and an envFrom reference.
+const workloadResourcesJson = `{
+  "apiVersion": "v1",
+  "kind": "List",
+  "items": [
+    {
+      "apiVersion": "apps/v1",
+      "kind": "Deployment",
+      "metadata": { "name": "my-deployment", "namespace": "my-namespace" },
+      "spec": {
+        "template": {
+          "spec": {
+            "initContainers": [
+              {
+                "name": "init",
+                "image": "init:1.0.0",
+                "env": [{ "name": "INIT_SECRET", "value": "` + initContainerEnvValue + `" }]
+              }
+            ],
+            "containers": [
+              {
+                "name": "app",
+                "image": "app:1.0.0",
+                "env": [
+                  { "name": "DATABASE_URL", "value": "` + deploymentEnvValue + `" },
+                  { "name": "POD_NAME", "valueFrom": { "fieldRef": { "fieldPath": "metadata.name" } } },
+                  {
+                    "name": "API_KEY",
+                    "valueFrom": { "secretKeyRef": { "name": "` + envVarSecretKeyName + `", "key": "api-key" } }
+                  }
+                ],
+                "envFrom": [{ "secretRef": { "name": "` + envVarSecretKeyName + `" } }]
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "apiVersion": "apps/v1",
+      "kind": "DaemonSet",
+      "metadata": {
+        "name": "dash0-operator-agent",
+        "namespace": "dash0-system",
+        "annotations": {
+          "kubectl.kubernetes.io/last-applied-configuration":
+            "{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"name\":\"agent\",\"env\":[{\"name\":\"` +
+	envVarName + `\",\"value\":\"` + lastAppliedEnvValue + `\"}]}]}}}}"
+        }
+      },
+      "spec": {
+        "template": {
+          "spec": {
+            "containers": [
+              { "name": "agent", "env": [{ "name": "` + envVarName + `", "value": "` + daemonSetEnvValue + `" }] }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "apiVersion": "batch/v1",
+      "kind": "CronJob",
+      "metadata": { "name": "my-cron-job", "namespace": "my-namespace" },
+      "spec": {
+        "jobTemplate": {
+          "spec": {
+            "template": {
+              "spec": {
+                "containers": [
+                  { "name": "job", "env": [{ "name": "JOB_SECRET", "value": "` + cronJobEnvValue + `" }] }
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "apiVersion": "apps/v1",
+      "kind": "ControllerRevision",
+      "metadata": { "name": "dash0-operator-agent-6cdb9d7c8f", "namespace": "dash0-system" },
+      "revision": 3,
+      "data": {
+        "spec": {
+          "template": {
+            "spec": {
+              "containers": [
+                {
+                  "name": "agent",
+                  "env": [{ "name": "` + envVarName + `", "value": "` + controllerRevisionEnvValue + `" }]
+                }
+              ]
+            }
+          }
+        }
+      }
+    },
+    {
+      "apiVersion": "v1",
+      "kind": "Pod",
+      "metadata": { "name": "my-pod", "namespace": "my-namespace" },
+      "spec": {
+        "ephemeralContainers": [
+          { "name": "debugger", "env": [{ "name": "DEBUG_TOKEN", "value": "` + ephemeralContainerEnvValue + `" }] }
+        ]
+      }
+    }
+  ]
+}`

--- a/images/agent0-connector/src/kubectl/validation.go
+++ b/images/agent0-connector/src/kubectl/validation.go
@@ -119,10 +119,35 @@ var redactableOutputFormats = map[string]struct{}{
 	"yaml": {},
 }
 
-// safeOrRedactableOutputFormats is the allowlist of output formats a command request may use when it targets a Dash0
-// custom resource type that can contain secrets (see dash0ResourceTypesWithSecrets). It lists the formats that never
-// contain resource content with secrets (e.g. "", "name", "wide") and the formats that can be reliably redacted because
-// they do not reshape the response ("json", "yaml").
+// unredactableOutputFormatReasons holds the output formats that are rejected for a resource type that can contain
+// secrets for a reason other than being able to reshape the response. Without it the rejection would tell the caller
+// that the format reshapes values, which is wrong for these and points them away from a format that would work.
+var unredactableOutputFormatReasons = map[string]string{
+	"kyaml": "the connector does not redact this output format yet",
+}
+
+// safeSortByPathPrefixes are the top-level fields a --sort-by expression may address when the request targets a
+// resource type that can contain secrets. Neither the metadata nor the status of such a resource holds a credential,
+// while its spec holds every field the response redacts.
+var safeSortByPathPrefixes = []string{"metadata", "status"}
+
+var safeSortByPathPrefixesHumanReadable = func() string {
+	quoted := make([]string, 0, len(safeSortByPathPrefixes))
+	for _, prefix := range safeSortByPathPrefixes {
+		quoted = append(quoted, fmt.Sprintf("%q", prefix))
+	}
+	return strings.Join(quoted, " or ")
+}()
+
+// unsafeSortByPathPrefix is the one field below safeSortByPathPrefixes that a --sort-by expression may not address:
+// kubectl apply stores a verbatim copy of the applied manifest, credentials included, in the
+// "kubectl.kubernetes.io/last-applied-configuration" annotation, see redactAnnotations.
+const unsafeSortByPathPrefix = "metadata.annotations"
+
+// safeOrRedactableOutputFormats is the allowlist of output formats a command request may use when it targets a
+// resource type that can contain secrets (see resourceTypesWithSecrets). It lists the formats that never contain
+// resource content with secrets (e.g. "", "name", "wide") and the formats that can be reliably redacted because they
+// do not reshape the response ("json", "yaml").
 var safeOrRedactableOutputFormats = func() map[string]struct{} {
 	formats := maps.Clone(contentFreeOutputFormats)
 	maps.Copy(formats, redactableOutputFormats)
@@ -187,6 +212,9 @@ func validateCommandAndParseArguments(req *pb.CommandRequest) (kubectlArguments,
 		return kubectlArguments{}, errors.New(reason)
 	}
 	if reason, blocked := unredactableOutputRequested(arguments); blocked {
+		return kubectlArguments{}, errors.New(reason)
+	}
+	if reason, blocked := unsafeSortByRequested(arguments); blocked {
 		return kubectlArguments{}, errors.New(reason)
 	}
 	if reason, blocked := describeOfResourceTypeWithSecrets(arguments); blocked {
@@ -265,18 +293,27 @@ func disallowedSubcommandRequested(parsed kubectlArguments) (string, bool) {
 	), true
 }
 
-// describeOfResourceTypeWithSecrets reports whether the kubectl arguments describe a Dash0 custom resource that can
-// contain secrets, returning a human-readable reason when they do. The describer renders a resource in a text format
-// that is not meant to be parsed and for which no parser is available, so the connector cannot locate the credentials
-// in its output in order to redact them.
+// describeOfResourceTypeWithSecrets reports whether the kubectl arguments describe a resource that can contain
+// secrets, returning a human-readable reason when they do. The describer renders a resource in a text format that is
+// not meant to be parsed and for which no parser is available, so the connector cannot locate the credentials in its
+// output in order to redact them.
 func describeOfResourceTypeWithSecrets(parsed kubectlArguments) (string, bool) {
-	if parsed.kubectlCommand != "describe" || !targetsResourceTypeWithSecrets(parsed) {
+	if parsed.kubectlCommand != "describe" {
 		return "", false
 	}
-	return "describing a Dash0 custom resource is not supported, because it can contain an authorization token or " +
-		"third-party credentials which cannot be redacted from the output of \"kubectl describe\"; read the resource " +
-		"with \"kubectl get ... -o yaml\" or \"-o json\" instead, which returns the same content with its credentials " +
-		"redacted, and its events with \"kubectl events --for <resource-type>/<name>\"", true
+	category, hasSecrets := targetsResourceTypeWithSecrets(parsed)
+	if !hasSecrets {
+		return "", false
+	}
+	return fmt.Sprintf(
+		"describing %s is not supported, because it can contain %s which cannot be redacted from the output of "+
+			"\"kubectl describe\"; read the resource with \"kubectl get ... -o yaml\" or \"-o json\" instead, which "+
+			"returns the same content with %s redacted, and its events with "+
+			"\"kubectl events --for <resource-type>/<name>\"",
+		category.description,
+		category.secrets,
+		category.redactedContent,
+	), true
 }
 
 // disallowedOutputFormat returns the first output format requested via -o/--output that is not in the
@@ -344,25 +381,102 @@ func lookupSensitiveResourceType(resourceType string) (sensitiveResource, bool) 
 	return resource, isSensitive
 }
 
-// unredactableOutputRequested reports whether the kubectl arguments would render a Dash0 custom resource that can
-// contain secrets in an output format whose result cannot be redacted reliably, returning a human-readable reason when
-// they do. Every occurrence of -o/--output is checked, not just the effective (last) one, and --template counts as
-// go-template output even without -o, mirroring outputIsContentFree.
+// unredactableOutputRequested reports whether the kubectl arguments would render a resource that can contain secrets
+// in an output format whose result cannot be redacted reliably, returning a human-readable reason when they do. Every
+// occurrence of -o/--output is checked, not just the effective (last) one, and --template counts as go-template output
+// even without -o, mirroring outputIsContentFree.
 func unredactableOutputRequested(parsed kubectlArguments) (string, bool) {
-	if !targetsResourceTypeWithSecrets(parsed) {
+	category, hasSecrets := targetsResourceTypeWithSecrets(parsed)
+	if !hasSecrets {
 		return "", false
 	}
 	format, unredactable := unredactableOutputFormat(parsed)
 	if !unredactable {
 		return "", false
 	}
+	if reason, hasOwnReason := unredactableOutputFormatReasons[format]; hasOwnReason {
+		return fmt.Sprintf(
+			"the output format %q cannot be redacted reliably for %s, which can contain %s, because %s; reading such "+
+				"a resource is supported with -o json/yaml/name/wide (or without an output format)",
+			format,
+			category.description,
+			category.secrets,
+			reason,
+		), true
+	}
 	return fmt.Sprintf(
-		"the output format %q cannot be redacted reliably for a Dash0 custom resource, which can contain an "+
-			"authorization token or third-party credentials; reading such a resource is supported with "+
-			"-o json/yaml/name/wide (or without an output format), but not with a format that can reshape its values "+
-			"(-o go-template/template/jsonpath/jsonpath-as-json/custom-columns or --template)",
+		"the output format %q cannot be redacted reliably for %s, which can contain %s; reading such a resource is "+
+			"supported with -o json/yaml/name/wide (or without an output format), but not with a format that can "+
+			"reshape its values (-o go-template/template/jsonpath/jsonpath-as-json/custom-columns or --template)",
 		format,
+		category.description,
+		category.secrets,
 	), true
+}
+
+// unsafeSortByRequested reports whether the kubectl arguments sort a resource that can contain secrets by a field the
+// response redacts, returning a human-readable reason when they do. kubectl evaluates a --sort-by expression against
+// the unredacted resources, so the connector cannot redact what the expression exposes: sorting by a redacted field
+// leaks its order, and a filter expression such as {.spec.containers[0].env[?(@.value>"S")].name} turns the presence
+// of a match into a comparison oracle that reveals the value character by character over several requests. Every
+// occurrence of the flag is checked, not just the effective (last) one, mirroring unredactableOutputRequested.
+func unsafeSortByRequested(parsed kubectlArguments) (string, bool) {
+	category, hasSecrets := targetsResourceTypeWithSecrets(parsed)
+	if !hasSecrets {
+		return "", false
+	}
+	for _, expression := range parsed.valuesOf("sort-by") {
+		if sortByExpressionIsSafe(expression) {
+			continue
+		}
+		return fmt.Sprintf(
+			"the --sort-by expression %q is not allowed for %s, which can contain %s; kubectl evaluates the "+
+				"expression against the resources before the connector redacts them, so only a plain path below "+
+				"%s may be sorted by, except %q (e.g. --sort-by=.metadata.name or --sort-by=.status.startTime)",
+			expression,
+			category.description,
+			category.secrets,
+			safeSortByPathPrefixesHumanReadable,
+			unsafeSortByPathPrefix,
+		), true
+	}
+	return "", false
+}
+
+// sortByExpressionIsSafe reports whether a --sort-by JSONPath expression addresses only fields that cannot hold a
+// credential. It fails closed: anything it does not recognize as a plain path below safeSortByPathPrefixes is unsafe.
+func sortByExpressionIsSafe(expression string) bool {
+	path := normalizeSortByPath(expression)
+	if path == "" {
+		return false
+	}
+	// A filter expression, a wildcard, a recursive descent or a second path can address any field of the resource,
+	// including the ones the response redacts.
+	if strings.ContainsAny(path, "?*{}") || strings.Contains(path, "..") {
+		return false
+	}
+	if isSortByPathBelow(path, unsafeSortByPathPrefix) {
+		return false
+	}
+	return slices.ContainsFunc(safeSortByPathPrefixes, func(prefix string) bool {
+		return isSortByPathBelow(path, prefix)
+	})
+}
+
+// isSortByPathBelow reports whether a normalized --sort-by path addresses the given field or anything below it.
+func isSortByPathBelow(path string, prefix string) bool {
+	return path == prefix ||
+		strings.HasPrefix(path, prefix+".") ||
+		strings.HasPrefix(path, prefix+"[")
+}
+
+// normalizeSortByPath strips the optional surrounding braces and the leading dot of a --sort-by expression, so that
+// "{.metadata.name}", ".metadata.name" and "metadata.name" all yield "metadata.name".
+func normalizeSortByPath(expression string) string {
+	path := strings.TrimSpace(expression)
+	path = strings.TrimPrefix(path, "{")
+	path = strings.TrimSuffix(path, "}")
+	return strings.TrimPrefix(path, ".")
 }
 
 // unredactableOutputFormat returns the first output format that is not in the safeOrRedactableOutputFormats allowlist.

--- a/images/agent0-connector/src/kubectl/validation_test.go
+++ b/images/agent0-connector/src/kubectl/validation_test.go
@@ -96,10 +96,56 @@ func outputFormatNotRedactable(format string) string {
 	)
 }
 
+func outputFormatNotRedactableForWorkload(format string) string {
+	return fmt.Sprintf(
+		"the output format %q cannot be redacted reliably for a workload resource, which can contain credentials in "+
+			"the values of its environment variables; reading such a resource is supported with "+
+			"-o json/yaml/name/wide (or without an output format), but not with a format that can reshape its values "+
+			"(-o go-template/template/jsonpath/jsonpath-as-json/custom-columns or --template)",
+		format,
+	)
+}
+
+func sortByNotAllowedForDash0Resource(expression string) string {
+	return fmt.Sprintf(
+		"the --sort-by expression %q is not allowed for a Dash0 custom resource, which can contain an authorization "+
+			"token or third-party credentials; kubectl evaluates the expression against the resources before the "+
+			"connector redacts them, so only a plain path below \"metadata\" or \"status\" may be sorted by, except "+
+			"\"metadata.annotations\" (e.g. --sort-by=.metadata.name or --sort-by=.status.startTime)",
+		expression,
+	)
+}
+
+func sortByNotAllowedForWorkload(expression string) string {
+	return fmt.Sprintf(
+		"the --sort-by expression %q is not allowed for a workload resource, which can contain credentials in the "+
+			"values of its environment variables; kubectl evaluates the expression against the resources before the "+
+			"connector redacts them, so only a plain path below \"metadata\" or \"status\" may be sorted by, except "+
+			"\"metadata.annotations\" (e.g. --sort-by=.metadata.name or --sort-by=.status.startTime)",
+		expression,
+	)
+}
+
+const kyamlNotRedactableForDash0Resource = "the output format \"kyaml\" cannot be redacted reliably for a Dash0 " +
+	"custom resource, which can contain an authorization token or third-party credentials, because the connector " +
+	"does not redact this output format yet; reading such a resource is supported with -o json/yaml/name/wide " +
+	"(or without an output format)"
+
+const kyamlNotRedactableForWorkload = "the output format \"kyaml\" cannot be redacted reliably for a workload " +
+	"resource, which can contain credentials in the values of its environment variables, because the connector does " +
+	"not redact this output format yet; reading such a resource is supported with -o json/yaml/name/wide " +
+	"(or without an output format)"
+
 const describeOfDash0ResourceNotSupported = "describing a Dash0 custom resource is not supported, because it can " +
 	"contain an authorization token or third-party credentials which cannot be redacted from the output of " +
 	"\"kubectl describe\"; read the resource with \"kubectl get ... -o yaml\" or \"-o json\" instead, which returns " +
 	"the same content with its credentials redacted, and its events with " +
+	"\"kubectl events --for <resource-type>/<name>\""
+
+const describeOfWorkloadNotSupported = "describing a workload resource is not supported, because it can contain " +
+	"credentials in the values of its environment variables which cannot be redacted from the output of " +
+	"\"kubectl describe\"; read the resource with \"kubectl get ... -o yaml\" or \"-o json\" instead, which returns " +
+	"the same content with the values of its environment variables redacted, and its events with " +
 	"\"kubectl events --for <resource-type>/<name>\""
 
 //nolint:lll
@@ -119,7 +165,7 @@ func TestValidateCommandRequest(t *testing.T) {
 
 		{name: "read-only get is allowed", command: "kubectl", arguments: []string{"get", "pods"}, allowed: true},
 		{name: "get with -n flag is allowed", command: "kubectl", arguments: []string{"get", "po", "-n", "x"}, allowed: true},
-		{name: "describe is allowed", command: "kubectl", arguments: []string{"describe", "pod", "x"}, allowed: true},
+		{name: "describe is allowed", command: "kubectl", arguments: []string{"describe", "node", "x"}, allowed: true},
 		{name: "logs is allowed", command: "kubectl", arguments: []string{"logs", "x"}, allowed: true},
 		{name: "version is allowed", command: "kubectl", arguments: []string{"version"}, allowed: true},
 		{name: "explain is allowed", command: "kubectl", arguments: []string{"explain", "pods"}, allowed: true},
@@ -287,23 +333,25 @@ func TestValidateCommandRequest(t *testing.T) {
 			command: "kubectl", arguments: []string{"get", "pods", "-o", "bogusformat"}, allowed: false,
 			rejectionReason: outputFormatNotAllowed("bogusformat")},
 
-		{name: "-o json is allowed", command: "kubectl", arguments: []string{"get", "pods", "-o", "json"}, allowed: true},
-		{name: "-o yaml is allowed", command: "kubectl", arguments: []string{"get", "pods", "-o", "yaml"}, allowed: true},
-		{name: "-o kyaml is allowed", command: "kubectl", arguments: []string{"get", "pods", "-o", "kyaml"}, allowed: true},
-		{name: "-o name is allowed", command: "kubectl", arguments: []string{"get", "pods", "-o", "name"}, allowed: true},
-		{name: "-o wide is allowed", command: "kubectl", arguments: []string{"get", "pods", "-o", "wide"}, allowed: true},
+		// The subject is a resource type without secrets, so that these cases exercise the general output format
+		// allowlist rather than the restrictions for the resource types whose response has to be redacted.
+		{name: "-o json is allowed", command: "kubectl", arguments: []string{"get", "services", "-o", "json"}, allowed: true},
+		{name: "-o yaml is allowed", command: "kubectl", arguments: []string{"get", "services", "-o", "yaml"}, allowed: true},
+		{name: "-o kyaml is allowed", command: "kubectl", arguments: []string{"get", "services", "-o", "kyaml"}, allowed: true},
+		{name: "-o name is allowed", command: "kubectl", arguments: []string{"get", "services", "-o", "name"}, allowed: true},
+		{name: "-o wide is allowed", command: "kubectl", arguments: []string{"get", "services", "-o", "wide"}, allowed: true},
 		{name: "-o jsonpath is allowed",
-			command: "kubectl", arguments: []string{"get", "pods", "-o", "jsonpath={.items[*].metadata.name}"}, allowed: true},
+			command: "kubectl", arguments: []string{"get", "services", "-o", "jsonpath={.items[*].metadata.name}"}, allowed: true},
 		{name: "-o jsonpath-as-json is allowed",
-			command: "kubectl", arguments: []string{"get", "pods", "-o", "jsonpath-as-json={.items[*].metadata.name}"}, allowed: true},
+			command: "kubectl", arguments: []string{"get", "services", "-o", "jsonpath-as-json={.items[*].metadata.name}"}, allowed: true},
 		{name: "-o go-template is allowed",
-			command: "kubectl", arguments: []string{"get", "pods", "-o", "go-template={{.metadata.name}}"}, allowed: true},
+			command: "kubectl", arguments: []string{"get", "services", "-o", "go-template={{.metadata.name}}"}, allowed: true},
 		{name: "-o template is allowed",
-			command: "kubectl", arguments: []string{"get", "pods", "-o", "template", "--template={{.metadata.name}}"}, allowed: true},
+			command: "kubectl", arguments: []string{"get", "services", "-o", "template", "--template={{.metadata.name}}"}, allowed: true},
 		{name: "-o custom-columns is allowed",
-			command: "kubectl", arguments: []string{"get", "pods", "-o", "custom-columns=NAME:.metadata.name"}, allowed: true},
+			command: "kubectl", arguments: []string{"get", "services", "-o", "custom-columns=NAME:.metadata.name"}, allowed: true},
 		{name: "an output format is matched case-insensitively",
-			command: "kubectl", arguments: []string{"get", "pods", "-o", "YAML"}, allowed: true},
+			command: "kubectl", arguments: []string{"get", "services", "-o", "YAML"}, allowed: true},
 		{name: "a file output format is rejected case-insensitively",
 			command: "kubectl", arguments: []string{"get", "pods", "-o", "JSONPath-File=/etc/passwd"}, allowed: false,
 			rejectionReason: outputFormatNotAllowed("jsonpath-file")},
@@ -336,7 +384,7 @@ func TestValidateCommandRequest(t *testing.T) {
 			rejectionReason: outputFormatNotRedactable("go-template")},
 		{name: "a Dash0 resource with kyaml is rejected",
 			command: "kubectl", arguments: []string{"get", "dash0monitorings", "-o", "kyaml"}, allowed: false,
-			rejectionReason: outputFormatNotRedactable("kyaml")},
+			rejectionReason: kyamlNotRedactableForDash0Resource},
 		{name: "a Dash0 resource with an attached reshaping format is rejected",
 			command: "kubectl", arguments: []string{"get", "dash0monitorings", "-ojsonpath={.items}"}, allowed: false,
 			rejectionReason: outputFormatNotRedactable("jsonpath")},
@@ -361,10 +409,10 @@ func TestValidateCommandRequest(t *testing.T) {
 			command: "kubectl", arguments: []string{"get", "dash0monitorings.operator.dash0.com", "-o", "jsonpath={.spec}"}, allowed: false,
 			rejectionReason: outputFormatNotRedactable("jsonpath")},
 		{name: "a Dash0 resource type in a comma-separated list is covered",
-			command: "kubectl", arguments: []string{"get", "pods,dash0monitorings", "-o", "jsonpath={.items}"}, allowed: false,
+			command: "kubectl", arguments: []string{"get", "services,dash0monitorings", "-o", "jsonpath={.items}"}, allowed: false,
 			rejectionReason: outputFormatNotRedactable("jsonpath")},
 		{name: "a Dash0 resource type in a type/name pair in a later slot is covered",
-			command: "kubectl", arguments: []string{"get", "pod/a", "dash0monitoring/b", "-o", "jsonpath={.spec}"}, allowed: false,
+			command: "kubectl", arguments: []string{"get", "service/a", "dash0monitoring/b", "-o", "jsonpath={.spec}"}, allowed: false,
 			rejectionReason: outputFormatNotRedactable("jsonpath")},
 		{name: "the operator configuration is covered",
 			command: "kubectl", arguments: []string{"get", "dash0operatorconfigurations", "-o", "jsonpath={.items}"}, allowed: false,
@@ -402,22 +450,104 @@ func TestValidateCommandRequest(t *testing.T) {
 			rejectionReason: describeOfDash0ResourceNotSupported},
 		{name: "describe of a Dash0 resource type without secrets is allowed",
 			command: "kubectl", arguments: []string{"describe", "dash0views"}, allowed: true},
-		{name: "describe of a non-Dash0 resource is allowed",
-			command: "kubectl", arguments: []string{"describe", "pod", "my-pod"}, allowed: true},
+		{name: "describe of a resource type that carries no pod spec is allowed",
+			command: "kubectl", arguments: []string{"describe", "node", "my-node"}, allowed: true},
 		{name: "events of a Dash0 resource are allowed",
 			command: "kubectl", arguments: []string{"events", "--for", "dash0monitoring/my-resource"}, allowed: true},
 		{name: "explain for a Dash0 resource is allowed",
 			command: "kubectl", arguments: []string{"explain", "dash0monitorings"}, allowed: true},
 
+		// Workload resource types carry a pod spec, so the literal values of their environment variables can hold a
+		// credential. They are restricted exactly like the Dash0 custom resources that can contain secrets.
+		{name: "a workload with -o go-template is rejected",
+			command: "kubectl", arguments: []string{"get", "deployments", "-o", "go-template={{.items}}"}, allowed: false,
+			rejectionReason: outputFormatNotRedactableForWorkload("go-template")},
+		{name: "a workload with -o jsonpath is rejected",
+			command: "kubectl", arguments: []string{"get", "pods", "-o", "jsonpath={.items[*].spec.containers[*].env}"}, allowed: false,
+			rejectionReason: outputFormatNotRedactableForWorkload("jsonpath")},
+		{name: "a workload with -o jsonpath-as-json is rejected",
+			command: "kubectl", arguments: []string{"get", "daemonsets", "-o", "jsonpath-as-json={.items}"}, allowed: false,
+			rejectionReason: outputFormatNotRedactableForWorkload("jsonpath-as-json")},
+		{name: "a workload with -o custom-columns is rejected",
+			command: "kubectl", arguments: []string{"get", "statefulsets", "-o", "custom-columns=E:.spec.template.spec.containers[*].env"}, allowed: false,
+			rejectionReason: outputFormatNotRedactableForWorkload("custom-columns")},
+		{name: "a workload with --template but no output format is rejected",
+			command: "kubectl", arguments: []string{"get", "jobs", "--template={{.items}}"}, allowed: false,
+			rejectionReason: outputFormatNotRedactableForWorkload("go-template")},
+		{name: "a workload with a truncating go-template is rejected",
+			command: "kubectl", arguments: []string{"get", "ds", "-o", `go-template={{printf "%.6s" (index .spec.template.spec.containers 0).env}}`}, allowed: false,
+			rejectionReason: outputFormatNotRedactableForWorkload("go-template")},
+		{name: "a workload with kyaml is rejected",
+			command: "kubectl", arguments: []string{"get", "deploy", "-o", "kyaml"}, allowed: false,
+			rejectionReason: kyamlNotRedactableForWorkload},
+		{name: "the all shorthand with a reshaping format is rejected",
+			command: "kubectl", arguments: []string{"get", "all", "-o", "jsonpath={.items}"}, allowed: false,
+			rejectionReason: outputFormatNotRedactableForWorkload("jsonpath")},
+		// A controller revision holds a copy of the pod template of the daemon set or stateful set it belongs to.
+		{name: "a controller revision with a reshaping format is rejected",
+			command: "kubectl", arguments: []string{"get", "controllerrevisions", "-o", "jsonpath={.items[*].data}"}, allowed: false,
+			rejectionReason: outputFormatNotRedactableForWorkload("jsonpath")},
+		{name: "a cron job with a reshaping format is rejected",
+			command: "kubectl", arguments: []string{"get", "cj", "-o", "jsonpath={.items}"}, allowed: false,
+			rejectionReason: outputFormatNotRedactableForWorkload("jsonpath")},
+		{name: "a pod template with a reshaping format is rejected",
+			command: "kubectl", arguments: []string{"get", "podtemplates", "-o", "jsonpath={.items}"}, allowed: false,
+			rejectionReason: outputFormatNotRedactableForWorkload("jsonpath")},
+		{name: "a replication controller with a reshaping format is rejected",
+			command: "kubectl", arguments: []string{"get", "rc", "-o", "jsonpath={.items}"}, allowed: false,
+			rejectionReason: outputFormatNotRedactableForWorkload("jsonpath")},
+		{name: "a replica set with a reshaping format is rejected",
+			command: "kubectl", arguments: []string{"get", "rs", "-o", "jsonpath={.items}"}, allowed: false,
+			rejectionReason: outputFormatNotRedactableForWorkload("jsonpath")},
+		{name: "the workload kind form is covered",
+			command: "kubectl", arguments: []string{"get", "Deployment", "-o", "jsonpath={.items}"}, allowed: false,
+			rejectionReason: outputFormatNotRedactableForWorkload("jsonpath")},
+		{name: "the fully qualified workload resource type is covered",
+			command: "kubectl", arguments: []string{"get", "deployments.v1.apps", "-o", "jsonpath={.items}"}, allowed: false,
+			rejectionReason: outputFormatNotRedactableForWorkload("jsonpath")},
+		{name: "a workload in a type/name pair in a later slot is covered",
+			command: "kubectl", arguments: []string{"get", "service/a", "pod/b", "-o", "jsonpath={.spec}"}, allowed: false,
+			rejectionReason: outputFormatNotRedactableForWorkload("jsonpath")},
+		{name: "describe of a workload is rejected",
+			command: "kubectl", arguments: []string{"describe", "pod", "my-pod"}, allowed: false,
+			rejectionReason: describeOfWorkloadNotSupported},
+		{name: "describe of workloads in all namespaces is rejected",
+			command: "kubectl", arguments: []string{"describe", "deployments", "-A"}, allowed: false,
+			rejectionReason: describeOfWorkloadNotSupported},
+		{name: "describe of a workload via type/name is rejected",
+			command: "kubectl", arguments: []string{"describe", "ds/my-daemonset"}, allowed: false,
+			rejectionReason: describeOfWorkloadNotSupported},
+
+		// The formats the connector can redact stay available for workloads, and the commands that do not render a pod
+		// spec are unaffected.
+		{name: "a workload with -o yaml is allowed",
+			command: "kubectl", arguments: []string{"get", "deployments", "-o", "yaml"}, allowed: true},
+		{name: "a workload with -o json is allowed",
+			command: "kubectl", arguments: []string{"get", "pods", "-A", "-o", "json"}, allowed: true},
+		{name: "a workload with -o name is allowed",
+			command: "kubectl", arguments: []string{"get", "pods", "-o", "name"}, allowed: true},
+		{name: "a workload with -o wide is allowed",
+			command: "kubectl", arguments: []string{"get", "pods", "-o", "wide"}, allowed: true},
+		{name: "a workload without an output format is allowed",
+			command: "kubectl", arguments: []string{"get", "pods"}, allowed: true},
+		{name: "logs of a workload are allowed",
+			command: "kubectl", arguments: []string{"logs", "pod/my-pod"}, allowed: true},
+		{name: "events of a workload are allowed",
+			command: "kubectl", arguments: []string{"events", "--for", "pod/my-pod"}, allowed: true},
+		{name: "top of a workload is allowed",
+			command: "kubectl", arguments: []string{"top", "pods"}, allowed: true},
+		{name: "explain for a workload is allowed",
+			command: "kubectl", arguments: []string{"explain", "pods"}, allowed: true},
+
 		// Resource types without secrets keep every generally allowed output format.
-		{name: "a reshaping format for a non-Dash0 resource is allowed",
-			command: "kubectl", arguments: []string{"get", "pods", "-o", "jsonpath={.items[*].metadata.name}"}, allowed: true},
-		{name: "a go-template for a non-Dash0 resource is allowed",
-			command: "kubectl", arguments: []string{"get", "pods", "-o", "go-template={{.items}}"}, allowed: true},
-		{name: "--template for a non-Dash0 resource is allowed",
-			command: "kubectl", arguments: []string{"get", "pods", "--template={{.items}}"}, allowed: true},
-		{name: "kyaml for a non-Dash0 resource is allowed",
-			command: "kubectl", arguments: []string{"get", "pods", "-o", "kyaml"}, allowed: true},
+		{name: "a reshaping format for a resource type without secrets is allowed",
+			command: "kubectl", arguments: []string{"get", "services", "-o", "jsonpath={.items[*].metadata.name}"}, allowed: true},
+		{name: "a go-template for a resource type without secrets is allowed",
+			command: "kubectl", arguments: []string{"get", "services", "-o", "go-template={{.items}}"}, allowed: true},
+		{name: "--template for a resource type without secrets is allowed",
+			command: "kubectl", arguments: []string{"get", "services", "--template={{.items}}"}, allowed: true},
+		{name: "kyaml for a resource type without secrets is allowed",
+			command: "kubectl", arguments: []string{"get", "services", "-o", "kyaml"}, allowed: true},
 		{name: "a Dash0 resource type without secrets keeps the reshaping formats",
 			command: "kubectl", arguments: []string{"get", "dash0views", "-o", "jsonpath={.items}"}, allowed: true},
 
@@ -566,14 +696,42 @@ func TestValidateCommandRequest(t *testing.T) {
 			command: "kubectl", arguments: []string{"get", "pods", "-n", "cm", "-o", "yaml"}, allowed: true},
 		{name: "pod named cm as yaml is allowed",
 			command: "kubectl", arguments: []string{"get", "pods", "cm", "-o", "yaml"}, allowed: true},
-		{name: "describe pod named cm is allowed",
-			command: "kubectl", arguments: []string{"describe", "pod", "cm"}, allowed: true},
+		{name: "describe node named cm is allowed",
+			command: "kubectl", arguments: []string{"describe", "node", "cm"}, allowed: true},
 
 		// Allowlisted flags keep working, in every spelling and combination.
 		{name: "all-namespaces and output shaping flags are allowed",
 			command: "kubectl", arguments: []string{"get", "pods", "-A", "--no-headers", "--show-labels", "-L", "app"}, allowed: true},
 		{name: "selector, field selector and sort-by are allowed",
 			command: "kubectl", arguments: []string{"get", "pods", "-l", "app=x", "--field-selector", "status.phase=Running", "--sort-by", ".metadata.name"}, allowed: true},
+		// --sort-by is evaluated by kubectl against the resources before the connector redacts them, so for a resource
+		// type that can contain secrets it may only address metadata and status.
+		{name: "sort-by a metadata field of a workload is allowed",
+			command: "kubectl", arguments: []string{"get", "pods", "--sort-by", ".metadata.creationTimestamp"}, allowed: true},
+		{name: "sort-by a status field of a workload is allowed",
+			command: "kubectl", arguments: []string{"get", "pods", "--sort-by", "{.status.startTime}"}, allowed: true},
+		{name: "sort-by an indexed status field of a workload is allowed",
+			command: "kubectl", arguments: []string{"get", "pods", "--sort-by", ".status.containerStatuses[0].restartCount"}, allowed: true},
+		{name: "sort-by a spec field of a workload is rejected",
+			command: "kubectl", arguments: []string{"get", "pods", "--sort-by", ".spec.containers[0].env[0].value"}, allowed: false,
+			rejectionReason: sortByNotAllowedForWorkload(".spec.containers[0].env[0].value")},
+		{name: "sort-by a filter expression over a workload is rejected",
+			command: "kubectl", arguments: []string{"get", "pods", "-o", "name", "--sort-by", "{.spec.containers[0].env[?(@.value>\"S\")].name}"}, allowed: false,
+			rejectionReason: sortByNotAllowedForWorkload("{.spec.containers[0].env[?(@.value>\"S\")].name}")},
+		{name: "sort-by the last-applied-configuration annotation of a workload is rejected",
+			command: "kubectl", arguments: []string{"get", "deploy", "--sort-by", ".metadata.annotations"}, allowed: false,
+			rejectionReason: sortByNotAllowedForWorkload(".metadata.annotations")},
+		{name: "sort-by a wildcard over a workload is rejected",
+			command: "kubectl", arguments: []string{"get", "pods", "--sort-by", ".spec.containers[*].env"}, allowed: false,
+			rejectionReason: sortByNotAllowedForWorkload(".spec.containers[*].env")},
+		{name: "sort-by a recursive descent over a workload is rejected",
+			command: "kubectl", arguments: []string{"get", "pods", "--sort-by", ".metadata..value"}, allowed: false,
+			rejectionReason: sortByNotAllowedForWorkload(".metadata..value")},
+		{name: "sort-by a spec field of a Dash0 custom resource is rejected",
+			command: "kubectl", arguments: []string{"get", "dash0monitorings", "--sort-by", ".spec.export.dash0.authorization.token"}, allowed: false,
+			rejectionReason: sortByNotAllowedForDash0Resource(".spec.export.dash0.authorization.token")},
+		{name: "sort-by a spec field of a resource type without secrets is allowed",
+			command: "kubectl", arguments: []string{"get", "services", "--sort-by", ".spec.clusterIP"}, allowed: true},
 		{name: "a value starting with a dash is not mistaken for a flag",
 			command: "kubectl", arguments: []string{"logs", "my-pod", "--tail", "-1"}, allowed: true},
 		{name: "logs flags are allowed",

--- a/internal/agent0connector/a0cresources/desired_state.go
+++ b/internal/agent0connector/a0cresources/desired_state.go
@@ -429,7 +429,7 @@ func assembleDeployment(
 				corev1.ResourceMemory: resource.MustParse("32Mi"),
 			},
 			Limits: corev1.ResourceList{
-				corev1.ResourceMemory: resource.MustParse("128Mi"),
+				corev1.ResourceMemory: resource.MustParse("256Mi"),
 			},
 		},
 	}

--- a/internal/agent0connector/a0cresources/desired_state_test.go
+++ b/internal/agent0connector/a0cresources/desired_state_test.go
@@ -11,6 +11,8 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 
@@ -294,6 +296,14 @@ var _ = Describe("The desired state of the agent0-connector resources", func() {
 				Name:         "tmp",
 				VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
 			}))
+		})
+
+		It("requests and limits memory", func() {
+			container := getDeployment(assembleDesiredState(testConfig(), authTokenEnvVar, util.ExtraConfig{})).Spec.Template.Spec.Containers[0]
+			Expect(container.Resources.Requests.Memory()).To(Equal(ptr.To(resource.MustParse("32Mi"))))
+			// The limit has to cover the peak of parsing and re-rendering a response of up to maxStdoutBytes, see
+			// images/agent0-connector/src/kubectl/kubectl.go.
+			Expect(container.Resources.Limits.Memory()).To(Equal(ptr.To(resource.MustParse("256Mi"))))
 		})
 
 		It("applies a restrictive container security context", func() {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -4,6 +4,7 @@
 package e2e
 
 import (
+	"encoding/json"
 	"fmt"
 	"maps"
 	"net/http"
@@ -15,6 +16,9 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/joho/godotenv"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/yaml"
 
 	dash0common "github.com/dash0hq/dash0-operator/api/operator/common"
 	"github.com/dash0hq/dash0-operator/internal/startup"
@@ -2209,6 +2213,140 @@ trace_statements:
 					ContainSubstring(defaultToken),
 					"the auth token should not occur anywhere in the response")
 			}, 90*time.Second, pollingInterval).Should(Succeed())
+		})
+
+		It("redacts the environment variable values from a command response containing a workload resource", func() {
+			deploymentName := "env-var-redaction-test"
+			literalValues := []string{
+				"a-plain-value",
+				"super-secret-token-value",
+				"https://example.com/webhook?auth=secret",
+			}
+
+			By("deploying a deployment with environment variables")
+			deploymentYaml := fmt.Sprintf(`apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: %s
+  template:
+    metadata:
+      labels:
+        app: %s
+    spec:
+      containers:
+      - name: test-container
+        image: does-not-need-to-start:latest
+        env:
+        - name: PLAIN_VALUE
+          value: "%s"
+        - name: SECRET_TOKEN
+          value: "%s"
+        - name: WEBHOOK_URL
+          value: "%s"
+        - name: EMPTY_VALUE
+          value: ""
+        - name: FROM_FIELD_REF
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+`,
+				deploymentName,
+				applicationUnderTestNamespace,
+				deploymentName,
+				deploymentName,
+				literalValues[0],
+				literalValues[1],
+				literalValues[2],
+			)
+			applyCmd := exec.Command("kubectl", "apply", "-f", "-")
+			applyCmd.Stdin = strings.NewReader(deploymentYaml)
+			Expect(runAndIgnoreOutput(applyCmd)).To(Succeed())
+			DeferCleanup(func() {
+				_ = runAndIgnoreOutput(exec.Command(
+					"kubectl",
+					"-n", applicationUnderTestNamespace,
+					"delete", "deployment", deploymentName,
+					"--ignore-not-found",
+				))
+			})
+
+			By("triggering a \"kubectl get deployments -o yaml\" command request")
+			var requestId string
+			Eventually(func(g Gomega) {
+				requestId = triggerOutboundConnectorMockCommandRequest(
+					g,
+					pseudoClusterUid,
+					"kubectl",
+					[]string{"get", "deployments", "-n", applicationUnderTestNamespace, "-o", "yaml"},
+				)
+			}, 30*time.Second, pollingInterval).Should(Succeed())
+
+			var response *outboundConnectorMockCommandResponse
+			By("verifying the environment variable values have been redacted from the command response")
+			Eventually(func(g Gomega) {
+				response = findOutboundConnectorMockCommandResponse(g, requestId)
+				g.Expect(response).ToNot(BeNil())
+				g.Expect(response.ExitCode).To(
+					BeEquivalentTo(0),
+					"kubectl get deployments should succeed; stderr was: %s", response.Stderr)
+			}, 90*time.Second, pollingInterval).Should(Succeed())
+
+			expectedRedactedEnvVars := func(fieldRefApiVersion string) []corev1.EnvVar {
+				return []corev1.EnvVar{
+					{Name: "PLAIN_VALUE", Value: "(redacted)"},
+					{Name: "SECRET_TOKEN", Value: "(redacted)"},
+					{Name: "WEBHOOK_URL", Value: "(redacted)"},
+					// an empty value holds no credential and is left as it is
+					{Name: "EMPTY_VALUE", Value: ""},
+					// a value sourced via valueFrom is left untouched
+					{Name: "FROM_FIELD_REF", ValueFrom: &corev1.EnvVarSource{
+						FieldRef: &corev1.ObjectFieldSelector{
+							APIVersion: fieldRefApiVersion,
+							FieldPath:  "metadata.name",
+						},
+					}},
+				}
+			}
+
+			var deploymentList appsv1.DeploymentList
+			Expect(yaml.Unmarshal([]byte(response.Stdout), &deploymentList)).To(
+				Succeed(),
+				"the response should be parsable as a deployment list; stdout was: %s", response.Stdout)
+			deploymentIdx := slices.IndexFunc(deploymentList.Items, func(deployment appsv1.Deployment) bool {
+				return deployment.Name == deploymentName
+			})
+			Expect(deploymentIdx).ToNot(
+				BeNumerically("<", 0),
+				"the response should contain the deployment %s", deploymentName)
+			deployment := deploymentList.Items[deploymentIdx]
+			Expect(deployment.Spec.Template.Spec.Containers).To(HaveLen(1))
+			Expect(deployment.Spec.Template.Spec.Containers[0].Env).To(Equal(expectedRedactedEnvVars("v1")))
+
+			// kubectl apply stores a full copy of the resource in this annotation, which carries the environment
+			// variable values a second time.
+			lastAppliedConfiguration, hasAnnotation :=
+				deployment.Annotations["kubectl.kubernetes.io/last-applied-configuration"]
+			Expect(hasAnnotation).To(
+				BeTrue(),
+				"the embedded copy of the resource should be part of the response")
+			var embeddedDeployment appsv1.Deployment
+			Expect(json.Unmarshal([]byte(lastAppliedConfiguration), &embeddedDeployment)).To(
+				Succeed(),
+				"the embedded copy should be parsable as a deployment; it was: %s", lastAppliedConfiguration)
+			Expect(embeddedDeployment.Spec.Template.Spec.Containers).To(HaveLen(1))
+			Expect(embeddedDeployment.Spec.Template.Spec.Containers[0].Env).To(Equal(expectedRedactedEnvVars("")))
+
+			for _, literalValue := range literalValues {
+				Expect(response.Stdout).ToNot(
+					ContainSubstring(literalValue),
+					"the value %s should not occur anywhere in the response", literalValue)
+			}
 		})
 
 		DescribeTable("denies/allows access to resource types depending on agent0-connector's cluster role",

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -14,6 +14,7 @@ require (
 	k8s.io/apimachinery v0.36.3
 	k8s.io/utils v0.0.0-20260507154919-ff6756f316d2
 	sigs.k8s.io/controller-runtime v0.24.1
+	sigs.k8s.io/yaml v1.6.0
 )
 
 require (
@@ -172,7 +173,6 @@ require (
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.4.0 // indirect
-	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
 replace github.com/dash0hq/dash0-operator => ../..


### PR DESCRIPTION
For deployments, daemonsets, statefulsets etc. (every resource type that
contains a pod spec), redact the values of all literal environment
variables, and HTTP probe headers.