### PR TITLE
chore(sc): check number of AZs less frequently

### DIFF
--- a/internal/collectors/collector_manager.go
+++ b/internal/collectors/collector_manager.go
@@ -10,6 +10,7 @@ import (
 	"slices"
 	"strings"
 	"sync/atomic"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -37,16 +38,27 @@ type CollectorManager struct {
 	signalControlFeatureEnabled bool
 	enablementChecker           enablement.Checker
 	updateInProgress            atomic.Bool
-	// lastReportedZoneCoverage remembers the (zone count, replica count) pair the zone coverage warning was last
-	// emitted for, so that the warning is logged on transitions instead of on every reconcile.
-	lastReportedZoneCoverage atomic.Pointer[zoneCoverage]
+	// now returns the current time. It is overridable in tests to exercise the zone-coverage check interval;
+	// NewCollectorManager defaults it to time.Now.
+	now func() time.Time
+	// lastZoneCoverage remembers the outcome of the most recent availability-zone coverage evaluation, so that the
+	// node list backing the check runs at most once per zoneCoverageCheckInterval and the warning is logged on a
+	// change of state rather than on every reconcile.
+	lastZoneCoverage atomic.Pointer[zoneCoverageState]
 }
 
-// zoneCoverage is the pair the zone coverage warning is keyed on.
-type zoneCoverage struct {
+// zoneCoverageState captures the most recent availability-zone coverage evaluation: when the node list was last
+// performed, the zone and replica counts it observed, and whether the warning was active for them.
+type zoneCoverageState struct {
+	checkedAt    time.Time
 	zoneCount    int
 	replicaCount int32
+	warned       bool
 }
+
+// zoneCoverageCheckInterval is the minimum time between two node-list backed availability-zone checks. An explicit
+// change to the Signal Control collector replica count bypasses it, so a reconfiguration is reflected without waiting.
+const zoneCoverageCheckInterval = 30 * time.Minute
 
 type CollectorReconcileTrigger string
 
@@ -78,8 +90,16 @@ func NewCollectorManager(
 		enablementChecker:           enablementChecker,
 		oTelColResourceManager:      oTelColResourceManager,
 	}
+	m.now = time.Now
 	m.extraConfig.Store(&extraConfig)
 	return m
+}
+
+func (m *CollectorManager) nowOrDefault() time.Time {
+	if m.now != nil {
+		return m.now()
+	}
+	return time.Now()
 }
 
 func (m *CollectorManager) UpdateExtraConfig(ctx context.Context, newConfig util.ExtraConfig, logger logd.Logger) {
@@ -231,6 +251,22 @@ func (m *CollectorManager) warnAboutInsufficientZoneCoverage(
 	if m.nodeMetadataClient == nil {
 		return
 	}
+
+	replicaCount := extraConfig.SignalControlCollectorReplicas
+	if replicaCount < 1 {
+		replicaCount = otelcolresources.SignalControlCollectorDefaultReplicas
+	}
+
+	now := m.nowOrDefault()
+	previous := m.lastZoneCoverage.Load()
+	replicaCountChanged := previous != nil && previous.replicaCount != replicaCount
+	// The node list is the expensive part of the check, so it is performed at most once per zoneCoverageCheckInterval.
+	// An explicit change to the replica count bypasses the interval, so a reconfiguration is evaluated - and its
+	// warning re-logged, or an info logged when it resolved the issue - without waiting for the next interval.
+	if previous != nil && !replicaCountChanged && now.Sub(previous.checkedAt) < zoneCoverageCheckInterval {
+		return
+	}
+
 	// The metadata client bypasses the controller-runtime cache on purpose: reading nodes through the cached client
 	// would start an informer that keeps every node object in memory for the lifetime of the operator. Only object
 	// metadata is requested, since the zone label is all that is read, which keeps the node status (in particular the
@@ -253,35 +289,57 @@ func (m *CollectorManager) warnAboutInsufficientZoneCoverage(
 		}
 	}
 
-	replicaCount := extraConfig.SignalControlCollectorReplicas
-	if replicaCount < 1 {
-		replicaCount = otelcolresources.SignalControlCollectorDefaultReplicas
-	}
-	m.reportZoneCoverage(len(zones), replicaCount, logger)
+	m.reportZoneCoverage(len(zones), replicaCount, now, logger)
 }
 
-// reportZoneCoverage emits the zone coverage warning when there are more availability zones than Signal Control
-// collector replicas, at most once per distinct (zone count, replica count) pair so that a steady state does not
-// produce a warning on every reconcile.
-func (m *CollectorManager) reportZoneCoverage(zoneCount int, replicaCount int32, logger logd.Logger) {
+// reportZoneCoverage evaluates the availability-zone coverage for the given zone and replica counts, logs the warning
+// when there are more zones than replicas, and records the outcome under checkedAt. In a steady state the warning is
+// logged once, on the transition into it, not on every check. A replica-count change is always acted on, so the
+// warning is re-logged if the situation persists. When a previously warned situation resolves - by more replicas or a
+// lower zone count - a short info is logged once.
+func (m *CollectorManager) reportZoneCoverage(
+	zoneCount int,
+	replicaCount int32,
+	checkedAt time.Time,
+	logger logd.Logger,
+) {
+	previous := m.lastZoneCoverage.Load()
+	wasWarned := previous != nil && previous.warned
+
 	// With zero or one zone there is nothing to spread over, the zone preference is inert either way.
-	if zoneCount <= 1 || int32(zoneCount) <= replicaCount {
-		m.lastReportedZoneCoverage.Store(nil)
+	insufficient := zoneCount > 1 && int32(zoneCount) > replicaCount
+
+	m.lastZoneCoverage.Store(&zoneCoverageState{
+		checkedAt:    checkedAt,
+		zoneCount:    zoneCount,
+		replicaCount: replicaCount,
+		warned:       insufficient,
+	})
+
+	if insufficient {
+		// A steady state - the same zone and replica count already warned about - is not warned about again.
+		if wasWarned && previous.zoneCount == zoneCount && previous.replicaCount == replicaCount {
+			return
+		}
+		logger.WarnTelemetryCollectionIssue(fmt.Sprintf(
+			"The cluster has %d availability zones but the Signal Control collector runs with %d replicas, so at least "+
+				"one zone has no Signal Control collector pod. Telemetry from those zones is sent to a collector in "+
+				"another zone, which works but incurs cross-zone traffic cost. Set "+
+				"operator.collectors.signalControlCollectorReplicas to at least %d to avoid that.",
+			zoneCount, replicaCount, zoneCount,
+		))
 		return
 	}
 
-	current := zoneCoverage{zoneCount: zoneCount, replicaCount: replicaCount}
-	if previous := m.lastReportedZoneCoverage.Load(); previous != nil && *previous == current {
-		return
+	// Resolved: announce it whenever a previously active warning has cleared, whether the replica count was raised
+	// or the zone count dropped on its own.
+	if wasWarned {
+		logger.Info(fmt.Sprintf(
+			"The Signal Control collector now runs with %d replicas across %d availability zones, so every zone has a "+
+				"Signal Control collector pod and cross-zone traffic is avoided.",
+			replicaCount, zoneCount,
+		))
 	}
-	m.lastReportedZoneCoverage.Store(&current)
-	logger.WarnTelemetryCollectionIssue(fmt.Sprintf(
-		"The cluster has %d availability zones but the Signal Control collector runs with %d replicas, so at least "+
-			"one zone has no Signal Control collector pod. Telemetry from those zones is sent to a collector in "+
-			"another zone, which works but incurs cross-zone traffic cost. Set "+
-			"operator.collectors.signalControlCollectorReplicas to at least %d to avoid that.",
-		zoneCount, replicaCount, zoneCount,
-	))
 }
 
 func (m *CollectorManager) createOrUpdateOpenTelemetryCollector(

--- a/internal/collectors/collector_manager_test.go
+++ b/internal/collectors/collector_manager_test.go
@@ -6,6 +6,7 @@ package collectors
 import (
 	"context"
 	"slices"
+	"time"
 
 	"github.com/go-logr/logr/funcr"
 	appsv1 "k8s.io/api/apps/v1"
@@ -457,50 +458,93 @@ var _ = Describe("The collector manager", Ordered, func() {
 			}, funcr.Options{}))
 		})
 
-		It("warns once per distinct zone/replica combination, not on every reconcile", func() {
+		It("warns once per distinct zone/replica combination, not on every check", func() {
 			manager := &CollectorManager{}
+			checkedAt := time.Unix(0, 0)
 
-			manager.reportZoneCoverage(3, 2, recordingLogger)
+			manager.reportZoneCoverage(3, 2, checkedAt, recordingLogger)
 			Expect(warnings).To(HaveLen(1))
 			Expect(warnings[0]).To(ContainSubstring("3 availability zones"))
 			Expect(warnings[0]).To(ContainSubstring("2 replicas"))
 			Expect(warnings[0]).To(ContainSubstring("signalControlCollectorReplicas"))
 
 			// A steady state must not produce a warning again.
-			manager.reportZoneCoverage(3, 2, recordingLogger)
-			manager.reportZoneCoverage(3, 2, recordingLogger)
+			manager.reportZoneCoverage(3, 2, checkedAt, recordingLogger)
+			manager.reportZoneCoverage(3, 2, checkedAt, recordingLogger)
 			Expect(warnings).To(HaveLen(1))
 
 			// A changed zone count is a new situation and is reported again.
-			manager.reportZoneCoverage(4, 2, recordingLogger)
+			manager.reportZoneCoverage(4, 2, checkedAt, recordingLogger)
 			Expect(warnings).To(HaveLen(2))
 		})
 
 		It("does not warn when there are at least as many replicas as zones", func() {
 			manager := &CollectorManager{}
-			manager.reportZoneCoverage(3, 3, recordingLogger)
-			manager.reportZoneCoverage(3, 5, recordingLogger)
+			checkedAt := time.Unix(0, 0)
+			manager.reportZoneCoverage(3, 3, checkedAt, recordingLogger)
+			manager.reportZoneCoverage(3, 5, checkedAt, recordingLogger)
 			Expect(warnings).To(BeEmpty())
 		})
 
 		It("does not warn on clusters with no zone labels or a single zone", func() {
 			manager := &CollectorManager{}
-			manager.reportZoneCoverage(0, 1, recordingLogger)
-			manager.reportZoneCoverage(1, 1, recordingLogger)
+			checkedAt := time.Unix(0, 0)
+			manager.reportZoneCoverage(0, 1, checkedAt, recordingLogger)
+			manager.reportZoneCoverage(1, 1, checkedAt, recordingLogger)
 			Expect(warnings).To(BeEmpty())
 		})
 
-		It("warns again after the situation was resolved and then reoccurs", func() {
+		It("logs the warning again when a replica change leaves the issue unresolved", func() {
 			manager := &CollectorManager{}
-			manager.reportZoneCoverage(3, 2, recordingLogger)
+			checkedAt := time.Unix(0, 0)
+			manager.reportZoneCoverage(3, 1, checkedAt, recordingLogger)
 			Expect(warnings).To(HaveLen(1))
-			manager.reportZoneCoverage(3, 3, recordingLogger)
+			Expect(warnings[0]).To(ContainSubstring("incurs cross-zone traffic cost"))
+
+			// Raising the replicas but not far enough is still insufficient: warn again.
+			manager.reportZoneCoverage(3, 2, checkedAt, recordingLogger)
+			Expect(warnings).To(HaveLen(2))
+			Expect(warnings[1]).To(ContainSubstring("incurs cross-zone traffic cost"))
+			Expect(warnings[1]).To(ContainSubstring("2 replicas"))
+		})
+
+		It("logs an info when a replica change resolves an active warning, and warns again if it reoccurs", func() {
+			manager := &CollectorManager{}
+			checkedAt := time.Unix(0, 0)
+			manager.reportZoneCoverage(3, 2, checkedAt, recordingLogger)
 			Expect(warnings).To(HaveLen(1))
-			manager.reportZoneCoverage(3, 2, recordingLogger)
+			Expect(warnings[0]).To(ContainSubstring("incurs cross-zone traffic cost"))
+
+			// Raising the replica count to match the zones resolves the issue and is announced once.
+			manager.reportZoneCoverage(3, 3, checkedAt, recordingLogger)
+			Expect(warnings).To(HaveLen(2))
+			Expect(warnings[1]).To(ContainSubstring("cross-zone traffic is avoided"))
+			Expect(warnings[1]).To(ContainSubstring("3 replicas"))
+
+			// Lowering the replicas again is a new insufficient situation: warn once more.
+			manager.reportZoneCoverage(3, 2, checkedAt, recordingLogger)
+			Expect(warnings).To(HaveLen(3))
+			Expect(warnings[2]).To(ContainSubstring("incurs cross-zone traffic cost"))
+		})
+
+		It("announces the resolution when the issue resolves on its own without a replica change", func() {
+			manager := &CollectorManager{}
+			checkedAt := time.Unix(0, 0)
+			manager.reportZoneCoverage(3, 2, checkedAt, recordingLogger)
+			Expect(warnings).To(HaveLen(1))
+			Expect(warnings[0]).To(ContainSubstring("incurs cross-zone traffic cost"))
+
+			// The zone count drops on its own; the resolution is announced.
+			manager.reportZoneCoverage(2, 2, checkedAt, recordingLogger)
+			Expect(warnings).To(HaveLen(2))
+			Expect(warnings[1]).To(ContainSubstring("cross-zone traffic is avoided"))
+
+			// Once resolved, a further healthy evaluation is not announced again.
+			manager.reportZoneCoverage(2, 2, checkedAt, recordingLogger)
 			Expect(warnings).To(HaveLen(2))
 		})
 
-		It("derives the zone count from the node labels reported by the API server", func() {
+		It("lists nodes at most once per interval and re-checks on a replica change", func() {
 			for _, zone := range []string{"zone-a", "zone-b", "zone-c"} {
 				node := &corev1.Node{
 					ObjectMeta: metav1.ObjectMeta{
@@ -514,20 +558,48 @@ var _ = Describe("The collector manager", Ordered, func() {
 				})
 			}
 
-			manager := &CollectorManager{nodeMetadataClient: nodeMetadataClient}
+			currentTime := time.Unix(0, 0)
+			manager := &CollectorManager{
+				nodeMetadataClient: nodeMetadataClient,
+				now:                func() time.Time { return currentTime },
+			}
+			twoReplicas := util.ExtraConfig{SignalControlCollectorReplicas: 2}
+			threeReplicas := util.ExtraConfig{SignalControlCollectorReplicas: 3}
+
 			// The node list is served from the API server's watch cache, which may not have caught up with the nodes
-			// created above yet.
+			// created above yet. Reset the state on every attempt so each one is a first check that lists the nodes.
 			Eventually(func(g Gomega) {
 				warnings = nil
-				manager.warnAboutInsufficientZoneCoverage(
-					ctx,
-					util.ExtraConfig{SignalControlCollectorReplicas: 2},
-					recordingLogger,
-				)
+				manager.lastZoneCoverage.Store(nil)
+				manager.warnAboutInsufficientZoneCoverage(ctx, twoReplicas, recordingLogger)
 				g.Expect(warnings).To(HaveLen(1))
 				g.Expect(warnings[0]).To(ContainSubstring("3 availability zones"))
 				g.Expect(warnings[0]).To(ContainSubstring("2 replicas"))
 			}).Should(Succeed())
+
+			// Within the interval and with an unchanged replica count, the node list is skipped and nothing is logged.
+			warnings = nil
+			manager.warnAboutInsufficientZoneCoverage(ctx, twoReplicas, recordingLogger)
+			Expect(warnings).To(BeEmpty())
+
+			// A replica change bypasses the interval: the check runs again and, now sufficient, logs the info.
+			warnings = nil
+			manager.warnAboutInsufficientZoneCoverage(ctx, threeReplicas, recordingLogger)
+			Expect(warnings).To(HaveLen(1))
+			Expect(warnings[0]).To(ContainSubstring("cross-zone traffic is avoided"))
+
+			// Once the interval has elapsed the periodic check runs again; back to two replicas, it warns once more.
+			currentTime = currentTime.Add(zoneCoverageCheckInterval)
+			warnings = nil
+			manager.warnAboutInsufficientZoneCoverage(ctx, twoReplicas, recordingLogger)
+			Expect(warnings).To(HaveLen(1))
+			Expect(warnings[0]).To(ContainSubstring("incurs cross-zone traffic cost"))
+
+			// A further periodic check in the same state does not warn again.
+			currentTime = currentTime.Add(zoneCoverageCheckInterval)
+			warnings = nil
+			manager.warnAboutInsufficientZoneCoverage(ctx, twoReplicas, recordingLogger)
+			Expect(warnings).To(BeEmpty())
 		})
 	})
 

--- a/internal/signalcontrol/scresources/sc_resources.go
+++ b/internal/signalcontrol/scresources/sc_resources.go
@@ -154,6 +154,9 @@ func (m *SignalControlResourceManager) updateResource(
 	if err = patch.DefaultAnnotator.SetLastAppliedAnnotation(desiredResource); err != nil {
 		return false, err
 	}
+	// Carry over the live resource version; some kinds (PodDisruptionBudget) reject an update without it
+	// ("resourceVersion: Invalid value: 0: must be specified for an update") and it adds optimistic locking.
+	desiredResource.SetResourceVersion(existingResource.GetResourceVersion())
 	if err = m.Update(ctx, desiredResource); err != nil {
 		return false, err
 	}


### PR DESCRIPTION
## Description

Since the number of AZs doesn't change very often, this PR updates the implementation to only refresh the cached number every 30 minutes. This doesn't have any functional consequences, it is only used for logging a warning when there are fewer SC collectors than AZs (or a short info when the issue is resolved).

## Authorship

<!--Human authorship attestation. AI agents must not check the following boxes on behalf of the user. The human author must check them personally before the PR will be reviewed.-->

The human author of this PR confirms they

- [x] fully understand the changes and can explain the reasoning behind the design decisions,
- [x] fully understand how to verify and test the changes,
- [x] did confirm the changes work as expected by testing them in a real cluster, and
- [x] personally wrote the PR description.