### PR TITLE
chore: add lint check for missing Ginkgo suite bootstrap files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -253,6 +253,11 @@ go-mod-tidy: ## Run go mod tidy for all modules
 		(cd "$$dir" && GOBIN=$(LOCALBIN) go mod tidy); \
 	done < <(find . -maxdepth 5 -type f -name go.mod -print0)
 
+.PHONY: ginkgo-suite-check
+ginkgo-suite-check: ## Check whether every package with Ginkgo specs has a suite bootstrap.
+	@echo "-------------------------------- (verifying every package with Ginkgo specs has a suite bootstrap)"
+	./test-resources/bin/ginkgo-suite-check.sh
+
 .PHONY: internal-config-map-lint
 internal-config-map-lint: ## Verify config map templates for resources managed by the collector.
 	@if grep -ne '[[:space:]]$$' internal/collectors/otelcolresources/daemonset.config.yaml.template; then \
@@ -355,7 +360,7 @@ perses-crd-version-check: ## Check whether all references to the PersesDashboard
 	./test-resources/bin/perses-crd-version-check.sh
 
 .PHONY: lint
-lint: go-version-check golangci-lint internal-config-map-lint helm-chart-lint shellcheck-lint instrumentation-test-lint perses-crd-version-check prometheus-crd-version-check ## Run all static code analysis checks (Go, Helm, shell scripts, etc.).
+lint: go-version-check golangci-lint ginkgo-suite-check internal-config-map-lint helm-chart-lint shellcheck-lint instrumentation-test-lint perses-crd-version-check prometheus-crd-version-check ## Run all static code analysis checks (Go, Helm, shell scripts, etc.).
 
 .PHONY: lint-fix
 lint-fix: golangci-lint-fix

--- a/internal/selfmonitoringapiaccess/otel_init_wait.go
+++ b/internal/selfmonitoringapiaccess/otel_init_wait.go
@@ -329,10 +329,10 @@ func startOTelSDK(
 			exporterFactory,
 		)
 
-	// Setting the zap OTel bridge as the delegate logger core will spool all messages that have been only logged to
-	// stdout so far (and buffered in the delegating zap core) to the newly created zap OTel bridge, so that we also see
-	// messages from the operator startup in self-monitoring, even if the OTel SDK is delayed until we have found and
-	// reconciled an operator configuration resource.
+	// Set the zap OTel bridge as the delegate logger core, then spool all buffered messages that have been only logged to
+	// stdout so far, to the newly created zap OTel bridge. This is so that we also see messages from the operator startup
+	// in self-monitoring, even if the OTel SDK is delayed until we have found and reconciled an operator configuration
+	// resource.
 	delegatingZapCoreWrapper.RootDelegatingZapCore.SetDelegate(zapOTelBridge)
 	delegatingZapCoreWrapper.LogMessageBuffer.ForAllAndClear(
 		func(entry *zaputil.ZapEntryWithFields) {

--- a/internal/util/zap/delegating_zap_core.go
+++ b/internal/util/zap/delegating_zap_core.go
@@ -11,8 +11,8 @@ import (
 )
 
 // DelegatingZapCore is a Zap core that keeps messages in a size-limited buffer until another core is added as a
-// delegate, then spools all buffered messages to the delegate. After that, the core will pass all messages to the
-// delegate.
+// delegate via SetDelegate. After that, the core will pass all messages to the delegate. The messages that are already
+// buffered can then be spooled to the new core via DelegatingZapCoreWrapper.LogMessageBuffer.ForAllAndClear.
 type DelegatingZapCore struct {
 	delegate         atomic.Pointer[zapcore.Core]
 	logMessageBuffer *Mru[*ZapEntryWithFields]
@@ -131,10 +131,9 @@ func (dc *DelegatingZapCore) Sync() error {
 	return nil
 }
 
-// SetDelegate sets the delegate core to which all messages will be forwarded. Also, all buffered messages will be
-// spooled to the delegate, and then deleted from the DelegatingZapCore's buffer. Check will not be called again, the
-// buffered entries will be written unconditionally. Errors occurring during spooling will be silently ignored.
-// The SetDelegate call will also be propagated to all clones created via With previous to this call.
+// SetDelegate sets the delegate core to which all messages will be forwarded. The messages that are already buffered
+// can then be spooled to the new core via DelegatingZapCoreWrapper.LogMessageBuffer.ForAllAndClear. The SetDelegate
+// call will also be propagated to all clones created via With previous to this call.
 func (dc *DelegatingZapCore) SetDelegate(delegate zapcore.Core) {
 	dc.delegate.Store(&delegate)
 	for _, clone := range dc.clones {

--- a/internal/util/zap/delegating_zap_core_test.go
+++ b/internal/util/zap/delegating_zap_core_test.go
@@ -97,19 +97,19 @@ var _ = Describe("Delegating Zap Core", func() {
 
 		Expect(logMessageBuffer.Len()).To(Equal(3))
 		Expect(logMessageBuffer.elements[0]).To(Equal(
-			ZapEntryWithFields{
+			&ZapEntryWithFields{
 				Entry:  entry2,
 				Fields: fields,
 			}),
 		)
 		Expect(logMessageBuffer.elements[1]).To(Equal(
-			ZapEntryWithFields{
+			&ZapEntryWithFields{
 				Entry:  entry3,
 				Fields: fields,
 			}),
 		)
 		Expect(logMessageBuffer.elements[2]).To(Equal(
-			ZapEntryWithFields{
+			&ZapEntryWithFields{
 				Entry:  entry4,
 				Fields: fields,
 			}),
@@ -150,7 +150,7 @@ var _ = Describe("Delegating Zap Core", func() {
 		Expect(delegate.syncCalls).To(Equal(1))
 	})
 
-	It("SetDelegate spools buffered messages to new delegate in order", func() {
+	It("SetDelegate keeps the buffered messages in order for the owner of the buffer to spool", func() {
 		logMessageBuffer := NewMruWithDefaultSizeLimit[*ZapEntryWithFields]()
 		delegatingCore := NewDelegatingZapCore(logMessageBuffer)
 		entry1 := zapcore.Entry{Level: zapcore.InfoLevel}
@@ -166,6 +166,15 @@ var _ = Describe("Delegating Zap Core", func() {
 		Expect(delegate.writtenEntries).To(BeEmpty())
 
 		delegatingCore.SetDelegate(delegate)
+
+		// SetDelegate only switches the core over to the delegate, the buffered messages are spooled by the owner of the
+		// buffer, see selfmonitoringapiaccess.startOTelSDK.
+		Expect(delegate.writtenEntries).To(BeEmpty())
+		Expect(logMessageBuffer.Len()).To(Equal(3))
+
+		logMessageBuffer.ForAllAndClear(func(bufferedEntry *ZapEntryWithFields) {
+			Expect(delegate.Write(bufferedEntry.Entry, bufferedEntry.Fields)).To(Succeed())
+		})
 
 		Expect(delegate.writtenEntries).To(HaveLen(3))
 		Expect(delegate.writtenEntries[0]).To(Equal(
@@ -209,12 +218,10 @@ var _ = Describe("Delegating Zap Core", func() {
 		}
 		dc2Raw := originalDelegatingCore.With(withFields1)
 
-		// verify With actually returned a clone, but with the same properties (except for buffered messages)
+		// verify With actually returned a clone, but with the same properties
 		dc2, ok := dc2Raw.(*DelegatingZapCore)
 		Expect(ok).To(BeTrue())
 		Expect(dc2 == originalDelegatingCore).To(BeFalse())
-		// we do not copy buffered messages when cloning via With
-		Expect(dc2.logMessageBuffer.IsEmpty()).To(BeTrue())
 		Expect(dc2.level).To(Equal(zapcore.DebugLevel))
 		Expect(dc2.fields).To(HaveLen(2))
 		Expect(dc2.fields[0].Key).To(Equal("with1"))
@@ -242,8 +249,8 @@ var _ = Describe("Delegating Zap Core", func() {
 		Expect(ok).To(BeTrue())
 		Expect(dc3 == originalDelegatingCore).To(BeFalse())
 		Expect(dc3 == dc2).To(BeFalse())
-		Expect(dc3.logMessageBuffer.IsEmpty()).To(BeTrue())
 		Expect(dc3.level).To(Equal(zapcore.DebugLevel))
+		// the clones share the log message buffer of the original core, buffered messages are not copied
 		Expect(dc3.logMessageBuffer == originalDelegatingCore.logMessageBuffer).To(BeTrue())
 		Expect(dc3.fields).To(HaveLen(5))
 		Expect(dc3.fields[0].Key).To(Equal("with1"))

--- a/internal/util/zap/zap_suite_test.go
+++ b/internal/util/zap/zap_suite_test.go
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: Copyright 2026 Dash0 Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package zap
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestZap(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Zap Util Suite")
+}

--- a/test-resources/bin/ginkgo-suite-check.sh
+++ b/test-resources/bin/ginkgo-suite-check.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright 2026 Dash0 Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+project_root="$(dirname "${BASH_SOURCE[0]}")"/../..
+
+cd "$project_root"
+
+# This script verifies that every Go package directory which contains Ginkgo specs also contains a suite bootstrap (e.g.
+# a Go test function which calls RunSpecs). Without such a bootstrap, go test compiles the specs and reports the
+# package as passing, but the specs are not executed.
+
+# Matches the Ginkgo DSL imports, that is, "github.com/onsi/ginkgo/v2" and its dsl sub-packages, but not the auxiliary
+# packages like ginkgo/v2/types, which do not bring specs with them.
+ginkgo_dsl_import_pattern='onsi/ginkgo/v2(/dsl/[a-z]+)?"'
+
+directories_with_specs=()
+
+while IFS= read -r -d '' test_file; do
+  if grep -qE "$ginkgo_dsl_import_pattern" "$test_file"; then
+    directories_with_specs+=("$(dirname "$test_file")")
+  fi
+done < <(
+  find . \
+    -type f \
+    -name '*_test.go' \
+    -not -path './images/collector/opentelemetry-collector/*' \
+    -not -path './images/collector/opentelemetry-collector-contrib/*' \
+    -not -path '*/node_modules/*' \
+    -print0
+)
+
+if [[ "${#directories_with_specs[@]}" -eq 0 ]]; then
+  echo "Error: no Go test file importing the Ginkgo DSL has been found, this check is most likely broken." >&2
+  exit 1
+fi
+
+errors=0
+
+while IFS= read -r directory; do
+  if ! grep -qE '\bRunSpecs\(' "$directory"/*_test.go; then
+    echo "Error: the directory $directory contains Ginkgo specs, but no suite bootstrap, hence none of its specs" \
+      "are executed. Add a file with a Go test function which calls RunSpecs, see the *_suite_test.go files of the" \
+      "other packages." >&2
+    errors=$((errors + 1))
+  fi
+done < <(printf '%s\n' "${directories_with_specs[@]}" | sort -u)
+
+if [[ "$errors" -gt 0 ]]; then
+  echo "${BASH_SOURCE[0]}": "$errors" package\(s\) with Ginkgo specs but without a suite bootstrap found. >&2
+  exit 1
+fi
+
+echo "${BASH_SOURCE[0]}": All checks have passed.


### PR DESCRIPTION
This adds a make lint step that checks whether every directory that contains Ginkgo test also has a suite bootstrap file. Without such a bootstrap, `go test` compiles the specs and reports the package as passing, but the specs are not executed.

This is motivated by internal/util/zap actually missing such a suite bootstrap, the tests in it never ran. Production code had also diverted from the original tests, which were broken by now (and are fixed now).