### PR TITLE
chore: make reservoir buffer_duration configurable

### DIFF
--- a/api/operator/v1alpha1/dash0signalcontrol_types.go
+++ b/api/operator/v1alpha1/dash0signalcontrol_types.go
@@ -241,6 +241,13 @@ type ReservoirConfig struct {
 	// +kubebuilder:default=serialized_memory
 	Type *ReservoirType `json:"type,omitempty"`
 
+	// The maximum age of buffered spans before the reservoir evicts them, i.e. how long a span is retained
+	// while it awaits a sampling decision. Applies to all reservoir types. Go duration syntax (e.g. "60s",
+	// "90s"). This setting is optional; the processor default (60s) applies when unset.
+	//
+	// +kubebuilder:validation:Optional
+	BufferDuration *metav1.Duration `json:"bufferDuration,omitempty"`
+
 	// The maximum total disk usage of the trace reservoir across all shards. Only used when type is "disk".
 	// When the reservoir exceeds this limit, the oldest buffered spans are evicted regardless of age. The
 	// operator also derives the reservoir volume's storage size limit and the collector container's

--- a/api/operator/v1alpha1/zz_generated.deepcopy.go
+++ b/api/operator/v1alpha1/zz_generated.deepcopy.go
@@ -2129,6 +2129,11 @@ func (in *ReservoirConfig) DeepCopyInto(out *ReservoirConfig) {
 		*out = new(ReservoirType)
 		**out = **in
 	}
+	if in.BufferDuration != nil {
+		in, out := &in.BufferDuration, &out.BufferDuration
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	if in.MaxDiskBytes != nil {
 		in, out := &in.MaxDiskBytes, &out.MaxDiskBytes
 		x := (*in).DeepCopy()

--- a/config/crd/bases/operator.dash0.com_dash0signalcontrols.yaml
+++ b/config/crd/bases/operator.dash0.com_dash0signalcontrols.yaml
@@ -275,6 +275,12 @@ spec:
                       Configuration for the trace reservoir, the buffer that holds spans awaiting a sampling decision.
                       This setting is optional.
                     properties:
+                      bufferDuration:
+                        description: |-
+                          The maximum age of buffered spans before the reservoir evicts them, i.e. how long a span is retained
+                          while it awaits a sampling decision. Applies to all reservoir types. Go duration syntax (e.g. "60s",
+                          "90s"). This setting is optional; the processor default (60s) applies when unset.
+                        type: string
                       maxDiskBytes:
                         anyOf:
                         - type: integer

--- a/helm-chart/dash0-operator/templates/operator/custom-resource-definition-signal-control.yaml
+++ b/helm-chart/dash0-operator/templates/operator/custom-resource-definition-signal-control.yaml
@@ -281,6 +281,12 @@ spec:
                       Configuration for the trace reservoir, the buffer that holds spans awaiting a sampling decision.
                       This setting is optional.
                     properties:
+                      bufferDuration:
+                        description: |-
+                          The maximum age of buffered spans before the reservoir evicts them, i.e. how long a span is retained
+                          while it awaits a sampling decision. Applies to all reservoir types. Go duration syntax (e.g. "60s",
+                          "90s"). This setting is optional; the processor default (60s) applies when unset.
+                        type: string
                       maxDiskBytes:
                         anyOf:
                         - type: integer

--- a/internal/collectors/otelcolresources/collector_config_maps_test.go
+++ b/internal/collectors/otelcolresources/collector_config_maps_test.go
@@ -3705,6 +3705,7 @@ var _ = Describe("The OpenTelemetry Collector ConfigMaps", func() {
 			Expect(reservoir).ToNot(HaveKey("data_dir"))
 			Expect(reservoir).ToNot(HaveKey("max_disk_bytes"))
 			Expect(reservoir).ToNot(HaveKey("max_memory_bytes"))
+			Expect(reservoir).ToNot(HaveKey("buffer_duration"))
 		})
 
 		It("should render the serialized_memory trace reservoir max_memory_bytes when set [SignalControl]", func() {
@@ -3734,6 +3735,32 @@ var _ = Describe("The OpenTelemetry Collector ConfigMaps", func() {
 			Expect(reservoir["max_memory_bytes"]).To(BeNumerically("==", int64(512*1024*1024)))
 			Expect(reservoir).ToNot(HaveKey("data_dir"))
 			Expect(reservoir).ToNot(HaveKey("max_disk_bytes"))
+		})
+
+		It("should render the trace reservoir buffer_duration when set [SignalControl]", func() {
+			configMap, err := assembleSignalControlCollectorConfigMap(&oTelColConfig{
+				OperatorNamespace: OperatorNamespace,
+				NamePrefix:        namePrefix,
+				Exporters:         cmTestSingleDefaultOtlpExporter(),
+				SignalControl: SignalControlConfig{
+					Enabled:                         true,
+					SamplingEnabled:                 true,
+					SamplingReservoirType:           "serialized_memory",
+					SamplingReservoirMetricLevel:    "basic",
+					SamplingReservoirBufferDuration: "1m30s",
+					Endpoint:                        "decision-maker.example.com:443",
+					ApiEndpoint:                     "https://control-plane-api.dash0.com",
+					Dataset:                         "default",
+				},
+				KubernetesInfrastructureMetricsCollectionEnabled: true,
+			}, monitoredNamespaces, false)
+
+			Expect(err).ToNot(HaveOccurred())
+			collectorConfig := parseConfigMapContent(configMap)
+			processors := collectorConfig["processors"].(map[string]interface{})
+			sampling := processors["dash0sampling"].(map[string]interface{})
+			reservoir := sampling["reservoir"].(map[string]interface{})
+			Expect(reservoir["buffer_duration"]).To(Equal("1m30s"))
 		})
 
 		It("should render sampling enable_batching when set [SignalControl]", func() {

--- a/internal/collectors/otelcolresources/desired_state.go
+++ b/internal/collectors/otelcolresources/desired_state.go
@@ -39,6 +39,7 @@ type SignalControlConfig struct {
 	SamplingReservoirMaxDiskBytes      int64
 	SamplingReservoirMaxMemoryBytes    int64
 	SamplingReservoirMetricLevel       string
+	SamplingReservoirBufferDuration    string
 	SignalToMetricsEnabled             bool
 	SignalToMetricsMaxTimeSeries       *int32
 	SignalToMetricsFlushInterval       string

--- a/internal/collectors/otelcolresources/otelcol_resources.go
+++ b/internal/collectors/otelcolresources/otelcol_resources.go
@@ -706,6 +706,7 @@ func signalControlConfigFromResource(
 	// applies for the memory/serialized_memory reservoir types.
 	var samplingReservoirMaxMemoryBytes int64
 	samplingReservoirMetricLevel := string(dash0v1alpha1.ReservoirMetricLevelBasic)
+	var samplingReservoirBufferDuration string
 	if r := resource.Spec.Sampling.Reservoir; r != nil {
 		if r.Type != nil && *r.Type != "" {
 			samplingReservoirType = string(*r.Type)
@@ -724,6 +725,9 @@ func signalControlConfigFromResource(
 		}
 		if r.MaxMemoryBytes != nil {
 			samplingReservoirMaxMemoryBytes = r.MaxMemoryBytes.Value()
+		}
+		if d := r.BufferDuration; d != nil && d.Duration > 0 {
+			samplingReservoirBufferDuration = d.Duration.String()
 		}
 		if r.MetricLevel != nil && *r.MetricLevel != "" {
 			samplingReservoirMetricLevel = string(*r.MetricLevel)
@@ -804,6 +808,7 @@ func signalControlConfigFromResource(
 		SamplingReservoirMaxDiskBytes:      samplingReservoirMaxDiskBytes,
 		SamplingReservoirMaxMemoryBytes:    samplingReservoirMaxMemoryBytes,
 		SamplingReservoirMetricLevel:       samplingReservoirMetricLevel,
+		SamplingReservoirBufferDuration:    samplingReservoirBufferDuration,
 		SignalToMetricsEnabled:             signalToMetricsEnabled,
 		SignalToMetricsMaxTimeSeries:       resource.Spec.SignalToMetrics.MaxTimeSeries,
 		SignalToMetricsFlushInterval:       signalToMetricsFlushInterval,

--- a/internal/collectors/otelcolresources/otelcol_resources_test.go
+++ b/internal/collectors/otelcolresources/otelcol_resources_test.go
@@ -889,6 +889,7 @@ var _ = Describe("signalControlConfigFromResource", func() {
 		Expect(config.SamplingReservoirMaxDiskBytes).To(Equal(int64(1024 * 1024 * 1024)))
 		Expect(config.SamplingReservoirMaxMemoryBytes).To(Equal(int64(0)))
 		Expect(config.SamplingReservoirMetricLevel).To(Equal("basic"))
+		Expect(config.SamplingReservoirBufferDuration).To(Equal(""))
 	})
 
 	It("should use the configured reservoir type and max memory bytes", func() {
@@ -909,6 +910,23 @@ var _ = Describe("signalControlConfigFromResource", func() {
 		config := signalControlConfigFromResource(edge, operatorConfig, operatorNamespace, namePrefix, logger)
 		Expect(config.SamplingReservoirType).To(Equal("serialized_memory"))
 		Expect(config.SamplingReservoirMaxMemoryBytes).To(Equal(int64(512 * 1024 * 1024)))
+	})
+
+	It("should use the configured reservoir buffer duration", func() {
+		bufferDuration := metav1.Duration{Duration: 90 * time.Second}
+		edge := &dash0v1alpha1.Dash0SignalControl{
+			Spec: dash0v1alpha1.Dash0SignalControlSpec{
+				Enabled:   boolPtr(true),
+				EdgeProxy: dash0v1alpha1.EdgeProxyConfig{Enabled: boolPtr(false)},
+				Sampling: dash0v1alpha1.SamplingConfig{
+					Reservoir: &dash0v1alpha1.ReservoirConfig{
+						BufferDuration: &bufferDuration,
+					},
+				},
+			},
+		}
+		config := signalControlConfigFromResource(edge, operatorConfig, operatorNamespace, namePrefix, logger)
+		Expect(config.SamplingReservoirBufferDuration).To(Equal("1m30s"))
 	})
 
 	It("should use the configured reservoir max disk bytes and metric level", func() {

--- a/internal/collectors/otelcolresources/signalcontrol.config.yaml.template
+++ b/internal/collectors/otelcolresources/signalcontrol.config.yaml.template
@@ -408,6 +408,9 @@ processors:
     reservoir:
       type: {{ .SignalControl.SamplingReservoirType }}
       metric_level: {{ .SignalControl.SamplingReservoirMetricLevel }}
+{{- if .SignalControl.SamplingReservoirBufferDuration }}
+      buffer_duration: {{ .SignalControl.SamplingReservoirBufferDuration }}
+{{- end }}
 {{- if eq .SignalControl.SamplingReservoirType "disk" }}
       data_dir: /var/lib/dash0/trace-reservoir
       max_disk_bytes: {{ .SignalControl.SamplingReservoirMaxDiskBytes }}


### PR DESCRIPTION
## Description

Exposes the reservoir buffer duration via the `Dash0SignalControl` CRD. If no custom value is configured, the default from the sampling processor is used.
