### PR TITLE
fix: fix memory leak in DelegatingZapCore

### DIFF
--- a/internal/util/zap/delegating_zap_core.go
+++ b/internal/util/zap/delegating_zap_core.go
@@ -10,17 +10,82 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
-// DelegatingZapCore is a Zap core that keeps messages in a size-limited buffer until another core is added as a
-// delegate via SetDelegate. After that, the core will pass all messages to the delegate. The messages that are already
-// buffered can then be spooled to the new core via DelegatingZapCoreWrapper.LogMessageBuffer.ForAllAndClear.
+// DelegatingZapCore is a Zap core that keeps messages in a size-limited buffer until an actual zapcore.Core is added as
+// a delegate via SetDelegate. The messages that are already buffered can then be spooled to the new core via
+// DelegatingZapCoreWrapper.LogMessageBuffer.ForAllAndClear. After SetDelegate, DelegatingZapCore will pass all messages
+// to the delegate.
+//
+// DelegatingZapCores conceptually form a tree structure, just like zap loggers do; without representing an actual tree
+// in memory. You start with a root DelegatingZapCore, and then derive child loggers (by calling `With`) that add
+// additional fields (which will be included in every log record written by that child logger). There are no references
+// from parent to child or vice versa.
 type DelegatingZapCore struct {
-	delegate         atomic.Pointer[zapcore.Core]
+	sharedDelegate   *sharedDelegate
+	derivedDelegate  atomic.Pointer[derivedDelegate]
 	logMessageBuffer *Mru[*ZapEntryWithFields]
 	level            zapcore.Level
 	fields           []zapcore.Field
-	clones           []*DelegatingZapCore
 }
 
+// sharedDelegate holds the single delegate for an entire DelegatingZapCore tree. It always starts out without an
+// actual Zap core. The intended usage is that some time later an actual zapcore.Core is provided via
+// DelegatingZapCore#SetDelegate. The zapcore.Core is then stored in the sharedDelegate.
+//
+// The root core of a tree and every core derived from it via `With` need to have access to the delegate. For that
+// purpose, all cores of the tree hold a pointer to the same sharedDelegate instance. They can look up the current core
+// from the sharedDelegate reference, and then write log messages to it.
+//
+// Note that the references only point from the derived DelegatingZapCores to the sharedDelegate, *not* the other way
+// around, or from a DelegatingZapCore to its child cores. This makes a DelegatingZapCore derived via `With` eligible
+// for garbage collection as soon as the logger holding it goes out of scope. Tracking the derived DelegatingZapCores
+// in their parent would create a reference chain from the root DelegatingZapCore to every derived DelegatingZapCore,
+// and retain every logger ever derived for the lifetime of the root DelegatingZapCore object - i.e. it would be a
+// memory leak.
+//
+// The generation counter is used for caching cores together with their applied Zap fields. The generation is
+// incremented on every SetDelegate/UnsetDelegate call. This lets a derived core detect that the delegate it has
+// memoized is stale. See also the `derivedDelegate` struct, which holds the counterpart for the generation comparison,
+// and DelegatingZapCore#delegate() which handles the memoization.
+//
+// The two fields (delegate and generation) are written separately, without a lock. That is safe because a derived
+// DelegatingZapCoreDelegatingZapCore only uses its memoized delegate while the memoized generation still equals the current one, and
+// because writers always store the delegate before they increment the generation: observing a generation means the
+// delegate for that generation has already been stored, so a reader either memoizes the matching delegate or memoizes
+// one tagged with a generation that is already superseded, which makes it derive again on the next call. Do not replace
+// the two fields with a single atomic pointer to a combined struct unless the update uses compare-and-swap: a plain
+// load-modify-store can drop a concurrent increment, and two writers would then be able to settle on a generation whose
+// delegate is not the one that was stored last.
+type sharedDelegate struct {
+	// delegate is the reference to the current zapcore.Core for the whole tree of DelegatingZapCore objects. If a new
+	// delegate is set (removed) via SetDelegate (UnsetDelegate), the generation counter is incremented as well.
+	delegate   atomic.Pointer[zapcore.Core]
+	generation atomic.Uint64
+}
+
+// derivedDelegate is the delegate of a single DelegatingZapCore, that is, it is that tree node's delegate with the
+// core's fields applied, together with the generation it has been derived from.
+//
+// A DelegatingZapCore derived via `With` cannot use sharedDelegate.delegate directly to write log messages, the fields
+// provided via With would be missing. Naively, it would need to call zapcore.Core#With(dc.fields) for every single log
+// message, to apply the Zap fields. The otelzap conversion is somewhat expensive though. Thus, each DelegatingZapCore
+// in the tree keeps its own copy of the zapcore.Core with all fields already applied. This is what the derivedDelegate
+// is for. Its generation counter is used to compare with sharedDelegate.generation, to determine if we are still
+// logging to the same zapcore.Core, or if it has been replaced via SetDelegate/UnsetDelegate since memoizing it.
+//
+// The first log call after a delegate change pays for the otelzap conversion once. Every call after that is two atomic
+// loads and a comparison.
+//
+// A nil delegate means the DelegatingZapCore tree had no delegate at that generation.
+type derivedDelegate struct {
+	// delegate is the zapcore.Core with applied fields
+	delegate zapcore.Core
+	// generation is the generation of the sharedDelegate that was active when this derivedDelegate was created. It is
+	// never updated, if a derivedDelegate's generation is checked in delegate() and does not match, a new derivedDelegate
+	// is created.
+	generation uint64
+}
+
+// ZapEntryWithFields represents a single log entry, i.e. a log message with additional fields.
 type ZapEntryWithFields struct {
 	Entry  zapcore.Entry
 	Fields []zapcore.Field
@@ -29,6 +94,7 @@ type ZapEntryWithFields struct {
 // NewDelegatingZapCore creates a DelegatingZapCore.
 func NewDelegatingZapCore(logMessageBuffer *Mru[*ZapEntryWithFields]) *DelegatingZapCore {
 	return &DelegatingZapCore{
+		sharedDelegate:   &sharedDelegate{},
 		logMessageBuffer: logMessageBuffer,
 		level:            zapcore.InfoLevel,
 	}
@@ -40,33 +106,50 @@ func (dc *DelegatingZapCore) SetBufferingLevel(lvl zapcore.Level) {
 	dc.level = lvl
 }
 
-// With adds structured context to the Core. The provided fields will be forwarded to the delegate if one is set. All
-// fields will also be stored, independent of whether a delegate is set or not.
+// With adds structured context to the Core. All fields are stored, independent of whether a delegate is set or not.
+// They are applied to the delegate lazily, when the returned core logs for the first time.
 func (dc *DelegatingZapCore) With(fields []zapcore.Field) zapcore.Core {
-	clone := DelegatingZapCore{
+	return &DelegatingZapCore{
+		sharedDelegate: dc.sharedDelegate,
 		// We deliberately do not clone the buffer, since the original DelegatingZapCore still has the buffered
 		// messages, cloning the buffer as well might lead to emitting log records twice
 		logMessageBuffer: dc.logMessageBuffer,
 		level:            dc.level,
 		fields:           slices.Concat(dc.fields, fields),
 	}
-	dc.clones = append(dc.clones, &clone)
+}
 
-	// If this core has a delegate, we propagate the With call to the delegate and set the result as the delegate for
-	// the cloned DelegatingZapCore.
-	delegate := dc.delegate.Load()
-	if delegate != nil {
-		newDelegate := (*delegate).With(fields)
-		clone.delegate.Store(&newDelegate)
+// delegate returns the tree's delegate with this core's fields applied, or nil if the tree has no delegate. The result
+// is memoized until the next SetDelegate or UnsetDelegate call.
+func (dc *DelegatingZapCore) delegate() zapcore.Core {
+	generation := dc.sharedDelegate.generation.Load()
+	if memoized := dc.derivedDelegate.Load(); memoized != nil && memoized.generation == generation {
+		// The cached derivedDelegate with its applied fields is still valid, there has been no SetDelegate/UnsetDelegate
+		// call since it has been memoized.
+		return memoized.delegate
 	}
 
-	return &clone
+	// Either we have never memoized a core for this DelegatingZapCore, or the memoized core has been invalidated by
+	// a SetDelegate/UnsetDelegate call. Create a new derivedDelegate and memoize it.
+	var delegate zapcore.Core
+	if treeDelegate := dc.sharedDelegate.delegate.Load(); treeDelegate != nil {
+		delegate = *treeDelegate
+		if len(dc.fields) > 0 {
+			// Apply the Zap fields.
+			delegate = delegate.With(dc.fields)
+		}
+	}
+
+	// Two goroutines can derive concurrently. Also, a concurrent SetDelegate can make the value we are about to store
+	// stale before we store it. Both are benign: the stored generation then no longer matches, and the next call
+	// derives again.
+	dc.derivedDelegate.Store(&derivedDelegate{delegate: delegate, generation: generation})
+	return delegate
 }
 
 func (dc *DelegatingZapCore) Enabled(lvl zapcore.Level) bool {
-	delegate := dc.delegate.Load()
-	if delegate != nil {
-		return lvl >= dc.level && (*delegate).Enabled(lvl)
+	if delegate := dc.delegate(); delegate != nil {
+		return lvl >= dc.level && delegate.Enabled(lvl)
 	}
 
 	return lvl >= dc.level
@@ -75,8 +158,7 @@ func (dc *DelegatingZapCore) Enabled(lvl zapcore.Level) bool {
 // Check determines whether the supplied Entry should be logged. If a delegate is set, the call will simply be delegated
 // to the delegate's Check method, otherwise it will be checked against the level set in SetBufferingLevel.
 func (dc *DelegatingZapCore) Check(entry zapcore.Entry, ce *zapcore.CheckedEntry) *zapcore.CheckedEntry {
-	delegate := dc.delegate.Load()
-	if delegate != nil {
+	if delegate := dc.delegate(); delegate != nil {
 		// Respect the configured level so that debug messages are not forwarded to the OTel pipeline when not in
 		// development mode.
 		if entry.Level < dc.level {
@@ -93,7 +175,7 @@ func (dc *DelegatingZapCore) Check(entry zapcore.Entry, ce *zapcore.CheckedEntry
 			// for self-monitoring. To prevent this, we directly filter out anything with a level < -1.
 			return ce
 		}
-		return (*delegate).Check(entry, ce)
+		return delegate.Check(entry, ce)
 	}
 
 	if dc.Enabled(entry.Level) {
@@ -106,13 +188,12 @@ func (dc *DelegatingZapCore) Check(entry zapcore.Entry, ce *zapcore.CheckedEntry
 //
 // If called, Write will always do one of those two things, it will not replicate the logic of Check.
 func (dc *DelegatingZapCore) Write(entry zapcore.Entry, fields []zapcore.Field) error {
-	delegate := dc.delegate.Load()
-	if delegate != nil {
+	if delegate := dc.delegate(); delegate != nil {
 		// Note: This branch is actually never executed. When a delegate is present, the Write method is no longer
 		// called for the delegating zap core, since the implementation of Check delegates the Check call to the
 		// delegate already. Within delegate.Check, the delegate adds itself via AddCore to the checked entry. Write is
 		// only called for cores that have been added to a checked entry.
-		return (*delegate).Write(entry, fields)
+		return delegate.Write(entry, fields)
 	}
 
 	finalFields := slices.Concat(dc.fields, fields)
@@ -122,34 +203,37 @@ func (dc *DelegatingZapCore) Write(entry zapcore.Entry, fields []zapcore.Field) 
 
 // Sync instructs the delegate to flush buffered logs, if there is a delegate. Otherwise, the call is ignored.
 func (dc *DelegatingZapCore) Sync() error {
-	delegate := dc.delegate.Load()
-	if delegate != nil {
-		return (*delegate).Sync()
+	if delegate := dc.delegate(); delegate != nil {
+		return delegate.Sync()
 	}
 
 	// ignore sync calls if no delegate is set
 	return nil
 }
 
-// SetDelegate sets the delegate core to which all messages will be forwarded. The messages that are already buffered
-// can then be spooled to the new core via DelegatingZapCoreWrapper.LogMessageBuffer.ForAllAndClear. The SetDelegate
-// call will also be propagated to all clones created via With previous to this call.
+// SetDelegate sets the delegate core to which all messages will be forwarded. This also applies to all cores that have
+// been derived from this core via With, before or after this call. The messages that are already buffered can then be
+// spooled to the new core via DelegatingZapCoreWrapper.LogMessageBuffer.ForAllAndClear.
 func (dc *DelegatingZapCore) SetDelegate(delegate zapcore.Core) {
-	dc.delegate.Store(&delegate)
-	for _, clone := range dc.clones {
-		clone.SetDelegate(delegate)
-	}
+	// Store the delegate before incrementing the generation, never the other way around. That way, if delegate() memoizes
+	// a new derivedDelegate, it would err on the side of storing a too-new delegate with an older generation counter, and
+	// memoize again on the next log call. That is, the error is a wasted With call.
+	//
+	// If instead we did the increment first, a reader can observe the new generation together with an outdated delegate.
+	// That is much worse, it will memoize that pair and the stale delegate is potentially trusted for the rest of the
+	// process lifetime.
+	dc.sharedDelegate.delegate.Store(&delegate)
+	dc.sharedDelegate.generation.Add(1)
 }
 
-// UnsetDelegate will remove the current delegate (if any). The UnsetDelegate call will also be propagated to all clones
-// created via With previous to this call.
+// UnsetDelegate will remove the current delegate (if any). This also applies to all cores that have been derived from
+// this core via With, before or after this call.
 func (dc *DelegatingZapCore) UnsetDelegate() {
-	dc.delegate.Store(nil)
-	for _, clone := range dc.clones {
-		clone.UnsetDelegate()
-	}
+	// Clear the delegate before incrementing the generation, for the same reason as in SetDelegate.
+	dc.sharedDelegate.delegate.Store(nil)
+	dc.sharedDelegate.generation.Add(1)
 }
 
 func (dc *DelegatingZapCore) ForTestOnlyHasDelegate() bool {
-	return dc.delegate.Load() != nil
+	return dc.delegate() != nil
 }

--- a/internal/util/zap/delegating_zap_core.go
+++ b/internal/util/zap/delegating_zap_core.go
@@ -48,7 +48,7 @@ type DelegatingZapCore struct {
 // and DelegatingZapCore#delegate() which handles the memoization.
 //
 // The two fields (delegate and generation) are written separately, without a lock. That is safe because a derived
-// DelegatingZapCoreDelegatingZapCore only uses its memoized delegate while the memoized generation still equals the current one, and
+// DelegatingZapCore only uses its memoized delegate while the memoized generation still equals the current one, and
 // because writers always store the delegate before they increment the generation: observing a generation means the
 // delegate for that generation has already been stored, so a reader either memoizes the matching delegate or memoizes
 // one tagged with a generation that is already superseded, which makes it derive again on the next call. Do not replace
@@ -148,22 +148,30 @@ func (dc *DelegatingZapCore) delegate() zapcore.Core {
 }
 
 func (dc *DelegatingZapCore) Enabled(lvl zapcore.Level) bool {
-	if delegate := dc.delegate(); delegate != nil {
-		return lvl >= dc.level && delegate.Enabled(lvl)
+	// Check the configured level before looking up the delegate: delegate() would apply this core's fields to the
+	// tree's delegate, which is the expensive part, for a level that is discarded anyway.
+	if lvl < dc.level {
+		return false
 	}
 
-	return lvl >= dc.level
+	if delegate := dc.delegate(); delegate != nil {
+		return delegate.Enabled(lvl)
+	}
+
+	return true
 }
 
 // Check determines whether the supplied Entry should be logged. If a delegate is set, the call will simply be delegated
 // to the delegate's Check method, otherwise it will be checked against the level set in SetBufferingLevel.
 func (dc *DelegatingZapCore) Check(entry zapcore.Entry, ce *zapcore.CheckedEntry) *zapcore.CheckedEntry {
+	// Respect the configured level so that debug messages are not forwarded to the OTel pipeline when not in
+	// development mode. Checking the level before looking up the delegate also avoids applying this core's fields to
+	// the tree's delegate for an entry that is dropped anyway.
+	if entry.Level < dc.level {
+		return ce
+	}
+
 	if delegate := dc.delegate(); delegate != nil {
-		// Respect the configured level so that debug messages are not forwarded to the OTel pipeline when not in
-		// development mode.
-		if entry.Level < dc.level {
-			return ce
-		}
 		if !zapcore.DebugLevel.Enabled(entry.Level) { // this is equivalent to `entry.Level < -1`
 			// There is some unfortunate interaction going on between controller-runtime debug logging and the zap OTel
 			// bridge. When controller-runtime logs with a level below -1, like for example here:
@@ -178,10 +186,7 @@ func (dc *DelegatingZapCore) Check(entry zapcore.Entry, ce *zapcore.CheckedEntry
 		return delegate.Check(entry, ce)
 	}
 
-	if dc.Enabled(entry.Level) {
-		return ce.AddCore(entry, dc)
-	}
-	return ce
+	return ce.AddCore(entry, dc)
 }
 
 // Write will forward the entry and fields to the delegate if one is set, or put it into the interal buffer otherwise.
@@ -235,5 +240,5 @@ func (dc *DelegatingZapCore) UnsetDelegate() {
 }
 
 func (dc *DelegatingZapCore) ForTestOnlyHasDelegate() bool {
-	return dc.delegate() != nil
+	return dc.sharedDelegate.delegate.Load() != nil
 }

--- a/internal/util/zap/delegating_zap_core.go
+++ b/internal/util/zap/delegating_zap_core.go
@@ -12,10 +12,10 @@ import (
 
 // DelegatingZapCore is a Zap core that keeps messages in a size-limited buffer until an actual zapcore.Core is added as
 // a delegate via SetDelegate. The messages that are already buffered can then be spooled to the new core via
-// DelegatingZapCoreWrapper.LogMessageBuffer.ForAllAndClear. After SetDelegate, DelegatingZapCore will pass all messages
-// to the delegate.
+// DelegatingZapCoreWrapper.LogMessageBuffer.ForAllAndClear. After SetDelegate, DelegatingZapCore will pass new incoming
+// messages to the new delegate.
 //
-// DelegatingZapCores conceptually form a tree structure, just like zap loggers do; without representing an actual tree
+// DelegatingZapCores conceptually form a tree structure, just like zap loggers do; without representing the actual tree
 // in memory. You start with a root DelegatingZapCore, and then derive child loggers (by calling `With`) that add
 // additional fields (which will be included in every log record written by that child logger). There are no references
 // from parent to child or vice versa.
@@ -36,11 +36,11 @@ type DelegatingZapCore struct {
 // from the sharedDelegate reference, and then write log messages to it.
 //
 // Note that the references only point from the derived DelegatingZapCores to the sharedDelegate, *not* the other way
-// around, or from a DelegatingZapCore to its child cores. This makes a DelegatingZapCore derived via `With` eligible
-// for garbage collection as soon as the logger holding it goes out of scope. Tracking the derived DelegatingZapCores
-// in their parent would create a reference chain from the root DelegatingZapCore to every derived DelegatingZapCore,
-// and retain every logger ever derived for the lifetime of the root DelegatingZapCore object - i.e. it would be a
-// memory leak.
+// around, nor from a DelegatingZapCore to its child/derived cores. This makes a DelegatingZapCore derived via `With`
+// eligible for garbage collection as soon as the logger holding it goes out of scope. Tracking the derived
+// DelegatingZapCores in their parent would create a reference chain from the root DelegatingZapCore to every derived
+// DelegatingZapCore, and retain every logger ever derived for the lifetime of the root DelegatingZapCore object
+// (which is often alive for the entire process) - i.e. it would be a memory leak.
 //
 // The generation counter is used for caching cores together with their applied Zap fields. The generation is
 // incremented on every SetDelegate/UnsetDelegate call. This lets a derived core detect that the delegate it has
@@ -63,14 +63,15 @@ type sharedDelegate struct {
 }
 
 // derivedDelegate is the delegate of a single DelegatingZapCore, that is, it is that tree node's delegate with the
-// core's fields applied, together with the generation it has been derived from.
+// core's fields applied, together with the sharedDelegate generation it has been derived from.
 //
 // A DelegatingZapCore derived via `With` cannot use sharedDelegate.delegate directly to write log messages, the fields
 // provided via With would be missing. Naively, it would need to call zapcore.Core#With(dc.fields) for every single log
 // message, to apply the Zap fields. The otelzap conversion is somewhat expensive though. Thus, each DelegatingZapCore
-// in the tree keeps its own copy of the zapcore.Core with all fields already applied. This is what the derivedDelegate
-// is for. Its generation counter is used to compare with sharedDelegate.generation, to determine if we are still
-// logging to the same zapcore.Core, or if it has been replaced via SetDelegate/UnsetDelegate since memoizing it.
+// in the tree keeps its own lazily initialized copy of the zapcore.Core with all fields already applied. This is what
+// the derivedDelegate is for. Its generation counter is used to compare with sharedDelegate.generation, to determine if
+// we are still logging to the same zapcore.Core, or if it has been replaced via SetDelegate/UnsetDelegate since
+// memoizing it.
 //
 // The first log call after a delegate change pays for the otelzap conversion once. Every call after that is two atomic
 // loads and a comparison.
@@ -221,12 +222,12 @@ func (dc *DelegatingZapCore) Sync() error {
 // spooled to the new core via DelegatingZapCoreWrapper.LogMessageBuffer.ForAllAndClear.
 func (dc *DelegatingZapCore) SetDelegate(delegate zapcore.Core) {
 	// Store the delegate before incrementing the generation, never the other way around. That way, if delegate() memoizes
-	// a new derivedDelegate, it would err on the side of storing a too-new delegate with an older generation counter, and
-	// memoize again on the next log call. That is, the error is a wasted With call.
+	// a new derivedDelegate right between the two calls, it would err on the side of storing a too-new delegate with an
+	// older generation counter, and memoize again on the next log call. That is, the error is a wasted With call.
 	//
-	// If instead we did the increment first, a reader can observe the new generation together with an outdated delegate.
-	// That is much worse, it will memoize that pair and the stale delegate is potentially trusted for the rest of the
-	// process lifetime.
+	// If instead we did the increment first, a reader can observe the new generation counter together with an outdated
+	// delegate. That is much worse, it will memoize that pair and the stale delegate is potentially trusted for the rest
+	// of the process lifetime.
 	dc.sharedDelegate.delegate.Store(&delegate)
 	dc.sharedDelegate.generation.Add(1)
 }

--- a/internal/util/zap/delegating_zap_core_test.go
+++ b/internal/util/zap/delegating_zap_core_test.go
@@ -4,6 +4,8 @@
 package zap
 
 import (
+	"runtime"
+
 	"go.uber.org/zap/zapcore"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -67,7 +69,7 @@ var _ = Describe("Delegating Zap Core", func() {
 		Expect(e.calledWith[3]).To(Equal(zapcore.ErrorLevel))
 	})
 
-	It("Enabled with a delegate", func() {
+	It("Check is delegated when there is a delegate", func() {
 		logMessageBuffer := NewMruWithDefaultSizeLimit[*ZapEntryWithFields]()
 		delegatingCore := NewDelegatingZapCore(logMessageBuffer)
 		delegate := &mockDelegate{}
@@ -81,10 +83,10 @@ var _ = Describe("Delegating Zap Core", func() {
 	It("Write without a delegate, hitting the limit", func() {
 		logMessageBuffer := NewMru[*ZapEntryWithFields](3)
 		delegatingCore := NewDelegatingZapCore(logMessageBuffer)
-		entry1 := zapcore.Entry{Level: zapcore.InfoLevel}
-		entry2 := zapcore.Entry{Level: zapcore.InfoLevel}
-		entry3 := zapcore.Entry{Level: zapcore.InfoLevel}
-		entry4 := zapcore.Entry{Level: zapcore.InfoLevel}
+		entry1 := zapcore.Entry{Level: zapcore.InfoLevel, Message: "1"}
+		entry2 := zapcore.Entry{Level: zapcore.InfoLevel, Message: "2"}
+		entry3 := zapcore.Entry{Level: zapcore.InfoLevel, Message: "3"}
+		entry4 := zapcore.Entry{Level: zapcore.InfoLevel, Message: "4"}
 		field := zapcore.Field{Key: "key", String: "value"}
 		fields := []zapcore.Field{field}
 		Expect(delegatingCore.Write(entry1, fields)).To(Succeed())
@@ -96,20 +98,20 @@ var _ = Describe("Delegating Zap Core", func() {
 		Expect(delegatingCore.Write(entry4, fields)).To(Succeed())
 
 		Expect(logMessageBuffer.Len()).To(Equal(3))
-		Expect(logMessageBuffer.elements[0]).To(Equal(
-			&ZapEntryWithFields{
+		Expect(*logMessageBuffer.elements[0]).To(Equal(
+			ZapEntryWithFields{
 				Entry:  entry2,
 				Fields: fields,
 			}),
 		)
-		Expect(logMessageBuffer.elements[1]).To(Equal(
-			&ZapEntryWithFields{
+		Expect(*logMessageBuffer.elements[1]).To(Equal(
+			ZapEntryWithFields{
 				Entry:  entry3,
 				Fields: fields,
 			}),
 		)
-		Expect(logMessageBuffer.elements[2]).To(Equal(
-			&ZapEntryWithFields{
+		Expect(*logMessageBuffer.elements[2]).To(Equal(
+			ZapEntryWithFields{
 				Entry:  entry4,
 				Fields: fields,
 			}),
@@ -150,30 +152,27 @@ var _ = Describe("Delegating Zap Core", func() {
 		Expect(delegate.syncCalls).To(Equal(1))
 	})
 
-	It("SetDelegate keeps the buffered messages in order for the owner of the buffer to spool", func() {
+	It("buffered messages survive SetDelegate and can be spooled in order", func() {
 		logMessageBuffer := NewMruWithDefaultSizeLimit[*ZapEntryWithFields]()
 		delegatingCore := NewDelegatingZapCore(logMessageBuffer)
-		entry1 := zapcore.Entry{Level: zapcore.InfoLevel}
-		entry2 := zapcore.Entry{Level: zapcore.InfoLevel}
-		entry3 := zapcore.Entry{Level: zapcore.InfoLevel}
+		entry1 := zapcore.Entry{Level: zapcore.InfoLevel, Message: "1"}
+		entry2 := zapcore.Entry{Level: zapcore.InfoLevel, Message: "2"}
+		entry3 := zapcore.Entry{Level: zapcore.InfoLevel, Message: "3"}
 		field := zapcore.Field{Key: "key", String: "value"}
 		fields := []zapcore.Field{field}
 		Expect(delegatingCore.Write(entry1, fields)).To(Succeed())
 		Expect(delegatingCore.Write(entry2, fields)).To(Succeed())
 		Expect(delegatingCore.Write(entry3, fields)).To(Succeed())
-		Expect(delegatingCore.logMessageBuffer.Len()).To(Equal(3))
+		Expect(logMessageBuffer.Len()).To(Equal(3))
 		delegate := &mockDelegate{}
-		Expect(delegate.writtenEntries).To(BeEmpty())
 
 		delegatingCore.SetDelegate(delegate)
 
-		// SetDelegate only switches the core over to the delegate, the buffered messages are spooled by the owner of the
-		// buffer, see selfmonitoringapiaccess.startOTelSDK.
 		Expect(delegate.writtenEntries).To(BeEmpty())
 		Expect(logMessageBuffer.Len()).To(Equal(3))
 
-		logMessageBuffer.ForAllAndClear(func(bufferedEntry *ZapEntryWithFields) {
-			Expect(delegate.Write(bufferedEntry.Entry, bufferedEntry.Fields)).To(Succeed())
+		logMessageBuffer.ForAllAndClear(func(entry *ZapEntryWithFields) {
+			Expect(delegate.Write(entry.Entry, entry.Fields)).To(Succeed())
 		})
 
 		Expect(delegate.writtenEntries).To(HaveLen(3))
@@ -195,30 +194,30 @@ var _ = Describe("Delegating Zap Core", func() {
 				Fields: fields,
 			}),
 		)
-		Expect(delegatingCore.logMessageBuffer.IsEmpty()).To(BeTrue())
+		Expect(logMessageBuffer.IsEmpty()).To(BeTrue())
 	})
 
-	It("With without a delegate returns a clone", func() {
+	It("With without a delegate returns a derived core that accumulates fields", func() {
 		logMessageBuffer := NewMru[*ZapEntryWithFields](13)
 		originalDelegatingCore := NewDelegatingZapCore(logMessageBuffer)
 		originalDelegatingCore.SetBufferingLevel(zapcore.DebugLevel)
-		entry1 := zapcore.Entry{Level: zapcore.InfoLevel}
-		entry2 := zapcore.Entry{Level: zapcore.InfoLevel}
-		entry3 := zapcore.Entry{Level: zapcore.InfoLevel}
+		entry1 := zapcore.Entry{Level: zapcore.InfoLevel, Message: "1"}
+		entry2 := zapcore.Entry{Level: zapcore.InfoLevel, Message: "2"}
+		entry3 := zapcore.Entry{Level: zapcore.InfoLevel, Message: "3"}
 		writeFields := []zapcore.Field{{Key: "key", String: "value"}}
 		// write some log records to the original core
 		Expect(originalDelegatingCore.Write(entry1, writeFields)).To(Succeed())
 		Expect(originalDelegatingCore.Write(entry2, writeFields)).To(Succeed())
 		Expect(logMessageBuffer.Len()).To(Equal(2))
 
-		// create a clone via With
+		// create a derived core via With
 		withFields1 := []zapcore.Field{
 			{Key: "with1", String: "value1"},
 			{Key: "with2", String: "value2"},
 		}
 		dc2Raw := originalDelegatingCore.With(withFields1)
 
-		// verify With actually returned a clone, but with the same properties
+		// verify With actually returned a new core, but with the same properties
 		dc2, ok := dc2Raw.(*DelegatingZapCore)
 		Expect(ok).To(BeTrue())
 		Expect(dc2 == originalDelegatingCore).To(BeFalse())
@@ -229,15 +228,20 @@ var _ = Describe("Delegating Zap Core", func() {
 		Expect(dc2.fields[1].Key).To(Equal("with2"))
 		Expect(dc2.fields[1].String).To(Equal("value2"))
 
-		// write some log records to the first clone
+		// write some log records to the derived core
 		Expect(dc2.Write(entry1, writeFields)).To(Succeed())
 		Expect(dc2.Write(entry2, writeFields)).To(Succeed())
 		Expect(dc2.Write(entry3, writeFields)).To(Succeed())
-		// verify both write to the same buffer
+		// the derived core shares the buffer with the original core
 		Expect(dc2.logMessageBuffer == originalDelegatingCore.logMessageBuffer).To(BeTrue())
 		Expect(logMessageBuffer.Len()).To(Equal(5))
+		// the derived core's own fields are prepended to the fields of the log record
+		Expect(logMessageBuffer.elements[4].Fields).To(HaveLen(3))
+		Expect(logMessageBuffer.elements[4].Fields[0].Key).To(Equal("with1"))
+		Expect(logMessageBuffer.elements[4].Fields[1].Key).To(Equal("with2"))
+		Expect(logMessageBuffer.elements[4].Fields[2].Key).To(Equal("key"))
 
-		// create a clone of the clone
+		// derive once more, from the derived core
 		withFields2 := []zapcore.Field{
 			{Key: "with3", String: "value3"},
 			{Key: "with4", String: "value4"},
@@ -265,96 +269,129 @@ var _ = Describe("Delegating Zap Core", func() {
 		Expect(dc3.fields[4].String).To(Equal("value5"))
 	})
 
-	It("With delegates the call to the delegate when there is one", func() {
+	It("With applies the accumulated fields to the delegate lazily, then memoizes the result", func() {
 		logMessageBuffer := NewMru[*ZapEntryWithFields](13)
 		delegatingCore := NewDelegatingZapCore(logMessageBuffer)
 		delegatingCore.SetBufferingLevel(zapcore.DebugLevel)
 		delegate := &mockDelegate{}
 		delegatingCore.SetDelegate(delegate)
-		expectedDelegateOfClone := &mockDelegate{}
-		delegate.setWithReturnValue(expectedDelegateOfClone)
+		expectedDelegateOfDerivedCore := &mockDelegate{}
+		delegate.setWithReturnValue(expectedDelegateOfDerivedCore)
 
-		// create a clone via With
 		withFields1 := []zapcore.Field{
 			{Key: "with1", String: "value1"},
 			{Key: "with2", String: "value2"},
 		}
 		dc2Raw := delegatingCore.With(withFields1)
-
-		// verify With actually returned a clone, but with the same properties
 		dc2, ok := dc2Raw.(*DelegatingZapCore)
 		Expect(ok).To(BeTrue())
-		delegateOfCloneRaw := dc2.delegate.Load()
-		Expect(delegateOfCloneRaw).ToNot(BeNil())
-		delegateOfClone, ok := (*delegateOfCloneRaw).(*mockDelegate)
-		Expect(ok).To(BeTrue())
-		Expect(delegateOfClone == expectedDelegateOfClone).To(BeTrue())
 
+		// With does not touch the delegate, the fields are applied on first use
+		Expect(delegate.withFields).To(BeEmpty())
+
+		Expect(dc2.delegate() == expectedDelegateOfDerivedCore).To(BeTrue())
 		Expect(delegate.withFields).To(HaveLen(2))
 		Expect(delegate.withFields[0].Key).To(Equal("with1"))
 		Expect(delegate.withFields[0].String).To(Equal("value1"))
 		Expect(delegate.withFields[1].Key).To(Equal("with2"))
 		Expect(delegate.withFields[1].String).To(Equal("value2"))
+
+		// the derived delegate is memoized, a second use does not derive it again
+		delegate.withFields = nil
+		Expect(dc2.delegate() == expectedDelegateOfDerivedCore).To(BeTrue())
+		Expect(delegate.withFields).To(BeEmpty())
+
+		// the root core has no fields, so it uses the delegate as is
+		Expect(delegatingCore.delegate() == delegate).To(BeTrue())
+		Expect(delegate.withFields).To(BeEmpty())
 	})
 
-	It("With keeps track of all clones, SetDelegate and UnsetDelegate are propagated to clones", func() {
+	It("SetDelegate and UnsetDelegate apply to cores derived via With, before and after the call", func() {
 		logMessageBuffer := NewMru[*ZapEntryWithFields](13)
 		originalDelegatingCore := NewDelegatingZapCore(logMessageBuffer)
 		originalDelegatingCore.SetBufferingLevel(zapcore.DebugLevel)
 
-		// create two clones of originalDelegatingCore via With
-		withFields1 := []zapcore.Field{
+		// derive two cores from originalDelegatingCore via With, before there is a delegate
+		dc2, ok := originalDelegatingCore.With([]zapcore.Field{
 			{Key: "with1", String: "value1"},
+		}).(*DelegatingZapCore)
+		Expect(ok).To(BeTrue())
+		dc3, ok := dc2.With([]zapcore.Field{
 			{Key: "with2", String: "value2"},
-		}
-		dc2Raw := originalDelegatingCore.With(withFields1)
-		dc2, ok := dc2Raw.(*DelegatingZapCore)
-		Expect(ok).To(BeTrue())
-		withFields2 := []zapcore.Field{
-			{Key: "with3", String: "value4"},
-			{Key: "with4", String: "value4"},
-		}
-		dc3Raw := originalDelegatingCore.With(withFields2)
-		dc3, ok := dc3Raw.(*DelegatingZapCore)
+		}).(*DelegatingZapCore)
 		Expect(ok).To(BeTrue())
 
-		// verify we are keeping track of clones
-		Expect(originalDelegatingCore.clones).To(HaveLen(2))
-		Expect(originalDelegatingCore.clones[0] == dc2).To(BeTrue())
-		Expect(originalDelegatingCore.clones[1] == dc3).To(BeTrue())
+		Expect(originalDelegatingCore.delegate()).To(BeNil())
+		Expect(dc2.delegate()).To(BeNil())
+		Expect(dc3.delegate()).To(BeNil())
 
-		// set a delegate on the original, this delegate is supposed to be propagated to all clones
 		delegate := &mockDelegate{}
+		delegateOfDerivedCores := &mockDelegate{}
+		delegate.setWithReturnValue(delegateOfDerivedCores)
+
 		originalDelegatingCore.SetDelegate(delegate)
 
-		// verify the SetDelegate call has been propagated to all clones
-		delegateOfOriginalRaw := originalDelegatingCore.delegate.Load()
-		Expect(delegateOfOriginalRaw).ToNot(BeNil())
-		delegateOfOriginal, ok := (*delegateOfOriginalRaw).(*mockDelegate)
+		// the cores derived before the SetDelegate call pick up the new delegate
+		Expect(originalDelegatingCore.delegate() == delegate).To(BeTrue())
+		Expect(dc2.delegate() == delegateOfDerivedCores).To(BeTrue())
+		Expect(dc3.delegate() == delegateOfDerivedCores).To(BeTrue())
+
+		// a core derived after the SetDelegate call picks it up as well
+		dc4, ok := originalDelegatingCore.With([]zapcore.Field{
+			{Key: "with3", String: "value3"},
+		}).(*DelegatingZapCore)
 		Expect(ok).To(BeTrue())
+		Expect(dc4.delegate() == delegateOfDerivedCores).To(BeTrue())
 
-		delegateOfFirstCloneRaw := dc2.delegate.Load()
-		Expect(delegateOfFirstCloneRaw).ToNot(BeNil())
-		delegateOfFirstClone, ok := (*delegateOfFirstCloneRaw).(*mockDelegate)
-		Expect(ok).To(BeTrue())
-
-		delegateOfSecondCloneRaw := dc2.delegate.Load()
-		Expect(delegateOfSecondCloneRaw).ToNot(BeNil())
-		delegateOfSecondClone, ok := (*delegateOfSecondCloneRaw).(*mockDelegate)
-		Expect(ok).To(BeTrue())
-
-		Expect(delegateOfFirstClone == delegateOfOriginal).To(BeTrue())
-		Expect(delegateOfSecondClone == delegateOfOriginal).To(BeTrue())
-
-		// unset the delegate on the original, this is supposed to be propagated to all clones as well
 		originalDelegatingCore.UnsetDelegate()
 
-		// verify the UnsetDelegate call has been propagated to all clones
-		Expect(originalDelegatingCore.delegate.Load()).To(BeNil())
-		Expect(dc2.delegate.Load()).To(BeNil())
-		Expect(dc3.delegate.Load()).To(BeNil())
+		// the UnsetDelegate call applies to all derived cores, including their memoized delegates
+		Expect(originalDelegatingCore.delegate()).To(BeNil())
+		Expect(dc2.delegate()).To(BeNil())
+		Expect(dc3.delegate()).To(BeNil())
+		Expect(dc4.delegate()).To(BeNil())
+	})
+
+	It("does not retain cores derived via With", func() {
+		// Regression test for OPE-535: the root core used to keep a reference to every core derived from it via With,
+		// which retained one core plus its delegate per admission request and per reconcile for the lifetime of the
+		// process.
+		logMessageBuffer := NewMruWithDefaultSizeLimit[*ZapEntryWithFields]()
+		originalDelegatingCore := NewDelegatingZapCore(logMessageBuffer)
+		delegate := &mockDelegate{}
+		delegate.setWithReturnValue(&mockDelegate{})
+		originalDelegatingCore.SetDelegate(delegate)
+
+		collected := make(chan struct{}, 1)
+		deriveAndDrop(originalDelegatingCore, collected)
+
+		Eventually(func() bool {
+			runtime.GC()
+			select {
+			case <-collected:
+				return true
+			default:
+				return false
+			}
+		}, "5s", "10ms").Should(BeTrue(), "the core derived via With was not garbage collected")
+
+		// The root core lives for the lifetime of the process in production, so it has to stay reachable here as well.
+		// Without this, the whole tree would be collected and the assertion above would pass even if the root core
+		// retained every derived core.
+		runtime.KeepAlive(originalDelegatingCore)
 	})
 })
+
+// deriveAndDrop derives a core from the given core, uses it so that it memoizes its delegate, and registers a cleanup
+// that signals on the given channel once the derived core is garbage collected. The derived core is unreachable when
+// this function returns.
+func deriveAndDrop(dc *DelegatingZapCore, collected chan struct{}) {
+	derived, ok := dc.With([]zapcore.Field{{Key: "key", String: "value"}}).(*DelegatingZapCore)
+	Expect(ok).To(BeTrue())
+	// use the derived core, so that it memoizes its delegate
+	Expect(derived.delegate()).ToNot(BeNil())
+	runtime.AddCleanup(derived, func(ch chan struct{}) { ch <- struct{}{} }, collected)
+}
 
 type oddEvenEnabler struct {
 	calledWith []zapcore.Level

--- a/internal/util/zap/delegating_zap_core_test.go
+++ b/internal/util/zap/delegating_zap_core_test.go
@@ -5,6 +5,8 @@ package zap
 
 import (
 	"runtime"
+	"strconv"
+	"sync"
 
 	"go.uber.org/zap/zapcore"
 
@@ -254,7 +256,7 @@ var _ = Describe("Delegating Zap Core", func() {
 		Expect(dc3 == originalDelegatingCore).To(BeFalse())
 		Expect(dc3 == dc2).To(BeFalse())
 		Expect(dc3.level).To(Equal(zapcore.DebugLevel))
-		// the clones share the log message buffer of the original core, buffered messages are not copied
+		// derived cores share the log message buffer of the original core, buffered messages are not copied
 		Expect(dc3.logMessageBuffer == originalDelegatingCore.logMessageBuffer).To(BeTrue())
 		Expect(dc3.fields).To(HaveLen(5))
 		Expect(dc3.fields[0].Key).To(Equal("with1"))
@@ -380,6 +382,62 @@ var _ = Describe("Delegating Zap Core", func() {
 		// retained every derived core.
 		runtime.KeepAlive(originalDelegatingCore)
 	})
+
+	It("resolves the current delegate while SetDelegate and UnsetDelegate run concurrently", func() {
+		// The memoization in delegate() is lock-free and relies on SetDelegate/UnsetDelegate storing the delegate
+		// before incrementing the generation. Run this with -race to exercise that ordering.
+		logMessageBuffer := NewMruWithDefaultSizeLimit[*ZapEntryWithFields]()
+		rootCore := NewDelegatingZapCore(logMessageBuffer)
+		rootCore.SetBufferingLevel(zapcore.DebugLevel)
+
+		derivedOfA := &concurrencySafeDelegate{}
+		delegateA := &concurrencySafeDelegate{withReturnValue: derivedOfA}
+		derivedOfB := &concurrencySafeDelegate{}
+		delegateB := &concurrencySafeDelegate{withReturnValue: derivedOfB}
+
+		derivedCores := make([]*DelegatingZapCore, 8)
+		for i := range derivedCores {
+			derived, ok := rootCore.With([]zapcore.Field{{Key: "key", String: strconv.Itoa(i)}}).(*DelegatingZapCore)
+			Expect(ok).To(BeTrue())
+			derivedCores[i] = derived
+		}
+
+		stop := make(chan struct{})
+		var readers sync.WaitGroup
+		for _, core := range derivedCores {
+			readers.Add(1)
+			go func(dc *DelegatingZapCore) {
+				defer readers.Done()
+				defer GinkgoRecover()
+				entry := zapcore.Entry{Level: zapcore.InfoLevel, Message: "concurrent"}
+				for {
+					select {
+					case <-stop:
+						return
+					default:
+					}
+					dc.Enabled(zapcore.InfoLevel)
+					dc.Check(entry, &zapcore.CheckedEntry{})
+					Expect(dc.Write(entry, nil)).To(Succeed())
+					Expect(dc.Sync()).To(Succeed())
+				}
+			}(core)
+		}
+
+		for range 1000 {
+			rootCore.SetDelegate(delegateB)
+			rootCore.UnsetDelegate()
+			rootCore.SetDelegate(delegateA)
+		}
+		close(stop)
+		readers.Wait()
+
+		// No core is left pinned to a delegate of an earlier generation, they all pick up the final delegate.
+		Expect(rootCore.delegate() == zapcore.Core(delegateA)).To(BeTrue())
+		for _, dc := range derivedCores {
+			Expect(dc.delegate() == zapcore.Core(derivedOfA)).To(BeTrue())
+		}
+	})
 })
 
 // deriveAndDrop derives a core from the given core, uses it so that it memoizes its delegate, and registers a cleanup
@@ -438,5 +496,31 @@ func (dd *mockDelegate) Write(entry zapcore.Entry, fields []zapcore.Field) error
 // Sync instructs the delegate to flush buffered logs, if there is a delegate. Otherwise, the call is ignored.
 func (dd *mockDelegate) Sync() error {
 	dd.syncCalls++
+	return nil
+}
+
+// concurrencySafeDelegate is a delegate for tests that use it from multiple goroutines. In contrast to mockDelegate it
+// records nothing, so the race detector only reports races in the code under test.
+type concurrencySafeDelegate struct {
+	withReturnValue zapcore.Core
+}
+
+func (dd *concurrencySafeDelegate) With(_ []zapcore.Field) zapcore.Core {
+	return dd.withReturnValue
+}
+
+func (dd *concurrencySafeDelegate) Enabled(_ zapcore.Level) bool {
+	return true
+}
+
+func (dd *concurrencySafeDelegate) Check(_ zapcore.Entry, ce *zapcore.CheckedEntry) *zapcore.CheckedEntry {
+	return ce
+}
+
+func (dd *concurrencySafeDelegate) Write(_ zapcore.Entry, _ []zapcore.Field) error {
+	return nil
+}
+
+func (dd *concurrencySafeDelegate) Sync() error {
 	return nil
 }

--- a/internal/webhooks/instrumentation_webhook.go
+++ b/internal/webhooks/instrumentation_webhook.go
@@ -129,8 +129,9 @@ func (h *InstrumentationWebhookHandler) UpdateExtraConfig(_ context.Context, ext
 	h.ClusterInstrumentationConfig.ExtraConfig.Store(&extraConfig)
 }
 
-func (h *InstrumentationWebhookHandler) Handle(ctx context.Context, request admission.Request) admission.Response {
-	logger := logd.NewLogger(
+// newRequestLogger derives a logger with the attributes of one admission request.
+func newRequestLogger(request admission.Request) logd.Logger {
+	return logd.NewLogger(
 		instrumentationWebhookLog.WithValues(
 			"operation",
 			request.Operation,
@@ -142,7 +143,9 @@ func (h *InstrumentationWebhookHandler) Handle(ctx context.Context, request admi
 			request.Name,
 		),
 	)
+}
 
+func (h *InstrumentationWebhookHandler) Handle(ctx context.Context, request admission.Request) admission.Response {
 	targetNamespace := request.Namespace
 
 	dash0List := &dash0v1beta1.Dash0MonitoringList{}
@@ -164,7 +167,7 @@ func (h *InstrumentationWebhookHandler) Handle(ctx context.Context, request admi
 					targetNamespace,
 					err,
 				),
-				logger,
+				newRequestLogger(request),
 			)
 		}
 	}
@@ -179,6 +182,7 @@ func (h *InstrumentationWebhookHandler) Handle(ctx context.Context, request admi
 	}
 
 	dash0MonitoringResource := dash0List.Items[0]
+	logger := newRequestLogger(request)
 	logger.Debug(
 		"found Dash0 monitoring resource in namespace",
 		"namespace",

--- a/internal/workloads/workload_modifier.go
+++ b/internal/workloads/workload_modifier.go
@@ -620,9 +620,8 @@ func (m *ResourceModifier) instrumentContainer(
 	workloadMeta *metav1.ObjectMeta,
 	podMeta *metav1.ObjectMeta,
 ) []string {
-	perContainerLogger := m.logger.WithValues("container", container.Name)
 	m.addMount(container)
-	return m.addEnvironmentVariables(container, workloadMeta, podMeta, perContainerLogger)
+	return m.addEnvironmentVariables(container, workloadMeta, podMeta)
 }
 
 func (m *ResourceModifier) addMount(container *corev1.Container) {
@@ -653,7 +652,6 @@ func (m *ResourceModifier) addEnvironmentVariables(
 	container *corev1.Container,
 	workloadMeta *metav1.ObjectMeta,
 	podMeta *metav1.ObjectMeta,
-	perContainerLogger logd.Logger,
 ) []string {
 	var instrumentationIssues []string
 	if container.Env == nil {
@@ -689,12 +687,11 @@ func (m *ResourceModifier) addEnvironmentVariables(
 		container,
 		collectorBaseUrl,
 		instrumentationIssues,
-		perContainerLogger,
 	)
 
 	m.addOtelLogsExporterEnvVar(container)
 
-	instrumentationIssues = m.addOrAppendToLdPreloadEnvVar(container, instrumentationIssues, perContainerLogger)
+	instrumentationIssues = m.addOrAppendToLdPreloadEnvVar(container, instrumentationIssues)
 	addOrReplaceEnvironmentVariable(
 		container,
 		corev1.EnvVar{
@@ -988,7 +985,6 @@ func (m *ResourceModifier) addOrUpdateOtelExporterOtlpEnvVars(
 	container *corev1.Container,
 	otelExporterOtlpEndpointValue string,
 	instrumentationIssues []string,
-	perContainerLogger logd.Logger,
 ) []string {
 	if otelExportEnvVarsCanBeUpdatedForContainer(container, m.clusterInstrumentationConfig) {
 		// It is safe to set/update the OTEL_EXPORTER_OTLP_* env vars, and at least one of them needs to be changed.
@@ -1023,7 +1019,7 @@ func (m *ResourceModifier) addOrUpdateOtelExporterOtlpEnvVars(
 	//   an OTel SDK is set up manually in the workload's code.
 	// * It will also break for OTel SDKs that only support the GRPC exporter, but not HTTP (Python & nginx for
 	//   example).
-	perContainerLogger.WarnTelemetryCollectionIssue(otelExporterOtlpNoOverwriteMsg)
+	m.perContainerLogger(container).WarnTelemetryCollectionIssue(otelExporterOtlpNoOverwriteMsg)
 	instrumentationIssues = append(instrumentationIssues, otelExporterOtlpNoOverwriteMsg)
 	return instrumentationIssues
 }
@@ -1111,7 +1107,6 @@ func otelExporterOtlpEnvVarsAlreadyHaveDesiredValues(
 func (m *ResourceModifier) addOrAppendToLdPreloadEnvVar(
 	container *corev1.Container,
 	instrumentationIssues []string,
-	perContainerLogger logd.Logger,
 ) []string {
 	idx := findEnvVarIdx(container, envVarLdPreloadName)
 	if idx < 0 {
@@ -1127,7 +1122,7 @@ func (m *ResourceModifier) addOrAppendToLdPreloadEnvVar(
 				"Dash0 cannot prepend anything to the environment variable %s as it is specified via "+
 					"ValueFrom, this container will not be instrumented to send telemetry to Dash0.",
 				envVarLdPreloadName)
-			perContainerLogger.WarnTelemetryCollectionIssue(msg)
+			m.perContainerLogger(container).WarnTelemetryCollectionIssue(msg)
 			instrumentationIssues = append(instrumentationIssues, msg)
 			return instrumentationIssues
 		}
@@ -1974,4 +1969,11 @@ func (m *ResourceModifier) hasMatchingOwnerReference(workload client.Object, pos
 		}
 	}
 	return false
+}
+
+// perContainerLogger derives a logger for one container. It is only called when a telemetry collection issue actually
+// needs to be reported, which is rare: deriving it eagerly for every container of every admission request allocates a
+// zap core and a field slice that the happy path never uses.
+func (m *ResourceModifier) perContainerLogger(container *corev1.Container) logd.Logger {
+	return m.logger.WithValues("container", container.Name)
 }

--- a/internal/workloads/workload_modifier_test.go
+++ b/internal/workloads/workload_modifier_test.go
@@ -1212,7 +1212,6 @@ var _ = Describe("Dash0 Workload Modification", func() {
 					container,
 					&metav1.ObjectMeta{},
 					&metav1.ObjectMeta{},
-					logger,
 				)
 
 				VerifyEnvVar(testConfig.ldPreloadExpectation, container.Env, envVarLdPreloadName, "")
@@ -1755,19 +1754,18 @@ var _ = Describe("Dash0 Workload Modification", func() {
 				}, clusterInstrumentationConfig)
 				Expect(preInstrumentationCheckResult).To(Equal(testConfig.expectedPreInstrumentationCheckResult))
 
+				capturingLogger, capturingLogSink := NewCapturingLogger()
 				modifier := NewResourceModifier(
 					clusterInstrumentationConfig,
 					DefaultNamespaceInstrumentationConfig,
 					testActor,
-					logger,
+					capturingLogger,
 				)
 
-				capturingLogger, capturingLogSink := NewCapturingLogger()
 				instrumentationIssues := modifier.addEnvironmentVariables(
 					container,
 					&metav1.ObjectMeta{},
 					&metav1.ObjectMeta{},
-					capturingLogger,
 				)
 
 				envVars := container.Env
@@ -2254,7 +2252,6 @@ var _ = Describe("Dash0 Workload Modification", func() {
 					container,
 					&workloadMeta,
 					&podMeta,
-					logger,
 				)
 
 				envVars := container.Env
@@ -2651,7 +2648,6 @@ var _ = Describe("Dash0 Workload Modification", func() {
 				container1,
 				&workloadMeta1,
 				&podMeta1,
-				logger,
 			)
 
 			// now re-order the annotations and generate the DASH0_RESOURCE_ATTRIBUTES value again
@@ -2674,7 +2670,6 @@ var _ = Describe("Dash0 Workload Modification", func() {
 				container2,
 				&workloadMeta2,
 				&podMeta2,
-				logger,
 			)
 
 			// Verify that the value of DASH0_RESOURCE_ATTRIBUTES is independent of the order in which annotations
@@ -2715,7 +2710,6 @@ var _ = Describe("Dash0 Workload Modification", func() {
 					container,
 					&metav1.ObjectMeta{},
 					&metav1.ObjectMeta{},
-					logger,
 				)
 
 				envVars := container.Env
@@ -2990,7 +2984,6 @@ var _ = Describe("Dash0 Workload Modification", func() {
 					container,
 					&metav1.ObjectMeta{},
 					&metav1.ObjectMeta{},
-					logger,
 				)
 
 				VerifyEnvVarsFromMap(testConfig.expectedEnvVars, container.Env)
@@ -3375,7 +3368,6 @@ var _ = Describe("Dash0 Workload Modification", func() {
 					container,
 					&metav1.ObjectMeta{},
 					&metav1.ObjectMeta{},
-					logger,
 				)
 
 				envVars := container.Env


### PR DESCRIPTION
DelegatingZapCore appended each core derived via `With` to a slice named `dc.clones` on the parent, so that SetDelegate and UnsetDelegate could reach cores derived before the call. The root core lives for the lifetime of the process, and every logger ever derived stayed reachable from it via `clones`, together with its concatenated field slice and its otelzap.Core clone holding the converted OTel attributes.

The heap grew with every webhook request, and never shrank. Once the live heap reaches GOMEMLIMIT, GC runs back to back and eats the container's CPU budget.

This inverts the reference direction: the delegate now lives in a sharedDelegate (singleton) that the root core and all derived cores point to. A derived core resolves its own delegate lazily on first use and memoizes it. Nothing points from a parent to a derived core any more, so a derived core is eligible for garbage collection as soon as the logger holding it goes out of scope.