### PR TITLE
feat(agent0-connector): use worker queues for concurrent requests

### DIFF
--- a/helm-chart/dash0-operator/templates/operator/extra-config-map.yaml
+++ b/helm-chart/dash0-operator/templates/operator/extra-config-map.yaml
@@ -212,6 +212,7 @@ data:
 {{- if .Values.operator.agent0Connector.enabled }}
     agent0ConnectorContainerResources:
       {{- toYaml .Values.operator.agent0Connector.containerResources | nindent 6 }}
+    agent0ConnectorMaxConcurrentCommands: {{ .Values.operator.agent0Connector.maxConcurrentCommands }}
 {{- if .Values.operator.agent0Connector.clusterRole.rules }}
     agent0ConnectorClusterRoleRules:
       {{- include "dash0-operator.agent0ConnectorClusterRoleRules" . | nindent 6 }}

--- a/helm-chart/dash0-operator/tests/operator/extra-config-map_test.yaml
+++ b/helm-chart/dash0-operator/tests/operator/extra-config-map_test.yaml
@@ -296,6 +296,7 @@ tests:
               edge-proxy-pod-annotation: edge-proxy-pod-annotation-value
         agent0Connector:
           enabled: true
+          maxConcurrentCommands: 4
           containerResources:
             limits:
               cpu: 300m
@@ -669,6 +670,7 @@ tests:
               requests:
                 cpu: 20m
                 memory: 64Mi
+            agent0ConnectorMaxConcurrentCommands: 4
             agent0ConnectorTolerations:
               - effect: NoSchedule
                 key: key6
@@ -934,7 +936,7 @@ tests:
               limits:
                 memory: 256Mi
               requests:
-                memory: 32Mi
+                memory: 64Mi
 
   - it: should render custom agent0-connector container resources
     set:
@@ -948,7 +950,7 @@ tests:
             gomemlimit: 256MiB
             requests:
               cpu: 20m
-              memory: 64Mi
+              memory: 128Mi
     asserts:
       - matchRegex:
           path: data['extra.yaml']
@@ -960,7 +962,34 @@ tests:
                 memory: 512Mi
               requests:
                 cpu: 20m
-                memory: 64Mi
+                memory: 128Mi
+
+  - it: should render the default number of concurrent agent0-connector commands
+    set:
+      operator:
+        agent0Connector:
+          enabled: true
+    asserts:
+      - matchRegex:
+          path: data['extra.yaml']
+          pattern: 'agent0ConnectorMaxConcurrentCommands: 2'
+
+  - it: should render a custom number of concurrent agent0-connector commands
+    set:
+      operator:
+        agent0Connector:
+          enabled: true
+          maxConcurrentCommands: 6
+    asserts:
+      - matchRegex:
+          path: data['extra.yaml']
+          pattern: 'agent0ConnectorMaxConcurrentCommands: 6'
+
+  - it: should not render the number of concurrent agent0-connector commands when the agent0-connector is disabled
+    asserts:
+      - notMatchRegex:
+          path: data['extra.yaml']
+          pattern: agent0ConnectorMaxConcurrentCommands
 
   - it: should not render custom agent0-connector cluster role rules by default
     asserts:

--- a/helm-chart/dash0-operator/values.yaml
+++ b/helm-chart/dash0-operator/values.yaml
@@ -1341,7 +1341,23 @@ operator:
       # governed by GOMEMLIMIT but counts towards the container's memory limit.
       gomemlimit: 150MiB
       requests:
-        memory: 32Mi
+        memory: 64Mi
+
+    # The number of command requests the agent0-connector executes at the same time.
+    #
+    # Increasing this might be useful when multiple Agent0 sessions are routinely working actively with the connector in
+    # this cluster at the same time.
+    #
+    # The value is bounded by memory, not by CPU. A single request can peak at about 90 MiB memory usage: roughly 50 MiB
+    # for the kubectl child process (which GOMEMLIMIT does not govern), and roughly 40 MiB in the agent0-connector
+    # process itself, most of it to parse the output for secret redaction.
+    # The default of 2 fits into the default containerResources.limits.memory of 256Mi. Raising this value therefore
+    # requires raising containerResources.limits.memory and containerResources.gomemlimit correspondingly; otherwise the
+    # pod can get OOM-killed when several large requests coincide.
+    #
+    # With a value of 1, one slow command blocks the delivery of every request behind it for up to the command timeout
+    # of 30 seconds, hence down-sizing to 1 is not recommended.
+    maxConcurrentCommands: 2
 
     # Additional labels to be set on the agent0-connector deployment managed by the operator.
     labels: {}

--- a/images/agent0-connector/src/grpc/grpcclient.go
+++ b/images/agent0-connector/src/grpc/grpcclient.go
@@ -12,7 +12,9 @@ import (
 	"log/slog"
 	"math/rand/v2"
 	"os"
+	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/dash0hq/dash0-operator/images/agent0-connector/kubectl"
@@ -53,6 +55,26 @@ const (
 	// client ID when subscribing to command requests.
 	clusterUidEnvVarName = "K8S_CLUSTER_UID"
 
+	// maxConcurrentCommandsEnvVarName is the environment variable through which the operator passes how many command
+	// requests may be executed at the same time (set from the Helm value
+	// operator.agent0Connector.maxConcurrentCommands).
+	maxConcurrentCommandsEnvVarName = "DASH0_AGENT0_CONNECTOR_MAX_CONCURRENT_COMMANDS"
+
+	// defaultMaxConcurrentCommands is the number of command requests executed at the same time when the environment
+	// variable is absent or does not hold a positive integer. It mirrors defaultMaxConcurrentCommands in
+	// internal/agent0connector/a0cresources/desired_state.go, which is where the value comes from when the operator
+	// deploys this workload; the connector is a separate Go module, so the two cannot share a constant.
+	//
+	// The value is bounded by memory, not by CPU: a request that returns the full maxStdoutBytes of output costs about
+	// 90 MiB, roughly 50 MiB for the kubectl child process (which GOMEMLIMIT does not govern) and roughly 40 MiB in this
+	// process, most of it for parsing the output in order to redact credentials from it. Two of those fit into the
+	// default memory limit of the pod.
+	defaultMaxConcurrentCommands = 2
+
+	// commandQueueCapacity is how many received command requests wait for a free worker. (A queued request holds only
+	// the command and its arguments, so items in the queue are cheap with regard to memory consumption.)
+	commandQueueCapacity = 16
+
 	// initialReconnectDelay is the delay before the first reconnect attempt after a stream drops. Subsequent attempts
 	// back off exponentially up to maxReconnectDelay.
 	initialReconnectDelay = 1 * time.Second
@@ -74,12 +96,27 @@ func RunSubscriber(ctx context.Context, logger *slog.Logger) {
 	clientID := resolveClientID(logger)
 	authToken := resolveAuthToken(logger)
 	kubectlTmpDir := resolveKubectlTmpDir(logger)
-	logger.Info("connecting to the Dash0 backend", "address", serverAddress, "clientId", clientID)
+	maxConcurrentCommands := resolveMaxConcurrentCommands(logger)
+	logger.Info(
+		"connecting to the Dash0 backend",
+		"address", serverAddress,
+		"clientId", clientID,
+		"maxConcurrentCommands", maxConcurrentCommands,
+	)
 
 	reconnectDelay := initialReconnectDelay
 	for ctx.Err() == nil {
 		streamStart := time.Now()
-		err := runStream(ctx, logger, serverAddress, transportCredentials, clientID, authToken, kubectlTmpDir)
+		err := runStream(
+			ctx,
+			logger,
+			serverAddress,
+			transportCredentials,
+			clientID,
+			authToken,
+			kubectlTmpDir,
+			maxConcurrentCommands,
+		)
 		if ctx.Err() != nil {
 			return
 		}
@@ -208,6 +245,27 @@ func resolveKubectlTmpDir(logger *slog.Logger) string {
 	return tmpDir
 }
 
+// resolveMaxConcurrentCommands returns how many command requests are executed at the same time, read from the
+// DASH0_AGENT0_CONNECTOR_MAX_CONCURRENT_COMMANDS environment variable. An absent variable, or a value that is not a
+// positive integer, falls back to defaultMaxConcurrentCommands.
+func resolveMaxConcurrentCommands(logger *slog.Logger) int {
+	value := os.Getenv(maxConcurrentCommandsEnvVarName)
+	if value == "" {
+		return defaultMaxConcurrentCommands
+	}
+	maxConcurrentCommands, err := strconv.Atoi(value)
+	if err != nil || maxConcurrentCommands < 1 {
+		logger.Warn(
+			"the maximum number of concurrent commands is not a positive integer, using the default",
+			"envVar", maxConcurrentCommandsEnvVarName,
+			"value", value,
+			"default", defaultMaxConcurrentCommands,
+		)
+		return defaultMaxConcurrentCommands
+	}
+	return maxConcurrentCommands
+}
+
 // runStream opens a single SubscribeToCommandRequests stream and listens to incoming CommandRequest, until the stream
 // fails or the context is cancelled. For every received CommandRequest it executes the requested (read-only) kubectl
 // command and sends back the CommandResponse.
@@ -219,6 +277,7 @@ func runStream(
 	clientID string,
 	authToken string,
 	kubectlTmpDir string,
+	maxConcurrentCommands int,
 ) error {
 	conn, err := grpc.NewClient(
 		serverAddress,
@@ -254,7 +313,14 @@ func runStream(
 
 	logger.Info("subscribed to command requests")
 
-	return listenToCommandRequests(ctx, logger, stream, kubectlTmpDir)
+	return listenToCommandRequests(
+		ctx,
+		logger,
+		stream,
+		kubectlTmpDir,
+		maxConcurrentCommands,
+		kubectl.ExecuteCommandRequest,
+	)
 }
 
 // commandRequestStream is the subset of the gRPC bidirectional stream that listenToCommandRequests needs: receiving
@@ -265,14 +331,113 @@ type commandRequestStream interface {
 	Send(*pb.CommandResponse) error
 }
 
-// listenToCommandRequests reads CommandRequests from the stream until it is closed or fails. For every request it
-// executes the requested command and sends back the CommandResponse. It returns nil when the backend closed the stream
-// cleanly (io.EOF) and a wrapped error on any receive or send failure.
+// commandExecutor executes a single CommandRequest and returns the CommandResponse to send back.
+// kubectl.ExecuteCommandRequest is the implementation used in production; tests provide their own.
+type commandExecutor func(
+	ctx context.Context,
+	logger *slog.Logger,
+	kubectlTmpDir string,
+	req *pb.CommandRequest,
+) *pb.CommandResponse
+
+// listenToCommandRequests reads CommandRequests from the stream until it is closed or fails. Every request is handed to
+// a pool of maxConcurrentCommands workers which execute it and hand the CommandResponse to a single sender, so that one
+// slow command does not hold up the delivery of the requests behind it. Responses are not necessarily sent in the order
+// the requests arrived (the backend correlates them by request ID anyway).
+//
+// It returns nil when the backend closed the stream cleanly (io.EOF) and a wrapped error on any receive or send
+// failure.
 func listenToCommandRequests(
 	ctx context.Context,
 	logger *slog.Logger,
 	stream commandRequestStream,
 	kubectlTmpDir string,
+	maxConcurrentCommands int,
+	execute commandExecutor,
+) error {
+	workerCtx, cancelWorkers := context.WithCancel(ctx)
+	defer cancelWorkers()
+
+	requests := make(chan *pb.CommandRequest, commandQueueCapacity)
+	// Unbuffered: at most one finished response per worker waits for the sender, which bounds how much captured output
+	// is held in memory. A worker that parks here stops taking requests, the queue fills up, and the receive loop stops
+	// accepting - that is the intended backpressure.
+	responses := make(chan *pb.CommandResponse)
+
+	var workers sync.WaitGroup
+	for range maxConcurrentCommands {
+		workers.Add(1)
+		go func() {
+			defer workers.Done()
+			for req := range requests {
+				responses <- execute(workerCtx, logger, kubectlTmpDir, req)
+			}
+		}()
+	}
+
+	var sendErr error
+	senderDone := make(chan struct{})
+	go func() {
+		defer close(senderDone)
+		for resp := range responses {
+			if sendErr != nil {
+				// The stream is broken. Keep draining so that no worker blocks on handing over its response, but do not
+				// attempt to send any more.
+				logger.Warn(
+					"discarding a command response, the stream is broken",
+					"requestId", resp.GetRequestId(),
+					"exitCode", resp.GetExitCode(),
+				)
+				continue
+			}
+			if err := stream.Send(resp); err != nil {
+				sendErr = fmt.Errorf("stream send failed: %w", err)
+				// The responses of the commands that are still running cannot be delivered any more, so abort them
+				// instead of letting them run into their timeout. This also releases the receive loop.
+				cancelWorkers()
+				logger.Warn(
+					"failed to send a command response",
+					"requestId", resp.GetRequestId(),
+					"error", err,
+				)
+				continue
+			}
+			logger.Info(
+				"sent command response",
+				"requestId", resp.GetRequestId(),
+				"exitCode", resp.GetExitCode(),
+			)
+		}
+	}()
+
+	recvErr := receiveCommandRequests(workerCtx, logger, stream, requests)
+
+	if recvErr != nil {
+		// The stream is gone, so the responses of the commands that are still running cannot be delivered. Aborting them
+		// keeps the reconnect from waiting for up to commandTimeout. A stream the backend closed cleanly (recvErr == nil)
+		// lets them finish instead.
+		cancelWorkers()
+	}
+	close(requests)
+	workers.Wait()
+	close(responses)
+	<-senderDone
+
+	if sendErr != nil {
+		// The send failure is the more specific diagnosis: it broke the stream that the receive loop then stopped on.
+		return sendErr
+	}
+	return recvErr
+}
+
+// receiveCommandRequests reads CommandRequests from the stream and hands them to the worker queue, until the stream is
+// closed or fails, or until the context is cancelled. It returns nil when the backend closed the stream cleanly
+// (io.EOF) and a wrapped error on a receive failure.
+func receiveCommandRequests(
+	ctx context.Context,
+	logger *slog.Logger,
+	stream commandRequestStream,
+	requests chan<- *pb.CommandRequest,
 ) error {
 	for {
 		req, err := stream.Recv()
@@ -290,16 +455,16 @@ func listenToCommandRequests(
 			"arguments", req.GetArguments(),
 		)
 
-		resp := kubectl.ExecuteCommandRequest(ctx, logger, kubectlTmpDir, req)
-
-		if err := stream.Send(resp); err != nil {
-			return fmt.Errorf("stream send failed: %w", err)
+		select {
+		case requests <- req:
+		case <-ctx.Done():
+			// Either the process is shutting down, or sending a response failed and the stream is broken. In both cases
+			// the request cannot be answered any more.
+			logger.Warn(
+				"dropping a command request, it cannot be answered any more",
+				"requestId", req.GetRequestId(),
+			)
+			return nil
 		}
-
-		logger.Info(
-			"sent command response",
-			"requestId", resp.GetRequestId(),
-			"exitCode", resp.GetExitCode(),
-		)
 	}
 }

--- a/images/agent0-connector/src/grpc/grpcclient_test.go
+++ b/images/agent0-connector/src/grpc/grpcclient_test.go
@@ -6,8 +6,12 @@ package grpc
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
+	"slices"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -103,7 +107,18 @@ type fakeStream struct {
 	recvErr  error
 	sendErr  error
 
-	idx  int
+	// recvGate, when set, holds Recv once all queued requests have been yielded, until the channel is closed. This
+	// keeps the receive loop running while a test inspects what has been sent so far.
+	recvGate chan struct{}
+
+	// sentSignal, when set, receives every response that was sent, so that a test can wait for one instead of polling.
+	// It has to be buffered for as many responses as the test expects.
+	sentSignal chan *pb.CommandResponse
+
+	// idx is only accessed by Recv, which listenToCommandRequests calls from a single goroutine.
+	idx int
+
+	mu   sync.Mutex
 	sent []*pb.CommandResponse
 }
 
@@ -112,6 +127,9 @@ func (f *fakeStream) Recv() (*pb.CommandRequest, error) {
 		req := f.requests[f.idx]
 		f.idx++
 		return req, nil
+	}
+	if f.recvGate != nil {
+		<-f.recvGate
 	}
 	if f.recvErr != nil {
 		return nil, f.recvErr
@@ -123,8 +141,107 @@ func (f *fakeStream) Send(resp *pb.CommandResponse) error {
 	if f.sendErr != nil {
 		return f.sendErr
 	}
+	f.mu.Lock()
 	f.sent = append(f.sent, resp)
+	f.mu.Unlock()
+	if f.sentSignal != nil {
+		f.sentSignal <- resp
+	}
 	return nil
+}
+
+// sentResponses returns a copy of the responses sent so far, safe to read while the sender is still running.
+func (f *fakeStream) sentResponses() []*pb.CommandResponse {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return slices.Clone(f.sent)
+}
+
+// awaitSend returns the next response that is sent, and fails the test if none is sent in time.
+func (f *fakeStream) awaitSend(t *testing.T) *pb.CommandResponse {
+	t.Helper()
+	select {
+	case resp := <-f.sentSignal:
+		return resp
+	case <-time.After(testTimeout):
+		t.Fatal("timed out waiting for a response to be sent")
+		return nil
+	}
+}
+
+// testTimeout bounds every wait in the concurrency tests, so that a hang fails the test instead of the suite.
+const testTimeout = 10 * time.Second
+
+// awaitListenResult returns the error listenToCommandRequests returned, and fails the test if it does not return in
+// time.
+func awaitListenResult(t *testing.T, listenDone <-chan error) error {
+	t.Helper()
+	select {
+	case err := <-listenDone:
+		return err
+	case <-time.After(testTimeout):
+		t.Fatal("timed out waiting for listenToCommandRequests to return")
+		return nil
+	}
+}
+
+// listen runs listenToCommandRequests and returns its error, failing the test if it does not return within testTimeout
+// rather than hanging the whole suite on a deadlock.
+func listen(
+	t *testing.T,
+	logger *slog.Logger,
+	stream commandRequestStream,
+	maxConcurrentCommands int,
+	execute commandExecutor,
+) error {
+	t.Helper()
+	listenDone := startListening(logger, stream, maxConcurrentCommands, execute)
+	return awaitListenResult(t, listenDone)
+}
+
+// startListening runs listenToCommandRequests in the background and returns the channel on which it reports its error,
+// for the tests that have to interact with the stream while it is running.
+func startListening(
+	logger *slog.Logger,
+	stream commandRequestStream,
+	maxConcurrentCommands int,
+	execute commandExecutor,
+) <-chan error {
+	return startListeningWithContext(context.Background(), logger, stream, maxConcurrentCommands, execute)
+}
+
+// startListeningWithContext is startListening for the tests that have to cancel the context of
+// listenToCommandRequests.
+func startListeningWithContext(
+	ctx context.Context,
+	logger *slog.Logger,
+	stream commandRequestStream,
+	maxConcurrentCommands int,
+	execute commandExecutor,
+) <-chan error {
+	listenDone := make(chan error, 1)
+	go func() {
+		listenDone <- listenToCommandRequests(
+			ctx,
+			logger,
+			stream,
+			"/tmp",
+			maxConcurrentCommands,
+			execute,
+		)
+	}()
+	return listenDone
+}
+
+// requestIDs returns the request IDs of the given responses, sorted, so that a test can assert on them without
+// depending on the order in which the workers finished.
+func requestIDs(responses []*pb.CommandResponse) []string {
+	ids := make([]string, 0, len(responses))
+	for _, resp := range responses {
+		ids = append(ids, resp.GetRequestId())
+	}
+	slices.Sort(ids)
+	return ids
 }
 
 func TestListenToCommandRequests(t *testing.T) {
@@ -136,17 +253,18 @@ func TestListenToCommandRequests(t *testing.T) {
 			{RequestId: "req-1", Command: "not-kubectl", Arguments: []string{"get"}},
 		}}
 
-		if err := listenToCommandRequests(context.Background(), logger, stream, "/tmp"); err != nil {
+		if err := listen(t, logger, stream, defaultMaxConcurrentCommands, kubectl.ExecuteCommandRequest); err != nil {
 			t.Fatalf("expected a nil error on clean stream close, got %v", err)
 		}
-		if len(stream.sent) != 1 {
-			t.Fatalf("expected exactly one response to be sent, got %d", len(stream.sent))
+		sent := stream.sentResponses()
+		if len(sent) != 1 {
+			t.Fatalf("expected exactly one response to be sent, got %d", len(sent))
 		}
-		if stream.sent[0].GetRequestId() != "req-1" {
-			t.Errorf("expected the response to echo the request ID, got %q", stream.sent[0].GetRequestId())
+		if sent[0].GetRequestId() != "req-1" {
+			t.Errorf("expected the response to echo the request ID, got %q", sent[0].GetRequestId())
 		}
-		if stream.sent[0].GetExitCode() != 1 {
-			t.Errorf("expected the rejected exit code %d, got %d", 1, stream.sent[0].GetExitCode())
+		if sent[0].GetExitCode() != 1 {
+			t.Errorf("expected the rejected exit code %d, got %d", 1, sent[0].GetExitCode())
 		}
 	})
 
@@ -154,7 +272,7 @@ func TestListenToCommandRequests(t *testing.T) {
 		recvErr := errors.New("connection reset")
 		stream := &fakeStream{recvErr: recvErr}
 
-		err := listenToCommandRequests(context.Background(), logger, stream, "/tmp")
+		err := listen(t, logger, stream, defaultMaxConcurrentCommands, kubectl.ExecuteCommandRequest)
 		if err == nil {
 			t.Fatal("expected an error on a receive failure, got nil")
 		}
@@ -170,12 +288,239 @@ func TestListenToCommandRequests(t *testing.T) {
 			sendErr:  sendErr,
 		}
 
-		err := listenToCommandRequests(context.Background(), logger, stream, "/tmp")
+		err := listen(t, logger, stream, defaultMaxConcurrentCommands, kubectl.ExecuteCommandRequest)
 		if err == nil {
 			t.Fatal("expected an error on a send failure, got nil")
 		}
 		if !errors.Is(err, sendErr) {
 			t.Errorf("expected the send error to be wrapped, got %v", err)
+		}
+	})
+
+	t.Run("answers the requests behind a slow command while it is still running", func(t *testing.T) {
+		slowStarted := make(chan struct{})
+		releaseSlow := make(chan struct{})
+		recvGate := make(chan struct{})
+		stream := &fakeStream{
+			requests: []*pb.CommandRequest{
+				{RequestId: "slow-1", Command: "kubectl", Arguments: []string{"get", "pods", "-A"}},
+				{RequestId: "fast-2", Command: "kubectl", Arguments: []string{"version"}},
+			},
+			recvGate:   recvGate,
+			sentSignal: make(chan *pb.CommandResponse, 2),
+		}
+		execute := func(
+			ctx context.Context,
+			_ *slog.Logger,
+			_ string,
+			req *pb.CommandRequest,
+		) *pb.CommandResponse {
+			if req.GetRequestId() == "slow-1" {
+				close(slowStarted)
+				select {
+				case <-releaseSlow:
+				case <-ctx.Done():
+				}
+			}
+			return &pb.CommandResponse{RequestId: req.GetRequestId()}
+		}
+
+		listenDone := startListening(logger, stream, 2, execute)
+
+		<-slowStarted
+		// The slow command still occupies its worker, so this response can only have been produced concurrently.
+		if resp := stream.awaitSend(t); resp.GetRequestId() != "fast-2" {
+			t.Errorf("expected the fast request to be answered first, got %q", resp.GetRequestId())
+		}
+
+		close(releaseSlow)
+		close(recvGate)
+		if err := awaitListenResult(t, listenDone); err != nil {
+			t.Fatalf("expected a nil error on clean stream close, got %v", err)
+		}
+		if ids := requestIDs(stream.sentResponses()); !slices.Equal(ids, []string{"fast-2", "slow-1"}) {
+			t.Errorf("expected both requests to be answered, got %v", ids)
+		}
+	})
+
+	t.Run("executes at most maxConcurrentCommands commands at the same time", func(t *testing.T) {
+		const maxConcurrentCommands = 2
+		const numberOfRequests = maxConcurrentCommands + 3
+
+		requests := make([]*pb.CommandRequest, 0, numberOfRequests)
+		for i := range numberOfRequests {
+			requests = append(requests, &pb.CommandRequest{
+				RequestId: fmt.Sprintf("req-%d", i),
+				Command:   "kubectl",
+				Arguments: []string{"version"},
+			})
+		}
+		recvGate := make(chan struct{})
+		stream := &fakeStream{
+			requests:   requests,
+			recvGate:   recvGate,
+			sentSignal: make(chan *pb.CommandResponse, numberOfRequests),
+		}
+
+		release := make(chan struct{})
+		started := make(chan struct{}, numberOfRequests)
+		var running atomic.Int32
+		var peak atomic.Int32
+		execute := func(
+			_ context.Context,
+			_ *slog.Logger,
+			_ string,
+			req *pb.CommandRequest,
+		) *pb.CommandResponse {
+			current := running.Add(1)
+			for {
+				observed := peak.Load()
+				if current <= observed || peak.CompareAndSwap(observed, current) {
+					break
+				}
+			}
+			started <- struct{}{}
+			<-release
+			running.Add(-1)
+			return &pb.CommandResponse{RequestId: req.GetRequestId()}
+		}
+
+		listenDone := startListening(logger, stream, maxConcurrentCommands, execute)
+
+		for range maxConcurrentCommands {
+			select {
+			case <-started:
+			case <-time.After(testTimeout):
+				t.Fatal("timed out waiting for the workers to start executing")
+			}
+		}
+		// Every worker is now blocked in execute. Give the pool the chance to start a command it must not start.
+		time.Sleep(100 * time.Millisecond)
+		if observed := peak.Load(); observed != maxConcurrentCommands {
+			t.Errorf("expected exactly %d commands to run at the same time, got %d", maxConcurrentCommands, observed)
+		}
+
+		close(release)
+		close(recvGate)
+		if err := awaitListenResult(t, listenDone); err != nil {
+			t.Fatalf("expected a nil error on clean stream close, got %v", err)
+		}
+		if sent := stream.sentResponses(); len(sent) != numberOfRequests {
+			t.Errorf("expected all %d requests to be answered, got %d", numberOfRequests, len(sent))
+		}
+		if observed := peak.Load(); observed > maxConcurrentCommands {
+			t.Errorf("expected at most %d commands to run at the same time, got %d", maxConcurrentCommands, observed)
+		}
+	})
+}
+
+// TestListenToCommandRequestsAbortsRunningCommands covers the two paths that abort the commands which are still
+// running, because their responses cannot be delivered any more.
+func TestListenToCommandRequestsAbortsRunningCommands(t *testing.T) {
+	logger := discardLogger()
+
+	t.Run("aborts the running commands when sending a response fails", func(t *testing.T) {
+		sendErr := errors.New("broken pipe")
+		blockedStarted := make(chan struct{})
+		blockedCancelled := make(chan struct{})
+		stream := &fakeStream{
+			requests: []*pb.CommandRequest{
+				{RequestId: "blocked-1", Command: "kubectl", Arguments: []string{"get", "pods", "-A"}},
+				{RequestId: "quick-2", Command: "kubectl", Arguments: []string{"version"}},
+			},
+			sendErr: sendErr,
+		}
+		execute := func(
+			ctx context.Context,
+			_ *slog.Logger,
+			_ string,
+			req *pb.CommandRequest,
+		) *pb.CommandResponse {
+			if req.GetRequestId() == "blocked-1" {
+				close(blockedStarted)
+				<-ctx.Done()
+				close(blockedCancelled)
+			} else {
+				// Hand the response over only once the other worker is parked, so that the send failure happens while
+				// a command is still running.
+				<-blockedStarted
+			}
+			return &pb.CommandResponse{RequestId: req.GetRequestId()}
+		}
+
+		listenDone := startListening(logger, stream, 2, execute)
+
+		select {
+		case <-blockedCancelled:
+		case <-time.After(testTimeout):
+			t.Fatal("timed out waiting for the running command to be aborted after the send failure")
+		}
+		err := awaitListenResult(t, listenDone)
+		if err == nil {
+			t.Fatal("expected an error on a send failure, got nil")
+		}
+		if !errors.Is(err, sendErr) {
+			t.Errorf("expected the send error to be wrapped, got %v", err)
+		}
+	})
+
+	t.Run("aborts the running commands when the context is cancelled", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		longStarted := make(chan struct{})
+		longCancelled := make(chan struct{})
+		stream := &fakeStream{requests: []*pb.CommandRequest{
+			{RequestId: "long-1", Command: "kubectl", Arguments: []string{"get", "pods", "-A"}},
+		}}
+		execute := func(
+			execCtx context.Context,
+			_ *slog.Logger,
+			_ string,
+			req *pb.CommandRequest,
+		) *pb.CommandResponse {
+			close(longStarted)
+			<-execCtx.Done()
+			close(longCancelled)
+			return &pb.CommandResponse{RequestId: req.GetRequestId()}
+		}
+
+		listenDone := startListeningWithContext(ctx, logger, stream, defaultMaxConcurrentCommands, execute)
+
+		select {
+		case <-longStarted:
+		case <-time.After(testTimeout):
+			t.Fatal("timed out waiting for the command to start executing")
+		}
+		cancel()
+
+		select {
+		case <-longCancelled:
+		case <-time.After(testTimeout):
+			t.Fatal("timed out waiting for the running command to be aborted after the context was cancelled")
+		}
+		if err := awaitListenResult(t, listenDone); err != nil {
+			t.Fatalf("expected a nil error on clean stream close, got %v", err)
+		}
+	})
+}
+
+func TestResolveMaxConcurrentCommands(t *testing.T) {
+	logger := discardLogger()
+
+	t.Run("uses the value from the environment", func(t *testing.T) {
+		t.Setenv(maxConcurrentCommandsEnvVarName, "7")
+		if got := resolveMaxConcurrentCommands(logger); got != 7 {
+			t.Errorf("expected the value from the environment variable, got %d", got)
+		}
+	})
+
+	t.Run("falls back to the default", func(t *testing.T) {
+		for _, value := range []string{"", "0", "-1", "not-a-number", "2.5"} {
+			t.Setenv(maxConcurrentCommandsEnvVarName, value)
+			if got := resolveMaxConcurrentCommands(logger); got != defaultMaxConcurrentCommands {
+				t.Errorf("expected the default %d for the value %q, got %d", defaultMaxConcurrentCommands, value, got)
+			}
 		}
 	})
 }

--- a/internal/agent0connector/a0cresources/desired_state.go
+++ b/internal/agent0connector/a0cresources/desired_state.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"strconv"
 	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -28,6 +29,19 @@ const (
 	// authTokenEnvVarName is the environment variable through which the agent0-connector workload receives the Dash0
 	// authorization token (either a literal token value or resolved from a Kubernetes secret reference).
 	authTokenEnvVarName = "DASH0_AGENT0_CONNECTOR_AUTH_TOKEN"
+
+	// maxConcurrentCommandsEnvVarName is the environment variable through which the agent0-connector workload receives
+	// how many command requests it may execute at the same time.
+	maxConcurrentCommandsEnvVarName = "DASH0_AGENT0_CONNECTOR_MAX_CONCURRENT_COMMANDS"
+
+	// defaultMaxConcurrentCommands is the number of command requests the agent0-connector executes at the same time when
+	// the extra config does not specify a value (e.g. an older config map). It is bounded by memory: a request that
+	// returns the maximum output size costs about 90 MiB, most of it in the kubectl child process and in parsing the
+	// output in order to redact credentials from it. Raising it requires raising the container's memory limit and
+	// GOMEMLIMIT as well, which is why it is configurable via the Helm value
+	// operator.agent0Connector.maxConcurrentCommands. It mirrors defaultMaxConcurrentCommands in
+	// images/agent0-connector/src/grpc/grpcclient.go, the fallback within the workload itself.
+	defaultMaxConcurrentCommands int32 = 2
 
 	// label values
 	appKubernetesIoNameValue      = agent0Connector
@@ -511,6 +525,11 @@ func assembleDeployment(
 ) *appsv1.Deployment {
 	replicas := int32(1)
 
+	maxConcurrentCommands := extraConfig.Agent0ConnectorMaxConcurrentCommands
+	if maxConcurrentCommands < 1 {
+		maxConcurrentCommands = defaultMaxConcurrentCommands
+	}
+
 	container := corev1.Container{
 		Name:  containerName,
 		Image: c.Images.Agent0ConnectorImage,
@@ -535,6 +554,11 @@ func assembleDeployment(
 				// filesystem is read-only.
 				Name:  "DASH0_KUBECTL_TMP",
 				Value: "/tmp",
+			},
+			{
+				// How many command requests the workload executes at the same time.
+				Name:  maxConcurrentCommandsEnvVarName,
+				Value: strconv.Itoa(int(maxConcurrentCommands)),
 			},
 		},
 		VolumeMounts: []corev1.VolumeMount{

--- a/internal/agent0connector/a0cresources/desired_state_test.go
+++ b/internal/agent0connector/a0cresources/desired_state_test.go
@@ -502,6 +502,19 @@ var _ = Describe("The desired state of the agent0-connector resources", func() {
 			}
 		})
 
+		It("passes the default number of concurrent commands when the extra config has no value", func() {
+			container := getDeployment(assembleDesiredState(testConfig(), authTokenEnvVar, util.ExtraConfig{})).Spec.Template.Spec.Containers[0]
+			Expect(container.Env).To(ContainElement(
+				corev1.EnvVar{Name: "DASH0_AGENT0_CONNECTOR_MAX_CONCURRENT_COMMANDS", Value: "2"}))
+		})
+
+		It("passes the number of concurrent commands from the extra config", func() {
+			extraConfig := util.ExtraConfig{Agent0ConnectorMaxConcurrentCommands: 6}
+			container := getDeployment(assembleDesiredState(testConfig(), authTokenEnvVar, extraConfig)).Spec.Template.Spec.Containers[0]
+			Expect(container.Env).To(ContainElement(
+				corev1.EnvVar{Name: "DASH0_AGENT0_CONNECTOR_MAX_CONCURRENT_COMMANDS", Value: "6"}))
+		})
+
 		It("mounts a writable tmp volume for kubectl's cache", func() {
 			podSpec := getDeployment(assembleDesiredState(testConfig(), authTokenEnvVar, util.ExtraConfig{})).Spec.Template.Spec
 			container := podSpec.Containers[0]

--- a/internal/util/extra_config.go
+++ b/internal/util/extra_config.go
@@ -115,14 +115,15 @@ type ExtraConfig struct {
 	EdgeProxyPodLabels      map[string]string `json:"edgeProxyPodLabels,omitempty"`
 	EdgeProxyPodAnnotations map[string]string `json:"edgeProxyPodAnnotations,omitempty"`
 
-	Agent0ConnectorContainerResources ResourceRequirementsWithGoMemLimit `json:"agent0ConnectorContainerResources"`
-	Agent0ConnectorClusterRoleRules   []rbacv1.PolicyRule                `json:"agent0ConnectorClusterRoleRules,omitempty"`
-	Agent0ConnectorLabels             map[string]string                  `json:"agent0ConnectorLabels,omitempty"`
-	Agent0ConnectorAnnotations        map[string]string                  `json:"agent0ConnectorAnnotations,omitempty"`
-	Agent0ConnectorPodLabels          map[string]string                  `json:"agent0ConnectorPodLabels,omitempty"`
-	Agent0ConnectorPodAnnotations     map[string]string                  `json:"agent0ConnectorPodAnnotations,omitempty"`
-	Agent0ConnectorTolerations        []corev1.Toleration                `json:"agent0ConnectorTolerations,omitempty"`
-	Agent0ConnectorNodeAffinity       *corev1.NodeAffinity               `json:"agent0ConnectorNodeAffinity,omitempty"`
+	Agent0ConnectorMaxConcurrentCommands int32                              `json:"agent0ConnectorMaxConcurrentCommands,omitempty"`
+	Agent0ConnectorContainerResources    ResourceRequirementsWithGoMemLimit `json:"agent0ConnectorContainerResources"`
+	Agent0ConnectorClusterRoleRules      []rbacv1.PolicyRule                `json:"agent0ConnectorClusterRoleRules,omitempty"`
+	Agent0ConnectorLabels                map[string]string                  `json:"agent0ConnectorLabels,omitempty"`
+	Agent0ConnectorAnnotations           map[string]string                  `json:"agent0ConnectorAnnotations,omitempty"`
+	Agent0ConnectorPodLabels             map[string]string                  `json:"agent0ConnectorPodLabels,omitempty"`
+	Agent0ConnectorPodAnnotations        map[string]string                  `json:"agent0ConnectorPodAnnotations,omitempty"`
+	Agent0ConnectorTolerations           []corev1.Toleration                `json:"agent0ConnectorTolerations,omitempty"`
+	Agent0ConnectorNodeAffinity          *corev1.NodeAffinity               `json:"agent0ConnectorNodeAffinity,omitempty"`
 
 	// Actually we would like to use the type *dash0v1alpha1.MonitoringTemplate here, but that leads to circular package
 	// dependencies. We should revisit how to untangle this.
@@ -212,7 +213,7 @@ var (
 			},
 			GoMemLimit: "150MiB",
 			Requests: corev1.ResourceList{
-				corev1.ResourceMemory: resource.MustParse("32Mi"),
+				corev1.ResourceMemory: resource.MustParse("64Mi"),
 			},
 		},
 	}

--- a/internal/util/extra_config_test.go
+++ b/internal/util/extra_config_test.go
@@ -434,7 +434,7 @@ var _ = Describe("extra config map", func() {
 					Expect(extraConfig.Agent0ConnectorContainerResources.Limits.Memory().String()).To(Equal("256Mi"))
 					Expect(extraConfig.Agent0ConnectorContainerResources.GoMemLimit).To(Equal("150MiB"))
 					Expect(extraConfig.Agent0ConnectorContainerResources.Requests.Cpu().IsZero()).To(BeTrue())
-					Expect(extraConfig.Agent0ConnectorContainerResources.Requests.Memory().String()).To(Equal("32Mi"))
+					Expect(extraConfig.Agent0ConnectorContainerResources.Requests.Memory().String()).To(Equal("64Mi"))
 					Expect(extraConfig.Agent0ConnectorClusterRoleRules).To(BeNil())
 
 					Expect(extraConfig.MonitoringTemplateRaw).To(BeNil())


### PR DESCRIPTION
Previously, command requests would only be processed one after the other, e.g. one slow request would block all requests that are behind it in the queue.

Use a configurable number of worker queues to process multiple requests concurrently.