### PR TITLE
feat: make the operator compatible with OpenShift

### DIFF
--- a/helm-chart/dash0-operator/README.md
+++ b/helm-chart/dash0-operator/README.md
@@ -91,7 +91,7 @@ This README provides a quick overview. Detailed documentation is organized by to
 
 * **[Managing Dash0 Resources](docs/managing-dash0-resources.md)** - Managing dashboards, check rules, synthetic checks, views, notification channels, spam filters, signal-to-metrics, and teams via infrastructure-as-code
 * **[Advanced Configuration](docs/advanced-configuration.md)** - cert-manager, node affinity, tolerations, sysctls, and filelog offset volumes
-* **[Platform Specific](docs/platform-specific.md)** - Notes for AWS EKS, GKE Autopilot, Azure AKS, Docker Desktop, Minikube, Apple Silicon, and compatibility with OPA and Kyverno
+* **[Platform Specific](docs/platform-specific.md)** - Notes for AWS EKS, GKE Autopilot, OpenShift, Azure AKS, Docker Desktop, Minikube, Apple Silicon, and compatibility with OPA and Kyverno
 * **[SignalControl Edge](docs/signal-control-edge.md)** - How to configure Signal Control, which offers in-cluster tail-sampling, RED metrics, signal-to-metrics, and spam filters to reduce egress costs.
 
 ### Operations

--- a/helm-chart/dash0-operator/docs/platform-specific.md
+++ b/helm-chart/dash0-operator/docs/platform-specific.md
@@ -7,6 +7,7 @@ This document provides platform-specific guidance, compatibility notes, and work
 - [AWS EKS](#notes-on-aws-eks)
 - [GKE Autopilot](#notes-on-gke-autopilot)
   - [Managing the AllowlistSynchronizer Manually](#managing-the-allowlistsynchronizer-manually)
+- [OpenShift](#notes-on-openshift)
 - [Azure AKS](#notes-on-azure-aks)
 - [Open Policy Agent (OPA Gatekeeper)](#notes-on-the-open-policy-agent)
 - [Kyverno Admission Controller](#notes-on-kyverno-admission-controller)
@@ -93,6 +94,29 @@ kubectl apply -f dash0-gke-autopilot-allowlist-synchronizer.yaml
 
 When managing the `AllowlistSynchronizer` manually, you might need to update it from time to time for future Dash0
 operator releases.
+
+## Notes on OpenShift
+
+When deploying the Dash0 operator to a Red Hat OpenShift cluster, provide the following additional setting when applying
+the Helm chart:
+
+```yaml
+operator:
+  openShift:
+    enabled: true
+```
+
+OpenShift enforces [Security Context Constraints](https://docs.openshift.com/container-platform/latest/authentication/managing-security-context-constraints.html)
+(SCCs) on every pod. The default `restricted-v2` SCC assigns each pod a random, in-range UID from the namespace's
+`openshift.io/sa.scc.uid-range` and rejects pods that pin a UID outside that range. With `operator.openShift.enabled`
+set to `true`, the Dash0 operator Helm chart and operator:
+
+- create a custom `SecurityContextConstraints` resource plus the RBAC that binds it to the OpenTelemetry collector
+  DaemonSet's service account, so the DaemonSet may use the host access it requires (host log directories via `hostPath`
+  and the OTLP host ports), and
+- drop the hard-coded pod-level `runAsUser`/`runAsGroup` from the operator-managed workloads (the agent0-connector, the
+  target-allocator, and the Signal Control edge-proxy) and from the injected instrumentation init container, so that the
+  namespace's SCC assigns an in-range UID instead of a pinned one that `restricted-v2` would reject.
 
 ## Notes on Azure AKS
 

--- a/helm-chart/dash0-operator/templates/operator/cluster-roles.yaml
+++ b/helm-chart/dash0-operator/templates/operator/cluster-roles.yaml
@@ -116,6 +116,18 @@ rules:
   - get
   - list
 
+# The operator sets its own manager deployment as the owner (with blockOwnerDeletion) of the resources it manages. The
+# OwnerReferencesPermissionEnforcement admission plugin (upstream Kubernetes, enabled by default on OpenShift and
+# MicroShift, and enableable on any cluster) then requires update on the owner's finalizers subresource to set
+# blockOwnerDeletion. Granted unconditionally because it is a no-op where the plugin is off and the flag would be a
+# wrong proxy: a non-OpenShift cluster can enable the plugin too.
+- apiGroups:
+  - apps
+  resources:
+  - deployments/finalizers
+  verbs:
+  - update
+
 ---
 {{/*
 The -manager-iac cluster role holds permissions used for IaC tasks, like synchronizing dashboards and check rules.

--- a/helm-chart/dash0-operator/templates/operator/deployment-and-webhooks.yaml
+++ b/helm-chart/dash0-operator/templates/operator/deployment-and-webhooks.yaml
@@ -163,6 +163,7 @@ spec:
 {{- end }}
         - --dash0-force-use-otel-collector-service-url={{ .Values.operator.collectors.forceUseServiceUrl }}
         - --dash0-gke-autopilot={{ .Values.operator.gke.autopilot.enabled }}
+        - --dash0-openshift={{ .Values.operator.openShift.enabled }}
         - --dash0-disable-otel-collector-host-ports={{ .Values.operator.collectors.disableHostPorts }}
 {{- $otlpGrpcHostPort := int .Values.operator.collectors.otlpGrpcHostPort }}
 {{- $otlpHttpHostPort := int .Values.operator.collectors.otlpHttpHostPort }}

--- a/helm-chart/dash0-operator/templates/operator/openshift-scc.yaml
+++ b/helm-chart/dash0-operator/templates/operator/openshift-scc.yaml
@@ -1,0 +1,89 @@
+{{/*
+On Red Hat OpenShift, the OpenTelemetry collector DaemonSet needs host access (hostPath log directories, host
+ports) and runs its filelog-offset-volume-ownership init container as root. The built-in restricted-v2 SCC denies
+all of that. This custom SecurityContextConstraints, granted to the collector DaemonSet's service account via RBAC,
+grants that host access plus the SELinux latitude to read /var/log/pods across all pods' MCS labels and the CHOWN
+capability the ownership init container needs. Rendered only when operator.openShift.enabled is true; the
+security.openshift.io API group does not exist on non-OpenShift clusters.
+*/}}
+{{- if .Values.operator.openShift.enabled }}
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: {{ .Release.Name }}-dash0-collector
+  labels:
+    app.kubernetes.io/name: dash0-operator
+    app.kubernetes.io/component: collector
+    app.kubernetes.io/instance: openshift-scc
+    {{- include "dash0-operator.labels" . | nindent 4 }}
+allowPrivilegeEscalation: false
+allowHostDirVolumePlugin: true
+allowHostPorts: true
+allowHostNetwork: false
+allowHostPID: false
+allowHostIPC: false
+allowPrivilegedContainer: false
+requiredDropCapabilities:
+  - ALL
+allowedCapabilities:
+  - CHOWN
+readOnlyRootFilesystem: false
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+fsGroup:
+  type: RunAsAny
+supplementalGroups:
+  type: RunAsAny
+seccompProfiles:
+  - runtime/default
+volumes:
+  - configMap
+  - downwardAPI
+  - emptyDir
+  - hostPath
+  - persistentVolumeClaim
+  - projected
+  - secret
+users: []
+groups: []
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Name }}-dash0-collector-scc-use
+  labels:
+    app.kubernetes.io/name: dash0-operator
+    app.kubernetes.io/component: collector
+    app.kubernetes.io/instance: openshift-scc-use
+    {{- include "dash0-operator.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - security.openshift.io
+    resources:
+      - securitycontextconstraints
+    resourceNames:
+      - {{ .Release.Name }}-dash0-collector
+    verbs:
+      - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Release.Name }}-dash0-collector-scc-use
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: dash0-operator
+    app.kubernetes.io/component: collector
+    app.kubernetes.io/instance: openshift-scc-use
+    {{- include "dash0-operator.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Release.Name }}-dash0-collector-scc-use
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}-opentelemetry-collector-sa
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/helm-chart/dash0-operator/tests/operator/__snapshot__/cluster-roles_test.yaml.snap
+++ b/helm-chart/dash0-operator/tests/operator/__snapshot__/cluster-roles_test.yaml.snap
@@ -97,6 +97,12 @@ cluster roles should match snapshot:
         verbs:
           - get
           - list
+      - apiGroups:
+          - apps
+        resources:
+          - deployments/finalizers
+        verbs:
+          - update
   2: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
@@ -672,6 +678,12 @@ cluster roles should match snapshot with agent0-connector enabled:
         verbs:
           - get
           - list
+      - apiGroups:
+          - apps
+        resources:
+          - deployments/finalizers
+        verbs:
+          - update
   2: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole

--- a/helm-chart/dash0-operator/tests/operator/__snapshot__/deployment-and-webhooks_test.yaml.snap
+++ b/helm-chart/dash0-operator/tests/operator/__snapshot__/deployment-and-webhooks_test.yaml.snap
@@ -51,6 +51,7 @@ deployment should match snapshot (default values):
                 - --dash0-telemetry-collection-enabled=true
                 - --dash0-force-use-otel-collector-service-url=false
                 - --dash0-gke-autopilot=false
+                - --dash0-openshift=false
                 - --dash0-disable-otel-collector-host-ports=false
                 - --dash0-otel-collector-otlp-grpc-host-port=40317
                 - --dash0-otel-collector-otlp-http-host-port=40318
@@ -225,6 +226,7 @@ deployment should match snapshot when using cert-manager:
                 - --dash0-telemetry-collection-enabled=true
                 - --dash0-force-use-otel-collector-service-url=false
                 - --dash0-gke-autopilot=false
+                - --dash0-openshift=false
                 - --dash0-disable-otel-collector-host-ports=false
                 - --dash0-otel-collector-otlp-grpc-host-port=40317
                 - --dash0-otel-collector-otlp-http-host-port=40318

--- a/helm-chart/dash0-operator/tests/operator/cluster-roles_test.yaml
+++ b/helm-chart/dash0-operator/tests/operator/cluster-roles_test.yaml
@@ -14,6 +14,21 @@ tests:
     asserts:
       - matchSnapshot: {}
 
+  - it: should grant deployments/finalizers for OwnerReferencesPermissionEnforcement
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - apps
+            resources:
+              - deployments/finalizers
+            verbs:
+              - update
+        documentSelector:
+          path: metadata.name
+          value: dash0-operator-manager-base
+
   - it: should grant permissions for telemetry collection if telemetry collection is enabled
     asserts:
       - hasDocuments:

--- a/helm-chart/dash0-operator/tests/operator/deployment-and-webhooks_test.yaml
+++ b/helm-chart/dash0-operator/tests/operator/deployment-and-webhooks_test.yaml
@@ -244,6 +244,19 @@ tests:
           path: spec.template.spec.containers[0].args
           content: --dash0-otel-collector-otlp-http-host-port=4318
 
+  - it: should render --dash0-openshift=true when operator.openShift.enabled is true
+    documentSelector:
+      path: metadata.name
+      value: dash0-operator-controller
+    set:
+      operator:
+        openShift:
+          enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --dash0-openshift=true
+
   - it: should accept sendBatchMaxSize equal to sendBatchSize
     documentSelector:
       path: metadata.name
@@ -436,24 +449,27 @@ tests:
           value: --dash0-gke-autopilot=false
       - equal:
           path: spec.template.spec.containers[0].args[6]
-          value: --dash0-disable-otel-collector-host-ports=true
+          value: --dash0-openshift=false
       - equal:
           path: spec.template.spec.containers[0].args[7]
-          value: --dash0-otel-collector-otlp-grpc-host-port=40317
+          value: --dash0-disable-otel-collector-host-ports=true
       - equal:
           path: spec.template.spec.containers[0].args[8]
-          value: --dash0-otel-collector-otlp-http-host-port=40318
+          value: --dash0-otel-collector-otlp-grpc-host-port=40317
       - equal:
           path: spec.template.spec.containers[0].args[9]
-          value: --instrumentation-delay-after-each-workload-millis=13
+          value: --dash0-otel-collector-otlp-http-host-port=40318
       - equal:
           path: spec.template.spec.containers[0].args[10]
-          value: --instrumentation-delay-after-each-namespace-millis=123
+          value: --instrumentation-delay-after-each-workload-millis=13
       - equal:
           path: spec.template.spec.containers[0].args[11]
+          value: --instrumentation-delay-after-each-namespace-millis=123
+      - equal:
+          path: spec.template.spec.containers[0].args[12]
           value: --dash0-log-level=info
       - notExists:
-          path: spec.template.spec.containers[0].args[12]
+          path: spec.template.spec.containers[0].args[13]
       - equal:
           path: spec.template.spec.containers[0].env[0].name
           value: GOMEMLIMIT
@@ -761,22 +777,22 @@ tests:
         instrumentationDelayAfterEachNamespaceMillis: 135
     asserts:
       - equal:
-          path: spec.template.spec.containers[0].args[7]
+          path: spec.template.spec.containers[0].args[8]
           value: --dash0-otel-collector-otlp-grpc-host-port=40317
       - equal:
-          path: spec.template.spec.containers[0].args[8]
+          path: spec.template.spec.containers[0].args[9]
           value: --dash0-otel-collector-otlp-http-host-port=40318
       - equal:
-          path: spec.template.spec.containers[0].args[9]
+          path: spec.template.spec.containers[0].args[10]
           value: --instrumentation-delay-after-each-workload-millis=2
       - equal:
-          path: spec.template.spec.containers[0].args[10]
+          path: spec.template.spec.containers[0].args[11]
           value: --instrumentation-delay-after-each-namespace-millis=135
       - equal:
-          path: spec.template.spec.containers[0].args[11]
+          path: spec.template.spec.containers[0].args[12]
           value: --dash0-log-level=info
       - notExists:
-          path: spec.template.spec.containers[0].args[12]
+          path: spec.template.spec.containers[0].args[13]
 
   - it: should render disableReplicasetInformer from legacy path
     documentSelector:

--- a/helm-chart/dash0-operator/tests/operator/openshift-scc_test.yaml
+++ b/helm-chart/dash0-operator/tests/operator/openshift-scc_test.yaml
@@ -1,0 +1,58 @@
+suite: test openshift scc
+templates:
+  - operator/openshift-scc.yaml
+tests:
+  - it: should not render the SecurityContextConstraints and RBAC when operator.openShift.enabled is false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render the SecurityContextConstraints and RBAC when operator.openShift.enabled is true
+    set:
+      operator:
+        openShift:
+          enabled: true
+    asserts:
+      - hasDocuments:
+          count: 3
+
+  - it: should render a SecurityContextConstraints granting host access to the collector service account
+    set:
+      operator:
+        openShift:
+          enabled: true
+    documentSelector:
+      path: kind
+      value: SecurityContextConstraints
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-dash0-collector
+      - equal:
+          path: allowHostDirVolumePlugin
+          value: true
+      - equal:
+          path: allowHostPorts
+          value: true
+      - equal:
+          path: runAsUser.type
+          value: RunAsAny
+      - contains:
+          path: allowedCapabilities
+          content: CHOWN
+
+  - it: should bind the SCC-use ClusterRole to the collector service account
+    set:
+      operator:
+        openShift:
+          enabled: true
+    documentSelector:
+      path: kind
+      value: RoleBinding
+    asserts:
+      - equal:
+          path: roleRef.name
+          value: RELEASE-NAME-dash0-collector-scc-use
+      - equal:
+          path: subjects[0].name
+          value: RELEASE-NAME-opentelemetry-collector-sa

--- a/helm-chart/dash0-operator/values.yaml
+++ b/helm-chart/dash0-operator/values.yaml
@@ -217,6 +217,18 @@ operator:
       # for more information.
       deployAllowlistSynchronizer: true
 
+  # Settings for Red Hat OpenShift clusters:
+  openShift:
+    # Set operator.openShift.enabled=true if you are running the Dash0 operator in a Red Hat OpenShift cluster.
+    # This will:
+    # - create a SecurityContextConstraints object plus RBAC that lets the OpenTelemetry collector DaemonSet run with
+    #   its required UID and host access
+    # - drop the hard-coded pod-level runAsUser/runAsGroup from the operator-managed workloads (agent0-connector,
+    #   target-allocator, Signal Control edge-proxy) and from the injected instrumentation init container, so the
+    #   namespace's SecurityContextConstraints can assign an in-range UID instead of a pinned one the default
+    #   MustRunAsRange strategy would reject
+    enabled: false
+
   # An array of tolerations for the operator manager deployment. This can be used to make sure that the operator manager
   # pod(s) can be scheduled on nodes where they would not be scheduled otherwise due to Kubernetes taints.
   # Example:

--- a/images/instrumentation/Dockerfile
+++ b/images/instrumentation/Dockerfile
@@ -155,4 +155,7 @@ COPY --from=build-ruby-glibc /dash0-instrumentation/ruby /dash0-instrumentation/
 COPY --from=build-ruby-musl /dash0-instrumentation/ruby /dash0-instrumentation/agents/ruby/musl
 
 WORKDIR /
+# A numeric non-root USER lets the kubelet verify runAsNonRoot when the pod-level runAsUser is dropped. Matches
+# defaultInitContainerUser.
+USER 13020
 CMD ["/copy-instrumentation.sh"]

--- a/internal/agent0connector/a0cresources/desired_state.go
+++ b/internal/agent0connector/a0cresources/desired_state.go
@@ -620,8 +620,8 @@ func assembleDeployment(
 			SeccompProfile: &corev1.SeccompProfile{
 				Type: corev1.SeccompProfileTypeRuntimeDefault,
 			},
-			RunAsUser:  new(defaultUser),
-			RunAsGroup: new(defaultGroup),
+			RunAsUser:  util.RunAsID(c.IsOpenShift, defaultUser),
+			RunAsGroup: util.RunAsID(c.IsOpenShift, defaultGroup),
 		},
 	}
 

--- a/internal/agent0connector/a0cresources/desired_state_test.go
+++ b/internal/agent0connector/a0cresources/desired_state_test.go
@@ -547,6 +547,16 @@ var _ = Describe("The desired state of the agent0-connector resources", func() {
 			Expect(sc.SeccompProfile.Type).To(Equal(corev1.SeccompProfileTypeRuntimeDefault))
 		})
 
+		It("omits the pod-level runAsUser/runAsGroup on OpenShift so the SCC can assign an in-range UID", func() {
+			cfg := testConfig()
+			cfg.IsOpenShift = true
+			sc := getDeployment(assembleDesiredState(cfg, authTokenEnvVar, util.ExtraConfig{})).Spec.Template.Spec.SecurityContext
+			Expect(sc).ToNot(BeNil())
+			Expect(*sc.RunAsNonRoot).To(BeTrue())
+			Expect(sc.RunAsUser).To(BeNil())
+			Expect(sc.RunAsGroup).To(BeNil())
+		})
+
 		It("renders additional labels and annotations on the workload and the pods", func() {
 			deployment := getDeployment(assembleDesiredState(testConfig(), authTokenEnvVar, util.ExtraConfig{
 				Agent0ConnectorLabels:         map[string]string{"a0c-label": "a0c-label-value"},

--- a/internal/signalcontrol/scresources/desired_state.go
+++ b/internal/signalcontrol/scresources/desired_state.go
@@ -59,6 +59,7 @@ func assembleDesiredState(
 	otlpGrpcHostPort int32,
 	extraConfig util.ExtraConfig,
 	forDeletion bool,
+	isOpenShift bool,
 	logger logd.Logger,
 ) []clientObject {
 	edgeProxyEnabled := !forDeletion &&
@@ -74,7 +75,7 @@ func assembleDesiredState(
 	if forDeletion || edgeProxyEnabled {
 		if edgeProxyEnabled {
 			desiredState = append(desiredState,
-				addCommonMetadata(assembleEdgeProxyDeployment(operatorNamespace, namePrefix, signalControlResource, operatorConfig, edgeProxyImage, edgeProxyImagePullPolicy, operatorVersion, otlpGrpcHostPort, extraConfig, logger)),
+				addCommonMetadata(assembleEdgeProxyDeployment(operatorNamespace, namePrefix, signalControlResource, operatorConfig, edgeProxyImage, edgeProxyImagePullPolicy, operatorVersion, otlpGrpcHostPort, extraConfig, isOpenShift, logger)),
 				addCommonMetadata(assembleEdgeProxyService(operatorNamespace, namePrefix)),
 				addCommonMetadata(assembleEdgeProxyPodDisruptionBudget(operatorNamespace, namePrefix)),
 			)
@@ -94,7 +95,7 @@ func assembleDesiredStateForDelete(
 	namePrefix string,
 	logger logd.Logger,
 ) []clientObject {
-	return assembleDesiredState(operatorNamespace, namePrefix, nil, nil, "", "", "", 0, util.ExtraConfig{}, true, logger)
+	return assembleDesiredState(operatorNamespace, namePrefix, nil, nil, "", "", "", 0, util.ExtraConfig{}, true, false, logger)
 }
 
 func assembleEdgeProxyDeployment(
@@ -107,6 +108,7 @@ func assembleEdgeProxyDeployment(
 	operatorVersion string,
 	otlpGrpcHostPort int32,
 	extraConfig util.ExtraConfig,
+	isOpenShift bool,
 	logger logd.Logger,
 ) *appsv1.Deployment {
 	replicas := extraConfig.EdgeProxyReplicas
@@ -299,7 +301,7 @@ func assembleEdgeProxyDeployment(
 		TerminationGracePeriodSeconds: new(int64(30)),
 		SecurityContext: &corev1.PodSecurityContext{
 			RunAsNonRoot: new(true),
-			RunAsUser:    new(edgeProxyUserID),
+			RunAsUser:    util.RunAsID(isOpenShift, edgeProxyUserID),
 			SeccompProfile: &corev1.SeccompProfile{
 				Type: corev1.SeccompProfileTypeRuntimeDefault,
 			},

--- a/internal/signalcontrol/scresources/desired_state_test.go
+++ b/internal/signalcontrol/scresources/desired_state_test.go
@@ -51,7 +51,7 @@ var _ = Describe("Edge Proxy deployment self-monitoring env vars", func() {
 
 		dep := assembleEdgeProxyDeployment(
 			OperatorNamespace, "test-prefix", minimalSignalControl, opConfig,
-			"edge-proxy:latest", corev1.PullIfNotPresent, testOperatorVersion, testOtlpGrpcHostPort, util.ExtraConfig{}, logd.Discard(),
+			"edge-proxy:latest", corev1.PullIfNotPresent, testOperatorVersion, testOtlpGrpcHostPort, util.ExtraConfig{}, false, logd.Discard(),
 		)
 
 		container := dep.Spec.Template.Spec.Containers[0]
@@ -64,7 +64,7 @@ var _ = Describe("Edge Proxy deployment self-monitoring env vars", func() {
 
 		dep := assembleEdgeProxyDeployment(
 			OperatorNamespace, "test-prefix", minimalSignalControl, opConfig,
-			"edge-proxy:latest", corev1.PullIfNotPresent, testOperatorVersion, testOtlpGrpcHostPort, util.ExtraConfig{}, logd.Discard(),
+			"edge-proxy:latest", corev1.PullIfNotPresent, testOperatorVersion, testOtlpGrpcHostPort, util.ExtraConfig{}, false, logd.Discard(),
 		)
 
 		container := dep.Spec.Template.Spec.Containers[0]
@@ -78,7 +78,7 @@ var _ = Describe("Edge Proxy deployment self-monitoring env vars", func() {
 		dep := assembleEdgeProxyDeployment(
 			OperatorNamespace, "test-prefix", minimalSignalControl, opConfig,
 			"edge-proxy:latest", corev1.PullIfNotPresent, testOperatorVersion,
-			int32(4317), util.ExtraConfig{}, logd.Discard(),
+			int32(4317), util.ExtraConfig{}, false, logd.Discard(),
 		)
 
 		container := dep.Spec.Template.Spec.Containers[0]
@@ -91,7 +91,7 @@ var _ = Describe("Edge Proxy deployment self-monitoring env vars", func() {
 
 		dep := assembleEdgeProxyDeployment(
 			OperatorNamespace, "test-prefix", minimalSignalControl, opConfig,
-			"edge-proxy:latest", corev1.PullIfNotPresent, testOperatorVersion, testOtlpGrpcHostPort, util.ExtraConfig{}, logd.Discard(),
+			"edge-proxy:latest", corev1.PullIfNotPresent, testOperatorVersion, testOtlpGrpcHostPort, util.ExtraConfig{}, false, logd.Discard(),
 		)
 
 		container := dep.Spec.Template.Spec.Containers[0]
@@ -101,7 +101,7 @@ var _ = Describe("Edge Proxy deployment self-monitoring env vars", func() {
 	It("does not inject OTel exporter env vars when operator config is nil", func() {
 		dep := assembleEdgeProxyDeployment(
 			OperatorNamespace, "test-prefix", minimalSignalControl, nil,
-			"edge-proxy:latest", corev1.PullIfNotPresent, testOperatorVersion, testOtlpGrpcHostPort, util.ExtraConfig{}, logd.Discard(),
+			"edge-proxy:latest", corev1.PullIfNotPresent, testOperatorVersion, testOtlpGrpcHostPort, util.ExtraConfig{}, false, logd.Discard(),
 		)
 
 		container := dep.Spec.Template.Spec.Containers[0]
@@ -174,7 +174,7 @@ var _ = Describe("Edge Proxy deployment scheduling and resources", func() {
 
 		dep := assembleEdgeProxyDeployment(
 			OperatorNamespace, "test-prefix", minimalSignalControl, operatorConfigWithDash0Export,
-			"edge-proxy:latest", corev1.PullIfNotPresent, testOperatorVersion, testOtlpGrpcHostPort, extraConfig, logd.Discard(),
+			"edge-proxy:latest", corev1.PullIfNotPresent, testOperatorVersion, testOtlpGrpcHostPort, extraConfig, false, logd.Discard(),
 		)
 
 		podSpec := dep.Spec.Template.Spec
@@ -199,7 +199,7 @@ var _ = Describe("Edge Proxy deployment scheduling and resources", func() {
 	It("leaves Affinity unset when EdgeProxyNodeAffinity is nil", func() {
 		dep := assembleEdgeProxyDeployment(
 			OperatorNamespace, "test-prefix", minimalSignalControl, operatorConfigWithDash0Export,
-			"edge-proxy:latest", corev1.PullIfNotPresent, testOperatorVersion, testOtlpGrpcHostPort, util.ExtraConfig{}, logd.Discard(),
+			"edge-proxy:latest", corev1.PullIfNotPresent, testOperatorVersion, testOtlpGrpcHostPort, util.ExtraConfig{}, false, logd.Discard(),
 		)
 
 		Expect(dep.Spec.Template.Spec.Affinity).To(BeNil())
@@ -209,7 +209,7 @@ var _ = Describe("Edge Proxy deployment scheduling and resources", func() {
 	It("defaults to a single replica when EdgeProxyReplicas is unset", func() {
 		dep := assembleEdgeProxyDeployment(
 			OperatorNamespace, "test-prefix", minimalSignalControl, operatorConfigWithDash0Export,
-			"edge-proxy:latest", corev1.PullIfNotPresent, testOperatorVersion, testOtlpGrpcHostPort, util.ExtraConfig{}, logd.Discard(),
+			"edge-proxy:latest", corev1.PullIfNotPresent, testOperatorVersion, testOtlpGrpcHostPort, util.ExtraConfig{}, false, logd.Discard(),
 		)
 
 		Expect(dep.Spec.Replicas).ToNot(BeNil())
@@ -220,7 +220,7 @@ var _ = Describe("Edge Proxy deployment scheduling and resources", func() {
 		dep := assembleEdgeProxyDeployment(
 			OperatorNamespace, "test-prefix", minimalSignalControl, operatorConfigWithDash0Export,
 			"edge-proxy:latest", corev1.PullIfNotPresent, testOperatorVersion,
-			testOtlpGrpcHostPort, util.ExtraConfig{EdgeProxyReplicas: 3}, logd.Discard(),
+			testOtlpGrpcHostPort, util.ExtraConfig{EdgeProxyReplicas: 3}, false, logd.Discard(),
 		)
 
 		Expect(dep.Spec.Replicas).ToNot(BeNil())
@@ -248,7 +248,7 @@ var _ = Describe("Edge Proxy tail-sampling gating", func() {
 
 		dep := assembleEdgeProxyDeployment(
 			OperatorNamespace, "test-prefix", sc, opConfig,
-			"edge-proxy:latest", corev1.PullIfNotPresent, testOperatorVersion, testOtlpGrpcHostPort, util.ExtraConfig{}, logd.Discard(),
+			"edge-proxy:latest", corev1.PullIfNotPresent, testOperatorVersion, testOtlpGrpcHostPort, util.ExtraConfig{}, false, logd.Discard(),
 		)
 
 		env := envNames(dep.Spec.Template.Spec.Containers[0])
@@ -264,7 +264,7 @@ var _ = Describe("Edge Proxy tail-sampling gating", func() {
 
 		dep := assembleEdgeProxyDeployment(
 			OperatorNamespace, "test-prefix", minimalSignalControl, opConfig,
-			"edge-proxy:latest", corev1.PullIfNotPresent, testOperatorVersion, testOtlpGrpcHostPort, util.ExtraConfig{}, logd.Discard(),
+			"edge-proxy:latest", corev1.PullIfNotPresent, testOperatorVersion, testOtlpGrpcHostPort, util.ExtraConfig{}, false, logd.Discard(),
 		)
 
 		env := envNames(dep.Spec.Template.Spec.Containers[0])
@@ -281,7 +281,7 @@ var _ = Describe("Edge Proxy tail-sampling gating", func() {
 
 		dep := assembleEdgeProxyDeployment(
 			OperatorNamespace, "test-prefix", sc, operatorConfigWithDash0Export,
-			"edge-proxy:latest", corev1.PullIfNotPresent, testOperatorVersion, testOtlpGrpcHostPort, util.ExtraConfig{}, logd.Discard(),
+			"edge-proxy:latest", corev1.PullIfNotPresent, testOperatorVersion, testOtlpGrpcHostPort, util.ExtraConfig{}, false, logd.Discard(),
 		)
 
 		env := envNames(dep.Spec.Template.Spec.Containers[0])
@@ -301,7 +301,7 @@ var _ = Describe("Edge Proxy deployment labels and annotations", func() {
 
 		dep := assembleEdgeProxyDeployment(
 			OperatorNamespace, "test-prefix", minimalSignalControl, operatorConfigWithDash0Export,
-			"edge-proxy:latest", corev1.PullIfNotPresent, testOperatorVersion, testOtlpGrpcHostPort, extraConfig, logd.Discard(),
+			"edge-proxy:latest", corev1.PullIfNotPresent, testOperatorVersion, testOtlpGrpcHostPort, extraConfig, false, logd.Discard(),
 		)
 
 		Expect(dep.Labels).To(HaveKeyWithValue("team", "obs"))
@@ -312,6 +312,30 @@ var _ = Describe("Edge Proxy deployment labels and annotations", func() {
 		Expect(tmpl.Labels).To(HaveKeyWithValue("pod-label", "pv"))
 		Expect(tmpl.Labels).To(HaveKeyWithValue(util.AppKubernetesIoComponentLabel, edgeProxyComponentName))
 		Expect(tmpl.Annotations).To(HaveKeyWithValue("pod-ann/key", "pa"))
+	})
+})
+
+var _ = Describe("Edge Proxy pod security context", func() {
+	It("pins the pod-level runAsUser when not on OpenShift", func() {
+		dep := assembleEdgeProxyDeployment(
+			OperatorNamespace, "test-prefix", minimalSignalControl, nil,
+			"edge-proxy:latest", corev1.PullIfNotPresent, testOperatorVersion, testOtlpGrpcHostPort, util.ExtraConfig{}, false, logd.Discard(),
+		)
+		sc := dep.Spec.Template.Spec.SecurityContext
+		Expect(sc).ToNot(BeNil())
+		Expect(*sc.RunAsNonRoot).To(BeTrue())
+		Expect(*sc.RunAsUser).To(Equal(int64(10001)))
+	})
+
+	It("omits the pod-level runAsUser on OpenShift so the SCC can assign an in-range UID", func() {
+		dep := assembleEdgeProxyDeployment(
+			OperatorNamespace, "test-prefix", minimalSignalControl, nil,
+			"edge-proxy:latest", corev1.PullIfNotPresent, testOperatorVersion, testOtlpGrpcHostPort, util.ExtraConfig{}, true, logd.Discard(),
+		)
+		sc := dep.Spec.Template.Spec.SecurityContext
+		Expect(sc).ToNot(BeNil())
+		Expect(*sc.RunAsNonRoot).To(BeTrue())
+		Expect(sc.RunAsUser).To(BeNil())
 	})
 })
 

--- a/internal/signalcontrol/scresources/sc_resources.go
+++ b/internal/signalcontrol/scresources/sc_resources.go
@@ -30,6 +30,7 @@ type SignalControlResourceManager struct {
 	edgeProxyImagePullPolicy  corev1.PullPolicy
 	operatorVersion           string
 	otlpGrpcHostPort          int32
+	isOpenShift               bool
 }
 
 func NewSignalControlResourceManager(
@@ -42,6 +43,7 @@ func NewSignalControlResourceManager(
 	edgeProxyImagePullPolicy corev1.PullPolicy,
 	operatorVersion string,
 	otlpGrpcHostPort int32,
+	isOpenShift bool,
 ) *SignalControlResourceManager {
 	return &SignalControlResourceManager{
 		Client:                    k8sClient,
@@ -53,6 +55,7 @@ func NewSignalControlResourceManager(
 		edgeProxyImagePullPolicy:  edgeProxyImagePullPolicy,
 		operatorVersion:           operatorVersion,
 		otlpGrpcHostPort:          otlpGrpcHostPort,
+		isOpenShift:               isOpenShift,
 	}
 }
 
@@ -63,7 +66,7 @@ func (m *SignalControlResourceManager) CreateOrUpdateResources(
 	extraConfig util.ExtraConfig,
 	logger logd.Logger,
 ) (bool, bool, error) {
-	desiredState := assembleDesiredState(m.operatorNamespace, m.namePrefix, signalControlResource, operatorConfig, m.edgeProxyImage, m.edgeProxyImagePullPolicy, m.operatorVersion, m.otlpGrpcHostPort, extraConfig, false, logger)
+	desiredState := assembleDesiredState(m.operatorNamespace, m.namePrefix, signalControlResource, operatorConfig, m.edgeProxyImage, m.edgeProxyImagePullPolicy, m.operatorVersion, m.otlpGrpcHostPort, extraConfig, false, m.isOpenShift, logger)
 
 	resourcesHaveBeenCreated := false
 	resourcesHaveBeenUpdated := false

--- a/internal/signalcontrol/signalcontrol_controller_test.go
+++ b/internal/signalcontrol/signalcontrol_controller_test.go
@@ -52,6 +52,7 @@ var _ = Describe("The Signal Control controller", Ordered, func() {
 			corev1.PullIfNotPresent,
 			OperatorVersionTest,
 			otelcolresources.DefaultOtlpGrpcHostPort,
+			false,
 		)
 		scManager := NewSignalControlManager(k8sClient, scResourceManager, util.ExtraConfigDefaults)
 		oTelColResourceManager := otelcolresources.NewOTelColResourceManager(

--- a/internal/startup/operator_manager_startup.go
+++ b/internal/startup/operator_manager_startup.go
@@ -155,6 +155,7 @@ type commandLineArguments struct {
 	featureSignalControlEnabled                                           bool
 	forceUseOpenTelemetryCollectorServiceUrl                              bool
 	isGkeAutopilot                                                        bool
+	isOpenShift                                                           bool
 	disableOpenTelemetryCollectorHostPorts                                bool
 	otlpGrpcHostPort                                                      int
 	otlpHttpHostPort                                                      int
@@ -674,6 +675,12 @@ func defineCommandLineArguments() *commandLineArguments {
 		"dash0-gke-autopilot",
 		false,
 		"Whether the operator is running on GKE Autopilot.",
+	)
+	flag.BoolVar(
+		&cliArgs.isOpenShift,
+		"dash0-openshift",
+		false,
+		"Whether the operator is running on Red Hat OpenShift.",
 	)
 	flag.BoolVar(
 		&cliArgs.disableOpenTelemetryCollectorHostPorts,
@@ -1483,6 +1490,8 @@ func startOperatorManager(
 		cliArgs.disableOpenTelemetryCollectorHostPorts,
 		"is GKE Autopilot",
 		cliArgs.isGkeAutopilot,
+		"is OpenShift",
+		cliArgs.isOpenShift,
 
 		"metrics bind address",
 		cliArgs.metricsAddr,
@@ -1662,6 +1671,7 @@ func startDash0Controllers(
 		envVars.enablePythonAutoInstrumentation,
 		envVars.enableRubyAutoInstrumentation,
 	)
+	clusterInstrumentationConfig.IsOpenShift = cliArgs.isOpenShift
 
 	startMinimumKubeletVersionDetection(
 		ctx,
@@ -1766,6 +1776,7 @@ func startDash0Controllers(
 			TargetAllocatorNamePrefix: envVars.targetAllocatorNamePrefix,
 			CollectorComponent:        otelcolresources.CollectorDaemonSetServiceComponent(),
 			IsGkeAutopilot:            cliArgs.isGkeAutopilot,
+			IsOpenShift:               cliArgs.isOpenShift,
 		}
 		targetallocatorResourceManager := taresources.NewTargetAllocatorResourceManager(
 			k8sClient,
@@ -1798,6 +1809,7 @@ func startDash0Controllers(
 		operatorDeploymentSelfReference,
 		clusterUid,
 		developmentMode,
+		cliArgs.isOpenShift,
 	)
 	if err != nil {
 		return err
@@ -1818,6 +1830,7 @@ func startDash0Controllers(
 			envVars.edgeProxyImagePullPolicy,
 			images.GetOperatorVersion(),
 			int32(cliArgs.otlpGrpcHostPort),
+			cliArgs.isOpenShift,
 		)
 		scManager = signalcontrol.NewSignalControlManager(
 			k8sClient,
@@ -2280,6 +2293,7 @@ func setupAgent0ConnectorManager(
 	operatorDeploymentSelfReference *appsv1.Deployment,
 	pseudoClusterUid types.UID,
 	developmentMode bool,
+	isOpenShift bool,
 ) (*agent0connector.Agent0ConnectorManager, error) {
 	if !envVars.agent0ConnectorEnabled {
 		// We might not have the permissions to manage the agent0 connector resources (in particular when telemetry
@@ -2294,6 +2308,7 @@ func setupAgent0ConnectorManager(
 		ServerAddress:     envVars.agent0ConnectorServerAddress,
 		Insecure:          envVars.agent0ConnectorInsecure,
 		Authorization:     agent0ConnectorAuthorization(envVars),
+		IsOpenShift:       isOpenShift,
 		DevelopmentMode:   developmentMode,
 	}
 	agent0ConnectorResourceManager := a0cresources.NewAgent0ConnectorResourceManager(

--- a/internal/startup/operator_manager_startup_test.go
+++ b/internal/startup/operator_manager_startup_test.go
@@ -47,6 +47,7 @@ var _ = Describe("operator manager startup", func() {
 				&appsv1.Deployment{},
 				"cluster-uid",
 				false,
+				false,
 			)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(agent0ConnectorManager).To(BeNil())
@@ -66,6 +67,7 @@ var _ = Describe("operator manager startup", func() {
 				util.Images{},
 				&appsv1.Deployment{},
 				types.UID("cluster-uid"),
+				false,
 				false,
 			)
 			Expect(err).NotTo(HaveOccurred())

--- a/internal/targetallocator/taresources/desired_state.go
+++ b/internal/targetallocator/taresources/desired_state.go
@@ -62,6 +62,7 @@ type targetAllocatorConfig struct {
 	Images             util.Images
 
 	IsGkeAutopilot bool
+	IsOpenShift    bool
 }
 
 // This type just exists to ensure all created objects go through addCommonMetadata.
@@ -470,8 +471,8 @@ func assembleDeployment(c *targetAllocatorConfig, taConfigMap *corev1.ConfigMap,
 			SeccompProfile: &corev1.SeccompProfile{
 				Type: corev1.SeccompProfileTypeRuntimeDefault,
 			},
-			RunAsUser:  new(defaultUser),
-			RunAsGroup: new(defaultGroup),
+			RunAsUser:  util.RunAsID(c.IsOpenShift, defaultUser),
+			RunAsGroup: util.RunAsID(c.IsOpenShift, defaultGroup),
 		},
 		Volumes: podVolumes,
 	}

--- a/internal/targetallocator/taresources/desired_state_test.go
+++ b/internal/targetallocator/taresources/desired_state_test.go
@@ -180,6 +180,35 @@ var _ = Describe("The desired state of the OpenTelemetry TargetAllocator resourc
 		Expect(value).To(Equal(gkeAutopilotAllowlistValue))
 	})
 
+	It("pins the pod-level runAsUser/runAsGroup when not on OpenShift", func() {
+		desiredState, err := assembleDesiredStateForUpsert(&targetAllocatorConfig{
+			OperatorNamespace: OperatorNamespace,
+			NamePrefix:        TargetAllocatorPrefixTest,
+			Images:            TestImages,
+		}, nil, util.ExtraConfig{})
+		Expect(err).ToNot(HaveOccurred())
+
+		sc := getDeployment(desiredState).Spec.Template.Spec.SecurityContext
+		Expect(*sc.RunAsUser).To(Equal(int64(65532)))
+		Expect(*sc.RunAsGroup).To(Equal(int64(0)))
+	})
+
+	It("omits the pod-level runAsUser/runAsGroup on OpenShift so the SCC can assign an in-range UID", func() {
+		desiredState, err := assembleDesiredStateForUpsert(&targetAllocatorConfig{
+			OperatorNamespace: OperatorNamespace,
+			NamePrefix:        TargetAllocatorPrefixTest,
+			Images:            TestImages,
+			IsOpenShift:       true,
+		}, nil, util.ExtraConfig{})
+		Expect(err).ToNot(HaveOccurred())
+
+		sc := getDeployment(desiredState).Spec.Template.Spec.SecurityContext
+		Expect(sc).ToNot(BeNil())
+		Expect(*sc.RunAsNonRoot).To(BeTrue())
+		Expect(sc.RunAsUser).To(BeNil())
+		Expect(sc.RunAsGroup).To(BeNil())
+	})
+
 	When("mTLS is enabled", Ordered, func() {
 		const certSecretName = "ta-mtls-server-cert-secret"
 		var desiredState []clientObject

--- a/internal/targetallocator/taresources/ta_resources.go
+++ b/internal/targetallocator/taresources/ta_resources.go
@@ -52,6 +52,7 @@ func (m *TargetAllocatorResourceManager) CreateOrUpdateTargetAllocatorResources(
 		CollectorComponent: m.targetAllocatorConfig.CollectorComponent,
 		Images:             m.targetAllocatorConfig.Images,
 		IsGkeAutopilot:     m.targetAllocatorConfig.IsGkeAutopilot,
+		IsOpenShift:        m.targetAllocatorConfig.IsOpenShift,
 	}
 
 	desiredState, err := assembleDesiredStateForUpsert(config, namespacesWithPrometheusScraping, extraConfig)
@@ -194,6 +195,7 @@ func (m *TargetAllocatorResourceManager) DeleteResources(
 		OperatorNamespace: m.targetAllocatorConfig.OperatorNamespace,
 		NamePrefix:        m.targetAllocatorConfig.TargetAllocatorNamePrefix,
 		IsGkeAutopilot:    m.targetAllocatorConfig.IsGkeAutopilot,
+		IsOpenShift:       m.targetAllocatorConfig.IsOpenShift,
 	}
 	desiredResources, err := assembleDesiredStateForDelete(config, extraConfig)
 	if err != nil {

--- a/internal/util/types.go
+++ b/internal/util/types.go
@@ -130,6 +130,7 @@ type TargetAllocatorConfig struct {
 	// CollectorComponent is used as a label matcher, so scrape targets are only assigned to Dash0 daemonset collectors.
 	CollectorComponent string
 	IsGkeAutopilot     bool
+	IsOpenShift        bool
 	DevelopmentMode    bool
 }
 
@@ -155,6 +156,7 @@ type Agent0ConnectorConfig struct {
 	// value operator.agent0Connector.secretRef). It is passed to the workload via the DASH0_AGENT0_CONNECTOR_AUTH_TOKEN
 	// environment variable.
 	Authorization   dash0common.Authorization
+	IsOpenShift     bool
 	DevelopmentMode bool
 }
 
@@ -196,6 +198,16 @@ func getImageVersion(image string) string {
 	return ""
 }
 
+// RunAsID returns a pointer to id for use as a pod security context runAsUser or runAsGroup, or nil when the operator
+// runs on OpenShift. Returning nil lets the namespace's SecurityContextConstraints assign an in-range UID/GID, instead
+// of pinning a UID that the default MustRunAsRange strategy would reject as out of range.
+func RunAsID(isOpenShift bool, id int64) *int64 {
+	if isOpenShift {
+		return nil
+	}
+	return &id
+}
+
 // PossibleCollectorUrls holds the two possible base URLs for routing telemetry from instrumented workloads to the
 // OpenTelemetry collector daemonset: the service URL of the collector DaemonSet and the node-local URL (node IP plus
 // host port). The actual URL used for instrumentation is selected from these two values depending on the cluster setup.
@@ -232,6 +244,7 @@ type ClusterInstrumentationConfig struct {
 	InstrumentationDebug            bool
 	EnablePythonAutoInstrumentation bool
 	EnableRubyAutoInstrumentation   bool
+	IsOpenShift                     bool
 }
 
 func NewClusterInstrumentationConfig(

--- a/internal/workloads/workload_modifier.go
+++ b/internal/workloads/workload_modifier.go
@@ -564,7 +564,10 @@ func (m *ResourceModifier) createInitContainer(podSpec *corev1.PodSpec) *corev1.
 	if securityContext == nil {
 		securityContext = &corev1.PodSecurityContext{}
 	}
-	if securityContext.FSGroup != nil {
+	if m.clusterInstrumentationConfig.IsOpenShift {
+		initContainerUser = nil
+		initContainerGroup = nil
+	} else if securityContext.FSGroup != nil {
 		initContainerUser = securityContext.FSGroup
 		initContainerGroup = securityContext.FSGroup
 	}

--- a/internal/workloads/workload_modifier_test.go
+++ b/internal/workloads/workload_modifier_test.go
@@ -882,6 +882,48 @@ var _ = Describe("Dash0 Workload Modification", func() {
 			}),
 		)
 
+		It("pins the init container runAsUser/runAsGroup to 13020 when not on OpenShift", func() {
+			modifier := NewResourceModifier(
+				clusterInstrumentationConfigWithInitContainer,
+				DefaultNamespaceInstrumentationConfig,
+				testActor,
+				logger,
+			)
+			podSpec := &corev1.PodSpec{Containers: []corev1.Container{{Name: "test-container-0"}}}
+			modifier.modifyPodSpec(podSpec, &metav1.ObjectMeta{}, &metav1.ObjectMeta{})
+
+			Expect(podSpec.InitContainers).To(HaveLen(1))
+			sc := podSpec.InitContainers[0].SecurityContext
+			Expect(sc).ToNot(BeNil())
+			Expect(*sc.RunAsUser).To(Equal(int64(13020)))
+			Expect(*sc.RunAsGroup).To(Equal(int64(13020)))
+		})
+
+		It("drops the init container runAsUser/runAsGroup on OpenShift so the SCC can assign an in-range UID", func() {
+			osConfig := util.NewClusterInstrumentationConfig(
+				TestImages,
+				PossibleCollectorUrlsTest,
+				OTelCollectorNodeLocalBaseUrlTest,
+				util.ExtraConfigDefaults,
+				dash0v1alpha1.InstrumentationDeliveryInitContainer,
+				nil,
+				false,
+				false,
+				false,
+			)
+			osConfig.IsOpenShift = true
+			modifier := NewResourceModifier(osConfig, DefaultNamespaceInstrumentationConfig, testActor, logger)
+
+			podSpec := &corev1.PodSpec{Containers: []corev1.Container{{Name: "test-container-0"}}}
+			modifier.modifyPodSpec(podSpec, &metav1.ObjectMeta{}, &metav1.ObjectMeta{})
+
+			Expect(podSpec.InitContainers).To(HaveLen(1))
+			sc := podSpec.InitContainers[0].SecurityContext
+			Expect(sc).ToNot(BeNil())
+			Expect(sc.RunAsUser).To(BeNil())
+			Expect(sc.RunAsGroup).To(BeNil())
+		})
+
 		type detectNonLinuxPodTest struct {
 			podSpec         corev1.PodSpec
 			expectedMessage *string

--- a/test-resources/bin/lib/util
+++ b/test-resources/bin/lib/util
@@ -134,7 +134,11 @@ install_nginx_ingress() {
 
 is_remote_image() {
   image_name="$1"
-  if [[ $image_name = */* ]]; then
+  # localhost/ references resolve to the local container store, not a remote registry, so their pull policy must be
+  # preserved (a blanked policy would default a :latest image to Always and trigger a failing registry pull).
+  if [[ $image_name == localhost/* ]]; then
+    printf "false"
+  elif [[ $image_name = */* ]]; then
     printf "true"
   else
     printf "false"

--- a/test-resources/bin/lib/util
+++ b/test-resources/bin/lib/util
@@ -809,6 +809,10 @@ run_helm() {
     helm_install_command+=" --set operator.gke.autopilot.enabled=true"
   fi
 
+  if [[ "${OPENSHIFT_ENABLED:-}" = "true" ]]; then
+    helm_install_command+=" --set operator.openShift.enabled=true"
+  fi
+
   # on kind, the collectors sometimes need more time to start
   if [[ "${ALLOW_MORE_TIME_FOR_COLLECTOR_STARTUP:-}" == "true" ]]; then
     helm_install_command+=" --set operator.collectors.daemonSetProbes.startup.failureThreshold=60"


### PR DESCRIPTION
## Description

The following adaptions have been made to support installing the operator in OpenShift via Helm:

- added a custom SCC for the daemonset collector
- dropped the `runAsUser/runAsGroup` when running on OpenShift, so either the user id from the image is used or one is generated based on the configured range
- small change to RBAC since OpenShift/MicroShift enables the [OwnerReferencesPermissionEnforcement](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement) admission plugin (not gated behind the OpenShift flag since other clusters could technically enable it as well, even though it's off by default)

## Authorship

<!--Human authorship attestation. AI agents must not check the following boxes on behalf of the user. The human author must check them personally before the PR will be reviewed.-->

The human author of this PR confirms they

- [x] fully understand the changes and can explain the reasoning behind the design decisions,
- [x] fully understand how to verify and test the changes,
- [x] did confirm the changes work as expected by testing them in a real cluster, and
- [x] personally wrote the PR description.
