### PR TITLE
ci(gke-ap): fix failing gke autopilot check

### DIFF
--- a/.github/workflows/gke-ap-workload-allowlist-check.yaml
+++ b/.github/workflows/gke-ap-workload-allowlist-check.yaml
@@ -121,7 +121,7 @@ jobs:
       always() &&
       (needs.build_and_push_images.result == 'success' || needs.build_and_push_images.result == 'skipped') &&
       (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success')
-    timeout-minutes: 20
+    timeout-minutes: 15
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/gke-ap-workload-allowlist-check.yaml
+++ b/.github/workflows/gke-ap-workload-allowlist-check.yaml
@@ -157,7 +157,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: gke-ap-allowlist-check-diagnostics
-          path: gke-ap-allowlist-check-diagnostics.tar.gz
+          path: gke-ap-allowlist-check-diagnostics
           if-no-files-found: ignore
 
       - name: send Slack notification on success

--- a/.github/workflows/gke-ap-workload-allowlist-check.yaml
+++ b/.github/workflows/gke-ap-workload-allowlist-check.yaml
@@ -121,7 +121,7 @@ jobs:
       always() &&
       (needs.build_and_push_images.result == 'success' || needs.build_and_push_images.result == 'skipped') &&
       (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success')
-    timeout-minutes: 15
+    timeout-minutes: 20
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/gke-ap-workload-allowlist-check.yaml
+++ b/.github/workflows/gke-ap-workload-allowlist-check.yaml
@@ -121,7 +121,7 @@ jobs:
       always() &&
       (needs.build_and_push_images.result == 'success' || needs.build_and_push_images.result == 'skipped') &&
       (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success')
-    timeout-minutes: 8
+    timeout-minutes: 15
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/scripts/gke-ap-workload-allowlist-check.sh
+++ b/.github/workflows/scripts/gke-ap-workload-allowlist-check.sh
@@ -288,7 +288,7 @@ kubectl \
   rollout status \
   daemonset "${helm_release_name}-opentelemetry-collector-agent-daemonset" \
   --namespace "$operator_namespace" \
-  --timeout 180s
+  --timeout 300s
 set +x
 
 log "the daemonset collector is ready now"

--- a/.github/workflows/scripts/gke-ap-workload-allowlist-check.sh
+++ b/.github/workflows/scripts/gke-ap-workload-allowlist-check.sh
@@ -48,19 +48,18 @@ else
 fi
 helm_release_name=dash0-operator
 
-# Directory and archive used to collect cluster diagnostics when the check fails. These paths are relative to the
-# repository root (we cd into it above), which is also the working directory of the GitHub Actions job, so the workflow
-# can upload the archive as an artifact.
+# Directory used to collect cluster diagnostics when the check fails. The path is relative to the repository root (we cd
+# into it above), which is also the working directory of the GitHub Actions job, so the workflow can upload the directory
+# as an artifact. The upload-artifact action will automatically creates a zip archive.
 diagnostics_dir=gke-ap-allowlist-check-diagnostics
-diagnostics_archive="${diagnostics_dir}.tar.gz"
 
 # Set to "true" once all checks have passed. As long as this is not "true" when cleanup() runs, we assume the check has
 # failed and collect cluster diagnostics before tearing everything down.
 check_succeeded=false
 
 # Collects diagnostic information from the cluster (workloads, pods, their logs, events, config maps and the relevant
-# custom resources) into $diagnostics_dir and compresses it into $diagnostics_archive. This runs at the start of
-# cleanup() when the check has failed, that is, before "helm uninstall" removes everything from the cluster.
+# custom resources) into $diagnostics_dir. This runs at the start of cleanup() when the check has failed, that is,
+# before "helm uninstall" removes everything from the cluster.
 collect_diagnostics() {
   set +e
   log "the check did not succeed, collecting cluster diagnostics into \"$diagnostics_dir\" before cleanup"
@@ -123,12 +122,7 @@ collect_diagnostics() {
       -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null)
   done
 
-  log "creating the diagnostics archive \"$diagnostics_archive\""
-  if tar -czf "$diagnostics_archive" "$diagnostics_dir"; then
-    log "cluster diagnostics have been collected in \"$diagnostics_archive\""
-  else
-    log "WARNING: failed to create the diagnostics archive \"$diagnostics_archive\""
-  fi
+  log "cluster diagnostics have been collected in \"$diagnostics_dir\""
   set -e
 }
 

--- a/.github/workflows/scripts/gke-ap-workload-allowlist-check.sh
+++ b/.github/workflows/scripts/gke-ap-workload-allowlist-check.sh
@@ -79,6 +79,12 @@ collect_diagnostics() {
     } > "$file" || echo "(command exited with a non-zero status)" >> "$file"
   }
 
+  # Nodes, including their labels, taints and allocatable/allocated resources. A daemonset pod is pinned to exactly one
+  # node via nodeAffinity, so a pod that stays pending is a statement about that one node (its free capacity, its taints
+  # or its architecture), not about the cluster as a whole.
+  dump nodes-get.txt kubectl get nodes -o wide --show-labels
+  dump nodes-describe.txt kubectl describe nodes
+
   # Cluster-scoped GKE Autopilot allowlist resources. A mismatch or a not-yet-ready AllowlistSynchronizer is the most
   # likely reason for this check to fail.
   dump allowlistsynchronizers-get.txt kubectl get allowlistsynchronizers.auto.gke.io -o wide

--- a/.github/workflows/scripts/gke-ap-workload-allowlist-check.sh
+++ b/.github/workflows/scripts/gke-ap-workload-allowlist-check.sh
@@ -282,7 +282,7 @@ kubectl \
   rollout status \
   daemonset "${helm_release_name}-opentelemetry-collector-agent-daemonset" \
   --namespace "$operator_namespace" \
-  --timeout 90s
+  --timeout 180s
 set +x
 
 log "the daemonset collector is ready now"
@@ -293,7 +293,7 @@ kubectl wait \
   --for=create \
   deployment "${helm_release_name}-cluster-metrics-collector-deployment" \
   --namespace "$operator_namespace" \
-  --timeout=20s
+  --timeout=30s
 set +x
 log "waiting for the deployment collector rollout to finish"
 set -x

--- a/.github/workflows/scripts/gke-ap-workload-allowlist-check.sh
+++ b/.github/workflows/scripts/gke-ap-workload-allowlist-check.sh
@@ -79,9 +79,6 @@ collect_diagnostics() {
     } > "$file" || echo "(command exited with a non-zero status)" >> "$file"
   }
 
-  # Nodes, including their labels, taints and allocatable/allocated resources. A daemonset pod is pinned to exactly one
-  # node via nodeAffinity, so a pod that stays pending is a statement about that one node (its free capacity, its taints
-  # or its architecture), not about the cluster as a whole.
   dump nodes-get.txt kubectl get nodes -o wide --show-labels
   dump nodes-describe.txt kubectl describe nodes
 
@@ -282,16 +279,33 @@ kubectl wait \
   --namespace "$operator_namespace" \
   --timeout=60s
 set +x
-log "waiting for the daemonset collector rollout to finish"
-set -x
-kubectl \
-  rollout status \
-  daemonset "${helm_release_name}-opentelemetry-collector-agent-daemonset" \
+# Wait for one ready pod instead of using "kubectl rollout status", which requires a ready pod on every node: GKE
+# Autopilot inflates a gke-system-balloon-pod to park the spare capacity of an under-utilized node, and that pod runs
+# with the priority class system-node-critical, which a daemonset pod (priority 0) can neither fit alongside nor
+# preempt. A daemonset pod pinned to such a node stays pending no matter how long we wait.
+log "waiting for at least one pod of the daemonset collector to become ready"
+deadline=$((SECONDS + 90))
+until [[ "$(kubectl get daemonset "${helm_release_name}-opentelemetry-collector-agent-daemonset" \
+  --namespace "$operator_namespace" -o jsonpath='{.status.numberReady}')" -ge 1 ]]; do
+  if (( SECONDS >= deadline )); then
+    log "ERROR: no pod of the daemonset collector became ready within 90 seconds"
+    exit 1
+  fi
+  sleep 5
+done
+# Verify that the GKE Autopilot warden has added the WorkloadAllowlist match label to the daemonset pod.
+all_matching_allowlists=$(kubectl get pods \
   --namespace "$operator_namespace" \
-  --timeout 300s
-set +x
-
-log "the daemonset collector is ready now"
+  --selector app.kubernetes.io/component=agent-collector \
+  --field-selector status.phase=Running \
+  -o jsonpath="{.items[*].metadata.labels['cloud\.google\.com/matching-allowlist']}")
+read -r matching_allowlist _ <<< "$all_matching_allowlists"
+if [[ -z "$matching_allowlist" ]]; then
+  log "ERROR: the daemonset collector pods did not match any GKE Autopilot WorkloadAllowlist,"
+  log "the WorkloadAllowlists probably need to be updated for the current Helm chart."
+  exit 1
+fi
+log "at least one daemonset collector pod is ready now, and the daemonset pods matched the WorkloadAllowlist \"$matching_allowlist\""
 
 log "waiting for the deployment collector to be created"
 set -x

--- a/.github/workflows/scripts/gke-ap-workload-allowlist-check.sh
+++ b/.github/workflows/scripts/gke-ap-workload-allowlist-check.sh
@@ -24,6 +24,11 @@ set -euo pipefail
 
 cd "$(dirname "${BASH_SOURCE[0]}")"/../../..
 
+# Prints a message prefixed with the current UTC time, so the duration of each step can be derived from the output.
+log() {
+  echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*"
+}
+
 operator_namespace=gke-ap-workload-allowlist-check-operator
 monitored_namespace=gke-ap-workload-allowlist-check-monitored
 use_local_chart="${USE_LOCAL_CHART:-}"
@@ -34,8 +39,8 @@ if [[ "$use_local_chart" = "true" ]]; then
   # Only the official ghcr.io/dash0hq repositories and the ghcr.io/dash0hq/gke-ap- repositories are allow-listed on the
   # GKE Autopilot cluster. Using any other prefix would make the operator pods unschedulable.
   if [[ "$image_repository_prefix" != "ghcr.io/dash0hq/" && "$image_repository_prefix" != "ghcr.io/dash0hq/gke-ap-" ]]; then
-    echo "ERROR: unsupported IMAGE_REPOSITORY_PREFIX '$image_repository_prefix'."
-    echo "Only 'ghcr.io/dash0hq/' and 'ghcr.io/dash0hq/gke-ap-' are allow-listed."
+    log "ERROR: unsupported IMAGE_REPOSITORY_PREFIX '$image_repository_prefix'."
+    log "Only 'ghcr.io/dash0hq/' and 'ghcr.io/dash0hq/gke-ap-' are allow-listed."
     exit 1
   fi
 else
@@ -58,7 +63,7 @@ check_succeeded=false
 # cleanup() when the check has failed, that is, before "helm uninstall" removes everything from the cluster.
 collect_diagnostics() {
   set +e
-  echo "the check did not succeed, collecting cluster diagnostics into \"$diagnostics_dir\" before cleanup"
+  log "the check did not succeed, collecting cluster diagnostics into \"$diagnostics_dir\" before cleanup"
   mkdir -p "$diagnostics_dir"
 
   # Runs a command and stores its combined stdout/stderr in $diagnostics_dir/$1. Best effort: a failing command must
@@ -66,6 +71,7 @@ collect_diagnostics() {
   dump() {
     local file="$diagnostics_dir/$1"
     shift
+    log "collecting $file"
     mkdir -p "$(dirname "$file")"
     {
       echo "\$ $*"
@@ -108,6 +114,7 @@ collect_diagnostics() {
       dump "$namespace/logs-${pod}.txt" \
         kubectl logs --namespace "$namespace" "$pod" --all-containers=true --prefix=true
       # Previous logs only exist for containers that have restarted; ignore the file if there are none.
+      log "collecting the previous logs of pod $pod in namespace $namespace, if any"
       if ! kubectl logs --namespace "$namespace" "$pod" --all-containers=true --prefix=true --previous \
         > "$diagnostics_dir/$namespace/logs-${pod}-previous.txt" 2>/dev/null; then
         rm -f "$diagnostics_dir/$namespace/logs-${pod}-previous.txt"
@@ -116,10 +123,11 @@ collect_diagnostics() {
       -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null)
   done
 
+  log "creating the diagnostics archive \"$diagnostics_archive\""
   if tar -czf "$diagnostics_archive" "$diagnostics_dir"; then
-    echo "cluster diagnostics have been collected in \"$diagnostics_archive\""
+    log "cluster diagnostics have been collected in \"$diagnostics_archive\""
   else
-    echo "WARNING: failed to create the diagnostics archive \"$diagnostics_archive\""
+    log "WARNING: failed to create the diagnostics archive \"$diagnostics_archive\""
   fi
   set -e
 }
@@ -131,8 +139,9 @@ cleanup() {
 
   set +e
   set -x
-  echo "running cleanup"
+  log "running cleanup"
 
+  log "uninstalling the helm release $helm_release_name"
   helm uninstall \
     --namespace "$operator_namespace" \
     --ignore-not-found \
@@ -140,12 +149,16 @@ cleanup() {
     "$helm_release_name"
 
   # If the workload allow list for the pre-delete hook does not match, it might stick around as a Zombie job, force-delete it.
+  log "deleting the pre-delete job"
   kubectl delete job --namespace "$operator_namespace" --ignore-not-found "${helm_release_name}-pre-delete" --wait --grace-period=0 --force
 
+  log "deleting namespace $operator_namespace"
   kubectl delete namespace "$operator_namespace" --ignore-not-found --grace-period=0 --force
 
+  log "deleting namespace $monitored_namespace"
   kubectl delete namespace "$monitored_namespace" --ignore-not-found --grace-period=0 --force
 
+  log "uninstalling podinfo and deleting the namespace ensure-at-least-one-node"
   helm uninstall --namespace ensure-at-least-one-node podinfo
   kubectl delete namespace ensure-at-least-one-node --ignore-not-found --grace-period=0 --force
 
@@ -165,20 +178,20 @@ retry_command() {
     fi
 
     if [[ $attempt -eq $max_retries ]]; then
-      echo "Command failed after $max_retries attempts: $*"
+      log "Command failed after $max_retries attempts: $*"
       return 1
     fi
 
-    echo "Attempt $attempt failed, retrying in ${retry_delay} seconds..."
+    log "Attempt $attempt failed, retrying in ${retry_delay} seconds..."
     sleep $retry_delay
     attempt=$((attempt + 1))
   done
 }
 
-echo kubectl version:
+log "kubectl version:"
 kubectl version
 echo
-echo "current kubectx: $(kubectl config current-context)"
+log "current kubectx: $(kubectl config current-context)"
 echo
 
 # Install a trap to make sure we clean up after ourselves, no matter the outcome of the check.
@@ -186,12 +199,13 @@ trap cleanup HUP INT TERM EXIT
 
 # Deploy a dummy pod, to ensure the cluster is scaled up to at least one node. GKE AP has the infuriating UX problem
 # that for example a namespace can be in state terminating forever if it is scaled down to zero nodes.
+log "deploying podinfo to make sure the cluster is scaled up to at least one node"
 helm repo add podinfo https://stefanprodan.github.io/podinfo
 kubectl create namespace ensure-at-least-one-node || true
 helm install --namespace ensure-at-least-one-node podinfo podinfo/podinfo || true
 
 if [[ "$chart" != "helm-chart/dash0-operator" ]]; then
-  echo "installing the operator helm repo"
+  log "installing the operator helm repo"
   helm repo add dash0-operator https://dash0hq.github.io/dash0-operator
   helm repo update dash0-operator
 fi
@@ -200,24 +214,24 @@ fi
 # make the test invalid. We want to verify that the Helm chart correctly installs the AllowlistSynchronizer before deploying
 # the operator, and that cleanup works correctly when removing the Helm chart. A manually installed AllowlistSynchronizer
 # or WorkloadAllowlist might hide issues.
-echo "checking that no GKE Autopilot allowlist resources exist before the check starts"
+log "checking that no GKE Autopilot allowlist resources exist before the check starts"
 existing_synchronizers=$(kubectl get allowlistsynchronizers.auto.gke.io --no-headers --ignore-not-found 2>/dev/null || true)
 existing_allowlists=$(kubectl get workloadallowlists.auto.gke.io --no-headers --ignore-not-found 2>/dev/null || true)
 if [[ -n "$existing_synchronizers" || -n "$existing_allowlists" ]]; then
-  echo "ERROR: the cluster already contains GKE Autopilot allowlist resources, please clean them up before running the check."
+  log "ERROR: the cluster already contains GKE Autopilot allowlist resources, please clean them up before running the check."
   if [[ -n "$existing_synchronizers" ]]; then
-    echo "Existing AllowlistSynchronizers:"
+    log "Existing AllowlistSynchronizers:"
     echo "$existing_synchronizers"
   fi
   if [[ -n "$existing_allowlists" ]]; then
-    echo "Existing WorkloadAllowlists:"
+    log "Existing WorkloadAllowlists:"
     echo "$existing_allowlists"
   fi
   exit 1
 fi
 
 # Create the namespace and a dummy auth token secret.
-echo "creating operator namespace $operator_namespace and auth token secret"
+log "creating operator namespace $operator_namespace and auth token secret"
 kubectl create namespace "$operator_namespace"
 kubectl create secret \
   generic \
@@ -254,18 +268,22 @@ fi
 helm_command+=" $helm_release_name"
 helm_command+=" $chart"
 
-echo "running: $helm_command"
+log "running: $helm_command"
 $helm_command
 
 # Wait for the OTel collector workloads to become ready, this ensures that the WorkloadAllowlists for those also match.
-echo "helm install has been successful, waiting for the collectors to be deployed and become ready"
+log "helm install has been successful, waiting for the collectors to be deployed and become ready"
 
+log "waiting for the daemonset collector to be created"
 set -x
 kubectl wait \
   --for=create \
   daemonset "${helm_release_name}-opentelemetry-collector-agent-daemonset" \
   --namespace "$operator_namespace" \
   --timeout=60s
+set +x
+log "waiting for the daemonset collector rollout to finish"
+set -x
 kubectl \
   rollout status \
   daemonset "${helm_release_name}-opentelemetry-collector-agent-daemonset" \
@@ -273,14 +291,18 @@ kubectl \
   --timeout 90s
 set +x
 
-echo "the daemonset collector is ready now"
+log "the daemonset collector is ready now"
 
+log "waiting for the deployment collector to be created"
 set -x
 kubectl wait \
   --for=create \
   deployment "${helm_release_name}-cluster-metrics-collector-deployment" \
   --namespace "$operator_namespace" \
   --timeout=20s
+set +x
+log "waiting for the deployment collector rollout to finish"
+set -x
 kubectl \
   rollout status \
   deployment "${helm_release_name}-cluster-metrics-collector-deployment" \
@@ -288,9 +310,9 @@ kubectl \
   --timeout 60s
 set +x
 
-echo "the deployment collector is ready now"
+log "the deployment collector is ready now"
 
-echo "deploying a monitoring resource to trigger deploying the target-allocator"
+log "deploying a monitoring resource to trigger deploying the target-allocator"
 
 kubectl create namespace "$monitored_namespace"
 kubectl apply --namespace "$monitored_namespace" -f - <<EOF
@@ -299,15 +321,21 @@ kind: Dash0Monitoring
 metadata:
   name: dash0-monitoring-resource
 EOF
+log "waiting for the monitoring resource to show up"
 retry_command kubectl get --namespace "$monitored_namespace" dash0monitorings.operator.dash0.com/dash0-monitoring-resource
+log "waiting for the monitoring resource to become available"
 kubectl wait --namespace "$monitored_namespace" dash0monitorings.operator.dash0.com/dash0-monitoring-resource --for condition=Available --timeout 30s
 
+log "waiting for the target-allocator to be created"
 set -x
 kubectl wait \
   --for=create \
   deployment "${helm_release_name}-opentelemetry-target-allocator-deployment" \
   --namespace "$operator_namespace" \
   --timeout=60s
+set +x
+log "waiting for the target-allocator rollout to finish"
+set -x
 kubectl \
   rollout status \
   deployment "${helm_release_name}-opentelemetry-target-allocator-deployment" \
@@ -315,9 +343,9 @@ kubectl \
   --timeout 60s
 set +x
 
-echo "the target-allocator is ready now"
+log "the target-allocator is ready now"
 echo
-echo "success: all checks have passed"
+log "success: all checks have passed"
 echo
 
 # Mark the check as successful so that cleanup() does not collect diagnostics.

--- a/.gitignore
+++ b/.gitignore
@@ -48,4 +48,3 @@ test-resources/*.env
 
 # cluster diagnostics collected by the GKE Autopilot WorkloadAllowlist check on failure
 /gke-ap-allowlist-check-diagnostics
-/gke-ap-allowlist-check-diagnostics.tar.gz


### PR DESCRIPTION
Only wait for at least one daemonset collector pod to get ready instead of waiting for the entire daemonset to become ready via "kubectl rollout status".

When the GKE AutoPilot cluster scales up (adds more nodes), the DESIRED goal for the daemonset increases with each node. For each new node it takes time until the node is ready for scheduling. Whether the entire daemonset becomes ready within a given timeout is quite non-deterministic and depends entirely on GKE AutoPilot auto-scaling behavior, not on whether the allowlist matches the daemonset.

We are only interested in whether the allowlist matches and collector pods generally are able to start.

One collector daemonset pod is good enough to prove that the matched allowlist permits the workload to actually run.

Also:
* increase CI timeout for GKE AutoPilot AllowList check
* add timestamps to gke-ap-workload-allowlist-check.sh output
* do not double-wrap diagnostics dir (tar.gz in zip)
* add node information to diagnostics

Disclaimer: It is not entirely clear, why the check started failing, but the behavior that made it fail more often recently seems to be a change in the GKE AutoPilot auto-scaling behavior or potentially a different node type. Either way, the individual pods of the daemonsets got ready just fine, the daemonset just never got ready in the allotted 90s because it was chasing up to 10 nodes coming up every few seconds.