### PR TITLE
feat(sc): az-awareness for edge-proxy

### DIFF
--- a/helm-chart/dash0-operator/templates/operator/cluster-roles.yaml
+++ b/helm-chart/dash0-operator/templates/operator/cluster-roles.yaml
@@ -107,7 +107,7 @@ rules:
   - update
 
 # Permissions required to detect the container runtime, and to count the cluster's availability zones when checking
-# whether the Signal Control collector has a replica in every zone:
+# whether the Signal Control collector and the Edge Proxy have a replica in every zone:
 - apiGroups:
   - ""
   resources:

--- a/helm-chart/dash0-operator/values.yaml
+++ b/helm-chart/dash0-operator/values.yaml
@@ -1238,9 +1238,12 @@ operator:
     # Settings for the Edge Proxy deployed when signalControl.enabled=true.
     edgeProxy:
       # The number of Edge Proxy pods to run. The Edge Proxy is stateless, so it can be scaled horizontally to
-      # handle higher collector-to-Decision-Maker traffic. Collectors connect via the Edge Proxy service,
-      # which distributes gRPC connections across the available pods. Defaults to 2, the availability floor: with the
-      # pod disruption budget a single pod restart, rollout or node drain always leaves one pod serving the fleet.
+      # handle higher collector-to-Decision-Maker traffic. Collectors connect via the Edge Proxy service, which on
+      # Kubernetes 1.31+ prefers an Edge Proxy pod in the sender's own availability zone and otherwise distributes gRPC
+      # connections across the available pods. Defaults to 2, the availability floor: with the pod disruption budget a
+      # single pod restart, rollout or node drain always leaves one pod serving the fleet. Set this to at least the
+      # number of availability zones so that every zone has a local Edge Proxy pod and the decision stream does not
+      # cross zones.
       replicas: 2
 
       # Resource settings for the Edge Proxy container of the Edge Proxy deployment managed by the operator.

--- a/internal/collectors/collector_manager.go
+++ b/internal/collectors/collector_manager.go
@@ -10,9 +10,7 @@ import (
 	"slices"
 	"strings"
 	"sync/atomic"
-	"time"
 
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/metadata"
@@ -24,39 +22,22 @@ import (
 	"github.com/dash0hq/dash0-operator/internal/collectors/otelcolresources"
 	"github.com/dash0hq/dash0-operator/internal/resources"
 	"github.com/dash0hq/dash0-operator/internal/util"
+	"github.com/dash0hq/dash0-operator/internal/util/cluster"
 	"github.com/dash0hq/dash0-operator/internal/util/logd"
 	"github.com/dash0hq/dash0-operator/internal/util/pointers"
 )
 
 type CollectorManager struct {
 	client.Client
-	nodeMetadataClient          metadata.Interface
 	oTelColResourceManager      *otelcolresources.OTelColResourceManager
 	extraConfig                 atomic.Pointer[util.ExtraConfig]
 	developmentMode             bool
 	signalControlFeatureEnabled bool
 	updateInProgress            atomic.Bool
-	// now returns the current time. It is overridable in tests to exercise the zone-coverage check interval;
-	// NewCollectorManager defaults it to time.Now.
-	now func() time.Time
-	// lastZoneCoverage remembers the outcome of the most recent availability-zone coverage evaluation, so that the
-	// node list backing the check runs at most once per zoneCoverageCheckInterval and the warning is logged on a
-	// change of state rather than on every reconcile.
-	lastZoneCoverage atomic.Pointer[zoneCoverageState]
+	// zoneCoverageReporter warns when the Signal Control collector has fewer replicas than the cluster has
+	// availability zones. See cluster.ZoneCoverageReporter.
+	zoneCoverageReporter *cluster.ZoneCoverageReporter
 }
-
-// zoneCoverageState captures the most recent availability-zone coverage evaluation: when the node list was last
-// performed, the zone and replica counts it observed, and whether the warning was active for them.
-type zoneCoverageState struct {
-	checkedAt    time.Time
-	zoneCount    int
-	replicaCount int32
-	warned       bool
-}
-
-// zoneCoverageCheckInterval is the minimum time between two node-list backed availability-zone checks. An explicit
-// change to the Signal Control collector replica count bypasses it, so a reconfiguration is reflected without waiting.
-const zoneCoverageCheckInterval = 30 * time.Minute
 
 type CollectorReconcileTrigger string
 
@@ -81,21 +62,13 @@ func NewCollectorManager(
 ) *CollectorManager {
 	m := &CollectorManager{
 		Client:                      k8sClient,
-		nodeMetadataClient:          nodeMetadataClient,
 		developmentMode:             developmentMode,
 		signalControlFeatureEnabled: signalControlFeatureEnabled,
 		oTelColResourceManager:      oTelColResourceManager,
+		zoneCoverageReporter:        cluster.NewZoneCoverageReporter(nodeMetadataClient),
 	}
-	m.now = time.Now
 	m.extraConfig.Store(&extraConfig)
 	return m
-}
-
-func (m *CollectorManager) nowOrDefault() time.Time {
-	if m.now != nil {
-		return m.now()
-	}
-	return time.Now()
 }
 
 func (m *CollectorManager) UpdateExtraConfig(ctx context.Context, newConfig util.ExtraConfig, logger logd.Logger) {
@@ -231,98 +204,29 @@ func (m *CollectorManager) warnAboutInsufficientZoneCoverage(
 	extraConfig util.ExtraConfig,
 	logger logd.Logger,
 ) {
-	if m.nodeMetadataClient == nil {
-		return
-	}
-
 	replicaCount := extraConfig.SignalControlCollectorReplicas
 	if replicaCount < 1 {
 		replicaCount = otelcolresources.SignalControlCollectorDefaultReplicas
 	}
-
-	now := m.nowOrDefault()
-	previous := m.lastZoneCoverage.Load()
-	replicaCountChanged := previous != nil && previous.replicaCount != replicaCount
-	// The node list is the expensive part of the check, so it is performed at most once per zoneCoverageCheckInterval.
-	// An explicit change to the replica count bypasses the interval, so a reconfiguration is evaluated - and its
-	// warning re-logged, or an info logged when it resolved the issue - without waiting for the next interval.
-	if previous != nil && !replicaCountChanged && now.Sub(previous.checkedAt) < zoneCoverageCheckInterval {
-		return
-	}
-
-	// The metadata client bypasses the controller-runtime cache on purpose: reading nodes through the cached client
-	// would start an informer that keeps every node object in memory for the lifetime of the operator. Only object
-	// metadata is requested, since the zone label is all that is read, which keeps the node status (in particular the
-	// image list) off the wire. The read is served from the API server's watch cache (ResourceVersion "0") and
-	// restricted to nodes that carry a zone label, since nodes without one contribute nothing to the zone count.
-	nodes, err := m.nodeMetadataClient.
-		Resource(corev1.SchemeGroupVersion.WithResource("nodes")).
-		List(ctx, metav1.ListOptions{
-			ResourceVersion: "0",
-			LabelSelector:   corev1.LabelTopologyZone,
-		})
-	if err != nil {
-		logger.Debug("cannot list nodes to check the Signal Control collector's availability zone coverage", "error", err)
-		return
-	}
-	zones := make(map[string]struct{})
-	for _, node := range nodes.Items {
-		if zone := node.Labels[corev1.LabelTopologyZone]; zone != "" {
-			zones[zone] = struct{}{}
-		}
-	}
-
-	m.reportZoneCoverage(len(zones), replicaCount, now, logger)
-}
-
-// reportZoneCoverage evaluates the availability-zone coverage for the given zone and replica counts, logs the warning
-// when there are more zones than replicas, and records the outcome under checkedAt. In a steady state the warning is
-// logged once, on the transition into it, not on every check. A replica-count change is always acted on, so the
-// warning is re-logged if the situation persists. When a previously warned situation resolves - by more replicas or a
-// lower zone count - a short info is logged once.
-func (m *CollectorManager) reportZoneCoverage(
-	zoneCount int,
-	replicaCount int32,
-	checkedAt time.Time,
-	logger logd.Logger,
-) {
-	previous := m.lastZoneCoverage.Load()
-	wasWarned := previous != nil && previous.warned
-
-	// With zero or one zone there is nothing to spread over, the zone preference is inert either way.
-	insufficient := zoneCount > 1 && int32(zoneCount) > replicaCount
-
-	m.lastZoneCoverage.Store(&zoneCoverageState{
-		checkedAt:    checkedAt,
-		zoneCount:    zoneCount,
-		replicaCount: replicaCount,
-		warned:       insufficient,
-	})
-
-	if insufficient {
-		// A steady state - the same zone and replica count already warned about - is not warned about again.
-		if wasWarned && previous.zoneCount == zoneCount && previous.replicaCount == replicaCount {
-			return
-		}
-		logger.WarnTelemetryCollectionIssue(fmt.Sprintf(
-			"The cluster has %d availability zones but the Signal Control collector runs with %d replicas, so at least "+
-				"one zone has no Signal Control collector pod. Telemetry from those zones is sent to a collector in "+
-				"another zone, which works but incurs cross-zone traffic cost. Set "+
-				"operator.collectors.signalControlCollectorReplicas to at least %d to avoid that.",
-			zoneCount, replicaCount, zoneCount,
-		))
-		return
-	}
-
-	// Resolved: announce it whenever a previously active warning has cleared, whether the replica count was raised
-	// or the zone count dropped on its own.
-	if wasWarned {
-		logger.Info(fmt.Sprintf(
-			"The Signal Control collector now runs with %d replicas across %d availability zones, so every zone has a "+
-				"Signal Control collector pod and cross-zone traffic is avoided.",
-			replicaCount, zoneCount,
-		))
-	}
+	m.zoneCoverageReporter.Report(ctx, replicaCount, cluster.ZoneCoverageMessages{
+		Warn: func(zoneCount int, replicaCount int32) string {
+			return fmt.Sprintf(
+				"The cluster has %d availability zones but the Signal Control collector runs with %d replicas, so at least "+
+					"one zone has no Signal Control collector pod. Telemetry from those zones is sent to a collector in "+
+					"another zone, which works but incurs cross-zone traffic cost. Set "+
+					"operator.collectors.signalControlCollectorReplicas to at least %d to avoid that.",
+				zoneCount, replicaCount, zoneCount,
+			)
+		},
+		Resolved: func(zoneCount int, replicaCount int32) string {
+			return fmt.Sprintf(
+				"The Signal Control collector now runs with %d replicas across %d availability zones, so every zone has a "+
+					"Signal Control collector pod and cross-zone traffic is avoided.",
+				replicaCount, zoneCount,
+			)
+		},
+		ListErrDebug: "cannot list nodes to check the Signal Control collector's availability zone coverage",
+	}, logger)
 }
 
 func (m *CollectorManager) createOrUpdateOpenTelemetryCollector(

--- a/internal/collectors/collector_manager_test.go
+++ b/internal/collectors/collector_manager_test.go
@@ -22,6 +22,7 @@ import (
 	dash0v1beta1 "github.com/dash0hq/dash0-operator/api/operator/v1beta1"
 	"github.com/dash0hq/dash0-operator/internal/collectors/otelcolresources"
 	"github.com/dash0hq/dash0-operator/internal/util"
+	"github.com/dash0hq/dash0-operator/internal/util/cluster"
 	"github.com/dash0hq/dash0-operator/internal/util/logd"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -456,93 +457,8 @@ var _ = Describe("The collector manager", Ordered, func() {
 			}, funcr.Options{}))
 		})
 
-		It("warns once per distinct zone/replica combination, not on every check", func() {
-			manager := &CollectorManager{}
-			checkedAt := time.Unix(0, 0)
-
-			manager.reportZoneCoverage(3, 2, checkedAt, recordingLogger)
-			Expect(warnings).To(HaveLen(1))
-			Expect(warnings[0]).To(ContainSubstring("3 availability zones"))
-			Expect(warnings[0]).To(ContainSubstring("2 replicas"))
-			Expect(warnings[0]).To(ContainSubstring("signalControlCollectorReplicas"))
-
-			// A steady state must not produce a warning again.
-			manager.reportZoneCoverage(3, 2, checkedAt, recordingLogger)
-			manager.reportZoneCoverage(3, 2, checkedAt, recordingLogger)
-			Expect(warnings).To(HaveLen(1))
-
-			// A changed zone count is a new situation and is reported again.
-			manager.reportZoneCoverage(4, 2, checkedAt, recordingLogger)
-			Expect(warnings).To(HaveLen(2))
-		})
-
-		It("does not warn when there are at least as many replicas as zones", func() {
-			manager := &CollectorManager{}
-			checkedAt := time.Unix(0, 0)
-			manager.reportZoneCoverage(3, 3, checkedAt, recordingLogger)
-			manager.reportZoneCoverage(3, 5, checkedAt, recordingLogger)
-			Expect(warnings).To(BeEmpty())
-		})
-
-		It("does not warn on clusters with no zone labels or a single zone", func() {
-			manager := &CollectorManager{}
-			checkedAt := time.Unix(0, 0)
-			manager.reportZoneCoverage(0, 1, checkedAt, recordingLogger)
-			manager.reportZoneCoverage(1, 1, checkedAt, recordingLogger)
-			Expect(warnings).To(BeEmpty())
-		})
-
-		It("logs the warning again when a replica change leaves the issue unresolved", func() {
-			manager := &CollectorManager{}
-			checkedAt := time.Unix(0, 0)
-			manager.reportZoneCoverage(3, 1, checkedAt, recordingLogger)
-			Expect(warnings).To(HaveLen(1))
-			Expect(warnings[0]).To(ContainSubstring("incurs cross-zone traffic cost"))
-
-			// Raising the replicas but not far enough is still insufficient: warn again.
-			manager.reportZoneCoverage(3, 2, checkedAt, recordingLogger)
-			Expect(warnings).To(HaveLen(2))
-			Expect(warnings[1]).To(ContainSubstring("incurs cross-zone traffic cost"))
-			Expect(warnings[1]).To(ContainSubstring("2 replicas"))
-		})
-
-		It("logs an info when a replica change resolves an active warning, and warns again if it reoccurs", func() {
-			manager := &CollectorManager{}
-			checkedAt := time.Unix(0, 0)
-			manager.reportZoneCoverage(3, 2, checkedAt, recordingLogger)
-			Expect(warnings).To(HaveLen(1))
-			Expect(warnings[0]).To(ContainSubstring("incurs cross-zone traffic cost"))
-
-			// Raising the replica count to match the zones resolves the issue and is announced once.
-			manager.reportZoneCoverage(3, 3, checkedAt, recordingLogger)
-			Expect(warnings).To(HaveLen(2))
-			Expect(warnings[1]).To(ContainSubstring("cross-zone traffic is avoided"))
-			Expect(warnings[1]).To(ContainSubstring("3 replicas"))
-
-			// Lowering the replicas again is a new insufficient situation: warn once more.
-			manager.reportZoneCoverage(3, 2, checkedAt, recordingLogger)
-			Expect(warnings).To(HaveLen(3))
-			Expect(warnings[2]).To(ContainSubstring("incurs cross-zone traffic cost"))
-		})
-
-		It("announces the resolution when the issue resolves on its own without a replica change", func() {
-			manager := &CollectorManager{}
-			checkedAt := time.Unix(0, 0)
-			manager.reportZoneCoverage(3, 2, checkedAt, recordingLogger)
-			Expect(warnings).To(HaveLen(1))
-			Expect(warnings[0]).To(ContainSubstring("incurs cross-zone traffic cost"))
-
-			// The zone count drops on its own; the resolution is announced.
-			manager.reportZoneCoverage(2, 2, checkedAt, recordingLogger)
-			Expect(warnings).To(HaveLen(2))
-			Expect(warnings[1]).To(ContainSubstring("cross-zone traffic is avoided"))
-
-			// Once resolved, a further healthy evaluation is not announced again.
-			manager.reportZoneCoverage(2, 2, checkedAt, recordingLogger)
-			Expect(warnings).To(HaveLen(2))
-		})
-
-		It("lists nodes at most once per interval and re-checks on a replica change", func() {
+		It("warns with the Signal Control collector wording, lists nodes at most once per interval, and re-checks on a "+
+			"replica change", func() {
 			for _, zone := range []string{"zone-a", "zone-b", "zone-c"} {
 				node := &corev1.Node{
 					ObjectMeta: metav1.ObjectMeta{
@@ -557,22 +473,21 @@ var _ = Describe("The collector manager", Ordered, func() {
 			}
 
 			currentTime := time.Unix(0, 0)
-			manager := &CollectorManager{
-				nodeMetadataClient: nodeMetadataClient,
-				now:                func() time.Time { return currentTime },
-			}
+			manager := &CollectorManager{}
 			twoReplicas := util.ExtraConfig{SignalControlCollectorReplicas: 2}
 			threeReplicas := util.ExtraConfig{SignalControlCollectorReplicas: 3}
 
 			// The node list is served from the API server's watch cache, which may not have caught up with the nodes
-			// created above yet. Reset the state on every attempt so each one is a first check that lists the nodes.
+			// created above yet. A fresh reporter on every attempt makes each one a first check that lists the nodes.
 			Eventually(func(g Gomega) {
 				warnings = nil
-				manager.lastZoneCoverage.Store(nil)
+				manager.zoneCoverageReporter = cluster.NewZoneCoverageReporter(
+					nodeMetadataClient, cluster.WithClock(func() time.Time { return currentTime }))
 				manager.warnAboutInsufficientZoneCoverage(ctx, twoReplicas, recordingLogger)
 				g.Expect(warnings).To(HaveLen(1))
 				g.Expect(warnings[0]).To(ContainSubstring("3 availability zones"))
 				g.Expect(warnings[0]).To(ContainSubstring("2 replicas"))
+				g.Expect(warnings[0]).To(ContainSubstring("signalControlCollectorReplicas"))
 			}).Should(Succeed())
 
 			// Within the interval and with an unchanged replica count, the node list is skipped and nothing is logged.
@@ -587,14 +502,14 @@ var _ = Describe("The collector manager", Ordered, func() {
 			Expect(warnings[0]).To(ContainSubstring("cross-zone traffic is avoided"))
 
 			// Once the interval has elapsed the periodic check runs again; back to two replicas, it warns once more.
-			currentTime = currentTime.Add(zoneCoverageCheckInterval)
+			currentTime = currentTime.Add(cluster.ZoneCoverageCheckInterval)
 			warnings = nil
 			manager.warnAboutInsufficientZoneCoverage(ctx, twoReplicas, recordingLogger)
 			Expect(warnings).To(HaveLen(1))
 			Expect(warnings[0]).To(ContainSubstring("incurs cross-zone traffic cost"))
 
 			// A further periodic check in the same state does not warn again.
-			currentTime = currentTime.Add(zoneCoverageCheckInterval)
+			currentTime = currentTime.Add(cluster.ZoneCoverageCheckInterval)
 			warnings = nil
 			manager.warnAboutInsufficientZoneCoverage(ctx, twoReplicas, recordingLogger)
 			Expect(warnings).To(BeEmpty())

--- a/internal/signalcontrol/scresources/desired_state.go
+++ b/internal/signalcontrol/scresources/desired_state.go
@@ -18,6 +18,7 @@ import (
 	dash0v1alpha1 "github.com/dash0hq/dash0-operator/api/operator/v1alpha1"
 	"github.com/dash0hq/dash0-operator/internal/collectors/otelcolresources"
 	"github.com/dash0hq/dash0-operator/internal/util"
+	"github.com/dash0hq/dash0-operator/internal/util/cluster"
 	"github.com/dash0hq/dash0-operator/internal/util/logd"
 	"github.com/dash0hq/dash0-operator/internal/util/pointers"
 )
@@ -44,6 +45,12 @@ var (
 	}
 )
 
+// EdgeProxyDefaultReplicas is used when the extra config map does not specify a replica count (e.g. older config
+// maps). The Helm chart ships a higher default; this only backstops a missing value. The topology spread constraints
+// bias replicas onto separate zones and nodes (see edgeProxyTopologySpreadConstraints), and the operator warns when
+// there are fewer replicas than availability zones.
+const EdgeProxyDefaultReplicas int32 = 1
+
 type clientObject struct {
 	object client.Object
 }
@@ -57,6 +64,7 @@ func assembleDesiredState(
 	edgeProxyImagePullPolicy corev1.PullPolicy,
 	operatorVersion string,
 	otlpGrpcHostPort int32,
+	kubernetesApiServerVersion cluster.KubernetesVersionInfo,
 	extraConfig util.ExtraConfig,
 	forDeletion bool,
 	logger logd.Logger,
@@ -73,9 +81,10 @@ func assembleDesiredState(
 	var desiredState []clientObject
 	if forDeletion || edgeProxyEnabled {
 		if edgeProxyEnabled {
+			trafficDistribution := cluster.ResolveServiceTrafficDistribution(kubernetesApiServerVersion, logger)
 			desiredState = append(desiredState,
 				addCommonMetadata(assembleEdgeProxyDeployment(operatorNamespace, namePrefix, signalControlResource, operatorConfig, edgeProxyImage, edgeProxyImagePullPolicy, operatorVersion, otlpGrpcHostPort, extraConfig, logger)),
-				addCommonMetadata(assembleEdgeProxyService(operatorNamespace, namePrefix)),
+				addCommonMetadata(assembleEdgeProxyService(operatorNamespace, namePrefix, trafficDistribution)),
 				addCommonMetadata(assembleEdgeProxyPodDisruptionBudget(operatorNamespace, namePrefix)),
 			)
 		} else {
@@ -94,7 +103,7 @@ func assembleDesiredStateForDelete(
 	namePrefix string,
 	logger logd.Logger,
 ) []clientObject {
-	return assembleDesiredState(operatorNamespace, namePrefix, nil, nil, "", "", "", 0, util.ExtraConfig{}, true, logger)
+	return assembleDesiredState(operatorNamespace, namePrefix, nil, nil, "", "", "", 0, cluster.KubernetesVersionInfo{}, util.ExtraConfig{}, true, logger)
 }
 
 func assembleEdgeProxyDeployment(
@@ -111,8 +120,7 @@ func assembleEdgeProxyDeployment(
 ) *appsv1.Deployment {
 	replicas := extraConfig.EdgeProxyReplicas
 	if replicas < 1 {
-		// Default to a single replica when the extra config does not specify a value (e.g. older config maps).
-		replicas = 1
+		replicas = EdgeProxyDefaultReplicas
 	}
 
 	dmEndpoint, authorization, dataset, apiEndpoint := deriveUpstreamConfig(operatorConfig)
@@ -414,10 +422,16 @@ func assembleEdgeProxyDeploymentForDeletion(operatorNamespace string, namePrefix
 	}
 }
 
-func assembleEdgeProxyService(operatorNamespace string, namePrefix string) *corev1.Service {
+func assembleEdgeProxyService(operatorNamespace string, namePrefix string, trafficDistribution *string) *corev1.Service {
 	service := assembleEdgeProxyServiceForDeletion(operatorNamespace, namePrefix)
 	service.Spec = corev1.ServiceSpec{
 		Selector: edgeProxyMatchLabels,
+		// Prefer endpoints in the sender's own availability zone, so the collectors' decision stream to the Edge Proxy
+		// does not cross zones. This only takes effect when the sender's zone has a ready Edge Proxy endpoint;
+		// otherwise kube-proxy falls back to the full endpoint set for that node, which costs cross-zone traffic but
+		// never drops it. That is also why the operator warns when there are fewer Edge Proxy replicas than zones, see
+		// SignalControlManager.warnAboutInsufficientZoneCoverage.
+		TrafficDistribution: trafficDistribution,
 		Ports: []corev1.ServicePort{
 			{
 				Name:        "grpc",

--- a/internal/signalcontrol/scresources/desired_state_test.go
+++ b/internal/signalcontrol/scresources/desired_state_test.go
@@ -12,6 +12,7 @@ import (
 	dash0common "github.com/dash0hq/dash0-operator/api/operator/common"
 	dash0v1alpha1 "github.com/dash0hq/dash0-operator/api/operator/v1alpha1"
 	"github.com/dash0hq/dash0-operator/internal/util"
+	"github.com/dash0hq/dash0-operator/internal/util/cluster"
 	"github.com/dash0hq/dash0-operator/internal/util/logd"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -327,3 +328,50 @@ func expectSelfMonitoringEnvVarsAbsent(container corev1.Container) {
 }
 
 func ptr[T any](v T) *T { return &v }
+
+var _ = Describe("Edge Proxy service zone-aware routing", func() {
+	DescribeTable("sets spec.trafficDistribution according to the Kubernetes version",
+		func(versionInfo cluster.KubernetesVersionInfo, expected *string) {
+			desiredState := assembleDesiredState(
+				OperatorNamespace, "test-prefix", minimalSignalControl, operatorConfigWithDash0Export,
+				"edge-proxy:latest", corev1.PullIfNotPresent, testOperatorVersion, testOtlpGrpcHostPort,
+				versionInfo, util.ExtraConfig{}, false, logd.Discard(),
+			)
+			service := edgeProxyServiceFrom(desiredState)
+			Expect(service).ToNot(BeNil())
+			if expected == nil {
+				Expect(service.Spec.TrafficDistribution).To(BeNil())
+			} else {
+				Expect(service.Spec.TrafficDistribution).ToNot(BeNil())
+				Expect(*service.Spec.TrafficDistribution).To(Equal(*expected))
+			}
+		},
+		Entry("omitted on 1.29",
+			cluster.KubernetesVersionInfo{Version: cluster.KubernetesVersion{Major: 1, Minor: 29}, Detected: true}, nil),
+		Entry("omitted on 1.30",
+			cluster.KubernetesVersionInfo{Version: cluster.KubernetesVersion{Major: 1, Minor: 30}, Detected: true}, nil),
+		Entry("set on 1.31",
+			cluster.KubernetesVersionInfo{Version: cluster.KubernetesVersion{Major: 1, Minor: 31}, Detected: true},
+			ptr("PreferClose")),
+		Entry("set on 1.34",
+			cluster.KubernetesVersionInfo{Version: cluster.KubernetesVersion{Major: 1, Minor: 34}, Detected: true},
+			ptr("PreferClose")),
+		Entry("omitted when the version is unknown", cluster.KubernetesVersionInfo{}, nil),
+	)
+
+	It("omits spec.trafficDistribution on the service assembled for deletion", func() {
+		desiredState := assembleDesiredStateForDelete(OperatorNamespace, "test-prefix", logd.Discard())
+		service := edgeProxyServiceFrom(desiredState)
+		Expect(service).ToNot(BeNil())
+		Expect(service.Spec.TrafficDistribution).To(BeNil())
+	})
+})
+
+func edgeProxyServiceFrom(objs []clientObject) *corev1.Service {
+	for _, o := range objs {
+		if service, ok := o.object.(*corev1.Service); ok {
+			return service
+		}
+	}
+	return nil
+}

--- a/internal/signalcontrol/scresources/sc_resources.go
+++ b/internal/signalcontrol/scresources/sc_resources.go
@@ -16,20 +16,22 @@ import (
 
 	dash0v1alpha1 "github.com/dash0hq/dash0-operator/api/operator/v1alpha1"
 	"github.com/dash0hq/dash0-operator/internal/util"
+	"github.com/dash0hq/dash0-operator/internal/util/cluster"
 	"github.com/dash0hq/dash0-operator/internal/util/logd"
 	"github.com/dash0hq/dash0-operator/internal/util/resources"
 )
 
 type SignalControlResourceManager struct {
 	client.Client
-	scheme                    *runtime.Scheme
-	operatorManagerDeployment *appsv1.Deployment
-	operatorNamespace         string
-	namePrefix                string
-	edgeProxyImage            string
-	edgeProxyImagePullPolicy  corev1.PullPolicy
-	operatorVersion           string
-	otlpGrpcHostPort          int32
+	scheme                     *runtime.Scheme
+	operatorManagerDeployment  *appsv1.Deployment
+	operatorNamespace          string
+	namePrefix                 string
+	edgeProxyImage             string
+	edgeProxyImagePullPolicy   corev1.PullPolicy
+	operatorVersion            string
+	otlpGrpcHostPort           int32
+	kubernetesApiServerVersion cluster.KubernetesVersionInfo
 }
 
 func NewSignalControlResourceManager(
@@ -42,17 +44,19 @@ func NewSignalControlResourceManager(
 	edgeProxyImagePullPolicy corev1.PullPolicy,
 	operatorVersion string,
 	otlpGrpcHostPort int32,
+	kubernetesApiServerVersion cluster.KubernetesVersionInfo,
 ) *SignalControlResourceManager {
 	return &SignalControlResourceManager{
-		Client:                    k8sClient,
-		scheme:                    scheme,
-		operatorManagerDeployment: operatorManagerDeployment,
-		operatorNamespace:         operatorNamespace,
-		namePrefix:                namePrefix,
-		edgeProxyImage:            edgeProxyImage,
-		edgeProxyImagePullPolicy:  edgeProxyImagePullPolicy,
-		operatorVersion:           operatorVersion,
-		otlpGrpcHostPort:          otlpGrpcHostPort,
+		Client:                     k8sClient,
+		scheme:                     scheme,
+		operatorManagerDeployment:  operatorManagerDeployment,
+		operatorNamespace:          operatorNamespace,
+		namePrefix:                 namePrefix,
+		edgeProxyImage:             edgeProxyImage,
+		edgeProxyImagePullPolicy:   edgeProxyImagePullPolicy,
+		operatorVersion:            operatorVersion,
+		otlpGrpcHostPort:           otlpGrpcHostPort,
+		kubernetesApiServerVersion: kubernetesApiServerVersion,
 	}
 }
 
@@ -63,7 +67,7 @@ func (m *SignalControlResourceManager) CreateOrUpdateResources(
 	extraConfig util.ExtraConfig,
 	logger logd.Logger,
 ) (bool, bool, error) {
-	desiredState := assembleDesiredState(m.operatorNamespace, m.namePrefix, signalControlResource, operatorConfig, m.edgeProxyImage, m.edgeProxyImagePullPolicy, m.operatorVersion, m.otlpGrpcHostPort, extraConfig, false, logger)
+	desiredState := assembleDesiredState(m.operatorNamespace, m.namePrefix, signalControlResource, operatorConfig, m.edgeProxyImage, m.edgeProxyImagePullPolicy, m.operatorVersion, m.otlpGrpcHostPort, m.kubernetesApiServerVersion, extraConfig, false, logger)
 
 	resourcesHaveBeenCreated := false
 	resourcesHaveBeenUpdated := false

--- a/internal/signalcontrol/signalcontrol_controller_test.go
+++ b/internal/signalcontrol/signalcontrol_controller_test.go
@@ -5,7 +5,9 @@ package signalcontrol
 
 import (
 	"context"
+	"time"
 
+	"github.com/go-logr/logr/funcr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
@@ -24,6 +26,8 @@ import (
 	"github.com/dash0hq/dash0-operator/internal/collectors/otelcolresources"
 	"github.com/dash0hq/dash0-operator/internal/signalcontrol/scresources"
 	"github.com/dash0hq/dash0-operator/internal/util"
+	"github.com/dash0hq/dash0-operator/internal/util/cluster"
+	"github.com/dash0hq/dash0-operator/internal/util/logd"
 
 	. "github.com/dash0hq/dash0-operator/test/util"
 )
@@ -52,8 +56,9 @@ var _ = Describe("The Signal Control controller", Ordered, func() {
 			corev1.PullIfNotPresent,
 			OperatorVersionTest,
 			otelcolresources.DefaultOtlpGrpcHostPort,
+			cluster.KubernetesVersionInfo{},
 		)
-		scManager := NewSignalControlManager(k8sClient, scResourceManager, util.ExtraConfigDefaults)
+		scManager := NewSignalControlManager(k8sClient, scResourceManager, nodeMetadataClient, util.ExtraConfigDefaults)
 		oTelColResourceManager := otelcolresources.NewOTelColResourceManager(
 			k8sClient,
 			k8sClient.Scheme(),
@@ -152,3 +157,56 @@ func loadSignalControlResource(ctx context.Context) *dash0v1alpha1.Dash0SignalCo
 		To(Succeed())
 	return signalControlResource
 }
+
+var _ = Describe("Edge Proxy availability zone coverage", func() {
+	ctx := context.Background()
+
+	var warnings []string
+	var recordingLogger logd.Logger
+
+	BeforeEach(func() {
+		warnings = nil
+		recordingLogger = logd.NewLogger(funcr.New(func(_ string, args string) {
+			warnings = append(warnings, args)
+		}, funcr.Options{}))
+	})
+
+	It("warns with the Edge Proxy wording when there are more zones than replicas, and clears it when resolved", func() {
+		for _, zone := range []string{"ep-zone-a", "ep-zone-b", "ep-zone-c"} {
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "edge-proxy-zone-coverage-" + zone,
+					Labels: map[string]string{corev1.LabelTopologyZone: zone},
+				},
+			}
+			Expect(k8sClient.Create(ctx, node)).To(Succeed())
+			DeferCleanup(func() {
+				Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, node))).To(Succeed())
+			})
+		}
+
+		currentTime := time.Unix(0, 0)
+		manager := &SignalControlManager{}
+		twoReplicas := util.ExtraConfig{EdgeProxyReplicas: 2}
+		threeReplicas := util.ExtraConfig{EdgeProxyReplicas: 3}
+
+		// A fresh reporter on every attempt makes each one a first check that lists the nodes, working around watch
+		// cache lag.
+		Eventually(func(g Gomega) {
+			warnings = nil
+			manager.zoneCoverageReporter = cluster.NewZoneCoverageReporter(
+				nodeMetadataClient, cluster.WithClock(func() time.Time { return currentTime }))
+			manager.warnAboutInsufficientZoneCoverage(ctx, twoReplicas, recordingLogger)
+			g.Expect(warnings).To(HaveLen(1))
+			g.Expect(warnings[0]).To(ContainSubstring("3 availability zones"))
+			g.Expect(warnings[0]).To(ContainSubstring("Edge Proxy runs with 2 replicas"))
+			g.Expect(warnings[0]).To(ContainSubstring("operator.signalControl.edgeProxy.replicas"))
+		}).Should(Succeed())
+
+		// A replica change bypasses the interval: now sufficient, it logs the resolution with the Edge Proxy wording.
+		warnings = nil
+		manager.warnAboutInsufficientZoneCoverage(ctx, threeReplicas, recordingLogger)
+		Expect(warnings).To(HaveLen(1))
+		Expect(warnings[0]).To(ContainSubstring("Edge Proxy now runs with 3 replicas"))
+	})
+})

--- a/internal/signalcontrol/signalcontrol_manager.go
+++ b/internal/signalcontrol/signalcontrol_manager.go
@@ -9,13 +9,16 @@ import (
 	"reflect"
 	"sync/atomic"
 
+	"k8s.io/client-go/metadata"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	dash0v1alpha1 "github.com/dash0hq/dash0-operator/api/operator/v1alpha1"
 	"github.com/dash0hq/dash0-operator/internal/resources"
 	"github.com/dash0hq/dash0-operator/internal/signalcontrol/scresources"
 	"github.com/dash0hq/dash0-operator/internal/util"
+	"github.com/dash0hq/dash0-operator/internal/util/cluster"
 	"github.com/dash0hq/dash0-operator/internal/util/logd"
+	"github.com/dash0hq/dash0-operator/internal/util/pointers"
 )
 
 type SignalControlManager struct {
@@ -23,16 +26,21 @@ type SignalControlManager struct {
 	resourceManager  *scresources.SignalControlResourceManager
 	extraConfig      atomic.Pointer[util.ExtraConfig]
 	updateInProgress atomic.Bool
+	// zoneCoverageReporter warns when the Edge Proxy has fewer replicas than the cluster has availability zones. See
+	// cluster.ZoneCoverageReporter.
+	zoneCoverageReporter *cluster.ZoneCoverageReporter
 }
 
 func NewSignalControlManager(
 	k8sClient client.Client,
 	resourceManager *scresources.SignalControlResourceManager,
+	nodeMetadataClient metadata.Interface,
 	extraConfig util.ExtraConfig,
 ) *SignalControlManager {
 	m := &SignalControlManager{
-		Client:          k8sClient,
-		resourceManager: resourceManager,
+		Client:               k8sClient,
+		resourceManager:      resourceManager,
+		zoneCoverageReporter: cluster.NewZoneCoverageReporter(nodeMetadataClient),
 	}
 	m.extraConfig.Store(&extraConfig)
 	return m
@@ -131,6 +139,12 @@ func (m *SignalControlManager) createOrUpdateSignalControl(
 		return false, fmt.Errorf("extra config is nil in SignalControlManager#createOrUpdateSignalControl")
 	}
 
+	// Only relevant when the Edge Proxy is actually deployed: with it disabled there is nothing to spread over
+	// availability zones.
+	if pointers.ReadBoolPointerWithDefault(signalControlResource.Spec.EdgeProxy.Enabled, true) {
+		m.warnAboutInsufficientZoneCoverage(ctx, *extraConfig, logger)
+	}
+
 	resourcesHaveBeenCreated, resourcesHaveBeenUpdated, err :=
 		m.resourceManager.CreateOrUpdateResources(ctx, signalControlResource, operatorConfig, *extraConfig, logger)
 	if err != nil {
@@ -145,6 +159,44 @@ func (m *SignalControlManager) createOrUpdateSignalControl(
 		logger.Info("Signal Control resources have been updated.")
 	}
 	return true, nil
+}
+
+// warnAboutInsufficientZoneCoverage warns when the cluster has more availability zones than the Edge Proxy has
+// replicas. The Edge Proxy service prefers endpoints in the sender's own zone, but kube-proxy can only do that for
+// zones that actually have a ready endpoint; collectors in the remaining zones fall back to the full endpoint set and
+// their decision stream to the Edge Proxy crosses zones.
+//
+// Like the Signal Control collector's check, this deliberately only warns and never derives the replica count from the
+// zone count: writing spec.replicas from the reconciler that also watches that deployment would turn any
+// nondeterminism in the zone count into replica churn.
+func (m *SignalControlManager) warnAboutInsufficientZoneCoverage(
+	ctx context.Context,
+	extraConfig util.ExtraConfig,
+	logger logd.Logger,
+) {
+	replicaCount := extraConfig.EdgeProxyReplicas
+	if replicaCount < 1 {
+		replicaCount = scresources.EdgeProxyDefaultReplicas
+	}
+	m.zoneCoverageReporter.Report(ctx, replicaCount, cluster.ZoneCoverageMessages{
+		Warn: func(zoneCount int, replicaCount int32) string {
+			return fmt.Sprintf(
+				"The cluster has %d availability zones but the Edge Proxy runs with %d replicas, so at least one zone "+
+					"has no Edge Proxy pod. Collectors in those zones connect to an Edge Proxy in another zone, which "+
+					"works but incurs cross-zone traffic cost. Set operator.signalControl.edgeProxy.replicas to at "+
+					"least %d to avoid that.",
+				zoneCount, replicaCount, zoneCount,
+			)
+		},
+		Resolved: func(zoneCount int, replicaCount int32) string {
+			return fmt.Sprintf(
+				"The Edge Proxy now runs with %d replicas across %d availability zones, so every zone has an Edge Proxy "+
+					"pod and cross-zone traffic is avoided.",
+				replicaCount, zoneCount,
+			)
+		},
+		ListErrDebug: "cannot list nodes to check the Edge Proxy's availability zone coverage",
+	}, logger)
 }
 
 func (m *SignalControlManager) removeSignalControl(ctx context.Context) (bool, error) {

--- a/internal/startup/operator_manager_startup.go
+++ b/internal/startup/operator_manager_startup.go
@@ -1818,10 +1818,12 @@ func startDash0Controllers(
 			envVars.edgeProxyImagePullPolicy,
 			images.GetOperatorVersion(),
 			int32(cliArgs.otlpGrpcHostPort),
+			kubernetesApiServerVersionInfo,
 		)
 		scManager = signalcontrol.NewSignalControlManager(
 			k8sClient,
 			scResourceManager,
+			nodeMetadataClient,
 			extraConfig,
 		)
 		// Update the extra config in the Signal Control manager when the extra config map changes, and also trigger a

--- a/internal/util/cluster/zone_coverage.go
+++ b/internal/util/cluster/zone_coverage.go
@@ -1,0 +1,170 @@
+// SPDX-FileCopyrightText: Copyright 2026 Dash0 Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package cluster
+
+import (
+	"context"
+	"sync/atomic"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/metadata"
+
+	"github.com/dash0hq/dash0-operator/internal/util/logd"
+)
+
+// ZoneCoverageCheckInterval is the minimum time between two node-list backed availability-zone checks. An explicit
+// change to the observed replica count bypasses it, so a reconfiguration is reflected without waiting.
+const ZoneCoverageCheckInterval = 30 * time.Minute
+
+// zoneCoverageState captures the most recent availability-zone coverage evaluation: when the node list was last
+// performed, the zone and replica counts it observed, and whether the warning was active for them.
+type zoneCoverageState struct {
+	checkedAt    time.Time
+	zoneCount    int
+	replicaCount int32
+	warned       bool
+}
+
+// ZoneCoverageMessages provides the component-specific wording for a ZoneCoverageReporter. Warn is logged as a
+// telemetry-collection issue when there are more availability zones than replicas; Resolved is logged as info, once,
+// when a previously active warning clears; ListErrDebug is logged at debug level when the node list fails.
+type ZoneCoverageMessages struct {
+	Warn         func(zoneCount int, replicaCount int32) string
+	Resolved     func(zoneCount int, replicaCount int32) string
+	ListErrDebug string
+}
+
+// ZoneCoverageReporter warns when a zone-preferring workload has fewer replicas than the cluster has availability
+// zones. Its service prefers endpoints in the sender's own zone, but kube-proxy can only do that for zones that have a
+// ready endpoint; senders in the remaining zones fall back to the full endpoint set and their traffic crosses zones.
+// The node list backing the check is the expensive part, so it runs at most once per ZoneCoverageCheckInterval and the
+// warning is logged on a change of state rather than on every call.
+type ZoneCoverageReporter struct {
+	nodeMetadataClient metadata.Interface
+	// now returns the current time. It is overridable in tests to exercise the check interval; NewZoneCoverageReporter
+	// defaults it to time.Now.
+	now  func() time.Time
+	last atomic.Pointer[zoneCoverageState]
+}
+
+// ZoneCoverageReporterOption customizes a ZoneCoverageReporter.
+type ZoneCoverageReporterOption func(*ZoneCoverageReporter)
+
+// WithClock overrides the reporter's time source. Intended for tests exercising the check interval.
+func WithClock(now func() time.Time) ZoneCoverageReporterOption {
+	return func(r *ZoneCoverageReporter) {
+		r.now = now
+	}
+}
+
+// NewZoneCoverageReporter returns a reporter backed by the given node metadata client. A nil client turns Report into a
+// no-op, mirroring clusters where the operator has no node read access.
+func NewZoneCoverageReporter(nodeMetadataClient metadata.Interface, opts ...ZoneCoverageReporterOption) *ZoneCoverageReporter {
+	r := &ZoneCoverageReporter{
+		nodeMetadataClient: nodeMetadataClient,
+		now:                time.Now,
+	}
+	for _, opt := range opts {
+		opt(r)
+	}
+	return r
+}
+
+// Report lists the cluster's zone-labelled nodes - at most once per ZoneCoverageCheckInterval, unless replicaCount
+// changed since the last call - and logs msgs.Warn when there are more availability zones than replicaCount, or
+// msgs.Resolved once when a previous warning clears. It is a no-op when the reporter has no node metadata client.
+func (r *ZoneCoverageReporter) Report(
+	ctx context.Context,
+	replicaCount int32,
+	msgs ZoneCoverageMessages,
+	logger logd.Logger,
+) {
+	if r == nil || r.nodeMetadataClient == nil {
+		return
+	}
+
+	now := r.nowOrDefault()
+	previous := r.last.Load()
+	replicaCountChanged := previous != nil && previous.replicaCount != replicaCount
+	// The node list is the expensive part of the check, so it is performed at most once per ZoneCoverageCheckInterval.
+	// An explicit change to the replica count bypasses the interval, so a reconfiguration is evaluated - and its
+	// warning re-logged, or an info logged when it resolved the issue - without waiting for the next interval.
+	if previous != nil && !replicaCountChanged && now.Sub(previous.checkedAt) < ZoneCoverageCheckInterval {
+		return
+	}
+
+	// The metadata client bypasses the controller-runtime cache on purpose: reading nodes through the cached client
+	// would start an informer that keeps every node object in memory for the lifetime of the operator. Only object
+	// metadata is requested, since the zone label is all that is read, which keeps the node status (in particular the
+	// image list) off the wire. The read is served from the API server's watch cache (ResourceVersion "0") and
+	// restricted to nodes that carry a zone label, since nodes without one contribute nothing to the zone count.
+	nodes, err := r.nodeMetadataClient.
+		Resource(corev1.SchemeGroupVersion.WithResource("nodes")).
+		List(ctx, metav1.ListOptions{
+			ResourceVersion: "0",
+			LabelSelector:   corev1.LabelTopologyZone,
+		})
+	if err != nil {
+		logger.Debug(msgs.ListErrDebug, "error", err)
+		return
+	}
+	zones := make(map[string]struct{})
+	for _, node := range nodes.Items {
+		if zone := node.Labels[corev1.LabelTopologyZone]; zone != "" {
+			zones[zone] = struct{}{}
+		}
+	}
+
+	r.report(len(zones), replicaCount, now, msgs, logger)
+}
+
+func (r *ZoneCoverageReporter) nowOrDefault() time.Time {
+	if r.now != nil {
+		return r.now()
+	}
+	return time.Now()
+}
+
+// report evaluates the availability-zone coverage for the given zone and replica counts, logs the warning when there
+// are more zones than replicas, and records the outcome under checkedAt. In a steady state the warning is logged once,
+// on the transition into it, not on every check. A replica-count change is always acted on, so the warning is
+// re-logged if the situation persists. When a previously warned situation resolves - by more replicas or a lower zone
+// count - a short info is logged once.
+func (r *ZoneCoverageReporter) report(
+	zoneCount int,
+	replicaCount int32,
+	checkedAt time.Time,
+	msgs ZoneCoverageMessages,
+	logger logd.Logger,
+) {
+	previous := r.last.Load()
+	wasWarned := previous != nil && previous.warned
+
+	// With zero or one zone there is nothing to spread over, the zone preference is inert either way.
+	insufficient := zoneCount > 1 && int32(zoneCount) > replicaCount
+
+	r.last.Store(&zoneCoverageState{
+		checkedAt:    checkedAt,
+		zoneCount:    zoneCount,
+		replicaCount: replicaCount,
+		warned:       insufficient,
+	})
+
+	if insufficient {
+		// A steady state - the same zone and replica count already warned about - is not warned about again.
+		if wasWarned && previous.zoneCount == zoneCount && previous.replicaCount == replicaCount {
+			return
+		}
+		logger.WarnTelemetryCollectionIssue(msgs.Warn(zoneCount, replicaCount))
+		return
+	}
+
+	// Resolved: announce it whenever a previously active warning has cleared, whether the replica count was raised or
+	// the zone count dropped on its own.
+	if wasWarned {
+		logger.Info(msgs.Resolved(zoneCount, replicaCount))
+	}
+}

--- a/internal/util/cluster/zone_coverage_test.go
+++ b/internal/util/cluster/zone_coverage_test.go
@@ -1,0 +1,139 @@
+// SPDX-FileCopyrightText: Copyright 2026 Dash0 Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/go-logr/logr/funcr"
+
+	"github.com/dash0hq/dash0-operator/internal/util/logd"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("The zone coverage reporter", func() {
+	ctx := context.Background()
+
+	var logged []string
+	var recordingLogger logd.Logger
+	var msgs ZoneCoverageMessages
+
+	BeforeEach(func() {
+		logged = nil
+		recordingLogger = logd.NewLogger(funcr.New(func(_ string, args string) {
+			logged = append(logged, args)
+		}, funcr.Options{}))
+		msgs = ZoneCoverageMessages{
+			Warn: func(zoneCount int, replicaCount int32) string {
+				return fmt.Sprintf("insufficient: %d zones, %d replicas", zoneCount, replicaCount)
+			},
+			Resolved: func(zoneCount int, replicaCount int32) string {
+				return fmt.Sprintf("resolved: %d zones, %d replicas", zoneCount, replicaCount)
+			},
+			ListErrDebug: "cannot list nodes",
+		}
+	})
+
+	Describe("evaluating a zone/replica combination", func() {
+		It("warns once per distinct zone/replica combination, not on every check", func() {
+			reporter := &ZoneCoverageReporter{}
+			checkedAt := time.Unix(0, 0)
+
+			reporter.report(3, 2, checkedAt, msgs, recordingLogger)
+			Expect(logged).To(HaveLen(1))
+			Expect(logged[0]).To(ContainSubstring("insufficient: 3 zones, 2 replicas"))
+
+			// A steady state must not produce a warning again.
+			reporter.report(3, 2, checkedAt, msgs, recordingLogger)
+			reporter.report(3, 2, checkedAt, msgs, recordingLogger)
+			Expect(logged).To(HaveLen(1))
+
+			// A changed zone count is a new situation and is reported again.
+			reporter.report(4, 2, checkedAt, msgs, recordingLogger)
+			Expect(logged).To(HaveLen(2))
+		})
+
+		It("does not warn when there are at least as many replicas as zones", func() {
+			reporter := &ZoneCoverageReporter{}
+			checkedAt := time.Unix(0, 0)
+			reporter.report(3, 3, checkedAt, msgs, recordingLogger)
+			reporter.report(3, 5, checkedAt, msgs, recordingLogger)
+			Expect(logged).To(BeEmpty())
+		})
+
+		It("does not warn on clusters with no zone labels or a single zone", func() {
+			reporter := &ZoneCoverageReporter{}
+			checkedAt := time.Unix(0, 0)
+			reporter.report(0, 1, checkedAt, msgs, recordingLogger)
+			reporter.report(1, 1, checkedAt, msgs, recordingLogger)
+			Expect(logged).To(BeEmpty())
+		})
+
+		It("logs the warning again when a replica change leaves the issue unresolved", func() {
+			reporter := &ZoneCoverageReporter{}
+			checkedAt := time.Unix(0, 0)
+			reporter.report(3, 1, checkedAt, msgs, recordingLogger)
+			Expect(logged).To(HaveLen(1))
+			Expect(logged[0]).To(ContainSubstring("insufficient: 3 zones, 1 replicas"))
+
+			// Raising the replicas but not far enough is still insufficient: warn again.
+			reporter.report(3, 2, checkedAt, msgs, recordingLogger)
+			Expect(logged).To(HaveLen(2))
+			Expect(logged[1]).To(ContainSubstring("insufficient: 3 zones, 2 replicas"))
+		})
+
+		It("logs the resolution when a replica change resolves an active warning, and warns again if it reoccurs", func() {
+			reporter := &ZoneCoverageReporter{}
+			checkedAt := time.Unix(0, 0)
+			reporter.report(3, 2, checkedAt, msgs, recordingLogger)
+			Expect(logged).To(HaveLen(1))
+			Expect(logged[0]).To(ContainSubstring("insufficient"))
+
+			// Raising the replica count to match the zones resolves the issue and is announced once.
+			reporter.report(3, 3, checkedAt, msgs, recordingLogger)
+			Expect(logged).To(HaveLen(2))
+			Expect(logged[1]).To(ContainSubstring("resolved: 3 zones, 3 replicas"))
+
+			// Lowering the replicas again is a new insufficient situation: warn once more.
+			reporter.report(3, 2, checkedAt, msgs, recordingLogger)
+			Expect(logged).To(HaveLen(3))
+			Expect(logged[2]).To(ContainSubstring("insufficient"))
+		})
+
+		It("announces the resolution when the issue resolves on its own without a replica change", func() {
+			reporter := &ZoneCoverageReporter{}
+			checkedAt := time.Unix(0, 0)
+			reporter.report(3, 2, checkedAt, msgs, recordingLogger)
+			Expect(logged).To(HaveLen(1))
+			Expect(logged[0]).To(ContainSubstring("insufficient"))
+
+			// The zone count drops on its own; the resolution is announced.
+			reporter.report(2, 2, checkedAt, msgs, recordingLogger)
+			Expect(logged).To(HaveLen(2))
+			Expect(logged[1]).To(ContainSubstring("resolved: 2 zones, 2 replicas"))
+
+			// Once resolved, a further healthy evaluation is not announced again.
+			reporter.report(2, 2, checkedAt, msgs, recordingLogger)
+			Expect(logged).To(HaveLen(2))
+		})
+	})
+
+	Describe("without a node metadata client", func() {
+		It("is a no-op", func() {
+			reporter := NewZoneCoverageReporter(nil)
+			reporter.Report(ctx, 1, msgs, recordingLogger)
+			Expect(logged).To(BeEmpty())
+		})
+
+		It("is a no-op on a nil reporter", func() {
+			var reporter *ZoneCoverageReporter
+			Expect(func() { reporter.Report(ctx, 1, msgs, recordingLogger) }).ToNot(Panic())
+			Expect(logged).To(BeEmpty())
+		})
+	})
+})

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1948,6 +1948,54 @@ log_statements:
 					"kubectl", "-n", operatorNamespace, "get", "service", edgeProxyDeployment,
 				))).To(Succeed())
 
+				By("verifying zone-aware routing is configured on the Edge Proxy service")
+				// The Edge Proxy ships two replicas by default; on a multi-zone cluster the topology spread lands one
+				// per zone, which is what the per-zone endpoint hints below rely on.
+				edgeProxyExpectedReplicas := 2
+				if kubernetesMajor == 1 && kubernetesMinor < 31 {
+					GinkgoWriter.Printf(
+						"skipping the spec.trafficDistribution assertions, the field is only enabled by default from "+
+							"Kubernetes 1.31 on, server is %d.%d\n", kubernetesMajor, kubernetesMinor)
+				} else {
+					Eventually(func(g Gomega) {
+						trafficDistribution, err := run(exec.Command(
+							"kubectl",
+							"-n", operatorNamespace,
+							"get", "service", edgeProxyDeployment,
+							"-o", "jsonpath={.spec.trafficDistribution}",
+						), false)
+						g.Expect(err).ToNot(HaveOccurred())
+						g.Expect(strings.TrimSpace(trafficDistribution)).To(Equal("PreferClose"))
+					}, 30*time.Second, pollingInterval).Should(Succeed())
+
+					// The endpoint slice controller writes the zone hints kube-proxy needs only for ready endpoints,
+					// so this has to be eventually-consistent even though the deployment is already available.
+					By("verifying every ready Edge Proxy endpoint is hinted for its own zone")
+					Eventually(func(g Gomega) {
+						endpoints, err := run(exec.Command(
+							"kubectl",
+							"-n", operatorNamespace,
+							"get", "endpointslice",
+							"-l", "kubernetes.io/service-name="+edgeProxyDeployment,
+							"-o", "jsonpath={range .items[*].endpoints[?(@.conditions.ready==true)]}"+
+								"{.zone}={.hints.forZones[0].name}{\"\\n\"}{end}",
+						), false)
+						g.Expect(err).ToNot(HaveOccurred())
+						pairs := strings.Fields(strings.TrimSpace(endpoints))
+						g.Expect(pairs).To(
+							HaveLen(edgeProxyExpectedReplicas),
+							"expected one ready endpoint per replica, got %q", endpoints)
+						for _, pair := range pairs {
+							zone, hint, found := strings.Cut(pair, "=")
+							g.Expect(found).To(BeTrue(), "malformed endpoint entry %q", pair)
+							g.Expect(zone).ToNot(BeEmpty(), "endpoint has no zone, is the kind node labelled?")
+							g.Expect(hint).To(
+								Equal(zone),
+								"endpoint in zone %s must be hinted for its own zone, got %q", zone, hint)
+						}
+					}, 60*time.Second, pollingInterval).Should(Succeed())
+				}
+
 				By("verifying the Edge Proxy container is configured with the Decision Maker mock endpoint")
 				upstream, err := run(exec.Command(
 					"kubectl",


### PR DESCRIPTION
## Description

Adds AZ-awareness for the edge-proxy, i.e. collectors will connect to an edge-proxy in the same AZ if possible.

## Authorship

<!--Human authorship attestation. AI agents must not check the following boxes on behalf of the user. The human author must check them personally before the PR will be reviewed.-->

The human author of this PR confirms they

- [x] fully understand the changes and can explain the reasoning behind the design decisions,
- [x] fully understand how to verify and test the changes,
- [x] did confirm the changes work as expected by testing them in a real cluster, and
- [x] personally wrote the PR description.
